### PR TITLE
Migrate all history dialogs onto HistoryDialogBase; rename event-log dialogs to Audit

### DIFF
--- a/doc/agile/product_backlog/inbox/appversion-history-diff-mislabelled.org
+++ b/doc/agile/product_backlog/inbox/appversion-history-diff-mislabelled.org
@@ -1,0 +1,41 @@
+:PROPERTIES:
+:ID: FC2EF34E-F873-4793-BA38-4026BD78E7FE
+:END:
+#+title: AppVersionHistoryDialog diff rows mislabelled
+#+description: The AppVersion history changes tab emits mislabelled diff rows: both 'Wrapper Version' and 'Name' diff wrapper_version, and 'Description' diffs engine_version. Full details similarly maps codeValue to wrapper_version and both nameValue and descriptionValue to engine_version. Pre-existing bug found during the HistoryDialogBase migration and preserved verbatim; fields should map to the actual app_version domain fields.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Fix the field mappings in =AppVersionHistoryDialog=. The changes tab
+emits three mislabelled diff rows: both /Wrapper Version/ and /Name/
+diff =wrapper_version=, and /Description/ diffs =engine_version=. The
+full-details panel has the same confusion: =codeValue= shows
+=wrapper_version=, and both =nameValue= and =descriptionValue= show
+=engine_version=. The labels should map to the actual
+=app_version= domain fields (and the dialog's =.ui= labels should be
+checked against the domain model at the same time).
+
+* Why
+
+A user inspecting an app version's history sees the same value under
+two different field names and never sees the engine version labelled
+correctly, which undermines trust in the history view. The bug is
+pre-existing; it was found during the HistoryDialogBase migration
+(story: consolidate history dialogs) and deliberately preserved
+verbatim there so the migration stayed behaviour-neutral.
+
+* References
+
+- =projects/ores.qt/compute/src/AppVersionHistoryDialog.cpp= —
+  =calculateDiffAt= and =displayFullDetails=.
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :qt:refactor:history:consolidate_history_dialogs:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/grow-history-dialog-base
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -30,7 +30,7 @@ broke GCC/AppleClang).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs onto HistoryDialogBase]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
@@ -75,11 +75,14 @@ broke GCC/AppleClang).
   family reverted to the version older than the selection and the
   generated family reverted to the selection without confirmation.
   Recorded in the UX language knowledge doc.
-- Out of scope — event-log "history" screens, not version histories:
-  =SessionHistoryDialog= (login-session telemetry with charts),
-  =PublicationHistoryDialog= (dataset publication audit log),
-  =JobDefinitionHistoryDialog= (job execution run log). The base's
-  version-list/diff/open-revert contract does not apply to them.
+- The three event-log "history" screens are not version histories, so
+  they stay off the base — instead they were *renamed to Audit*
+  (Marco's decision) so /history/ retains a single meaning in the
+  codebase: =SessionAuditDialog= (login-session telemetry),
+  =PublicationAuditDialog= (dataset publication log),
+  =JobDefinitionAuditDialog= (job execution run log). User-visible
+  titles, menu options and tooltips renamed alike; the distinction is
+  recorded in the UX language doc ("History vs Audit").
 - Pre-existing AppVersion diff mislabelling preserved verbatim and
   captured separately: [[id:FC2EF34E-F873-4793-BA38-4026BD78E7FE][AppVersionHistoryDialog diff rows mislabelled]].
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
@@ -89,13 +89,19 @@ broke GCC/AppleClang).
 * PRs
 
 | PR | Title |
-|----+-------|
-|    |       |
+|------+-------------------------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/1080][1080]] | Migrate all history dialogs onto HistoryDialogBase; rename event-log dialogs to Audit |
 
 * Review
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | unique_ptr with forward-declared Ui needs out-of-line dtor (×4: Account, SystemSetting hpp+cpp) | admin history dialogs | Accepted | Premise was wrong (headers included ui_*.h; build was green) but the forward-decl pattern is better; applied to all six hand-rolled dialogs in f09464d20 |
+| 2 | Wrap toolbar action names and tooltips in tr() | HistoryDialogBase.cpp | Accepted | 282f9c518 |
+| 3 | Wrap load-failure error strings in tr() | HistoryDialogBase.cpp | Accepted | 282f9c518 |
+| 4 | Wrap changes-table placeholders in tr() | HistoryDialogBase.cpp | Accepted | 282f9c518 |
+| 5 | Wrap revert confirmation in tr() | HistoryDialogBase.cpp | Accepted | 282f9c518 |
+| 6 | Wrap Yes/No boolean diff values in tr() | HistoryDialogBase.cpp | Accepted | 282f9c518 |
+| 7 | Task doc must include * Review section | task_grow-history-dialog-base.org | Declined | Section already present with the standard table; comment anchored on the adjacent empty PRs table |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
@@ -32,9 +32,9 @@ broke GCC/AppleClang).
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs onto HistoryDialogBase]] |
-| Now          | Not yet started.                       |
+| Now          | All 64 version-history dialogs migrated; full build green; raising the PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Raise the PR and run the review runbook. |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -59,6 +59,29 @@ broke GCC/AppleClang).
    codegen-free.
 
 * Notes
+
+- Scope expanded by Marco during implementation: migrate /all/
+  history dialogs with the same pattern, not just the six hand-rolled
+  ones — first hand-crafted, then the generated family. Final tally:
+  6 hand-rolled + 58 generated-pattern dialogs (including the
+  ZeroConvention exemplar and the original Workspace adopter) are on
+  the base; 64 in total.
+- =VersionRow= became {version, ordered cell list} because version
+  lists vary per dialog (3–6 columns: change reason, commentary,
+  performed by, enabled).
+- Revert semantics were unified (Marco's decision): *Revert restores
+  the selected version* as a new current version, after confirmation,
+  and is disabled on the latest version. Previously the hand-rolled
+  family reverted to the version older than the selection and the
+  generated family reverted to the selection without confirmation.
+  Recorded in the UX language knowledge doc.
+- Out of scope — event-log "history" screens, not version histories:
+  =SessionHistoryDialog= (login-session telemetry with charts),
+  =PublicationHistoryDialog= (dataset publication audit log),
+  =JobDefinitionHistoryDialog= (job execution run log). The base's
+  version-list/diff/open-revert contract does not apply to them.
+- Pre-existing AppVersion diff mislabelling preserved verbatim and
+  captured separately: [[id:FC2EF34E-F873-4793-BA38-4026BD78E7FE][AppVersionHistoryDialog diff rows mislabelled]].
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_shell-unified-diff.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_shell-unified-diff.org
@@ -48,6 +48,11 @@ Qt dialogs — demonstrating that frontends need no comparison logic.
    the =changes= rows (and =fields= context), defaulting per UX
    discussion — either the default view or behind a =--diff= flag.
 2. Reuse ores.diff types; no comparison logic in the shell.
+3. For the unified-diff /rendering/ itself, prefer an established
+   vcpkg library over hand-rolling the format (survey candidates:
+   e.g. diff-match-patch, dtl — pick whichever is maintained and fits
+   the std+rfl dependency posture). Hand-roll only if nothing
+   suitable exists in the registry.
 3. Update the shell recipes documenting the history command.
 4. Depends on the pilot task for the extended response (currency
    first; per-entity availability follows the rollout).

--- a/doc/knowledge/ui/ux_language.org
+++ b/doc/knowledge/ui/ux_language.org
@@ -186,6 +186,16 @@ detail dialog. Deleting a record preserves its history.
   no-op. History is immutable: reverting never removes intermediate
   versions.
 
+*** History vs Audit
+
+/History/ always means *versioned-entity history*: the version list,
+field-by-field diff, and Open/Revert actions described above. Screens
+that show a log of /events that happened/ — login sessions, dataset
+publications, job executions — are called *Audit* instead, in class
+names, window titles, menu options and tooltips alike. Audit screens
+are read-only event logs: they have a Refresh action but no versions,
+no diff and no revert.
+
 * See also
 
 - [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]] — the aesthetic rules: typography, colour

--- a/doc/knowledge/ui/ux_language.org
+++ b/doc/knowledge/ui/ux_language.org
@@ -180,6 +180,12 @@ record, newest first, with the same badge and provenance vocabulary as
 the detail dialog. Selecting a version opens it read-only in the
 detail dialog. Deleting a record preserves its history.
 
+- /Revert semantics/ — =Revert= restores *the selected version* as a
+  new current version, after a confirmation dialog. It is disabled
+  when the latest version is selected, where reverting would be a
+  no-op. History is immutable: reverting never removes intermediate
+  versions.
+
 * See also
 
 - [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]] — the aesthetic rules: typography, colour

--- a/projects/ores.qt/admin/include/ores.qt/AccountController.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountController.hpp
@@ -148,15 +148,15 @@ private slots:
     void onShowAccountHistory(const QString& username);
 
     /**
-     * @brief Handles request to show session history.
+     * @brief Handles request to show the session audit.
      *
-     * Creates and displays a session history dialog for viewing login
+     * Creates and displays a session audit dialog for viewing login
      * sessions of an account.
      *
      * @param accountId The account UUID
      * @param username The username of the account
      */
-    void onShowSessionHistory(const boost::uuids::uuid& accountId, const QString& username);
+    void onShowSessionAudit(const boost::uuids::uuid& accountId, const QString& username);
 
     /**
      * @brief Handles request to open a historical account version in read-only mode.

--- a/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
@@ -25,7 +25,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/HistoryDialogBase.hpp"
-#include "ui_AccountHistoryDialog.h"
 #include <QString>
 #include <memory>
 
@@ -54,7 +53,7 @@ public:
     explicit AccountHistoryDialog(QString username,
                                   ClientManager* clientManager,
                                   QWidget* parent = nullptr);
-    ~AccountHistoryDialog() override = default;
+    ~AccountHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
@@ -24,11 +24,9 @@
 #include "ores.iam.api/messaging/account_history_protocol.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ui_AccountHistoryDialog.h"
-#include <QAction>
 #include <QString>
-#include <QToolBar>
-#include <QWidget>
 #include <memory>
 
 namespace Ui {
@@ -40,7 +38,7 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying account version history.
  */
-class AccountHistoryDialog : public QWidget {
+class AccountHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -52,37 +50,22 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit AccountHistoryDialog(QString username,
                                   ClientManager* clientManager,
                                   QWidget* parent = nullptr);
-    ~AccountHistoryDialog() override;
+    ~AccountHistoryDialog() override = default;
 
-    void loadHistory();
-
-    QSize sizeHint() const override;
-
-    /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this account has
-     * changed on the server. Automatically reloads the history data.
-     */
-    void markAsStale();
+    void loadHistory() override;
 
     /**
      * @brief Returns the username of the account.
      */
-    [[nodiscard]] QString username() const {
+    [[nodiscard]] QString code() const override {
         return username_;
     }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param account The account data at the selected version.
@@ -96,31 +79,21 @@ signals:
      */
     void revertVersionRequested(const iam::domain::account& account);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::AccountHistoryDialog> ui_;
     ClientManager* clientManager_;
     QString username_;
     iam::messaging::account_version_history history_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/include/ores.qt/AccountMdiWindow.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountMdiWindow.hpp
@@ -71,7 +71,7 @@ signals:
     void addNewRequested();
     void showAccountDetails(const AccountWithLoginInfo& accountWithLoginInfo);
     void showAccountHistory(const QString& username);
-    void showSessionHistory(const boost::uuids::uuid& accountId, const QString& username);
+    void showSessionAudit(const boost::uuids::uuid& accountId, const QString& username);
     void accountDeleted(const boost::uuids::uuid& account_id);
 
 public slots:

--- a/projects/ores.qt/admin/include/ores.qt/BadgeDefinitionHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/BadgeDefinitionHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/badge_definition.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BadgeDefinitionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a badge definition with ability
  * to view details or revert to a previous version.
  */
-class BadgeDefinitionHistoryDialog final : public QWidget {
+class BadgeDefinitionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                           QWidget* parent = nullptr);
     ~BadgeDefinitionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the badge definition.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::badge_definition& definition, int versionNumber);
     void revertVersionRequested(const dq::domain::badge_definition& definition);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BadgeDefinitionHistoryDialog* ui_;
+    std::unique_ptr<Ui::BadgeDefinitionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::badge_definition> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/include/ores.qt/BadgeSeverityHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/BadgeSeverityHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/badge_severity.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BadgeSeverityHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a badge severity with ability
  * to view details or revert to a previous version.
  */
-class BadgeSeverityHistoryDialog final : public QWidget {
+class BadgeSeverityHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                         QWidget* parent = nullptr);
     ~BadgeSeverityHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the badge severity.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::badge_severity& severity, int versionNumber);
     void revertVersionRequested(const dq::domain::badge_severity& severity);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BadgeSeverityHistoryDialog* ui_;
+    std::unique_ptr<Ui::BadgeSeverityHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::badge_severity> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
@@ -22,15 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.variability.api/domain/system_setting.hpp"
 #include "ui_SystemSettingHistoryDialog.h"
-#include <QAction>
-#include <QPair>
 #include <QString>
-#include <QToolBar>
-#include <QVector>
-#include <QWidget>
 #include <memory>
+#include <vector>
 
 namespace Ui {
 class SystemSettingHistoryDialog;
@@ -41,7 +38,7 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying system setting version history.
  */
-class SystemSettingHistoryDialog : public QWidget {
+class SystemSettingHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -53,30 +50,18 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit SystemSettingHistoryDialog(QString name,
                                         ClientManager* clientManager,
                                         QWidget* parent = nullptr);
-    ~SystemSettingHistoryDialog() override;
+    ~SystemSettingHistoryDialog() override = default;
 
-    void loadHistory();
-
-    QSize sizeHint() const override;
-
-    /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this system setting has
-     * changed on the server. Automatically reloads the history data.
-     */
-    void markAsStale();
+    void loadHistory() override;
 
     /**
      * @brief Returns the name of the system setting.
      */
-    [[nodiscard]] QString flagName() const {
+    [[nodiscard]] QString code() const override {
         return flagName_;
     }
 
@@ -88,9 +73,6 @@ public:
     }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param flag The system setting data at the selected version.
@@ -104,40 +86,21 @@ signals:
      */
     void revertVersionRequested(const variability::domain::system_setting& flag);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const variability::domain::system_setting& current,
-                             const variability::domain::system_setting& previous);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::SystemSettingHistoryDialog> ui_;
     ClientManager* clientManager_;
     QString flagName_;
     std::vector<variability::domain::system_setting> history_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
@@ -24,7 +24,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.variability.api/domain/system_setting.hpp"
-#include "ui_SystemSettingHistoryDialog.h"
 #include <QString>
 #include <memory>
 #include <vector>
@@ -54,7 +53,7 @@ public:
     explicit SystemSettingHistoryDialog(QString name,
                                         ClientManager* clientManager,
                                         QWidget* parent = nullptr);
-    ~SystemSettingHistoryDialog() override = default;
+    ~SystemSettingHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/admin/include/ores.qt/TenantHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/TenantHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.iam.api/domain/tenant.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class TenantHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a tenant with ability
  * to view details or revert to a previous version.
  */
-class TenantHistoryDialog final : public QWidget {
+class TenantHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                  QWidget* parent = nullptr);
     ~TenantHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the tenant.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const iam::domain::tenant& tenant, int versionNumber);
     void revertVersionRequested(const iam::domain::tenant& tenant);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::TenantHistoryDialog* ui_;
+    std::unique_ptr<Ui::TenantHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<iam::domain::tenant> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/include/ores.qt/TenantTypeHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/TenantTypeHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.iam.api/domain/tenant_type.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class TenantTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a tenant type with ability
  * to view details or revert to a previous version.
  */
-class TenantTypeHistoryDialog final : public QWidget {
+class TenantTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                      QWidget* parent = nullptr);
     ~TenantTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the tenant type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const iam::domain::tenant_type& tenant_type, int versionNumber);
     void revertVersionRequested(const iam::domain::tenant_type& tenant_type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::TenantTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::TenantTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<iam::domain::tenant_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/admin/src/AccountController.cpp
+++ b/projects/ores.qt/admin/src/AccountController.cpp
@@ -29,7 +29,7 @@
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
-#include "ores.qt/SessionHistoryDialog.hpp"
+#include "ores.qt/SessionAuditDialog.hpp"
 #include <QFutureWatcher>
 #include <QPointer>
 #include <QtConcurrent>
@@ -163,9 +163,9 @@ void AccountController::showListWindow() {
             this,
             &AccountController::onShowAccountHistory);
     connect(accountWidget,
-            &AccountMdiWindow::showSessionHistory,
+            &AccountMdiWindow::showSessionAudit,
             this,
-            &AccountController::onShowSessionHistory);
+            &AccountController::onShowSessionAudit);
 
     accountListWindow_ = new DetachableMdiSubWindow();
     accountListWindow_->setAttribute(Qt::WA_DeleteOnClose);
@@ -318,15 +318,15 @@ void AccountController::onShowAccountHistory(const QString& username) {
     historyDialog->loadHistory();
 }
 
-void AccountController::onShowSessionHistory(const boost::uuids::uuid& accountId,
+void AccountController::onShowSessionAudit(const boost::uuids::uuid& accountId,
                                              const QString& username) {
-    BOOST_LOG_SEV(lg(), info) << "Showing session history for: " << username.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Showing session audit for: " << username.toStdString();
 
-    auto* sessionDialog = new SessionHistoryDialog(clientManager_, mainWindow_);
+    auto* sessionDialog = new SessionAuditDialog(clientManager_, mainWindow_);
 
     // Connect status signals
     connect(sessionDialog,
-            &SessionHistoryDialog::statusMessage,
+            &SessionAuditDialog::statusMessage,
             this,
             [self = QPointer<AccountController>(this)](const QString& message) {
                 if (!self)
@@ -334,7 +334,7 @@ void AccountController::onShowSessionHistory(const boost::uuids::uuid& accountId
                 emit self->statusMessage(message);
             });
     connect(sessionDialog,
-            &SessionHistoryDialog::errorMessage,
+            &SessionAuditDialog::errorMessage,
             this,
             [self = QPointer<AccountController>(this)](const QString& err_msg) {
                 if (!self)
@@ -346,7 +346,7 @@ void AccountController::onShowSessionHistory(const boost::uuids::uuid& accountId
     auto* sessionWindow = new DetachableMdiSubWindow();
     sessionWindow->setAttribute(Qt::WA_DeleteOnClose);
     sessionWindow->setWidget(sessionDialog);
-    sessionWindow->setWindowTitle(QString("Session History: %1").arg(username));
+    sessionWindow->setWindowTitle(QString("Session Audit: %1").arg(username));
     sessionWindow->setWindowIcon(
         IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor));
 

--- a/projects/ores.qt/admin/src/AccountController.cpp
+++ b/projects/ores.qt/admin/src/AccountController.cpp
@@ -252,7 +252,7 @@ void AccountController::onNotificationReceived(const QString& eventType,
             // since we don't have easy access to account_id
             historyDialog->markAsStale();
             BOOST_LOG_SEV(lg(), debug) << "Marked account history dialog as stale for: "
-                                       << historyDialog->username().toStdString();
+                                       << historyDialog->code().toStdString();
         }
     }
 }

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -19,266 +19,83 @@
  */
 #include "ores.qt/AccountHistoryDialog.hpp"
 #include "ores.iam.api/messaging/protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
-#include <QPair>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QVector>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& AccountHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
-}
-
 AccountHistoryDialog::AccountHistoryDialog(QString username,
                                            ClientManager* clientManager,
                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::AccountHistoryDialog)
     , clientManager_(clientManager)
-    , username_(std::move(username))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , username_(std::move(username)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating account history widget for: " << username_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating account history widget for: "
+                              << username_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
-
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-}
-
-AccountHistoryDialog::~AccountHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying account history widget";
-
-    // Disconnect and cancel any active QFutureWatcher objects
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-        watcher->waitForFinished();
-    }
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
 void AccountHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading account history for: " << username_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading account history for: "
+                              << username_.toStdString();
 
-    using HistoryResult = std::expected<iam::messaging::get_account_history_response, std::string>;
-    QPointer<AccountHistoryDialog> self = this;
-    const auto username = username_.toStdString();
+    iam::messaging::get_account_history_request request;
+    request.username = username_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, username]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        iam::messaging::get_account_history_request request;
-        request.username = username;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->history_ = std::move(result->history);
-        self->onHistoryLoaded();
+        history_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void AccountHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << history_.versions.size()
-                              << " versions";
-
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(history_.versions.size());
-
-    for (int i = 0; i < static_cast<int>(history_.versions.size()); ++i) {
-        const auto& version = history_.versions[i];
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version_number));
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 2, modifiedByItem);
-    }
-
-    if (!history_.versions.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!history_.versions.empty()) {
-        const auto& latest = history_.versions[0];
-        ui_->titleLabel->setText(
-            QString("Account History: %1").arg(QString::fromStdString(latest.data.username)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(history_.versions.size()));
+int AccountHistoryDialog::historySize() const {
+    return static_cast<int>(history_.versions.size());
 }
 
-void AccountHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
-
-    emit errorOccurred(QString("Failed to load account history: %1").arg(error_msg));
-    MessageBoxHelper::critical(
-        this, "History Load Error", QString("Failed to load account history:\n%1").arg(error_msg));
+HistoryDialogBase::VersionRow AccountHistoryDialog::versionRow(int index) const {
+    const auto& version = history_.versions[index];
+    return {.version = version.version_number,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by)}};
 }
 
-void AccountHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
+QString AccountHistoryDialog::historyTitle() const {
+    const auto& latest = history_.versions.front();
+    return QString("Account History: %1")
+        .arg(QString::fromStdString(latest.data.username));
 }
 
-namespace {
-
-/**
- * @brief Vector of (field_name, (old_value, new_value)) pairs.
- *
- * Local to this translation unit; the planned HistoryDialogBase
- * consolidation will move DiffResult and the calculateDiff template
- * method into the base class.
- */
-using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-
-void check_diff_string(DiffResult& diffs,
-                       const QString& field_name,
-                       const std::string& current_val,
-                       const std::string& previous_val) {
-    if (current_val != previous_val)
-        diffs.append({field_name,
-                      {QString::fromStdString(previous_val), QString::fromStdString(current_val)}});
-}
-
-DiffResult calculateDiff(const iam::domain::account_version& current,
-                         const iam::domain::account_version& previous) {
+HistoryDialogBase::DiffResult
+AccountHistoryDialog::calculateDiffAt(int current_index,
+                                      int previous_index) const {
+    const auto& current = history_.versions[current_index].data;
+    const auto& previous = history_.versions[previous_index].data;
 
     DiffResult diffs;
-
-    check_diff_string(diffs, "Username", current.data.username, previous.data.username);
-    check_diff_string(diffs, "Email", current.data.email, previous.data.email);
+    checkString(diffs, "Username", current.username, previous.username);
+    checkString(diffs, "Email", current.email, previous.email);
 
     return diffs;
 }
 
-}
-
-void AccountHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    const auto& current = history_.versions[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(history_.versions.size()) - 1)
-        return;
-
-    // Calculate diff with previous version
-    const auto& previous = history_.versions[version_index + 1];
-    auto diffs = calculateDiff(current, previous);
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        auto* oldItem = new QTableWidgetItem(old_val);
-        auto* newItem = new QTableWidgetItem(new_val);
-
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-        ui_->changesTableWidget->setItem(i, 1, oldItem);
-        ui_->changesTableWidget->setItem(i, 2, newItem);
-    }
-}
-
-void AccountHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    const auto& version = history_.versions[version_index];
+void AccountHistoryDialog::displayFullDetails(int index) {
+    const auto& version = history_.versions[index];
     const auto& data = version.data;
 
     ui_->usernameValue->setText(QString::fromStdString(data.username));
@@ -288,148 +105,29 @@ void AccountHistoryDialog::displayFullDetailsTab(int version_index) {
     ui_->isAdminValue->setVisible(false);
     ui_->versionNumberValue->setText(QString::number(version.version_number));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
 }
 
-void AccountHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_, &QAction::triggered, this, &AccountHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(openAction_, &QAction::triggered, this, &AccountHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert account to this version");
-    connect(revertAction_, &QAction::triggered, this, &AccountHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
-}
-
-void AccountHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(history_.versions.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int AccountHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void AccountHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
+void AccountHistoryDialog::openVersionAt(int index) {
     const auto& version = history_.versions[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening account version " << version.version_number
+    BOOST_LOG_SEV(lg(), info) << "Opening account version "
+                              << version.version_number
                               << " in read-only mode";
-
     emit openVersionRequested(version.data, version.version_number);
 }
 
-void AccountHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = history_.versions[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(history_.versions.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void AccountHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection, stamped with the latest version number.
     const auto& previous = history_.versions[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version_number
-                              << " to version " << previous.version_number;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version_number;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert Account",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(username_)
-            .arg(current.version_number)
-            .arg(previous.version_number),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) with the latest version number
     iam::domain::account account = previous.data;
-    account.version = history_.versions[0].version_number;
+    account.version = history_.versions.front().version_number;
     emit revertVersionRequested(account);
-}
-
-void AccountHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for account history: "
-                              << username_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(username_));
-    loadHistory();
-}
-
-QSize AccountHistoryDialog::sizeHint() const {
-    // Call the base implementation first to get the minimum size required by
-    // the layout manager and its content's size policies.
-    QSize baseSize = QWidget::sizeHint();
-
-    // Define a reasonable minimum size for a history dialog. This ensures the
-    // two panes (Version List and Details/Changes) are comfortably visible.
-    const int minimumWidth = 900;
-    const int minimumHeight = 600;
-
-    // Return the maximum of the base size (to accommodate large text/UI
-    // elements) and the defined minimum size.
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void AccountHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "Account history marked as stale for: " << username_.toStdString()
-                              << ", reloading...";
-
-    emit statusChanged(QString("Account %1 was modified - reloading history...").arg(username_));
-
-    // Reload history data
-    loadHistory();
 }
 
 }

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -118,14 +118,14 @@ void AccountHistoryDialog::openVersionAt(int index) {
 }
 
 void AccountHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection, stamped with the latest version number.
-    const auto& previous = history_.versions[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version, stamped with the latest version number.
+    const auto& selected = history_.versions[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version_number;
+                              << selected.version_number;
 
-    iam::domain::account account = previous.data;
+    iam::domain::account account = selected.data;
     account.version = history_.versions.front().version_number;
     emit revertVersionRequested(account);
 }

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/AccountHistoryDialog.hpp"
+#include "ui_AccountHistoryDialog.h"
 #include "ores.iam.api/messaging/protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -45,6 +46,8 @@ AccountHistoryDialog::AccountHistoryDialog(QString username,
                          .titleLabel = ui_->titleLabel,
                          .closeButton = ui_->closeButton});
 }
+
+AccountHistoryDialog::~AccountHistoryDialog() = default;
 
 void AccountHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading account history for: "

--- a/projects/ores.qt/admin/src/AccountMdiWindow.cpp
+++ b/projects/ores.qt/admin/src/AccountMdiWindow.cpp
@@ -131,7 +131,7 @@ AccountMdiWindow::AccountMdiWindow(ClientManager* clientManager,
 
     sessionsAction_->setIcon(
         IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor));
-    sessionsAction_->setToolTip("View session history");
+    sessionsAction_->setToolTip("View session audit");
     connect(sessionsAction_, &QAction::triggered, this, &AccountMdiWindow::viewSessionsSelected);
     toolBar_->addAction(sessionsAction_);
 
@@ -895,8 +895,8 @@ void AccountMdiWindow::viewSessionsSelected() {
         return;
     }
 
-    BOOST_LOG_SEV(lg(), debug) << "Emitting showSessionHistory for account: " << account->username;
-    emit showSessionHistory(account->id, QString::fromStdString(account->username));
+    BOOST_LOG_SEV(lg(), debug) << "Emitting showSessionAudit for account: " << account->username;
+    emit showSessionAudit(account->id, QString::fromStdString(account->username));
 }
 
 void AccountMdiWindow::updateActionStates() {

--- a/projects/ores.qt/admin/src/BadgeDefinitionHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/BadgeDefinitionHistoryDialog.cpp
@@ -19,13 +19,8 @@
  */
 #include "ores.qt/BadgeDefinitionHistoryDialog.hpp"
 #include "ores.dq.api/messaging/badge_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_BadgeDefinitionHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,246 +29,79 @@ using namespace ores::logging;
 BadgeDefinitionHistoryDialog::BadgeDefinitionHistoryDialog(const QString& code,
                                                            ClientManager* clientManager,
                                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BadgeDefinitionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BadgeDefinitionHistoryDialog::~BadgeDefinitionHistoryDialog() {
-    delete ui_;
-}
-
-void BadgeDefinitionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BadgeDefinitionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BadgeDefinitionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BadgeDefinitionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BadgeDefinitionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &BadgeDefinitionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BadgeDefinitionHistoryDialog::~BadgeDefinitionHistoryDialog() = default;
 
 void BadgeDefinitionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for badge definition: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BadgeDefinitionHistoryDialog> self = this;
+    dq::messaging::get_badge_definition_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::badge_definition> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        dq::messaging::get_badge_definition_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, response_result.error(), {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BadgeDefinitionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BadgeDefinitionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BadgeDefinitionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BadgeDefinitionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BadgeDefinitionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BadgeDefinitionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BadgeDefinitionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BadgeDefinitionHistoryDialog::calculateDiffAt(int current_index,
+                                              int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void BadgeDefinitionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -284,37 +112,22 @@ void BadgeDefinitionHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void BadgeDefinitionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BadgeDefinitionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening badge definition version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BadgeDefinitionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BadgeDefinitionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BadgeDefinitionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/admin/src/BadgeSeverityHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/BadgeSeverityHistoryDialog.cpp
@@ -19,13 +19,8 @@
  */
 #include "ores.qt/BadgeSeverityHistoryDialog.hpp"
 #include "ores.dq.api/messaging/badge_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_BadgeSeverityHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,245 +29,79 @@ using namespace ores::logging;
 BadgeSeverityHistoryDialog::BadgeSeverityHistoryDialog(const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BadgeSeverityHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BadgeSeverityHistoryDialog::~BadgeSeverityHistoryDialog() {
-    delete ui_;
-}
-
-void BadgeSeverityHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BadgeSeverityHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BadgeSeverityHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BadgeSeverityHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BadgeSeverityHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &BadgeSeverityHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BadgeSeverityHistoryDialog::~BadgeSeverityHistoryDialog() = default;
 
 void BadgeSeverityHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for badge severity: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BadgeSeverityHistoryDialog> self = this;
+    dq::messaging::get_badge_severity_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::badge_severity> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        dq::messaging::get_badge_severity_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, response_result.error(), {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BadgeSeverityHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BadgeSeverityHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BadgeSeverityHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BadgeSeverityHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BadgeSeverityHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BadgeSeverityHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BadgeSeverityHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BadgeSeverityHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void BadgeSeverityHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -283,37 +112,22 @@ void BadgeSeverityHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void BadgeSeverityHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BadgeSeverityHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening badge severity version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BadgeSeverityHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BadgeSeverityHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BadgeSeverityHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/admin/src/CMakeLists.txt
+++ b/projects/ores.qt/admin/src/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(${lib_target_name} PUBLIC
 target_include_directories(${lib_target_name} PRIVATE
     "${CMAKE_CURRENT_BINARY_DIR}/${lib_target_name}_autogen/include"
     # Transient: admin controllers include headers still in ores.qt (e.g.
-    # SessionHistoryDialog).  Remove as files migrate.
+    # SessionAuditDialog).  Remove as files migrate.
     "${CMAKE_SOURCE_DIR}/projects/ores.qt/application/include"
     )
 
@@ -64,7 +64,7 @@ target_link_libraries(${lib_target_name}
         ores.controller.api.lib
         ores.variability.api.lib
     PRIVATE
-        # Transient: SessionHistoryDialog and other shared dialogs still live in
+        # Transient: SessionAuditDialog and other shared dialogs still live in
         # ores.qt until migration is complete. Remove when files move.
         ores.qt.lib)
 

--- a/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
@@ -128,15 +128,15 @@ void SystemSettingHistoryDialog::openVersionAt(int index) {
 }
 
 void SystemSettingHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection. The server handles versioning - we just
-    // send the data we want to restore.
-    const auto& previous = history_[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning - we just send
+    // the data we want to restore.
+    const auto& selected = history_[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version;
+                              << selected.version;
 
-    emit revertVersionRequested(previous);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
@@ -18,40 +18,29 @@
  *
  */
 #include "ores.qt/SystemSettingHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
-#include <QLabel>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& SystemSettingHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
+namespace {
+
+QString enabledText(const std::string& value) {
+    return value == "true" ? QStringLiteral("Yes") : QStringLiteral("No");
+}
+
 }
 
 SystemSettingHistoryDialog::SystemSettingHistoryDialog(QString name,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::SystemSettingHistoryDialog)
     , clientManager_(clientManager)
-    , flagName_(std::move(name))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , flagName_(std::move(name)) {
 
     BOOST_LOG_SEV(lg(), info) << "Creating system setting history widget for: "
                               << flagName_.toStdString();
@@ -59,374 +48,95 @@ SystemSettingHistoryDialog::SystemSettingHistoryDialog(QString name,
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
-
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-}
-
-SystemSettingHistoryDialog::~SystemSettingHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying system setting history widget";
-
-    // Disconnect and cancel any active QFutureWatcher objects
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-        watcher->waitForFinished();
-    }
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
 void SystemSettingHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading system setting history for: " << flagName_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading system setting history for: "
+                              << flagName_.toStdString();
 
-    using HistoryResult =
-        std::expected<variability::messaging::get_setting_history_response, std::string>;
-    QPointer<SystemSettingHistoryDialog> self = this;
-    const auto flagName = flagName_.toStdString();
+    variability::messaging::get_setting_history_request request;
+    request.name = flagName_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, flagName]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        variability::messaging::get_setting_history_request request;
-        request.name = flagName;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->history_ = std::move(result->history);
-        self->onHistoryLoaded();
+        history_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void SystemSettingHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << history_.size() << " versions";
-
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(history_.size());
-
-    for (int i = 0; i < static_cast<int>(history_.size()); ++i) {
-        const auto& flag = history_[i];
-
-        BOOST_LOG_SEV(lg(), trace)
-            << "Displaying version [" << i << "]: "
-            << "version=" << flag.version << ", modified_by=" << flag.modified_by;
-
-        auto* versionItem = new QTableWidgetItem(QString::number(flag.version));
-        auto* enabledItem = new QTableWidgetItem((flag.value == "true") ? "Yes" : "No");
-        auto* recordedAtItem = new QTableWidgetItem(relative_time_helper::format(flag.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(flag.modified_by));
-
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, enabledItem);
-        ui_->versionListWidget->setItem(i, 2, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 3, modifiedByItem);
-    }
-
-    if (!history_.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!history_.empty()) {
-        const auto& latest = history_[0];
-        ui_->titleLabel->setText(
-            QString("System Setting History: %1").arg(QString::fromStdString(latest.name)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(history_.size()));
+int SystemSettingHistoryDialog::historySize() const {
+    return static_cast<int>(history_.size());
 }
 
-void SystemSettingHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
-
-    emit errorOccurred(QString("Failed to load system setting history: %1").arg(error_msg));
-    MessageBoxHelper::critical(
-        this,
-        "History Load Error",
-        QString("Failed to load system setting history:\n%1").arg(error_msg));
+HistoryDialogBase::VersionRow
+SystemSettingHistoryDialog::versionRow(int index) const {
+    const auto& flag = history_[index];
+    return {.version = flag.version,
+            .cells = {enabledText(flag.value),
+                      relative_time_helper::format(flag.recorded_at),
+                      QString::fromStdString(flag.modified_by)}};
 }
 
-void SystemSettingHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
+QString SystemSettingHistoryDialog::historyTitle() const {
+    const auto& latest = history_.front();
+    return QString("System Setting History: %1")
+        .arg(QString::fromStdString(latest.name));
 }
 
-void SystemSettingHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(history_.size()))
-        return;
-
-    const auto& current = history_[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(history_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), trace) << "No previous version to diff against for oldest version";
-        return;
-    }
-
-    // Calculate diff with previous version
-    const auto& previous = history_[version_index + 1];
-
-    BOOST_LOG_SEV(lg(), trace) << "Calculating diff between version " << current.version << " and "
-                               << previous.version;
-
-    auto diffs = calculateDiff(current, previous);
-
-    BOOST_LOG_SEV(lg(), trace) << "Found " << diffs.size() << " differences";
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        auto* oldItem = new QTableWidgetItem(old_val);
-        auto* newItem = new QTableWidgetItem(new_val);
-
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-        ui_->changesTableWidget->setItem(i, 1, oldItem);
-        ui_->changesTableWidget->setItem(i, 2, newItem);
-    }
-}
-
-void SystemSettingHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(history_.size()))
-        return;
-
-    const auto& flag = history_[version_index];
-
-    ui_->nameValue->setText(QString::fromStdString(flag.name));
-    ui_->enabledValue->setText((flag.value == "true") ? "Yes" : "No");
-    ui_->descriptionValue->setText(QString::fromStdString(flag.description));
-    ui_->versionNumberValue->setText(QString::number(flag.version));
-    ui_->modifiedByValue->setText(QString::fromStdString(flag.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(flag.recorded_at));
-}
-
-SystemSettingHistoryDialog::DiffResult
-SystemSettingHistoryDialog::calculateDiff(const variability::domain::system_setting& current,
-                                          const variability::domain::system_setting& previous) {
+HistoryDialogBase::DiffResult
+SystemSettingHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = history_[current_index];
+    const auto& previous = history_[previous_index];
 
     DiffResult diffs;
-
-    // Compare value (enabled flag)
     if (current.value != previous.value) {
         diffs.append({"Enabled",
-                      {(previous.value == "true") ? "Yes" : "No",
-                       (current.value == "true") ? "Yes" : "No"}});
+                      {enabledText(previous.value), enabledText(current.value)}});
     }
-
-    // Compare description
-    if (current.description != previous.description) {
-        diffs.append({"Description",
-                      {QString::fromStdString(previous.description),
-                       QString::fromStdString(current.description)}});
-    }
+    checkString(diffs, "Description", current.description,
+                previous.description);
 
     return diffs;
 }
 
-void SystemSettingHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_, &QAction::triggered, this, &SystemSettingHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(openAction_, &QAction::triggered, this, &SystemSettingHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert system setting to this version");
-    connect(revertAction_, &QAction::triggered, this, &SystemSettingHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
-}
-
-void SystemSettingHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(history_.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int SystemSettingHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void SystemSettingHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
+void SystemSettingHistoryDialog::displayFullDetails(int index) {
     const auto& flag = history_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening system setting version " << flag.version
-                              << " in read-only mode";
 
+    ui_->nameValue->setText(QString::fromStdString(flag.name));
+    ui_->enabledValue->setText(enabledText(flag.value));
+    ui_->descriptionValue->setText(QString::fromStdString(flag.description));
+    ui_->versionNumberValue->setText(QString::number(flag.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(flag.modified_by));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(flag.recorded_at));
+}
+
+void SystemSettingHistoryDialog::openVersionAt(int index) {
+    const auto& flag = history_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening system setting version "
+                              << flag.version << " in read-only mode";
     emit openVersionRequested(flag, flag.version);
 }
 
-void SystemSettingHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = history_[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(history_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void SystemSettingHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection. The server handles versioning - we just
+    // send the data we want to restore.
     const auto& previous = history_[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version
-                              << " to version " << previous.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert System Setting",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(flagName_)
-            .arg(current.version)
-            .arg(previous.version),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) for the revert.
-    // Server handles versioning - we just send the data we want to restore.
-    variability::domain::system_setting flagToRevert = previous;
-    emit revertVersionRequested(flagToRevert);
-}
-
-void SystemSettingHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for system setting history: "
-                              << flagName_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(flagName_));
-    loadHistory();
-}
-
-QSize SystemSettingHistoryDialog::sizeHint() const {
-    QSize baseSize = QWidget::sizeHint();
-
-    const int minimumWidth = 800;
-    const int minimumHeight = 500;
-
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void SystemSettingHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "System setting history marked as stale for: "
-                              << flagName_.toStdString() << ", reloading...";
-
-    emit statusChanged(
-        QString("System setting %1 was modified - reloading history...").arg(flagName_));
-
-    // Reload history data
-    loadHistory();
+    emit revertVersionRequested(previous);
 }
 
 }

--- a/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/SystemSettingHistoryDialog.hpp"
+#include "ui_SystemSettingHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
@@ -53,6 +54,8 @@ SystemSettingHistoryDialog::SystemSettingHistoryDialog(QString name,
                          .titleLabel = ui_->titleLabel,
                          .closeButton = ui_->closeButton});
 }
+
+SystemSettingHistoryDialog::~SystemSettingHistoryDialog() = default;
 
 void SystemSettingHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading system setting history for: "

--- a/projects/ores.qt/admin/src/TenantHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/TenantHistoryDialog.cpp
@@ -19,13 +19,8 @@
  */
 #include "ores.qt/TenantHistoryDialog.hpp"
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_TenantHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,256 +31,82 @@ TenantHistoryDialog::TenantHistoryDialog(const boost::uuids::uuid& id,
                                          const QString& code,
                                          ClientManager* clientManager,
                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::TenantHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-TenantHistoryDialog::~TenantHistoryDialog() {
-    delete ui_;
-}
-
-void TenantHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void TenantHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void TenantHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &TenantHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &TenantHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &TenantHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+TenantHistoryDialog::~TenantHistoryDialog() = default;
 
 void TenantHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for tenant: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<TenantHistoryDialog> self = this;
+    iam::messaging::get_tenant_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<iam::domain::tenant> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        iam::messaging::get_tenant_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->versions)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void TenantHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int TenantHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void TenantHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+TenantHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void TenantHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.type != previous.type) {
-        addChange(
-            "Type", QString::fromStdString(previous.type), QString::fromStdString(current.type));
-    }
-
-    if (current.hostname != previous.hostname) {
-        addChange("Hostname",
-                  QString::fromStdString(previous.hostname),
-                  QString::fromStdString(current.hostname));
-    }
-
-    if (current.status != previous.status) {
-        addChange("Status",
-                  QString::fromStdString(previous.status),
-                  QString::fromStdString(current.status));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString TenantHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void TenantHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+TenantHistoryDialog::calculateDiffAt(int current_index,
+                                     int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Type", current.type, previous.type);
+    checkString(diffs, "Hostname", current.hostname, previous.hostname);
+    checkString(diffs, "Status", current.status, previous.status);
+
+    return diffs;
+}
+
+void TenantHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -298,37 +119,22 @@ void TenantHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void TenantHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void TenantHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening tenant version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void TenantHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void TenantHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void TenantHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/admin/src/TenantTypeHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/TenantTypeHistoryDialog.cpp
@@ -19,13 +19,8 @@
  */
 #include "ores.qt/TenantTypeHistoryDialog.hpp"
 #include "ores.iam.api/messaging/tenant_type_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_TenantTypeHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,246 +29,79 @@ using namespace ores::logging;
 TenantTypeHistoryDialog::TenantTypeHistoryDialog(const QString& code,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::TenantTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-TenantTypeHistoryDialog::~TenantTypeHistoryDialog() {
-    delete ui_;
-}
-
-void TenantTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void TenantTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void TenantTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &TenantTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &TenantTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &TenantTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+TenantTypeHistoryDialog::~TenantTypeHistoryDialog() = default;
 
 void TenantTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for tenant type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<TenantTypeHistoryDialog> self = this;
+    iam::messaging::get_tenant_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<iam::domain::tenant_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        iam::messaging::get_tenant_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void TenantTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int TenantTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void TenantTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+TenantTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void TenantTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.type != previous.type) {
-        addChange(
-            "Type", QString::fromStdString(previous.type), QString::fromStdString(current.type));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString TenantTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void TenantTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+TenantTypeHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Type", current.type, previous.type);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void TenantTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.type));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -284,37 +112,22 @@ void TenantTypeHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void TenantTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void TenantTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening tenant type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void TenantTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void TenantTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void TenantTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/analytics/include/ores.qt/PricingEngineTypeHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingEngineTypeHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.analytics.api/domain/pricing_engine_type.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PricingEngineTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a pricing engine type with ability
  * to view details or revert to a previous version.
  */
-class PricingEngineTypeHistoryDialog final : public QWidget {
+class PricingEngineTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,37 +58,35 @@ public:
                                             QWidget* parent = nullptr);
     ~PricingEngineTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the pricing engine type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const analytics::domain::pricing_engine_type& type,
                               int versionNumber);
     void revertVersionRequested(const analytics::domain::pricing_engine_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PricingEngineTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::PricingEngineTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<analytics::domain::pricing_engine_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelConfigHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelConfigHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.analytics.api/domain/pricing_model_config.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PricingModelConfigHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a pricing model configuration with ability
  * to view details or revert to a previous version.
  */
-class PricingModelConfigHistoryDialog final : public QWidget {
+class PricingModelConfigHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,38 +60,36 @@ public:
                                              QWidget* parent = nullptr);
     ~PricingModelConfigHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the pricing model configuration.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const analytics::domain::pricing_model_config& config,
                               int versionNumber);
     void revertVersionRequested(const analytics::domain::pricing_model_config& config);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PricingModelConfigHistoryDialog* ui_;
+    std::unique_ptr<Ui::PricingModelConfigHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<analytics::domain::pricing_model_config> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelProductHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelProductHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.analytics.api/domain/pricing_model_product.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PricingModelProductHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a pricing model product with ability
  * to view details or revert to a previous version.
  */
-class PricingModelProductHistoryDialog final : public QWidget {
+class PricingModelProductHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,38 +60,36 @@ public:
                                               QWidget* parent = nullptr);
     ~PricingModelProductHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the pricing model product.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const analytics::domain::pricing_model_product& product,
                               int versionNumber);
     void revertVersionRequested(const analytics::domain::pricing_model_product& product);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PricingModelProductHistoryDialog* ui_;
+    std::unique_ptr<Ui::PricingModelProductHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<analytics::domain::pricing_model_product> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelProductParameterHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelProductParameterHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.analytics.api/domain/pricing_model_product_parameter.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PricingModelProductParameterHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a pricing model product parameter with ability
  * to view details or revert to a previous version.
  */
-class PricingModelProductParameterHistoryDialog final : public QWidget {
+class PricingModelProductParameterHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -60,39 +61,37 @@ public:
                                                        QWidget* parent = nullptr);
     ~PricingModelProductParameterHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the pricing model product parameter.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const analytics::domain::pricing_model_product_parameter& parameter,
                               int versionNumber);
     void
     revertVersionRequested(const analytics::domain::pricing_model_product_parameter& parameter);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PricingModelProductParameterHistoryDialog* ui_;
+    std::unique_ptr<Ui::PricingModelProductParameterHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<analytics::domain::pricing_model_product_parameter> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/analytics/src/PricingEngineTypeHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingEngineTypeHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/PricingEngineTypeHistoryDialog.hpp"
 #include "ores.analytics.api/messaging/pricing_engine_type_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_PricingEngineTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,281 +30,110 @@ using namespace ores::logging;
 PricingEngineTypeHistoryDialog::PricingEngineTypeHistoryDialog(const QString& code,
                                                                ClientManager* clientManager,
                                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PricingEngineTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PricingEngineTypeHistoryDialog::~PricingEngineTypeHistoryDialog() {
-    delete ui_;
-}
-
-void PricingEngineTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PricingEngineTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PricingEngineTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PricingEngineTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PricingEngineTypeHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &PricingEngineTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PricingEngineTypeHistoryDialog::~PricingEngineTypeHistoryDialog() = default;
 
 void PricingEngineTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for pricing engine type: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PricingEngineTypeHistoryDialog> self = this;
+    analytics::messaging::get_pricing_engine_type_history_request request;
+    request.code = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<analytics::messaging::get_pricing_engine_type_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            analytics::messaging::get_pricing_engine_type_history_request request;
-            request.code = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->types);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.types);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void PricingEngineTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PricingEngineTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PricingEngineTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PricingEngineTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PricingEngineTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (current.instrument_type_code != previous.instrument_type_code) {
-        addChange("Instrument Type Code",
-                  QString::fromStdString(previous.instrument_type_code),
-                  QString::fromStdString(current.instrument_type_code));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PricingEngineTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PricingEngineTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PricingEngineTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Instrument Type Code", current.instrument_type_code,
+                previous.instrument_type_code);
+
+    return diffs;
+}
+
+void PricingEngineTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->instrumentTypeCodeValue->setText(QString::fromStdString(version.instrument_type_code));
+    ui_->instrumentTypeCodeValue->setText(
+        QString::fromStdString(version.instrument_type_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PricingEngineTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PricingEngineTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing engine type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PricingEngineTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PricingEngineTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PricingEngineTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/analytics/src/PricingModelConfigHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelConfigHistoryDialog.cpp
@@ -19,301 +19,129 @@
  */
 #include "ores.qt/PricingModelConfigHistoryDialog.hpp"
 #include "ores.analytics.api/messaging/pricing_model_config_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_PricingModelConfigHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 PricingModelConfigHistoryDialog::PricingModelConfigHistoryDialog(const boost::uuids::uuid& id,
                                                                  const QString& code,
                                                                  ClientManager* clientManager,
                                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PricingModelConfigHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PricingModelConfigHistoryDialog::~PricingModelConfigHistoryDialog() {
-    delete ui_;
-}
-
-void PricingModelConfigHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PricingModelConfigHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PricingModelConfigHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PricingModelConfigHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelConfigHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelConfigHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PricingModelConfigHistoryDialog::~PricingModelConfigHistoryDialog() = default;
 
 void PricingModelConfigHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for pricing model configuration: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PricingModelConfigHistoryDialog> self = this;
+    analytics::messaging::get_pricing_model_config_history_request request;
+    request.id = id_;
 
-    using HistoryResult =
-        std::expected<analytics::messaging::get_pricing_model_config_history_response, std::string>;
-
-    QFuture<HistoryResult> future = QtConcurrent::run([self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return std::unexpected("Dialog closed");
-        analytics::messaging::get_pricing_model_config_history_request request;
-        request.id = id;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result)
-            return std::unexpected(result.error());
-        return std::move(*result);
-    });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->configs);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.configs);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void PricingModelConfigHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PricingModelConfigHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PricingModelConfigHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PricingModelConfigHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PricingModelConfigHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.config_variant != previous.config_variant) {
-        addChange(
-            "Variant",
-            previous.config_variant ? QString::fromStdString(*previous.config_variant) : QString{},
-            current.config_variant ? QString::fromStdString(*current.config_variant) : QString{});
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PricingModelConfigHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PricingModelConfigHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PricingModelConfigHistoryDialog::calculateDiffAt(int current_index,
+                                                 int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Variant", current.config_variant, previous.config_variant);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void PricingModelConfigHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
-    ui_->configVariantValue->setText(
-        version.config_variant ? QString::fromStdString(*version.config_variant) : QString{});
+    ui_->configVariantValue->setText(optionalText(version.config_variant));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PricingModelConfigHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PricingModelConfigHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing model configuration version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PricingModelConfigHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PricingModelConfigHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PricingModelConfigHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/analytics/src/PricingModelProductHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelProductHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/PricingModelProductHistoryDialog.hpp"
 #include "ores.analytics.api/messaging/pricing_model_product_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_PricingModelProductHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,243 +31,82 @@ PricingModelProductHistoryDialog::PricingModelProductHistoryDialog(const boost::
                                                                    const QString& code,
                                                                    ClientManager* clientManager,
                                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PricingModelProductHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PricingModelProductHistoryDialog::~PricingModelProductHistoryDialog() {
-    delete ui_;
-}
-
-void PricingModelProductHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PricingModelProductHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PricingModelProductHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PricingModelProductHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelProductHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelProductHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PricingModelProductHistoryDialog::~PricingModelProductHistoryDialog() = default;
 
 void PricingModelProductHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for pricing model product: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PricingModelProductHistoryDialog> self = this;
+    analytics::messaging::get_pricing_model_product_history_request request;
+    request.id = id_;
 
-    using HistoryResult =
-        std::expected<analytics::messaging::get_pricing_model_product_history_response,
-                      std::string>;
-
-    QFuture<HistoryResult> future = QtConcurrent::run([self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return std::unexpected("Dialog closed");
-        analytics::messaging::get_pricing_model_product_history_request request;
-        request.id = id;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result)
-            return std::unexpected(result.error());
-        return std::move(*result);
-    });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->products);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.products);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void PricingModelProductHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PricingModelProductHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PricingModelProductHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PricingModelProductHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PricingModelProductHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.pricing_engine_type_code != previous.pricing_engine_type_code) {
-        addChange("Pricing Engine Type",
-                  QString::fromStdString(previous.pricing_engine_type_code),
-                  QString::fromStdString(current.pricing_engine_type_code));
-    }
-
-    if (current.model != previous.model) {
-        addChange(
-            "Model", QString::fromStdString(previous.model), QString::fromStdString(current.model));
-    }
-
-    if (current.engine != previous.engine) {
-        addChange("Engine",
-                  QString::fromStdString(previous.engine),
-                  QString::fromStdString(current.engine));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PricingModelProductHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PricingModelProductHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PricingModelProductHistoryDialog::calculateDiffAt(int current_index,
+                                                  int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Pricing Engine Type", current.pricing_engine_type_code,
+                previous.pricing_engine_type_code);
+    checkString(diffs, "Model", current.model, previous.model);
+    checkString(diffs, "Engine", current.engine, previous.engine);
+
+    return diffs;
+}
+
+void PricingModelProductHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->pricingEngineTypeCodeValue->setText(
         QString::fromStdString(version.pricing_engine_type_code));
@@ -279,41 +114,28 @@ void PricingModelProductHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->engineValue->setText(QString::fromStdString(version.engine));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PricingModelProductHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PricingModelProductHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing model product version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PricingModelProductHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PricingModelProductHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PricingModelProductHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/analytics/src/PricingModelProductParameterHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelProductParameterHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/PricingModelProductParameterHistoryDialog.hpp"
 #include "ores.analytics.api/messaging/pricing_model_product_parameter_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_PricingModelProductParameterHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,285 +32,109 @@ PricingModelProductParameterHistoryDialog::PricingModelProductParameterHistoryDi
     const QString& code,
     ClientManager* clientManager,
     QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PricingModelProductParameterHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PricingModelProductParameterHistoryDialog::~PricingModelProductParameterHistoryDialog() {
-    delete ui_;
-}
-
-void PricingModelProductParameterHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PricingModelProductParameterHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PricingModelProductParameterHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PricingModelProductParameterHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelProductParameterHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &PricingModelProductParameterHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PricingModelProductParameterHistoryDialog::~PricingModelProductParameterHistoryDialog() = default;
 
 void PricingModelProductParameterHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for pricing model product parameter: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PricingModelProductParameterHistoryDialog> self = this;
+    analytics::messaging::get_pricing_model_product_parameter_history_request request;
+    request.id = id_;
 
-    using HistoryResult =
-        std::expected<analytics::messaging::get_pricing_model_product_parameter_history_response,
-                      std::string>;
-
-    QFuture<HistoryResult> future = QtConcurrent::run([self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return std::unexpected("Dialog closed");
-        analytics::messaging::get_pricing_model_product_parameter_history_request request;
-        request.id = id;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result)
-            return std::unexpected(result.error());
-        return std::move(*result);
-    });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->parameters);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.parameters);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void PricingModelProductParameterHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PricingModelProductParameterHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PricingModelProductParameterHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PricingModelProductParameterHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PricingModelProductParameterHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.parameter_scope != previous.parameter_scope) {
-        addChange("Scope",
-                  QString::fromStdString(previous.parameter_scope),
-                  QString::fromStdString(current.parameter_scope));
-    }
-
-    if (current.parameter_name != previous.parameter_name) {
-        addChange("Name",
-                  QString::fromStdString(previous.parameter_name),
-                  QString::fromStdString(current.parameter_name));
-    }
-
-    if (current.parameter_value != previous.parameter_value) {
-        addChange("Value",
-                  QString::fromStdString(previous.parameter_value),
-                  QString::fromStdString(current.parameter_value));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PricingModelProductParameterHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PricingModelProductParameterHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PricingModelProductParameterHistoryDialog::calculateDiffAt(int current_index,
+                                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Scope", current.parameter_scope, previous.parameter_scope);
+    checkString(diffs, "Name", current.parameter_name, previous.parameter_name);
+    checkString(diffs, "Value", current.parameter_value, previous.parameter_value);
+
+    return diffs;
+}
+
+void PricingModelProductParameterHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->parameterScopeValue->setText(QString::fromStdString(version.parameter_scope));
     ui_->parameterNameValue->setText(QString::fromStdString(version.parameter_name));
     ui_->parameterValueValue->setText(QString::fromStdString(version.parameter_value));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PricingModelProductParameterHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PricingModelProductParameterHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing model product parameter version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PricingModelProductParameterHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PricingModelProductParameterHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PricingModelProductParameterHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
+++ b/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
@@ -20,38 +20,261 @@
 #ifndef ORES_QT_HISTORY_DIALOG_BASE_HPP
 #define ORES_QT_HISTORY_DIALOG_BASE_HPP
 
-#include "ores.qt/export.hpp"
+#include <string>
+#include <expected>
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QList>
+#include <QPair>
+#include <QPointer>
 #include <QString>
+#include <QStringList>
 #include <QWidget>
+#include <QtConcurrent>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/export.hpp"
+
+class QAction;
+class QLabel;
+class QPushButton;
+class QTableWidget;
+class QToolBar;
 
 namespace ores::qt {
 
 /**
  * @brief Base class for all history dialogs.
  *
- * Provides:
- * - statusChanged / errorOccurred signals shared by all history dialogs.
- * - markAsStale() — called by the controller when a server-side change event
- *   arrives; default is a no-op; derived classes override to show a stale
- *   indicator and/or reload.
- * - code() — returns the entity identifier displayed in this dialog;
- *   used by controllers to filter notifications.
+ * Owns the machinery every entity history dialog shares:
+ *
+ * - statusChanged / errorOccurred signals.
+ * - The Reload / Open / Revert toolbar and its action states.
+ * - Version-list population and selection handling.
+ * - The changes-tab rendering flow, which calls the calculateDiffAt()
+ *   template method; once history responses carry server-computed
+ *   diffs, implementations collapse into rendering the provided rows.
+ * - checkString / checkInt / checkBool field-diff helpers so all
+ *   dialogs format values identically in the interim.
+ * - Async request plumbing (runHistoryRequest) and watcher cleanup.
+ * - markAsStale() — reloads by default; code() identifies the entity.
+ *
+ * Derived dialogs call initializeHistoryUi() once their Ui is set up,
+ * and override the protected hooks for what is genuinely
+ * entity-specific. Hooks have safe defaults so existing derived
+ * classes migrate incrementally.
  */
 class ORES_QT_API HistoryDialogBase : public QWidget {
     Q_OBJECT
 
 public:
+    /**
+     * @brief Field-level diff rows: (field, (old value, new value)).
+     */
+    using DiffResult = QList<QPair<QString, QPair<QString, QString>>>;
+
     using QWidget::QWidget;
     ~HistoryDialogBase() override;
 
-    virtual void markAsStale() {}
+    /**
+     * @brief Reloads the history; called when a server-side change
+     * event arrives for this entity.
+     */
+    virtual void markAsStale();
+
+    /**
+     * @brief Returns the entity identifier displayed in this dialog;
+     * used by controllers to filter notifications.
+     */
     [[nodiscard]] virtual QString code() const {
         return {};
     }
 
+    /**
+     * @brief Loads (or reloads) the history from the server.
+     */
+    virtual void loadHistory() {}
+
+    QSize sizeHint() const override;
+
 signals:
     void statusChanged(const QString& message);
     void errorOccurred(const QString& error_message);
+
+protected:
+    /**
+     * @brief One row of the version list, rendered as strings.
+     *
+     * The version number always occupies column zero; cells supplies
+     * the remaining columns in the order the dialog's version list
+     * defines them (dialogs vary: some add change reason and
+     * commentary columns, others an enabled flag).
+     */
+    struct VersionRow {
+        int version{};
+        QStringList cells;
+    };
+
+    /**
+     * @brief The widgets the base machinery drives, owned by the
+     * derived dialog's Ui. changesTable, titleLabel and closeButton
+     * may be null when the dialog lacks the corresponding element.
+     */
+    struct HistoryWidgets {
+        QTableWidget* versionList{};
+        QTableWidget* changesTable{};
+        QLabel* titleLabel{};
+        QPushButton* closeButton{};
+    };
+
+    /**
+     * @brief Wires the shared machinery: toolbar, table behaviour,
+     * selection handling, close button. Call once after setupUi().
+     */
+    void initializeHistoryUi(const HistoryWidgets& widgets);
+
+    /**
+     * @brief Repopulates the version list from the hooks and selects
+     * the newest version. Call from the derived loadHistory()
+     * success path; emits statusChanged.
+     */
+    void historyLoaded();
+
+    /**
+     * @brief Reports a history load failure: logs, emits
+     * errorOccurred, and shows the standard message box.
+     */
+    void historyLoadFailed(const QString& error_message);
+
+    /**
+     * @brief Currently selected version-list row, or -1.
+     */
+    [[nodiscard]] int selectedVersionIndex() const;
+
+    // ---- Hooks: override what is entity-specific. -------------------
+
+    /**
+     * @brief Number of versions currently loaded.
+     */
+    [[nodiscard]] virtual int historySize() const {
+        return 0;
+    }
+
+    /**
+     * @brief The version-list row for the given index (0 = newest).
+     */
+    [[nodiscard]] virtual VersionRow versionRow(int index) const;
+
+    /**
+     * @brief Title shown above the version list once loaded.
+     */
+    [[nodiscard]] virtual QString historyTitle() const {
+        return {};
+    }
+
+    /**
+     * @brief Field-level diff between two loaded versions. The
+     * interim seam: once server-side diffs land this renders the
+     * response rows and eventually disappears.
+     */
+    [[nodiscard]] virtual DiffResult
+    calculateDiffAt(int current_index, int previous_index) const;
+
+    /**
+     * @brief Renders the full-details panel for the given version.
+     */
+    virtual void displayFullDetails(int index);
+
+    /**
+     * @brief Opens the given version read-only (Open action /
+     * double-click). Derived dialogs emit their typed signal.
+     */
+    virtual void openVersionAt(int index);
+
+    /**
+     * @brief Reverts to the version older than the given index, after
+     * the base has confirmed with the user. Derived dialogs emit
+     * their typed signal.
+     */
+    virtual void revertToVersionAt(int index);
+
+    /**
+     * @brief Optional widget rendering for a changes-table cell (e.g.
+     * flag icons); return null for the default text item.
+     */
+    virtual QWidget* changeCellWidget(const QString& field,
+                                      const QString& value);
+
+    // ---- Interim diff helpers. --------------------------------------
+
+    static void checkString(DiffResult& diffs, const QString& field,
+                            const std::string& current,
+                            const std::string& previous);
+    static void checkInt(DiffResult& diffs, const QString& field,
+                         int current, int previous);
+    static void checkBool(DiffResult& diffs, const QString& field,
+                          bool current, bool previous);
+
+    /**
+     * @brief Runs an authenticated request off the UI thread and
+     * delivers the response (or a load failure) back on it.
+     *
+     * @param request The typed request message.
+     * @param on_success Invoked with the moved response on success.
+     */
+    template <typename Request, typename OnSuccess>
+    void runHistoryRequest(ClientManager* client_manager, Request request,
+                           OnSuccess on_success) {
+        using Response =
+            typename decltype(client_manager->process_authenticated_request(
+                std::move(request)))::value_type;
+        using Result = std::expected<Response, std::string>;
+
+        QPointer<HistoryDialogBase> self = this;
+        QFuture<Result> future = QtConcurrent::run(
+            [self, client_manager, request = std::move(request)]() mutable
+            -> Result {
+                if (!client_manager || !client_manager->isConnected())
+                    return std::unexpected("Disconnected from server");
+                auto result = client_manager->process_authenticated_request(
+                    std::move(request));
+                if (!result)
+                    return std::unexpected(result.error());
+                return std::move(*result);
+            });
+
+        auto* watcher = new QFutureWatcher<Result>(this);
+        connect(watcher, &QFutureWatcher<Result>::finished, this,
+                [self, watcher, on_success = std::move(on_success)]() mutable {
+                    if (!self)
+                        return;
+                    auto result = watcher->result();
+                    watcher->deleteLater();
+                    if (!result) {
+                        self->historyLoadFailed(
+                            QString::fromStdString(result.error()));
+                        return;
+                    }
+                    on_success(std::move(*result));
+                });
+        watcher->setFuture(future);
+    }
+
+private slots:
+    void onReloadClicked();
+    void onOpenClicked();
+    void onRevertClicked();
+
+private:
+    void setupToolbar();
+    void displayChangesTab(int version_index);
+    void onVersionSelectedRow(int row);
+    void updateActionStates();
+
+    HistoryWidgets widgets_;
+    QToolBar* toolBar_{};
+    QAction* reloadAction_{};
+    QAction* openAction_{};
+    QAction* revertAction_{};
 };
 
 }

--- a/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
+++ b/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <expected>
+#include <optional>
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QList>
@@ -191,9 +192,9 @@ protected:
     virtual void openVersionAt(int index);
 
     /**
-     * @brief Reverts to the version older than the given index, after
-     * the base has confirmed with the user. Derived dialogs emit
-     * their typed signal.
+     * @brief Reverts to the version at the given index, after the
+     * base has confirmed with the user. Derived dialogs emit their
+     * typed signal.
      */
     virtual void revertToVersionAt(int index);
 
@@ -209,8 +210,14 @@ protected:
     static void checkString(DiffResult& diffs, const QString& field,
                             const std::string& current,
                             const std::string& previous);
+    static void checkString(DiffResult& diffs, const QString& field,
+                            const std::optional<std::string>& current,
+                            const std::optional<std::string>& previous);
     static void checkInt(DiffResult& diffs, const QString& field,
                          int current, int previous);
+    static void checkInt(DiffResult& diffs, const QString& field,
+                         const std::optional<int>& current,
+                         const std::optional<int>& previous);
     static void checkBool(DiffResult& diffs, const QString& field,
                           bool current, bool previous);
 

--- a/projects/ores.qt/api/src/HistoryDialogBase.cpp
+++ b/projects/ores.qt/api/src/HistoryDialogBase.cpp
@@ -18,9 +18,321 @@
  *
  */
 #include "ores.qt/HistoryDialogBase.hpp"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+
+#include <QAction>
+#include <QHeaderView>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QToolBar>
+#include <QVBoxLayout>
 
 namespace ores::qt {
 
-HistoryDialogBase::~HistoryDialogBase() = default;
+namespace {
+
+const QIcon& historyIcon() {
+    static const QIcon icon = IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor);
+    return icon;
+}
+
+}
+
+HistoryDialogBase::~HistoryDialogBase() {
+    // Disconnect and cancel any active QFutureWatcher objects so late
+    // results cannot land on a destroyed widget.
+    const auto watchers = findChildren<QFutureWatcherBase*>();
+    for (auto* watcher : watchers) {
+        disconnect(watcher, nullptr, this, nullptr);
+        watcher->cancel();
+        watcher->waitForFinished();
+    }
+}
+
+void HistoryDialogBase::markAsStale() {
+    emit statusChanged(
+        QString("%1 was modified - reloading history...").arg(code()));
+    loadHistory();
+}
+
+QSize HistoryDialogBase::sizeHint() const {
+    const QSize base = QWidget::sizeHint();
+    return {qMax(base.width(), 900), qMax(base.height(), 600)};
+}
+
+void HistoryDialogBase::initializeHistoryUi(const HistoryWidgets& widgets) {
+    widgets_ = widgets;
+
+    setupToolbar();
+
+    if (widgets_.versionList) {
+        connect(widgets_.versionList, &QTableWidget::currentCellChanged, this,
+                [this](int currentRow, int, int, int) {
+                    onVersionSelectedRow(currentRow);
+                });
+        connect(widgets_.versionList, &QTableWidget::cellDoubleClicked, this,
+                [this](int, int) { onOpenClicked(); });
+
+        widgets_.versionList->setAlternatingRowColors(true);
+        widgets_.versionList->setSelectionMode(
+            QAbstractItemView::SingleSelection);
+        widgets_.versionList->setSelectionBehavior(
+            QAbstractItemView::SelectRows);
+        widgets_.versionList->resizeRowsToContents();
+        widgets_.versionList->verticalHeader()->setSectionResizeMode(
+            QHeaderView::ResizeToContents);
+        widgets_.versionList->horizontalHeader()->setSectionResizeMode(
+            QHeaderView::ResizeToContents);
+    }
+
+    if (widgets_.changesTable) {
+        widgets_.changesTable->horizontalHeader()->setStretchLastSection(true);
+        widgets_.changesTable->setColumnWidth(0, 200);
+        widgets_.changesTable->setColumnWidth(1, 200);
+    }
+
+    if (widgets_.closeButton) {
+        widgets_.closeButton->setIcon(IconUtils::createRecoloredIcon(
+            Icon::Dismiss, IconUtils::DefaultIconColor));
+        connect(widgets_.closeButton, &QPushButton::clicked, this, [this]() {
+            if (window())
+                window()->close();
+        });
+    }
+
+    updateActionStates();
+}
+
+void HistoryDialogBase::setupToolbar() {
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    reloadAction_ = new QAction("Reload", this);
+    reloadAction_->setIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowClockwise, IconUtils::DefaultIconColor));
+    reloadAction_->setToolTip("Reload history from server");
+    connect(reloadAction_, &QAction::triggered, this,
+            &HistoryDialogBase::onReloadClicked);
+    toolBar_->addAction(reloadAction_);
+
+    toolBar_->addSeparator();
+
+    openAction_ = new QAction("Open", this);
+    openAction_->setIcon(IconUtils::createRecoloredIcon(
+        Icon::Edit, IconUtils::DefaultIconColor));
+    openAction_->setToolTip("Open this version in read-only mode");
+    connect(openAction_, &QAction::triggered, this,
+            &HistoryDialogBase::onOpenClicked);
+    toolBar_->addAction(openAction_);
+
+    revertAction_ = new QAction("Revert", this);
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+    revertAction_->setToolTip("Revert to this version");
+    connect(revertAction_, &QAction::triggered, this,
+            &HistoryDialogBase::onRevertClicked);
+    toolBar_->addAction(revertAction_);
+
+    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
+    if (mainLayout)
+        mainLayout->insertWidget(0, toolBar_);
+}
+
+void HistoryDialogBase::historyLoaded() {
+    if (!widgets_.versionList)
+        return;
+
+    const int size = historySize();
+    const QIcon& icon = historyIcon();
+
+    widgets_.versionList->setRowCount(0);
+    widgets_.versionList->setRowCount(size);
+
+    for (int i = 0; i < size; ++i) {
+        const VersionRow row = versionRow(i);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(row.version));
+        versionItem->setIcon(icon);
+        widgets_.versionList->setItem(i, 0, versionItem);
+
+        for (int j = 0; j < row.cells.size(); ++j) {
+            widgets_.versionList->setItem(i, j + 1,
+                new QTableWidgetItem(row.cells[j]));
+        }
+    }
+
+    if (size > 0) {
+        widgets_.versionList->selectRow(0);
+        if (widgets_.titleLabel)
+            widgets_.titleLabel->setText(historyTitle());
+    }
+
+    updateActionStates();
+
+    emit statusChanged(QString("Loaded %1 versions").arg(size));
+}
+
+void HistoryDialogBase::historyLoadFailed(const QString& error_message) {
+    emit errorOccurred(
+        QString("Failed to load history: %1").arg(error_message));
+    MessageBoxHelper::critical(
+        this, "History Load Error",
+        QString("Failed to load history:\n%1").arg(error_message));
+}
+
+int HistoryDialogBase::selectedVersionIndex() const {
+    return widgets_.versionList ? widgets_.versionList->currentRow() : -1;
+}
+
+HistoryDialogBase::VersionRow HistoryDialogBase::versionRow(int) const {
+    return {};
+}
+
+HistoryDialogBase::DiffResult
+HistoryDialogBase::calculateDiffAt(int, int) const {
+    return {};
+}
+
+void HistoryDialogBase::displayFullDetails(int) {}
+
+void HistoryDialogBase::openVersionAt(int) {}
+
+void HistoryDialogBase::revertToVersionAt(int) {}
+
+QWidget* HistoryDialogBase::changeCellWidget(const QString&, const QString&) {
+    return nullptr;
+}
+
+void HistoryDialogBase::onVersionSelectedRow(int row) {
+    if (row < 0 || row >= historySize())
+        return;
+
+    displayChangesTab(row);
+    displayFullDetails(row);
+    updateActionStates();
+}
+
+void HistoryDialogBase::displayChangesTab(int version_index) {
+    if (!widgets_.changesTable)
+        return;
+
+    widgets_.changesTable->setRowCount(0);
+
+    if (version_index >= historySize())
+        return;
+
+    // The oldest version has nothing to diff against.
+    if (version_index == historySize() - 1)
+        return;
+
+    const DiffResult diffs =
+        calculateDiffAt(version_index, version_index + 1);
+
+    widgets_.changesTable->setRowCount(diffs.size());
+    for (int i = 0; i < diffs.size(); ++i) {
+        const auto& [field, values] = diffs[i];
+        const auto& [old_val, new_val] = values;
+
+        widgets_.changesTable->setItem(i, 0, new QTableWidgetItem(field));
+
+        if (QWidget* old_widget = changeCellWidget(field, old_val))
+            widgets_.changesTable->setCellWidget(i, 1, old_widget);
+        else
+            widgets_.changesTable->setItem(i, 1,
+                new QTableWidgetItem(old_val));
+
+        if (QWidget* new_widget = changeCellWidget(field, new_val))
+            widgets_.changesTable->setCellWidget(i, 2, new_widget);
+        else
+            widgets_.changesTable->setItem(i, 2,
+                new QTableWidgetItem(new_val));
+    }
+}
+
+void HistoryDialogBase::updateActionStates() {
+    const int index = selectedVersionIndex();
+    const bool hasSelection = index >= 0 && index < historySize();
+
+    if (openAction_)
+        openAction_->setEnabled(hasSelection);
+    if (revertAction_)
+        revertAction_->setEnabled(hasSelection);
+}
+
+void HistoryDialogBase::onReloadClicked() {
+    emit statusChanged(QString("Reloading history for %1...").arg(code()));
+    loadHistory();
+}
+
+void HistoryDialogBase::onOpenClicked() {
+    const int index = selectedVersionIndex();
+    if (index < 0 || index >= historySize())
+        return;
+
+    openVersionAt(index);
+}
+
+void HistoryDialogBase::onRevertClicked() {
+    const int index = selectedVersionIndex();
+    if (index < 0 || index >= historySize())
+        return;
+
+    if (index == historySize() - 1) {
+        MessageBoxHelper::information(
+            this, "Cannot Revert",
+            "This is the oldest version. There is no previous version to "
+            "revert to.");
+        return;
+    }
+
+    const VersionRow current = versionRow(index);
+    const VersionRow previous = versionRow(index + 1);
+
+    const auto reply = MessageBoxHelper::question(
+        this, "Revert",
+        QString("Are you sure you want to revert '%1' from version %2 back "
+                "to version %3?\n\nThis will create a new version with the "
+                "data from version %3.")
+            .arg(code())
+            .arg(current.version)
+            .arg(previous.version),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes)
+        return;
+
+    revertToVersionAt(index);
+}
+
+void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
+                                    const std::string& current,
+                                    const std::string& previous) {
+    if (current != previous) {
+        diffs.append({field,
+                      {QString::fromStdString(previous),
+                       QString::fromStdString(current)}});
+    }
+}
+
+void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
+                                 int current, int previous) {
+    if (current != previous) {
+        diffs.append({field,
+                      {QString::number(previous), QString::number(current)}});
+    }
+}
+
+void HistoryDialogBase::checkBool(DiffResult& diffs, const QString& field,
+                                  bool current, bool previous) {
+    if (current != previous) {
+        auto text = [](bool b) { return b ? QString("Yes") : QString("No"); };
+        diffs.append({field, {text(previous), text(current)}});
+    }
+}
 
 }

--- a/projects/ores.qt/api/src/HistoryDialogBase.cpp
+++ b/projects/ores.qt/api/src/HistoryDialogBase.cpp
@@ -112,28 +112,28 @@ void HistoryDialogBase::setupToolbar() {
     toolBar_->setMovable(false);
     toolBar_->setFloatable(false);
 
-    reloadAction_ = new QAction("Reload", this);
+    reloadAction_ = new QAction(tr("Reload"), this);
     reloadAction_->setIcon(IconUtils::createRecoloredIcon(
         Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
+    reloadAction_->setToolTip(tr("Reload history from server"));
     connect(reloadAction_, &QAction::triggered, this,
             &HistoryDialogBase::onReloadClicked);
     toolBar_->addAction(reloadAction_);
 
     toolBar_->addSeparator();
 
-    openAction_ = new QAction("Open", this);
+    openAction_ = new QAction(tr("Open"), this);
     openAction_->setIcon(IconUtils::createRecoloredIcon(
         Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
+    openAction_->setToolTip(tr("Open this version in read-only mode"));
     connect(openAction_, &QAction::triggered, this,
             &HistoryDialogBase::onOpenClicked);
     toolBar_->addAction(openAction_);
 
-    revertAction_ = new QAction("Revert", this);
+    revertAction_ = new QAction(tr("Revert"), this);
     revertAction_->setIcon(IconUtils::createRecoloredIcon(
         Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert to this version");
+    revertAction_->setToolTip(tr("Revert to this version"));
     connect(revertAction_, &QAction::triggered, this,
             &HistoryDialogBase::onRevertClicked);
     toolBar_->addAction(revertAction_);
@@ -179,10 +179,10 @@ void HistoryDialogBase::historyLoaded() {
 
 void HistoryDialogBase::historyLoadFailed(const QString& error_message) {
     emit errorOccurred(
-        QString("Failed to load history: %1").arg(error_message));
+        tr("Failed to load history: %1").arg(error_message));
     MessageBoxHelper::critical(
-        this, "History Load Error",
-        QString("Failed to load history:\n%1").arg(error_message));
+        this, tr("History Load Error"),
+        tr("Failed to load history:\n%1").arg(error_message));
 }
 
 int HistoryDialogBase::selectedVersionIndex() const {
@@ -235,7 +235,7 @@ void HistoryDialogBase::displayChangesTab(int version_index) {
 
     // The oldest version has nothing to diff against.
     if (version_index == historySize() - 1) {
-        placeholderRow("(Initial version)");
+        placeholderRow(tr("(Initial version)"));
         return;
     }
 
@@ -243,7 +243,7 @@ void HistoryDialogBase::displayChangesTab(int version_index) {
         calculateDiffAt(version_index, version_index + 1);
 
     if (diffs.isEmpty()) {
-        placeholderRow("(No field changes)");
+        placeholderRow(tr("(No field changes)"));
         return;
     }
 
@@ -305,10 +305,10 @@ void HistoryDialogBase::onRevertClicked() {
     const VersionRow selected = versionRow(index);
 
     const auto reply = MessageBoxHelper::question(
-        this, "Revert",
-        QString("Are you sure you want to revert '%1' from version %2 back "
-                "to version %3?\n\nThis will create a new version with the "
-                "data from version %3.")
+        this, tr("Revert"),
+        tr("Are you sure you want to revert '%1' from version %2 back "
+           "to version %3?\n\nThis will create a new version with the "
+           "data from version %3.")
             .arg(code())
             .arg(latest.version)
             .arg(selected.version),
@@ -363,7 +363,7 @@ void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
 void HistoryDialogBase::checkBool(DiffResult& diffs, const QString& field,
                                   bool current, bool previous) {
     if (current != previous) {
-        auto text = [](bool b) { return b ? QString("Yes") : QString("No"); };
+        auto text = [](bool b) { return b ? tr("Yes") : tr("No"); };
         diffs.append({field, {text(previous), text(current)}});
     }
 }

--- a/projects/ores.qt/api/src/HistoryDialogBase.cpp
+++ b/projects/ores.qt/api/src/HistoryDialogBase.cpp
@@ -226,12 +226,26 @@ void HistoryDialogBase::displayChangesTab(int version_index) {
     if (version_index >= historySize())
         return;
 
+    auto placeholderRow = [this](const QString& text) {
+        widgets_.changesTable->setRowCount(1);
+        widgets_.changesTable->setItem(0, 0, new QTableWidgetItem(text));
+        widgets_.changesTable->setItem(0, 1, new QTableWidgetItem("-"));
+        widgets_.changesTable->setItem(0, 2, new QTableWidgetItem("-"));
+    };
+
     // The oldest version has nothing to diff against.
-    if (version_index == historySize() - 1)
+    if (version_index == historySize() - 1) {
+        placeholderRow("(Initial version)");
         return;
+    }
 
     const DiffResult diffs =
         calculateDiffAt(version_index, version_index + 1);
+
+    if (diffs.isEmpty()) {
+        placeholderRow("(No field changes)");
+        return;
+    }
 
     widgets_.changesTable->setRowCount(diffs.size());
     for (int i = 0; i < diffs.size(); ++i) {
@@ -260,8 +274,11 @@ void HistoryDialogBase::updateActionStates() {
 
     if (openAction_)
         openAction_->setEnabled(hasSelection);
+
+    // Reverting to the latest version is a no-op, so the action only
+    // makes sense for older versions.
     if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
+        revertAction_->setEnabled(hasSelection && index > 0);
 }
 
 void HistoryDialogBase::onReloadClicked() {
@@ -278,20 +295,14 @@ void HistoryDialogBase::onOpenClicked() {
 }
 
 void HistoryDialogBase::onRevertClicked() {
+    // Reverting restores the SELECTED version; the action is disabled
+    // for the latest version, where reverting would be a no-op.
     const int index = selectedVersionIndex();
-    if (index < 0 || index >= historySize())
+    if (index <= 0 || index >= historySize())
         return;
 
-    if (index == historySize() - 1) {
-        MessageBoxHelper::information(
-            this, "Cannot Revert",
-            "This is the oldest version. There is no previous version to "
-            "revert to.");
-        return;
-    }
-
-    const VersionRow current = versionRow(index);
-    const VersionRow previous = versionRow(index + 1);
+    const VersionRow latest = versionRow(0);
+    const VersionRow selected = versionRow(index);
 
     const auto reply = MessageBoxHelper::question(
         this, "Revert",
@@ -299,8 +310,8 @@ void HistoryDialogBase::onRevertClicked() {
                 "to version %3?\n\nThis will create a new version with the "
                 "data from version %3.")
             .arg(code())
-            .arg(current.version)
-            .arg(previous.version),
+            .arg(latest.version)
+            .arg(selected.version),
         QMessageBox::Yes | QMessageBox::No);
 
     if (reply != QMessageBox::Yes)
@@ -319,11 +330,33 @@ void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
     }
 }
 
+void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
+                                    const std::optional<std::string>& current,
+                                    const std::optional<std::string>& previous) {
+    if (current != previous) {
+        auto text = [](const std::optional<std::string>& v) {
+            return v ? QString::fromStdString(*v) : QString();
+        };
+        diffs.append({field, {text(previous), text(current)}});
+    }
+}
+
 void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
                                  int current, int previous) {
     if (current != previous) {
         diffs.append({field,
                       {QString::number(previous), QString::number(current)}});
+    }
+}
+
+void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
+                                 const std::optional<int>& current,
+                                 const std::optional<int>& previous) {
+    if (current != previous) {
+        auto text = [](const std::optional<int>& v) {
+            return v ? QString::number(*v) : QString();
+        };
+        diffs.append({field, {text(previous), text(current)}});
     }
 }
 

--- a/projects/ores.qt/application/include/ores.qt/MyAccountDialog.hpp
+++ b/projects/ores.qt/application/include/ores.qt/MyAccountDialog.hpp
@@ -73,7 +73,7 @@ private slots:
 signals:
     void changePasswordCompleted(bool success, const QString& error_message);
     void saveEmailCompleted(bool success, const QString& error_message);
-    void viewSessionHistoryRequested();
+    void viewSessionAuditRequested();
 
 private:
     void setupUI();

--- a/projects/ores.qt/application/include/ores.qt/SessionAuditDialog.hpp
+++ b/projects/ores.qt/application/include/ores.qt/SessionAuditDialog.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_QT_SESSION_HISTORY_DIALOG_HPP
-#define ORES_QT_SESSION_HISTORY_DIALOG_HPP
+#ifndef ORES_QT_SESSION_AUDIT_DIALOG_HPP
+#define ORES_QT_SESSION_AUDIT_DIALOG_HPP
 
 #include "ores.iam.api/domain/session.hpp"
 #include "ores.iam.api/messaging/session_samples_protocol.hpp"
@@ -40,13 +40,13 @@
 namespace ores::qt {
 
 /**
- * @brief Table model for displaying session history.
+ * @brief Table model for displaying the session audit trail.
  */
-class SessionHistoryModel : public QAbstractTableModel {
+class SessionAuditModel : public QAbstractTableModel {
     Q_OBJECT
 
 public:
-    explicit SessionHistoryModel(QObject* parent = nullptr);
+    explicit SessionAuditModel(QObject* parent = nullptr);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -89,16 +89,16 @@ private:
 };
 
 /**
- * @brief Dialog for displaying session history for an account.
+ * @brief Dialog for displaying the session audit trail for an account.
  *
  * Shows a table of all sessions with start/end times, durations,
  * bytes transferred, and geolocation information.
  */
-class SessionHistoryDialog : public QWidget {
+class SessionAuditDialog : public QWidget {
     Q_OBJECT
 
 private:
-    inline static std::string_view logger_name = "ores.qt.session_history_dialog";
+    inline static std::string_view logger_name = "ores.qt.session_audit_dialog";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
@@ -107,8 +107,8 @@ private:
     }
 
 public:
-    explicit SessionHistoryDialog(ClientManager* clientManager, QWidget* parent = nullptr);
-    ~SessionHistoryDialog() override;
+    explicit SessionAuditDialog(ClientManager* clientManager, QWidget* parent = nullptr);
+    ~SessionAuditDialog() override;
 
     /**
      * @brief Set the account to display sessions for.
@@ -138,7 +138,7 @@ private:
     void setupUi();
 
     QTableView* tableView_;
-    SessionHistoryModel* model_;
+    SessionAuditModel* model_;
     QSplitter* splitter_;
     QChartView* chartView_;
     ClientManager* clientManager_;

--- a/projects/ores.qt/application/modeling/ores.qt.puml
+++ b/projects/ores.qt/application/modeling/ores.qt.puml
@@ -320,16 +320,16 @@ namespace ores #F2F2F2 {
             -wizard_ : PartyProvisioningWizard*
             -summaryLabel_ : QLabel*
         }
-        class SessionHistoryModel {
+        class SessionAuditModel {
             +role : int
             -sessions_ : vector<iam::domain::session>
             -activeIcon_ : QIcon
             -historyIcon_ : QIcon
         }
-        class SessionHistoryDialog {
+        class SessionAuditDialog {
             +parent : QWidget*
             -tableView_ : QTableView*
-            -model_ : SessionHistoryModel*
+            -model_ : SessionAuditModel*
             -splitter_ : QSplitter*
             -chartView_ : QChartView*
             -clientManager_ : ClientManager*

--- a/projects/ores.qt/application/src/CMakeLists.txt
+++ b/projects/ores.qt/application/src/CMakeLists.txt
@@ -113,7 +113,7 @@ target_link_libraries(${exe_target_name}
         ${CMAKE_THREAD_LIBS_INIT})
 
 # Export all symbols from the exe so QPluginLoader-loaded plugins can resolve
-# symbols from ores.qt.lib (e.g. SessionHistoryDialog, host-only widgets).
+# symbols from ores.qt.lib (e.g. SessionAuditDialog, host-only widgets).
 if(NOT WIN32)
     target_link_options(${exe_target_name} PRIVATE -rdynamic)
 endif()

--- a/projects/ores.qt/application/src/MainWindow.cpp
+++ b/projects/ores.qt/application/src/MainWindow.cpp
@@ -34,7 +34,7 @@
 #include "ores.qt/PartyProvisioningWizard.hpp"
 #include "ores.qt/PluginBase.hpp"
 #include "ores.qt/PluginRegistry.hpp"
-#include "ores.qt/SessionHistoryDialog.hpp"
+#include "ores.qt/SessionAuditDialog.hpp"
 #include "ores.qt/ShellMdiWindow.hpp"
 #include "ores.qt/SignUpDialog.hpp"
 #include "ores.qt/SystemProvisionerWizard.hpp"
@@ -979,7 +979,7 @@ void MainWindow::onMyAccountTriggered() {
 
     auto* accountWidget = new MyAccountDialog(clientManager_, this);
     connect(accountWidget,
-            &MyAccountDialog::viewSessionHistoryRequested,
+            &MyAccountDialog::viewSessionAuditRequested,
             this,
             &MainWindow::onMySessionsTriggered);
 
@@ -1021,7 +1021,7 @@ void MainWindow::onMySessionsTriggered() {
 
     const QString username = QString::fromStdString(clientManager_->currentUsername());
 
-    auto* sessionWidget = new SessionHistoryDialog(clientManager_, this);
+    auto* sessionWidget = new SessionAuditDialog(clientManager_, this);
     sessionWidget->setAccount(*accountId, username);
 
     mySessionsWindow_ = new DetachableMdiSubWindow();

--- a/projects/ores.qt/application/src/MyAccountDialog.cpp
+++ b/projects/ores.qt/application/src/MyAccountDialog.cpp
@@ -44,7 +44,7 @@ MyAccountDialog::MyAccountDialog(ClientManager* clientManager, QWidget* parent)
     , email_status_label_(new QLabel(this))
     , active_sessions_label_(new QLabel(this))
     , current_session_label_(new QLabel(this))
-    , view_sessions_button_(new QPushButton("View Session History", this))
+    , view_sessions_button_(new QPushButton("View Session Audit", this))
     , new_password_edit_(new QLineEdit(this))
     , confirm_password_edit_(new QLineEdit(this))
     , change_password_button_(new QPushButton("Change Password", this))
@@ -465,7 +465,7 @@ void MyAccountDialog::loadSessionInfo() {
 
 void MyAccountDialog::onViewSessionsClicked() {
     BOOST_LOG_SEV(lg(), debug) << "View sessions clicked.";
-    emit viewSessionHistoryRequested();
+    emit viewSessionAuditRequested();
 }
 
 }

--- a/projects/ores.qt/application/src/SessionAuditDialog.cpp
+++ b/projects/ores.qt/application/src/SessionAuditDialog.cpp
@@ -17,7 +17,7 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.qt/SessionHistoryDialog.hpp"
+#include "ores.qt/SessionAuditDialog.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -40,27 +40,27 @@ namespace ores::qt {
 
 using namespace ores::logging;
 
-// SessionHistoryModel implementation
+// SessionAuditModel implementation
 
-SessionHistoryModel::SessionHistoryModel(QObject* parent)
+SessionAuditModel::SessionAuditModel(QObject* parent)
     : QAbstractTableModel(parent)
     , activeIcon_(
           IconUtils::createRecoloredIcon(Icon::PlugConnectedFilled, IconUtils::ConnectedColor))
     , historyIcon_(IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor)) {}
 
-int SessionHistoryModel::rowCount(const QModelIndex& parent) const {
+int SessionAuditModel::rowCount(const QModelIndex& parent) const {
     if (parent.isValid())
         return 0;
     return static_cast<int>(sessions_.size());
 }
 
-int SessionHistoryModel::columnCount(const QModelIndex& parent) const {
+int SessionAuditModel::columnCount(const QModelIndex& parent) const {
     if (parent.isValid())
         return 0;
     return ColumnCount;
 }
 
-QVariant SessionHistoryModel::data(const QModelIndex& index, int role) const {
+QVariant SessionAuditModel::data(const QModelIndex& index, int role) const {
     if (!index.isValid() || index.row() >= static_cast<int>(sessions_.size()))
         return QVariant();
 
@@ -148,7 +148,7 @@ QVariant SessionHistoryModel::data(const QModelIndex& index, int role) const {
     return QVariant();
 }
 
-QVariant SessionHistoryModel::headerData(int section, Qt::Orientation orientation, int role) const {
+QVariant SessionAuditModel::headerData(int section, Qt::Orientation orientation, int role) const {
     if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
         return QVariant();
 
@@ -174,19 +174,19 @@ QVariant SessionHistoryModel::headerData(int section, Qt::Orientation orientatio
     }
 }
 
-void SessionHistoryModel::setSessions(const std::vector<iam::domain::session>& sessions) {
+void SessionAuditModel::setSessions(const std::vector<iam::domain::session>& sessions) {
     beginResetModel();
     sessions_ = sessions;
     endResetModel();
 }
 
-void SessionHistoryModel::clear() {
+void SessionAuditModel::clear() {
     beginResetModel();
     sessions_.clear();
     endResetModel();
 }
 
-void SessionHistoryModel::updateActiveBytesFromClient(std::uint64_t bytes_sent,
+void SessionAuditModel::updateActiveBytesFromClient(std::uint64_t bytes_sent,
                                                       std::uint64_t bytes_received) {
     for (std::size_t i = 0; i < sessions_.size(); ++i) {
         if (!sessions_[i].end_time) {
@@ -198,9 +198,9 @@ void SessionHistoryModel::updateActiveBytesFromClient(std::uint64_t bytes_sent,
     }
 }
 
-// SessionHistoryDialog implementation
+// SessionAuditDialog implementation
 
-SessionHistoryDialog::SessionHistoryDialog(ClientManager* clientManager, QWidget* parent)
+SessionAuditDialog::SessionAuditDialog(ClientManager* clientManager, QWidget* parent)
     : QWidget(parent)
     , clientManager_(clientManager)
     , watcher_(new QFutureWatcher<FetchResult>(this))
@@ -211,23 +211,23 @@ SessionHistoryDialog::SessionHistoryDialog(ClientManager* clientManager, QWidget
     connect(watcher_,
             &QFutureWatcher<FetchResult>::finished,
             this,
-            &SessionHistoryDialog::onSessionsLoaded);
+            &SessionAuditDialog::onSessionsLoaded);
     connect(samplesWatcher_,
             &QFutureWatcher<FetchSamplesResult>::finished,
             this,
-            &SessionHistoryDialog::onSamplesLoaded);
+            &SessionAuditDialog::onSamplesLoaded);
 
     // Auto-refresh chart every ~60s (sample_flush_interval * heartbeat_interval)
     connect(
-        sampleRefreshTimer_, &QTimer::timeout, this, &SessionHistoryDialog::onSampleRefreshTimeout);
+        sampleRefreshTimer_, &QTimer::timeout, this, &SessionAuditDialog::onSampleRefreshTimeout);
     sampleRefreshTimer_->start(60000);
 }
 
-SessionHistoryDialog::~SessionHistoryDialog() = default;
+SessionAuditDialog::~SessionAuditDialog() = default;
 
-void SessionHistoryDialog::setupUi() {
+void SessionAuditDialog::setupUi() {
     WidgetUtils::setupComboBoxes(this);
-    setWindowTitle(tr("Session History"));
+    setWindowTitle(tr("Session Audit"));
     setMinimumSize(900, 600);
 
     auto* layout = new QVBoxLayout(this);
@@ -236,7 +236,7 @@ void SessionHistoryDialog::setupUi() {
 
     // Table view (top pane)
     tableView_ = new QTableView(this);
-    model_ = new SessionHistoryModel(this);
+    model_ = new SessionAuditModel(this);
     tableView_->setModel(model_);
     tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -264,11 +264,11 @@ void SessionHistoryDialog::setupUi() {
     connect(tableView_->selectionModel(),
             &QItemSelectionModel::selectionChanged,
             this,
-            &SessionHistoryDialog::onSessionSelectionChanged);
+            &SessionAuditDialog::onSessionSelectionChanged);
 
     // Button bar
     auto* refreshButton = new QPushButton(tr("Refresh"), this);
-    connect(refreshButton, &QPushButton::clicked, this, &SessionHistoryDialog::refresh);
+    connect(refreshButton, &QPushButton::clicked, this, &SessionAuditDialog::refresh);
 
     auto* buttonLayout = new QHBoxLayout;
     buttonLayout->addStretch();
@@ -276,15 +276,15 @@ void SessionHistoryDialog::setupUi() {
     layout->addLayout(buttonLayout);
 }
 
-void SessionHistoryDialog::setAccount(const boost::uuids::uuid& accountId,
+void SessionAuditDialog::setAccount(const boost::uuids::uuid& accountId,
                                       const QString& username) {
     accountId_ = accountId;
     username_ = username;
-    setWindowTitle(tr("Session History - %1").arg(username));
+    setWindowTitle(tr("Session Audit - %1").arg(username));
     refresh();
 }
 
-void SessionHistoryDialog::refresh() {
+void SessionAuditDialog::refresh() {
     if (!clientManager_ || !clientManager_->isConnected()) {
         BOOST_LOG_SEV(lg(), warn) << "Cannot refresh: not connected to server";
         return;
@@ -312,7 +312,7 @@ void SessionHistoryDialog::refresh() {
     watcher_->setFuture(future);
 }
 
-void SessionHistoryDialog::onSessionsLoaded() {
+void SessionAuditDialog::onSessionsLoaded() {
     auto result = watcher_->result();
 
     if (result.success) {
@@ -334,11 +334,11 @@ void SessionHistoryDialog::onSessionsLoaded() {
         emit statusMessage(tr("Loaded %1 sessions").arg(result.sessions.size()));
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to load sessions";
-        emit errorMessage(tr("Failed to load session history"));
+        emit errorMessage(tr("Failed to load session audit"));
     }
 }
 
-void SessionHistoryDialog::onSessionSelectionChanged(const QItemSelection& selected,
+void SessionAuditDialog::onSessionSelectionChanged(const QItemSelection& selected,
                                                      const QItemSelection&) {
 
     if (selected.isEmpty())
@@ -390,7 +390,7 @@ void SessionHistoryDialog::onSessionSelectionChanged(const QItemSelection& selec
     samplesWatcher_->setFuture(future);
 }
 
-void SessionHistoryDialog::onSamplesLoaded() {
+void SessionAuditDialog::onSamplesLoaded() {
     auto result = samplesWatcher_->result();
 
     auto* chart = chartView_->chart();
@@ -490,7 +490,7 @@ void SessionHistoryDialog::onSamplesLoaded() {
     }
 }
 
-void SessionHistoryDialog::onSampleRefreshTimeout() {
+void SessionAuditDialog::onSampleRefreshTimeout() {
     if (!clientManager_ || !clientManager_->isConnected())
         return;
 

--- a/projects/ores.qt/application/ui/MainWindow.ui
+++ b/projects/ores.qt/application/ui/MainWindow.ui
@@ -118,7 +118,7 @@
     <string>My &amp;Sessions...</string>
    </property>
    <property name="toolTip">
-    <string>View my login session history</string>
+    <string>View my login session audit</string>
    </property>
   </action>
   <action name="ActionConnect">

--- a/projects/ores.qt/compute/include/ores.qt/AppHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/AppHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.compute.api/domain/app.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class AppHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a compute app with ability
  * to view details or revert to a previous version.
  */
-class AppHistoryDialog final : public QWidget {
+class AppHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                               QWidget* parent = nullptr);
     ~AppHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the compute app.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const compute::domain::app& app, int versionNumber);
     void revertVersionRequested(const compute::domain::app& app);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::AppHistoryDialog* ui_;
+    std::unique_ptr<Ui::AppHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<compute::domain::app> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/include/ores.qt/AppVersionHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/AppVersionHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.compute.api/domain/app_version.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class AppVersionHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a app version with ability
  * to view details or revert to a previous version.
  */
-class AppVersionHistoryDialog final : public QWidget {
+class AppVersionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                      QWidget* parent = nullptr);
     ~AppVersionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the app version.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const compute::domain::app_version& app_version, int versionNumber);
     void revertVersionRequested(const compute::domain::app_version& app_version);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::AppVersionHistoryDialog* ui_;
+    std::unique_ptr<Ui::AppVersionHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<compute::domain::app_version> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.reporting.api/domain/concurrency_policy.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ConcurrencyPolicyHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a concurrency policy with ability
  * to view details or revert to a previous version.
  */
-class ConcurrencyPolicyHistoryDialog final : public QWidget {
+class ConcurrencyPolicyHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,37 +58,35 @@ public:
                                             QWidget* parent = nullptr);
     ~ConcurrencyPolicyHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the concurrency policy.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const reporting::domain::concurrency_policy& policy,
                               int versionNumber);
     void revertVersionRequested(const reporting::domain::concurrency_policy& policy);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ConcurrencyPolicyHistoryDialog* ui_;
+    std::unique_ptr<Ui::ConcurrencyPolicyHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<reporting::domain::concurrency_policy> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/include/ores.qt/ReportDefinitionHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportDefinitionHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.reporting.api/domain/report_definition.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ReportDefinitionHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a report definition with ability
  * to view details or revert to a previous version.
  */
-class ReportDefinitionHistoryDialog final : public QWidget {
+class ReportDefinitionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,38 +60,36 @@ public:
                                            QWidget* parent = nullptr);
     ~ReportDefinitionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the report definition.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const reporting::domain::report_definition& definition,
                               int versionNumber);
     void revertVersionRequested(const reporting::domain::report_definition& definition);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ReportDefinitionHistoryDialog* ui_;
+    std::unique_ptr<Ui::ReportDefinitionHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<reporting::domain::report_definition> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/include/ores.qt/ReportInstanceHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportInstanceHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.reporting.api/domain/report_instance.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ReportInstanceHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a report instance with ability
  * to view details or revert to a previous version.
  */
-class ReportInstanceHistoryDialog final : public QWidget {
+class ReportInstanceHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,38 +60,36 @@ public:
                                          QWidget* parent = nullptr);
     ~ReportInstanceHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the report instance.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const reporting::domain::report_instance& instance,
                               int versionNumber);
     void revertVersionRequested(const reporting::domain::report_instance& instance);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ReportInstanceHistoryDialog* ui_;
+    std::unique_ptr<Ui::ReportInstanceHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<reporting::domain::report_instance> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/include/ores.qt/ReportTypeHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.reporting.api/domain/report_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ReportTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a report type with ability
  * to view details or revert to a previous version.
  */
-class ReportTypeHistoryDialog final : public QWidget {
+class ReportTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                      QWidget* parent = nullptr);
     ~ReportTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the report type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const reporting::domain::report_type& type, int versionNumber);
     void revertVersionRequested(const reporting::domain::report_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ReportTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::ReportTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<reporting::domain::report_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/compute/src/AppHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/AppHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/AppHistoryDialog.hpp"
 #include "ores.compute.api/messaging/app_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_AppHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,274 +32,108 @@ AppHistoryDialog::AppHistoryDialog(const boost::uuids::uuid& id,
                                    const QString& code,
                                    ClientManager* clientManager,
                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::AppHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-AppHistoryDialog::~AppHistoryDialog() {
-    delete ui_;
-}
-
-void AppHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void AppHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void AppHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &AppHistoryDialog::onVersionSelected);
-    connect(openVersionAction_, &QAction::triggered, this, &AppHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &AppHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+AppHistoryDialog::~AppHistoryDialog() = default;
 
 void AppHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for compute app: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for compute app: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    using HistoryResult = std::pair<bool, std::vector<compute::domain::app>>;
-    QPointer<AppHistoryDialog> self = this;
-    const std::string id = boost::uuids::to_string(id_);
+    compute::messaging::get_app_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, id]() -> HistoryResult {
-        if (!self)
-            return {false, {}};
-
-        compute::messaging::get_app_history_request request;
-        request.id = id;
-
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!result || !result->success)
-            return {false, {}};
-        return {true, std::move(result->versions)};
-    });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(this);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto [success, versions] = watcher->result();
-        watcher->deleteLater();
-
-        if (!success) {
-            emit self->errorOccurred(tr("Failed to load history"));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->versions_ = std::move(versions);
-        self->updateVersionList();
-        emit self->statusChanged(tr("History loaded."));
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void AppHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int AppHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void AppHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+AppHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void AppHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString AppHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void AppHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+AppHistoryDialog::calculateDiffAt(int current_index,
+                                  int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void AppHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void AppHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void AppHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening compute app version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void AppHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void AppHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void AppHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/compute/src/AppVersionHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/AppVersionHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/AppVersionHistoryDialog.hpp"
 #include "ores.compute.api/messaging/app_version_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_AppVersionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,280 +32,113 @@ AppVersionHistoryDialog::AppVersionHistoryDialog(const boost::uuids::uuid& id,
                                                  const QString& code,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::AppVersionHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-AppVersionHistoryDialog::~AppVersionHistoryDialog() {
-    delete ui_;
-}
-
-void AppVersionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void AppVersionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void AppVersionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &AppVersionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &AppVersionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &AppVersionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+AppVersionHistoryDialog::~AppVersionHistoryDialog() = default;
 
 void AppVersionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for app version: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for app version: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    using HistoryResult = std::pair<bool, std::vector<compute::domain::app_version>>;
-    QPointer<AppVersionHistoryDialog> self = this;
-    const std::string id = boost::uuids::to_string(id_);
+    compute::messaging::get_app_version_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, id]() -> HistoryResult {
-        if (!self)
-            return {false, {}};
-
-        compute::messaging::get_app_version_history_request request;
-        request.id = id;
-
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!result || !result->success)
-            return {false, {}};
-        return {true, std::move(result->versions)};
-    });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(this);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto [success, versions] = watcher->result();
-        watcher->deleteLater();
-
-        if (!success) {
-            emit self->errorOccurred(tr("Failed to load history"));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->versions_ = std::move(versions);
-        self->updateVersionList();
-        emit self->statusChanged(tr("History loaded."));
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void AppVersionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int AppVersionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void AppVersionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+AppVersionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void AppVersionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.wrapper_version != previous.wrapper_version) {
-        addChange("Wrapper Version",
-                  QString::fromStdString(previous.wrapper_version),
-                  QString::fromStdString(current.wrapper_version));
-    }
-
-    if (current.wrapper_version != previous.wrapper_version) {
-        addChange("Name",
-                  QString::fromStdString(previous.wrapper_version),
-                  QString::fromStdString(current.wrapper_version));
-    }
-
-    if (current.engine_version != previous.engine_version) {
-        addChange("Description",
-                  QString::fromStdString(previous.engine_version),
-                  QString::fromStdString(current.engine_version));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString AppVersionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void AppVersionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+AppVersionHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Wrapper Version", current.wrapper_version,
+                previous.wrapper_version);
+    checkString(diffs, "Name", current.wrapper_version,
+                previous.wrapper_version);
+    checkString(diffs, "Description", current.engine_version,
+                previous.engine_version);
+
+    return diffs;
+}
+
+void AppVersionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.wrapper_version));
     ui_->nameValue->setText(QString::fromStdString(version.engine_version));
-    ui_->descriptionValue->setText(QString::fromStdString(version.engine_version));
+    ui_->descriptionValue->setText(
+        QString::fromStdString(version.engine_version));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void AppVersionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void AppVersionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening app version version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void AppVersionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void AppVersionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void AppVersionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/compute/src/ConcurrencyPolicyHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ConcurrencyPolicyHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/ConcurrencyPolicyHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.reporting.api/messaging/concurrency_policy_protocol.hpp"
 #include "ui_ConcurrencyPolicyHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,288 +30,109 @@ using namespace ores::logging;
 ConcurrencyPolicyHistoryDialog::ConcurrencyPolicyHistoryDialog(const QString& code,
                                                                ClientManager* clientManager,
                                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ConcurrencyPolicyHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ConcurrencyPolicyHistoryDialog::~ConcurrencyPolicyHistoryDialog() {
-    delete ui_;
-}
-
-void ConcurrencyPolicyHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ConcurrencyPolicyHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ConcurrencyPolicyHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ConcurrencyPolicyHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ConcurrencyPolicyHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &ConcurrencyPolicyHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ConcurrencyPolicyHistoryDialog::~ConcurrencyPolicyHistoryDialog() = default;
 
 void ConcurrencyPolicyHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for concurrency policy: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for concurrency policy: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ConcurrencyPolicyHistoryDialog> self = this;
+    reporting::messaging::get_concurrency_policy_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<reporting::domain::concurrency_policy> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        reporting::messaging::get_concurrency_policy_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void ConcurrencyPolicyHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ConcurrencyPolicyHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ConcurrencyPolicyHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ConcurrencyPolicyHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ConcurrencyPolicyHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ConcurrencyPolicyHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ConcurrencyPolicyHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ConcurrencyPolicyHistoryDialog::calculateDiffAt(int current_index,
+                                                int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void ConcurrencyPolicyHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ConcurrencyPolicyHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ConcurrencyPolicyHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening concurrency policy version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ConcurrencyPolicyHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ConcurrencyPolicyHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ConcurrencyPolicyHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/compute/src/ReportDefinitionHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportDefinitionHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/ReportDefinitionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.reporting.api/messaging/report_definition_protocol.hpp"
 #include "ui_ReportDefinitionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,304 +32,119 @@ ReportDefinitionHistoryDialog::ReportDefinitionHistoryDialog(const boost::uuids:
                                                              const QString& code,
                                                              ClientManager* clientManager,
                                                              QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ReportDefinitionHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ReportDefinitionHistoryDialog::~ReportDefinitionHistoryDialog() {
-    delete ui_;
-}
-
-void ReportDefinitionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ReportDefinitionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ReportDefinitionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ReportDefinitionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ReportDefinitionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &ReportDefinitionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ReportDefinitionHistoryDialog::~ReportDefinitionHistoryDialog() = default;
 
 void ReportDefinitionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report definition: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report definition: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ReportDefinitionHistoryDialog> self = this;
+    reporting::messaging::get_report_definition_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<reporting::domain::report_definition> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        reporting::messaging::get_report_definition_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void ReportDefinitionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ReportDefinitionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ReportDefinitionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ReportDefinitionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ReportDefinitionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (current.report_type != previous.report_type) {
-        addChange("Report Type",
-                  QString::fromStdString(previous.report_type),
-                  QString::fromStdString(current.report_type));
-    }
-
-    if (current.schedule_expression != previous.schedule_expression) {
-        addChange("Schedule (cron)",
-                  QString::fromStdString(previous.schedule_expression),
-                  QString::fromStdString(current.schedule_expression));
-    }
-
-    if (current.concurrency_policy != previous.concurrency_policy) {
-        addChange("Concurrency Policy",
-                  QString::fromStdString(previous.concurrency_policy),
-                  QString::fromStdString(current.concurrency_policy));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ReportDefinitionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ReportDefinitionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ReportDefinitionHistoryDialog::calculateDiffAt(int current_index,
+                                               int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+    checkString(diffs, "Report Type", current.report_type,
+                previous.report_type);
+    checkString(diffs, "Schedule (cron)", current.schedule_expression,
+                previous.schedule_expression);
+    checkString(diffs, "Concurrency Policy", current.concurrency_policy,
+                previous.concurrency_policy);
+
+    return diffs;
+}
+
+void ReportDefinitionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->reportTypeValue->setText(QString::fromStdString(version.report_type));
-    ui_->scheduleExpressionValue->setText(QString::fromStdString(version.schedule_expression));
-    ui_->concurrencyPolicyValue->setText(QString::fromStdString(version.concurrency_policy));
+    ui_->scheduleExpressionValue->setText(
+        QString::fromStdString(version.schedule_expression));
+    ui_->concurrencyPolicyValue->setText(
+        QString::fromStdString(version.concurrency_policy));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ReportDefinitionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ReportDefinitionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening report definition version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ReportDefinitionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ReportDefinitionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ReportDefinitionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/compute/src/ReportInstanceHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportInstanceHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/ReportInstanceHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.reporting.api/messaging/report_instance_protocol.hpp"
 #include "ui_ReportInstanceHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,290 +32,111 @@ ReportInstanceHistoryDialog::ReportInstanceHistoryDialog(const boost::uuids::uui
                                                          const QString& code,
                                                          ClientManager* clientManager,
                                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ReportInstanceHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ReportInstanceHistoryDialog::~ReportInstanceHistoryDialog() {
-    delete ui_;
-}
-
-void ReportInstanceHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ReportInstanceHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ReportInstanceHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ReportInstanceHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ReportInstanceHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &ReportInstanceHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ReportInstanceHistoryDialog::~ReportInstanceHistoryDialog() = default;
 
 void ReportInstanceHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report instance: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report instance: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ReportInstanceHistoryDialog> self = this;
+    reporting::messaging::get_report_instance_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<reporting::domain::report_instance> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        reporting::messaging::get_report_instance_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void ReportInstanceHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ReportInstanceHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ReportInstanceHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ReportInstanceHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ReportInstanceHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (current.output_message != previous.output_message) {
-        addChange("Output",
-                  QString::fromStdString(previous.output_message),
-                  QString::fromStdString(current.output_message));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ReportInstanceHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ReportInstanceHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ReportInstanceHistoryDialog::calculateDiffAt(int current_index,
+                                             int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+    checkString(diffs, "Output", current.output_message,
+                previous.output_message);
+
+    return diffs;
+}
+
+void ReportInstanceHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->outputValue->setText(QString::fromStdString(version.output_message));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ReportInstanceHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ReportInstanceHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening report instance version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ReportInstanceHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ReportInstanceHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ReportInstanceHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/compute/src/ReportTypeHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/ReportTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.reporting.api/messaging/report_type_protocol.hpp"
 #include "ui_ReportTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,287 +30,109 @@ using namespace ores::logging;
 ReportTypeHistoryDialog::ReportTypeHistoryDialog(const QString& code,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ReportTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ReportTypeHistoryDialog::~ReportTypeHistoryDialog() {
-    delete ui_;
-}
-
-void ReportTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ReportTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ReportTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ReportTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ReportTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &ReportTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ReportTypeHistoryDialog::~ReportTypeHistoryDialog() = default;
 
 void ReportTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ReportTypeHistoryDialog> self = this;
+    reporting::messaging::get_report_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<reporting::domain::report_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        reporting::messaging::get_report_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void ReportTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ReportTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ReportTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ReportTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ReportTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ReportTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ReportTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ReportTypeHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void ReportTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ReportTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ReportTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening report type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ReportTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ReportTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ReportTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/include/ores.qt/BusinessCentreHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessCentreHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/business_centre.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BusinessCentreHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a business centre with ability
  * to view details or revert to a previous version.
  */
-class BusinessCentreHistoryDialog final : public QWidget {
+class BusinessCentreHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,37 +58,35 @@ public:
                                          QWidget* parent = nullptr);
     ~BusinessCentreHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the business centre.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::business_centre& business_centre,
                               int versionNumber);
     void revertVersionRequested(const refdata::domain::business_centre& business_centre);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BusinessCentreHistoryDialog* ui_;
+    std::unique_ptr<Ui::BusinessCentreHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::business_centre> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/BusinessUnitHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessUnitHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/business_unit.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BusinessUnitHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a business unit with ability
  * to view details or revert to a previous version.
  */
-class BusinessUnitHistoryDialog final : public QWidget {
+class BusinessUnitHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,38 +60,36 @@ public:
                                        QWidget* parent = nullptr);
     ~BusinessUnitHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the business unit.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::business_unit& business_unit,
                               int versionNumber);
     void revertVersionRequested(const refdata::domain::business_unit& business_unit);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BusinessUnitHistoryDialog* ui_;
+    std::unique_ptr<Ui::BusinessUnitHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::business_unit> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/BusinessUnitTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessUnitTypeHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/business_unit_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BusinessUnitTypeHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a business unit type with ability
  * to view details or revert to a previous version.
  */
-class BusinessUnitTypeHistoryDialog final : public QWidget {
+class BusinessUnitTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                            QWidget* parent = nullptr);
     ~BusinessUnitTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the business unit type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::business_unit_type& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::business_unit_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BusinessUnitTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::BusinessUnitTypeHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::business_unit_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/ContactTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/ContactTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/contact_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ContactTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a contact type with ability
  * to view details or revert to a previous version.
  */
-class ContactTypeHistoryDialog final : public QWidget {
+class ContactTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                       QWidget* parent = nullptr);
     ~ContactTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the contact type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::contact_type& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::contact_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ContactTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::ContactTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::contact_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/CounterpartyHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/CounterpartyHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/counterparty.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CounterpartyHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a counterparty with ability
  * to view details or revert to a previous version.
  */
-class CounterpartyHistoryDialog final : public QWidget {
+class CounterpartyHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                        QWidget* parent = nullptr);
     ~CounterpartyHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the counterparty.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::counterparty& counterparty, int versionNumber);
     void revertVersionRequested(const refdata::domain::counterparty& counterparty);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CounterpartyHistoryDialog* ui_;
+    std::unique_ptr<Ui::CounterpartyHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::counterparty> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/PartyHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/party.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PartyHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a party with ability
  * to view details or revert to a previous version.
  */
-class PartyHistoryDialog final : public QWidget {
+class PartyHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                 QWidget* parent = nullptr);
     ~PartyHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the party.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::party& party, int versionNumber);
     void revertVersionRequested(const refdata::domain::party& party);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PartyHistoryDialog* ui_;
+    std::unique_ptr<Ui::PartyHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::party> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/PartyIdSchemeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyIdSchemeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/party_id_scheme.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PartyIdSchemeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a party ID scheme with ability
  * to view details or revert to a previous version.
  */
-class PartyIdSchemeHistoryDialog final : public QWidget {
+class PartyIdSchemeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                         QWidget* parent = nullptr);
     ~PartyIdSchemeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the party ID scheme.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::party_id_scheme& scheme, int versionNumber);
     void revertVersionRequested(const refdata::domain::party_id_scheme& scheme);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PartyIdSchemeHistoryDialog* ui_;
+    std::unique_ptr<Ui::PartyIdSchemeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::party_id_scheme> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/PartyStatusHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyStatusHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/party_status.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PartyStatusHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a party status with ability
  * to view details or revert to a previous version.
  */
-class PartyStatusHistoryDialog final : public QWidget {
+class PartyStatusHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                       QWidget* parent = nullptr);
     ~PartyStatusHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the party status.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::party_status& status, int versionNumber);
     void revertVersionRequested(const refdata::domain::party_status& status);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PartyStatusHistoryDialog* ui_;
+    std::unique_ptr<Ui::PartyStatusHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::party_status> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/include/ores.qt/PartyTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/party_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PartyTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a party type with ability
  * to view details or revert to a previous version.
  */
-class PartyTypeHistoryDialog final : public QWidget {
+class PartyTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                     QWidget* parent = nullptr);
     ~PartyTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the party type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::party_type& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::party_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PartyTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::PartyTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::party_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/party/src/BusinessCentreHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessCentreHistoryDialog.cpp
@@ -18,15 +18,10 @@
  *
  */
 #include "ores.qt/BusinessCentreHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/business_centre_protocol.hpp"
 #include "ui_BusinessCentreHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,301 +30,117 @@ using namespace ores::logging;
 BusinessCentreHistoryDialog::BusinessCentreHistoryDialog(const QString& code,
                                                          ClientManager* clientManager,
                                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BusinessCentreHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BusinessCentreHistoryDialog::~BusinessCentreHistoryDialog() {
-    delete ui_;
-}
-
-void BusinessCentreHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BusinessCentreHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BusinessCentreHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BusinessCentreHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BusinessCentreHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &BusinessCentreHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BusinessCentreHistoryDialog::~BusinessCentreHistoryDialog() = default;
 
 void BusinessCentreHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business centre: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business centre: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BusinessCentreHistoryDialog> self = this;
+    refdata::messaging::get_business_centre_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::business_centre> versions;
-    };
-
-    auto task = [cm = clientManager_, code = code_.toStdString()]() -> HistoryResult {
-        if (!cm) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_business_centre_history_request request;
-        request.code = code;
-        auto response_result = cm->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BusinessCentreHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BusinessCentreHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BusinessCentreHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BusinessCentreHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BusinessCentreHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.source != previous.source) {
-        addChange("Source",
-                  QString::fromStdString(previous.source),
-                  QString::fromStdString(current.source));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (current.coding_scheme_code != previous.coding_scheme_code) {
-        addChange("Coding Scheme",
-                  QString::fromStdString(previous.coding_scheme_code),
-                  QString::fromStdString(current.coding_scheme_code));
-    }
-
-    if (current.country_alpha2_code != previous.country_alpha2_code) {
-        addChange("Country",
-                  QString::fromStdString(previous.country_alpha2_code),
-                  QString::fromStdString(current.country_alpha2_code));
-    }
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BusinessCentreHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BusinessCentreHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BusinessCentreHistoryDialog::calculateDiffAt(int current_index,
+                                             int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Source", current.source, previous.source);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Coding Scheme", current.coding_scheme_code,
+                previous.coding_scheme_code);
+    checkString(diffs, "Country", current.country_alpha2_code,
+                previous.country_alpha2_code);
+
+    return diffs;
+}
+
+void BusinessCentreHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->sourceValue->setText(QString::fromStdString(version.source));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->codingSchemeValue->setText(QString::fromStdString(version.coding_scheme_code));
-    ui_->countryAlpha2Value->setText(QString::fromStdString(version.country_alpha2_code));
+    ui_->codingSchemeValue->setText(
+        QString::fromStdString(version.coding_scheme_code));
+    ui_->countryAlpha2Value->setText(
+        QString::fromStdString(version.country_alpha2_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void BusinessCentreHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BusinessCentreHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening business centre version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BusinessCentreHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BusinessCentreHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BusinessCentreHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/BusinessUnitHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessUnitHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/BusinessUnitHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/business_unit_protocol.hpp"
 #include "ui_BusinessUnitHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,289 +31,111 @@ BusinessUnitHistoryDialog::BusinessUnitHistoryDialog(const boost::uuids::uuid& i
                                                      const QString& code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BusinessUnitHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BusinessUnitHistoryDialog::~BusinessUnitHistoryDialog() {
-    delete ui_;
-}
-
-void BusinessUnitHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BusinessUnitHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BusinessUnitHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BusinessUnitHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BusinessUnitHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &BusinessUnitHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BusinessUnitHistoryDialog::~BusinessUnitHistoryDialog() = default;
 
 void BusinessUnitHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BusinessUnitHistoryDialog> self = this;
+    refdata::messaging::get_business_unit_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::business_unit> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_business_unit_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BusinessUnitHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BusinessUnitHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BusinessUnitHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BusinessUnitHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BusinessUnitHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.unit_code != previous.unit_code) {
-        addChange("Unit Code",
-                  QString::fromStdString(previous.unit_code),
-                  QString::fromStdString(current.unit_code));
-    }
-
-    if (current.unit_name != previous.unit_name) {
-        addChange("Unit Name",
-                  QString::fromStdString(previous.unit_name),
-                  QString::fromStdString(current.unit_name));
-    }
-
-    if (current.business_centre_code != previous.business_centre_code) {
-        addChange("Business Centre",
-                  QString::fromStdString(previous.business_centre_code),
-                  QString::fromStdString(current.business_centre_code));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BusinessUnitHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BusinessUnitHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BusinessUnitHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Unit Code", current.unit_code, previous.unit_code);
+    checkString(diffs, "Unit Name", current.unit_name, previous.unit_name);
+    checkString(diffs, "Business Centre", current.business_centre_code,
+                previous.business_centre_code);
+
+    return diffs;
+}
+
+void BusinessUnitHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.unit_code));
     ui_->nameValue->setText(QString::fromStdString(version.unit_name));
-    ui_->businessCentreValue->setText(QString::fromStdString(version.business_centre_code));
+    ui_->businessCentreValue->setText(
+        QString::fromStdString(version.business_centre_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void BusinessUnitHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BusinessUnitHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening business unit version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BusinessUnitHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BusinessUnitHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BusinessUnitHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/BusinessUnitTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessUnitTypeHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/BusinessUnitTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/business_unit_type_protocol.hpp"
 #include "ui_BusinessUnitTypeHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,298 +30,114 @@ BusinessUnitTypeHistoryDialog::BusinessUnitTypeHistoryDialog(const boost::uuids:
                                                              const QString& code,
                                                              ClientManager* clientManager,
                                                              QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BusinessUnitTypeHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BusinessUnitTypeHistoryDialog::~BusinessUnitTypeHistoryDialog() {
-    delete ui_;
-}
-
-void BusinessUnitTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BusinessUnitTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BusinessUnitTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BusinessUnitTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BusinessUnitTypeHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &BusinessUnitTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BusinessUnitTypeHistoryDialog::~BusinessUnitTypeHistoryDialog() = default;
 
 void BusinessUnitTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BusinessUnitTypeHistoryDialog> self = this;
+    refdata::messaging::get_business_unit_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::business_unit_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_business_unit_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BusinessUnitTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BusinessUnitTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BusinessUnitTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BusinessUnitTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BusinessUnitTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.level != previous.level) {
-        addChange("Level", QString::number(previous.level), QString::number(current.level));
-    }
-
-    if (current.coding_scheme_code != previous.coding_scheme_code) {
-        addChange("Coding Scheme",
-                  QString::fromStdString(previous.coding_scheme_code),
-                  QString::fromStdString(current.coding_scheme_code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BusinessUnitTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BusinessUnitTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BusinessUnitTypeHistoryDialog::calculateDiffAt(int current_index,
+                                               int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkInt(diffs, "Level", current.level, previous.level);
+    checkString(diffs, "Coding Scheme", current.coding_scheme_code,
+                previous.coding_scheme_code);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void BusinessUnitTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->levelValue->setText(QString::number(version.level));
-    ui_->codingSchemeValue->setText(QString::fromStdString(version.coding_scheme_code));
+    ui_->codingSchemeValue->setText(
+        QString::fromStdString(version.coding_scheme_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void BusinessUnitTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BusinessUnitTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening business unit type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BusinessUnitTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BusinessUnitTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BusinessUnitTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/ContactTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/ContactTypeHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/ContactTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/contact_type_protocol.hpp"
 #include "ui_ContactTypeHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,286 +29,108 @@ using namespace ores::logging;
 ContactTypeHistoryDialog::ContactTypeHistoryDialog(const QString& code,
                                                    ClientManager* clientManager,
                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ContactTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ContactTypeHistoryDialog::~ContactTypeHistoryDialog() {
-    delete ui_;
-}
-
-void ContactTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ContactTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ContactTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ContactTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ContactTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &ContactTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ContactTypeHistoryDialog::~ContactTypeHistoryDialog() = default;
 
 void ContactTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for contact type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for contact type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ContactTypeHistoryDialog> self = this;
+    refdata::messaging::get_contact_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::contact_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_contact_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void ContactTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ContactTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ContactTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ContactTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ContactTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ContactTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ContactTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ContactTypeHistoryDialog::calculateDiffAt(int current_index,
+                                          int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void ContactTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ContactTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ContactTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening contact type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ContactTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ContactTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ContactTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/CounterpartyHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/CounterpartyHistoryDialog.cpp
@@ -18,15 +18,10 @@
  *
  */
 #include "ores.qt/CounterpartyHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/counterparty_protocol.hpp"
 #include "ui_CounterpartyHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -37,267 +32,95 @@ CounterpartyHistoryDialog::CounterpartyHistoryDialog(const boost::uuids::uuid& i
                                                      const QString& code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CounterpartyHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CounterpartyHistoryDialog::~CounterpartyHistoryDialog() {
-    delete ui_;
-}
-
-void CounterpartyHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CounterpartyHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CounterpartyHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CounterpartyHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CounterpartyHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &CounterpartyHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CounterpartyHistoryDialog::~CounterpartyHistoryDialog() = default;
 
 void CounterpartyHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for counterparty: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for counterparty: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CounterpartyHistoryDialog> self = this;
+    refdata::messaging::get_counterparty_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::counterparty> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_counterparty_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void CounterpartyHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int CounterpartyHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CounterpartyHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CounterpartyHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CounterpartyHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.short_code != previous.short_code) {
-        addChange("Short Code",
-                  QString::fromStdString(previous.short_code),
-                  QString::fromStdString(current.short_code));
-    }
-
-    if (current.full_name != previous.full_name) {
-        addChange("Full Name",
-                  QString::fromStdString(previous.full_name),
-                  QString::fromStdString(current.full_name));
-    }
-
-    if (current.transliterated_name.value_or("") != previous.transliterated_name.value_or("")) {
-        addChange("Transliterated Name",
-                  QString::fromStdString(previous.transliterated_name.value_or("")),
-                  QString::fromStdString(current.transliterated_name.value_or("")));
-    }
-
-    if (current.party_type != previous.party_type) {
-        addChange("Party Type",
-                  QString::fromStdString(previous.party_type),
-                  QString::fromStdString(current.party_type));
-    }
-
-    if (current.status != previous.status) {
-        addChange("Status",
-                  QString::fromStdString(previous.status),
-                  QString::fromStdString(current.status));
-    }
-
-    if (current.business_center_code != previous.business_center_code) {
-        addChange("Business Center",
-                  QString::fromStdString(previous.business_center_code),
-                  QString::fromStdString(current.business_center_code));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CounterpartyHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void CounterpartyHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
+HistoryDialogBase::DiffResult
+CounterpartyHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
+
+    DiffResult diffs;
+    checkString(diffs, "Short Code", current.short_code, previous.short_code);
+    checkString(diffs, "Full Name", current.full_name, previous.full_name);
+
+    if (current.transliterated_name.value_or("") !=
+        previous.transliterated_name.value_or("")) {
+        diffs.append(
+            {"Transliterated Name",
+             {QString::fromStdString(previous.transliterated_name.value_or("")),
+              QString::fromStdString(
+                  current.transliterated_name.value_or(""))}});
     }
 
-    const auto& version = versions_[versionIndex];
+    checkString(diffs, "Party Type", current.party_type, previous.party_type);
+    checkString(diffs, "Status", current.status, previous.status);
+    checkString(diffs, "Business Center", current.business_center_code,
+                previous.business_center_code);
+
+    return diffs;
+}
+
+void CounterpartyHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.short_code));
     ui_->nameValue->setText(QString::fromStdString(version.full_name));
@@ -305,44 +128,32 @@ void CounterpartyHistoryDialog::updateFullDetails(int versionIndex) {
         QString::fromStdString(version.transliterated_name.value_or("")));
     ui_->partyTypeValue->setText(QString::fromStdString(version.party_type));
     ui_->statusValue->setText(QString::fromStdString(version.status));
-    ui_->businessCenterValue->setText(QString::fromStdString(version.business_center_code));
+    ui_->businessCenterValue->setText(
+        QString::fromStdString(version.business_center_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void CounterpartyHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CounterpartyHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening counterparty version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CounterpartyHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CounterpartyHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CounterpartyHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/PartyHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyHistoryDialog.cpp
@@ -18,15 +18,10 @@
  *
  */
 #include "ores.qt/PartyHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ui_PartyHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -37,318 +32,132 @@ PartyHistoryDialog::PartyHistoryDialog(const boost::uuids::uuid& id,
                                        const QString& code,
                                        ClientManager* clientManager,
                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PartyHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PartyHistoryDialog::~PartyHistoryDialog() {
-    delete ui_;
-}
-
-void PartyHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PartyHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PartyHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PartyHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &PartyHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PartyHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PartyHistoryDialog::~PartyHistoryDialog() = default;
 
 void PartyHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PartyHistoryDialog> self = this;
+    refdata::messaging::get_party_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::party> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_party_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PartyHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PartyHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PartyHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PartyHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PartyHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.short_code != previous.short_code) {
-        addChange("Short Code",
-                  QString::fromStdString(previous.short_code),
-                  QString::fromStdString(current.short_code));
-    }
-
-    if (current.full_name != previous.full_name) {
-        addChange("Full Name",
-                  QString::fromStdString(previous.full_name),
-                  QString::fromStdString(current.full_name));
-    }
-
-    if (current.transliterated_name.value_or("") != previous.transliterated_name.value_or("")) {
-        addChange("Transliterated Name",
-                  QString::fromStdString(previous.transliterated_name.value_or("")),
-                  QString::fromStdString(current.transliterated_name.value_or("")));
-    }
-
-    if (current.party_category != previous.party_category) {
-        addChange("Category",
-                  QString::fromStdString(previous.party_category),
-                  QString::fromStdString(current.party_category));
-    }
-
-    if (current.party_type != previous.party_type) {
-        addChange("Party Type",
-                  QString::fromStdString(previous.party_type),
-                  QString::fromStdString(current.party_type));
-    }
-
-    if (current.status != previous.status) {
-        addChange("Status",
-                  QString::fromStdString(previous.status),
-                  QString::fromStdString(current.status));
-    }
-
-    if (current.business_center_code != previous.business_center_code) {
-        addChange("Business Center",
-                  QString::fromStdString(previous.business_center_code),
-                  QString::fromStdString(current.business_center_code));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PartyHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PartyHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
+HistoryDialogBase::DiffResult
+PartyHistoryDialog::calculateDiffAt(int current_index,
+                                    int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
+
+    DiffResult diffs;
+    checkString(diffs, "Short Code", current.short_code, previous.short_code);
+    checkString(diffs, "Full Name", current.full_name, previous.full_name);
+
+    if (current.transliterated_name.value_or("") !=
+        previous.transliterated_name.value_or("")) {
+        diffs.append(
+            {"Transliterated Name",
+             {QString::fromStdString(previous.transliterated_name.value_or("")),
+              QString::fromStdString(
+                  current.transliterated_name.value_or(""))}});
     }
 
-    const auto& version = versions_[versionIndex];
+    checkString(diffs, "Category", current.party_category,
+                previous.party_category);
+    checkString(diffs, "Party Type", current.party_type, previous.party_type);
+    checkString(diffs, "Status", current.status, previous.status);
+    checkString(diffs, "Business Center", current.business_center_code,
+                previous.business_center_code);
+
+    return diffs;
+}
+
+void PartyHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.short_code));
     ui_->nameValue->setText(QString::fromStdString(version.full_name));
     ui_->transliteratedNameValue->setText(
         QString::fromStdString(version.transliterated_name.value_or("")));
-    ui_->partyCategoryValue->setText(QString::fromStdString(version.party_category));
+    ui_->partyCategoryValue->setText(
+        QString::fromStdString(version.party_category));
     ui_->partyTypeValue->setText(QString::fromStdString(version.party_type));
     ui_->statusValue->setText(QString::fromStdString(version.status));
-    ui_->businessCenterValue->setText(QString::fromStdString(version.business_center_code));
+    ui_->businessCenterValue->setText(
+        QString::fromStdString(version.business_center_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PartyHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PartyHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening party version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PartyHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PartyHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PartyHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/PartyIdSchemeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyIdSchemeHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/PartyIdSchemeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/party_id_scheme_protocol.hpp"
 #include "ui_PartyIdSchemeHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,287 +29,108 @@ using namespace ores::logging;
 PartyIdSchemeHistoryDialog::PartyIdSchemeHistoryDialog(const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PartyIdSchemeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PartyIdSchemeHistoryDialog::~PartyIdSchemeHistoryDialog() {
-    delete ui_;
-}
-
-void PartyIdSchemeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PartyIdSchemeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PartyIdSchemeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PartyIdSchemeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PartyIdSchemeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PartyIdSchemeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PartyIdSchemeHistoryDialog::~PartyIdSchemeHistoryDialog() = default;
 
 void PartyIdSchemeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party ID scheme: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party ID scheme: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PartyIdSchemeHistoryDialog> self = this;
+    refdata::messaging::get_party_id_scheme_history_request request;
+    request.scheme = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::party_id_scheme> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_party_id_scheme_history_request request;
-        request.scheme = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PartyIdSchemeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PartyIdSchemeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PartyIdSchemeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PartyIdSchemeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PartyIdSchemeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PartyIdSchemeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PartyIdSchemeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PartyIdSchemeHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void PartyIdSchemeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PartyIdSchemeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PartyIdSchemeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening party ID scheme version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PartyIdSchemeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PartyIdSchemeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PartyIdSchemeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/PartyStatusHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyStatusHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/PartyStatusHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/party_status_protocol.hpp"
 #include "ui_PartyStatusHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,287 +29,108 @@ using namespace ores::logging;
 PartyStatusHistoryDialog::PartyStatusHistoryDialog(const QString& code,
                                                    ClientManager* clientManager,
                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PartyStatusHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PartyStatusHistoryDialog::~PartyStatusHistoryDialog() {
-    delete ui_;
-}
-
-void PartyStatusHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PartyStatusHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PartyStatusHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PartyStatusHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PartyStatusHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PartyStatusHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PartyStatusHistoryDialog::~PartyStatusHistoryDialog() = default;
 
 void PartyStatusHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party status: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party status: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PartyStatusHistoryDialog> self = this;
+    refdata::messaging::get_party_status_history_request request;
+    request.status = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::party_status> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_party_status_history_request request;
-        request.status = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PartyStatusHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PartyStatusHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PartyStatusHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PartyStatusHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PartyStatusHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PartyStatusHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PartyStatusHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PartyStatusHistoryDialog::calculateDiffAt(int current_index,
+                                          int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void PartyStatusHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PartyStatusHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PartyStatusHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening party status version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PartyStatusHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PartyStatusHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PartyStatusHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/party/src/PartyTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyTypeHistoryDialog.cpp
@@ -18,14 +18,9 @@
  *
  */
 #include "ores.qt/PartyTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/party_type_protocol.hpp"
 #include "ui_PartyTypeHistoryDialog.h"
-#include <QFutureWatcher>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,287 +29,108 @@ using namespace ores::logging;
 PartyTypeHistoryDialog::PartyTypeHistoryDialog(const QString& code,
                                                ClientManager* clientManager,
                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PartyTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PartyTypeHistoryDialog::~PartyTypeHistoryDialog() {
-    delete ui_;
-}
-
-void PartyTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PartyTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PartyTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PartyTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PartyTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PartyTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PartyTypeHistoryDialog::~PartyTypeHistoryDialog() = default;
 
 void PartyTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PartyTypeHistoryDialog> self = this;
+    refdata::messaging::get_party_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::party_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_party_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PartyTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PartyTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PartyTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PartyTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PartyTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PartyTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PartyTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PartyTypeHistoryDialog::calculateDiffAt(int current_index,
+                                        int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void PartyTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PartyTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PartyTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening party type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PartyTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PartyTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PartyTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/BusinessDayConventionTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BusinessDayConventionTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/business_day_convention_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BusinessDayConventionTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a business day convention type with ability
  * to view details or revert to a previous version.
  */
-class BusinessDayConventionTypeHistoryDialog final : public QWidget {
+class BusinessDayConventionTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -58,37 +59,35 @@ public:
                                                     QWidget* parent = nullptr);
     ~BusinessDayConventionTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the business day convention type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::business_day_convention_type& type,
                               int versionNumber);
     void revertVersionRequested(const trading::domain::business_day_convention_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BusinessDayConventionTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::BusinessDayConventionTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::business_day_convention_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CatalogHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CatalogHistoryDialog.hpp
@@ -23,9 +23,9 @@
 #include "ores.dq.api/domain/catalog.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QAction>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
 #include <vector>
 
 namespace Ui {
@@ -37,7 +37,7 @@ namespace ores::qt {
 /**
  * @brief Dialog for viewing catalog version history.
  */
-class CatalogHistoryDialog : public QWidget {
+class CatalogHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -55,35 +55,34 @@ public:
                                   QWidget* parent = nullptr);
     ~CatalogHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the catalog.
+     */
+    [[nodiscard]] QString code() const override {
+        return name_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& message);
     void openVersionRequested(const dq::domain::catalog& catalog, int versionNumber);
     void revertVersionRequested(const dq::domain::catalog& catalog);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CatalogHistoryDialog* ui_;
+    std::unique_ptr<Ui::CatalogHistoryDialog> ui_;
     QString name_;
     ClientManager* clientManager_;
     std::vector<dq::domain::catalog> versions_;
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/cds_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CdsConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a CDS convention with ability
  * to view details or revert to a previous version.
  */
-class CdsConventionHistoryDialog final : public QWidget {
+class CdsConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                         QWidget* parent = nullptr);
     ~CdsConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the CDS convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::cds_convention& cc, int versionNumber);
     void revertVersionRequested(const refdata::domain::cds_convention& cc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CdsConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::CdsConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::cds_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
@@ -24,7 +24,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/HistoryDialogBase.hpp"
-#include "ui_ChangeReasonCategoryHistoryDialog.h"
 #include <QString>
 #include <memory>
 #include <vector>
@@ -55,7 +54,7 @@ public:
     explicit ChangeReasonCategoryHistoryDialog(QString code,
                                                ClientManager* clientManager,
                                                QWidget* parent = nullptr);
-    ~ChangeReasonCategoryHistoryDialog() override = default;
+    ~ChangeReasonCategoryHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
@@ -23,14 +23,11 @@
 #include "ores.dq.api/domain/change_reason_category.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ui_ChangeReasonCategoryHistoryDialog.h"
-#include <QAction>
-#include <QPair>
 #include <QString>
-#include <QToolBar>
-#include <QVector>
-#include <QWidget>
 #include <memory>
+#include <vector>
 
 namespace Ui {
 class ChangeReasonCategoryHistoryDialog;
@@ -41,11 +38,12 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying change reason category version history.
  */
-class ChangeReasonCategoryHistoryDialog : public QWidget {
+class ChangeReasonCategoryHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
-    inline static std::string_view logger_name = "ores.qt.change_reason_category_history_dialog";
+    inline static std::string_view logger_name =
+        "ores.qt.change_reason_category_history_dialog";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
@@ -53,37 +51,22 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit ChangeReasonCategoryHistoryDialog(QString code,
                                                ClientManager* clientManager,
                                                QWidget* parent = nullptr);
-    ~ChangeReasonCategoryHistoryDialog() override;
+    ~ChangeReasonCategoryHistoryDialog() override = default;
 
-    void loadHistory();
-
-    QSize sizeHint() const override;
+    void loadHistory() override;
 
     /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this category has
-     * changed on the server. Automatically reloads the history data.
+     * @brief Returns the code of the change reason category.
      */
-    void markAsStale();
-
-    /**
-     * @brief Returns the code of the category.
-     */
-    [[nodiscard]] QString code() const {
+    [[nodiscard]] QString code() const override {
         return code_;
     }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param category The category data at the selected version.
@@ -98,40 +81,21 @@ signals:
      */
     void revertVersionRequested(const dq::domain::change_reason_category& category);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const dq::domain::change_reason_category& current,
-                             const dq::domain::change_reason_category& previous);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::ChangeReasonCategoryHistoryDialog> ui_;
     ClientManager* clientManager_;
     QString code_;
     std::vector<dq::domain::change_reason_category> versions_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
@@ -23,14 +23,11 @@
 #include "ores.dq.api/domain/change_reason.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ui_ChangeReasonHistoryDialog.h"
-#include <QAction>
-#include <QPair>
 #include <QString>
-#include <QToolBar>
-#include <QVector>
-#include <QWidget>
 #include <memory>
+#include <vector>
 
 namespace Ui {
 class ChangeReasonHistoryDialog;
@@ -41,7 +38,7 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying change reason version history.
  */
-class ChangeReasonHistoryDialog : public QWidget {
+class ChangeReasonHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -53,37 +50,22 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit ChangeReasonHistoryDialog(QString code,
                                        ClientManager* clientManager,
                                        QWidget* parent = nullptr);
-    ~ChangeReasonHistoryDialog() override;
+    ~ChangeReasonHistoryDialog() override = default;
 
-    void loadHistory();
-
-    QSize sizeHint() const override;
-
-    /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this change reason has
-     * changed on the server. Automatically reloads the history data.
-     */
-    void markAsStale();
+    void loadHistory() override;
 
     /**
      * @brief Returns the code of the change reason.
      */
-    [[nodiscard]] QString code() const {
+    [[nodiscard]] QString code() const override {
         return code_;
     }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param reason The change reason data at the selected version.
@@ -97,40 +79,21 @@ signals:
      */
     void revertVersionRequested(const dq::domain::change_reason& reason);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const dq::domain::change_reason& current,
-                             const dq::domain::change_reason& previous);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::ChangeReasonHistoryDialog> ui_;
     ClientManager* clientManager_;
     QString code_;
     std::vector<dq::domain::change_reason> versions_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
@@ -24,7 +24,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/HistoryDialogBase.hpp"
-#include "ui_ChangeReasonHistoryDialog.h"
 #include <QString>
 #include <memory>
 #include <vector>
@@ -54,7 +53,7 @@ public:
     explicit ChangeReasonHistoryDialog(QString code,
                                        ClientManager* clientManager,
                                        QWidget* parent = nullptr);
-    ~ChangeReasonHistoryDialog() override = default;
+    ~ChangeReasonHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/refdata/include/ores.qt/CodeDomainHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodeDomainHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/code_domain.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CodeDomainHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a code domain with ability
  * to view details or revert to a previous version.
  */
-class CodeDomainHistoryDialog final : public QWidget {
+class CodeDomainHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                      QWidget* parent = nullptr);
     ~CodeDomainHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the code domain.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::code_domain& domain, int versionNumber);
     void revertVersionRequested(const dq::domain::code_domain& domain);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CodeDomainHistoryDialog* ui_;
+    std::unique_ptr<Ui::CodeDomainHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::code_domain> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CodingSchemeAuthorityTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodingSchemeAuthorityTypeHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/coding_scheme_authority_type.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CodingSchemeAuthorityTypeHistoryDialog;
@@ -33,7 +34,7 @@ class CodingSchemeAuthorityTypeHistoryDialog;
 
 namespace ores::qt {
 
-class CodingSchemeAuthorityTypeHistoryDialog final : public QWidget {
+class CodingSchemeAuthorityTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -52,37 +53,35 @@ public:
                                                     QWidget* parent = nullptr);
     ~CodingSchemeAuthorityTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the coding scheme authority type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::coding_scheme_authority_type& authorityType,
                               int versionNumber);
     void revertVersionRequested(const dq::domain::coding_scheme_authority_type& authorityType);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CodingSchemeAuthorityTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::CodingSchemeAuthorityTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::coding_scheme_authority_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CodingSchemeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodingSchemeHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/coding_scheme.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CodingSchemeHistoryDialog;
@@ -33,7 +34,7 @@ class CodingSchemeHistoryDialog;
 
 namespace ores::qt {
 
-class CodingSchemeHistoryDialog final : public QWidget {
+class CodingSchemeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -51,36 +52,34 @@ public:
                                        QWidget* parent = nullptr);
     ~CodingSchemeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the coding scheme.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::coding_scheme& scheme, int versionNumber);
     void revertVersionRequested(const dq::domain::coding_scheme& scheme);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CodingSchemeHistoryDialog* ui_;
+    std::unique_ptr<Ui::CodingSchemeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::coding_scheme> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
@@ -22,16 +22,13 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.qt/ImageCache.hpp"
 #include "ores.refdata.api/domain/country.hpp"
 #include "ui_CountryHistoryDialog.h"
-#include <QAction>
-#include <QPair>
 #include <QString>
-#include <QToolBar>
-#include <QVector>
-#include <QWidget>
 #include <memory>
+#include <vector>
 
 namespace Ui {
 class CountryHistoryDialog;
@@ -42,7 +39,7 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying country version history.
  */
-class CountryHistoryDialog : public QWidget {
+class CountryHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -54,35 +51,23 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit CountryHistoryDialog(QString alpha2_code,
                                   ClientManager* clientManager,
                                   QWidget* parent = nullptr);
-    ~CountryHistoryDialog() override;
+    ~CountryHistoryDialog() override = default;
 
-    void loadHistory();
+    void loadHistory() override;
 
     /**
      * @brief Set the image cache for displaying country flags.
      */
     void setImageCache(ImageCache* imageCache);
 
-    QSize sizeHint() const override;
-
-    /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this country has
-     * changed on the server. Automatically reloads the history data.
-     */
-    void markAsStale();
-
     /**
      * @brief Returns the alpha-2 code of the country.
      */
-    [[nodiscard]] QString alpha2Code() const {
+    [[nodiscard]] QString code() const override {
         return alpha2Code_;
     }
 
@@ -94,9 +79,6 @@ public:
     }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param country The country data at the selected version.
@@ -110,41 +92,24 @@ signals:
      */
     void revertVersionRequested(const refdata::domain::country& country);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
+    QWidget* changeCellWidget(const QString& field,
+                              const QString& value) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const refdata::domain::country& current,
-                             const refdata::domain::country& previous);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::CountryHistoryDialog> ui_;
     ClientManager* clientManager_;
     ImageCache* imageCache_;
     QString alpha2Code_;
     std::vector<refdata::domain::country> history_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
@@ -25,7 +25,6 @@
 #include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.qt/ImageCache.hpp"
 #include "ores.refdata.api/domain/country.hpp"
-#include "ui_CountryHistoryDialog.h"
 #include <QString>
 #include <memory>
 #include <vector>
@@ -55,7 +54,7 @@ public:
     explicit CountryHistoryDialog(QString alpha2_code,
                                   ClientManager* clientManager,
                                   QWidget* parent = nullptr);
-    ~CountryHistoryDialog() override = default;
+    ~CountryHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/ImageCache.hpp"
 #include "ores.refdata.api/domain/currency.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
-#include "ui_CurrencyHistoryDialog.h"
 #include <QString>
 #include <memory>
 
@@ -55,7 +54,7 @@ public:
     explicit CurrencyHistoryDialog(QString iso_code,
                                    ClientManager* clientManager,
                                    QWidget* parent = nullptr);
-    ~CurrencyHistoryDialog() override = default;
+    ~CurrencyHistoryDialog() override;
 
     void loadHistory() override;
 

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
@@ -22,19 +22,13 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.qt/ImageCache.hpp"
-#include "ores.refdata.api/domain/currency_version.hpp"
-#include "ores.refdata.api/messaging/currency_history_protocol.hpp"
-#include <QAction>
-#include <QPair>
-#include <QString>
-#include <QToolBar>
-#include <QVector>
-#include <QWidget>
-#include <memory>
-
-class QCloseEvent;
+#include "ores.refdata.api/domain/currency.hpp"
+#include "ores.refdata.api/messaging/protocol.hpp"
 #include "ui_CurrencyHistoryDialog.h"
+#include <QString>
+#include <memory>
 
 namespace Ui {
 class CurrencyHistoryDialog;
@@ -45,7 +39,7 @@ namespace ores::qt {
 /**
  * @brief Widget for displaying currency version history.
  */
-class CurrencyHistoryDialog : public QWidget {
+class CurrencyHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,35 +51,23 @@ private:
         return instance;
     }
 
-    const QIcon& getHistoryIcon() const;
-
 public:
     explicit CurrencyHistoryDialog(QString iso_code,
                                    ClientManager* clientManager,
                                    QWidget* parent = nullptr);
-    ~CurrencyHistoryDialog() override;
+    ~CurrencyHistoryDialog() override = default;
 
-    void loadHistory();
+    void loadHistory() override;
 
     /**
      * @brief Set the image cache for displaying currency flags.
      */
     void setImageCache(ImageCache* imageCache);
 
-    QSize sizeHint() const override;
-
-    /**
-     * @brief Mark the history data as stale and reload.
-     *
-     * Called when a notification is received indicating this currency has
-     * changed on the server. Automatically reloads the history data.
-     */
-    void markAsStale();
-
     /**
      * @brief Returns the ISO code of the currency.
      */
-    [[nodiscard]] QString isoCode() const {
+    [[nodiscard]] QString code() const override {
         return isoCode_;
     }
 
@@ -100,9 +82,6 @@ protected:
     void closeEvent(QCloseEvent* event) override;
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
-
     /**
      * @brief Emitted when user requests to open a version in read-only mode.
      * @param currency The currency data at the selected version.
@@ -116,41 +95,24 @@ signals:
      */
     void revertVersionRequested(const refdata::domain::currency& currency);
 
-private slots:
-    void onVersionSelected(int index);
-    void onHistoryLoaded();
-    void onHistoryLoadError(const QString& error);
-    void onOpenClicked();
-    void onRevertClicked();
-    void onReloadClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
+    QWidget* changeCellWidget(const QString& field,
+                              const QString& value) override;
 
 private:
-    void displayChangesTab(int version_index);
-    void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const refdata::domain::currency_version& current,
-                             const refdata::domain::currency_version& previous);
-
-    void setupToolbar();
-    void updateButtonStates();
-    int selectedVersionIndex() const;
-
     std::unique_ptr<Ui::CurrencyHistoryDialog> ui_;
     ClientManager* clientManager_;
     ImageCache* imageCache_;
     QString isoCode_;
     refdata::messaging::currency_version_history history_;
-
-    QToolBar* toolBar_;
-    QAction* reloadAction_;
-    QAction* openAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyMarketTierHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyMarketTierHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/currency_market_tier.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class CurrencyMarketTierHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a currency market tier with ability
  * to view details or revert to a previous version.
  */
-class CurrencyMarketTierHistoryDialog final : public QWidget {
+class CurrencyMarketTierHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                              QWidget* parent = nullptr);
     ~CurrencyMarketTierHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the currency market tier.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::currency_market_tier& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::currency_market_tier& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::CurrencyMarketTierHistoryDialog* ui_;
+    std::unique_ptr<Ui::CurrencyMarketTierHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::currency_market_tier> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/DataDomainHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DataDomainHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/data_domain.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class DataDomainHistoryDialog;
@@ -33,7 +34,7 @@ class DataDomainHistoryDialog;
 
 namespace ores::qt {
 
-class DataDomainHistoryDialog final : public QWidget {
+class DataDomainHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -51,36 +52,34 @@ public:
                                      QWidget* parent = nullptr);
     ~DataDomainHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the data domain.
+     */
+    [[nodiscard]] QString code() const override {
+        return name_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::data_domain& domain, int versionNumber);
     void revertVersionRequested(const dq::domain::data_domain& domain);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::DataDomainHistoryDialog* ui_;
+    std::unique_ptr<Ui::DataDomainHistoryDialog> ui_;
     QString name_;
     ClientManager* clientManager_;
     std::vector<dq::domain::data_domain> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/DataLibrarianWindow.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DataLibrarianWindow.hpp
@@ -117,7 +117,7 @@ private slots:
     void onRefreshClicked();
     void onViewDatasetClicked();
     void onPublishClicked();
-    void onPublicationHistoryClicked();
+    void onPublicationAuditClicked();
     void onDataLoaded();
     void onLoadError(const QString& error_message, const QString& details = {});
 
@@ -181,7 +181,7 @@ private:
     QAction* refreshAction_;
     QAction* viewDatasetAction_;
     QAction* publishAction_;
-    QAction* publicationHistoryAction_;
+    QAction* publicationAuditAction_;
     QAction* originDimensionsAction_;
     QAction* natureDimensionsAction_;
     QAction* treatmentDimensionsAction_;

--- a/projects/ores.qt/refdata/include/ores.qt/DatasetBundleHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DatasetBundleHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.dq.api/domain/dataset_bundle.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class DatasetBundleHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a dataset bundle with ability
  * to view details or revert to a previous version.
  */
-class DatasetBundleHistoryDialog final : public QWidget {
+class DatasetBundleHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                         QWidget* parent = nullptr);
     ~DatasetBundleHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the dataset bundle.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::dataset_bundle& bundle, int versionNumber);
     void revertVersionRequested(const dq::domain::dataset_bundle& bundle);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::DatasetBundleHistoryDialog* ui_;
+    std::unique_ptr<Ui::DatasetBundleHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::dataset_bundle> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/DatasetHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DatasetHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.dq.api/domain/dataset.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class DatasetHistoryDialog;
@@ -34,7 +35,7 @@ class DatasetHistoryDialog;
 
 namespace ores::qt {
 
-class DatasetHistoryDialog final : public QWidget {
+class DatasetHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -52,36 +53,32 @@ public:
                                   QWidget* parent = nullptr);
     ~DatasetHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the dataset.
+     */
+    [[nodiscard]] QString code() const override;
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::dataset& dataset, int versionNumber);
     void revertVersionRequested(const dq::domain::dataset& dataset);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::DatasetHistoryDialog* ui_;
+    std::unique_ptr<Ui::DatasetHistoryDialog> ui_;
     boost::uuids::uuid id_;
     ClientManager* clientManager_;
     std::vector<dq::domain::dataset> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/DayCountFractionTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DayCountFractionTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/day_count_fraction_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class DayCountFractionTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a day count fraction type with ability
  * to view details or revert to a previous version.
  */
-class DayCountFractionTypeHistoryDialog final : public QWidget {
+class DayCountFractionTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,37 +58,35 @@ public:
                                                QWidget* parent = nullptr);
     ~DayCountFractionTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the day count fraction type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::day_count_fraction_type& type,
                               int versionNumber);
     void revertVersionRequested(const trading::domain::day_count_fraction_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::DayCountFractionTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::DayCountFractionTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::day_count_fraction_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/deposit_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class DepositConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a deposit convention with ability
  * to view details or revert to a previous version.
  */
-class DepositConventionHistoryDialog final : public QWidget {
+class DepositConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                             QWidget* parent = nullptr);
     ~DepositConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the deposit convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::deposit_convention& dc, int versionNumber);
     void revertVersionRequested(const refdata::domain::deposit_convention& dc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::DepositConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::DepositConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::deposit_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/FloatingIndexTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FloatingIndexTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/floating_index_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class FloatingIndexTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a floating index type with ability
  * to view details or revert to a previous version.
  */
-class FloatingIndexTypeHistoryDialog final : public QWidget {
+class FloatingIndexTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                             QWidget* parent = nullptr);
     ~FloatingIndexTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the floating index type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::floating_index_type& type, int versionNumber);
     void revertVersionRequested(const trading::domain::floating_index_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::FloatingIndexTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::FloatingIndexTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::floating_index_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/FraConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FraConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/fra_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class FraConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a FRA convention with ability
  * to view details or revert to a previous version.
  */
-class FraConventionHistoryDialog final : public QWidget {
+class FraConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                         QWidget* parent = nullptr);
     ~FraConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the FRA convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::fra_convention& fc, int versionNumber);
     void revertVersionRequested(const refdata::domain::fra_convention& fc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::FraConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::FraConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::fra_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/FxConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FxConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/fx_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class FxConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a FX convention with ability
  * to view details or revert to a previous version.
  */
-class FxConventionHistoryDialog final : public QWidget {
+class FxConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                        QWidget* parent = nullptr);
     ~FxConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the FX convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::fx_convention& fxc, int versionNumber);
     void revertVersionRequested(const refdata::domain::fx_convention& fxc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::FxConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::FxConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::fx_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/ibor_index_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class IborIndexConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a IBOR index convention with ability
  * to view details or revert to a previous version.
  */
-class IborIndexConventionHistoryDialog final : public QWidget {
+class IborIndexConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                               QWidget* parent = nullptr);
     ~IborIndexConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the IBOR index convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::ibor_index_convention& ic, int versionNumber);
     void revertVersionRequested(const refdata::domain::ibor_index_convention& ic);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::IborIndexConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::IborIndexConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::ibor_index_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/LegTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/LegTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/leg_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class LegTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a leg type with ability
  * to view details or revert to a previous version.
  */
-class LegTypeHistoryDialog final : public QWidget {
+class LegTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                   QWidget* parent = nullptr);
     ~LegTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the leg type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::leg_type& type, int versionNumber);
     void revertVersionRequested(const trading::domain::leg_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::LegTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::LegTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::leg_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/MethodologyHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/MethodologyHistoryDialog.hpp
@@ -23,10 +23,11 @@
 #include "ores.dq.api/domain/methodology.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace Ui {
 class MethodologyHistoryDialog;
@@ -34,7 +35,7 @@ class MethodologyHistoryDialog;
 
 namespace ores::qt {
 
-class MethodologyHistoryDialog final : public QWidget {
+class MethodologyHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -52,36 +53,34 @@ public:
                                       QWidget* parent = nullptr);
     ~MethodologyHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the methodology.
+     */
+    [[nodiscard]] QString code() const override {
+        return QString::fromStdString(name_);
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::methodology& methodology, int versionNumber);
     void revertVersionRequested(const dq::domain::methodology& methodology);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::MethodologyHistoryDialog* ui_;
+    std::unique_ptr<Ui::MethodologyHistoryDialog> ui_;
     std::string name_;
     ClientManager* clientManager_;
     std::vector<dq::domain::methodology> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/MonetaryNatureHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/MonetaryNatureHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/monetary_nature.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class MonetaryNatureHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a monetary nature with ability
  * to view details or revert to a previous version.
  */
-class MonetaryNatureHistoryDialog final : public QWidget {
+class MonetaryNatureHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                          QWidget* parent = nullptr);
     ~MonetaryNatureHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the monetary nature.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::monetary_nature& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::monetary_nature& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::MonetaryNatureHistoryDialog* ui_;
+    std::unique_ptr<Ui::MonetaryNatureHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::monetary_nature> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/NatureDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/NatureDimensionHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/nature_dimension.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class NatureDimensionHistoryDialog;
@@ -33,7 +34,7 @@ class NatureDimensionHistoryDialog;
 
 namespace ores::qt {
 
-class NatureDimensionHistoryDialog final : public QWidget {
+class NatureDimensionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -51,36 +52,34 @@ public:
                                           QWidget* parent = nullptr);
     ~NatureDimensionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the nature dimension.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::nature_dimension& dimension, int versionNumber);
     void revertVersionRequested(const dq::domain::nature_dimension& dimension);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::NatureDimensionHistoryDialog* ui_;
+    std::unique_ptr<Ui::NatureDimensionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::nature_dimension> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/OisConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OisConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/ois_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class OisConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a OIS convention with ability
  * to view details or revert to a previous version.
  */
-class OisConventionHistoryDialog final : public QWidget {
+class OisConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                         QWidget* parent = nullptr);
     ~OisConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the OIS convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::ois_convention& oc, int versionNumber);
     void revertVersionRequested(const refdata::domain::ois_convention& oc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::OisConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::OisConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::ois_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/OriginDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OriginDimensionHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/origin_dimension.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class OriginDimensionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of an origin dimension with ability
  * to view details or revert to a previous version.
  */
-class OriginDimensionHistoryDialog final : public QWidget {
+class OriginDimensionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                           QWidget* parent = nullptr);
     ~OriginDimensionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the origin dimension.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::origin_dimension& dimension, int versionNumber);
     void revertVersionRequested(const dq::domain::origin_dimension& dimension);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::OriginDimensionHistoryDialog* ui_;
+    std::unique_ptr<Ui::OriginDimensionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::origin_dimension> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/overnight_index_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class OvernightIndexConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a overnight index convention with ability
  * to view details or revert to a previous version.
  */
-class OvernightIndexConventionHistoryDialog final : public QWidget {
+class OvernightIndexConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -58,37 +59,35 @@ public:
                                                    QWidget* parent = nullptr);
     ~OvernightIndexConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the overnight index convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::overnight_index_convention& ni,
                               int versionNumber);
     void revertVersionRequested(const refdata::domain::overnight_index_convention& ni);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::OvernightIndexConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::OvernightIndexConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::overnight_index_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/PaymentFrequencyTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/PaymentFrequencyTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/payment_frequency_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PaymentFrequencyTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a payment frequency type with ability
  * to view details or revert to a previous version.
  */
-class PaymentFrequencyTypeHistoryDialog final : public QWidget {
+class PaymentFrequencyTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,37 +58,35 @@ public:
                                                QWidget* parent = nullptr);
     ~PaymentFrequencyTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the payment frequency type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::payment_frequency_type& type,
                               int versionNumber);
     void revertVersionRequested(const trading::domain::payment_frequency_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PaymentFrequencyTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::PaymentFrequencyTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::payment_frequency_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/PublicationAuditDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/PublicationAuditDialog.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_QT_PUBLICATION_HISTORY_DIALOG_HPP
-#define ORES_QT_PUBLICATION_HISTORY_DIALOG_HPP
+#ifndef ORES_QT_PUBLICATION_AUDIT_DIALOG_HPP
+#define ORES_QT_PUBLICATION_AUDIT_DIALOG_HPP
 
 #include "ores.dq.api/domain/publication.hpp"
 #include "ores.logging/make_logger.hpp"
@@ -34,13 +34,13 @@
 namespace ores::qt {
 
 /**
- * @brief Table model for displaying publication history.
+ * @brief Table model for displaying the publication audit trail.
  */
-class PublicationHistoryModel : public QAbstractTableModel {
+class PublicationAuditModel : public QAbstractTableModel {
     Q_OBJECT
 
 public:
-    explicit PublicationHistoryModel(QObject* parent = nullptr);
+    explicit PublicationAuditModel(QObject* parent = nullptr);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -68,16 +68,16 @@ private:
 };
 
 /**
- * @brief Dialog for displaying publication history.
+ * @brief Dialog for displaying the publication audit trail.
  *
  * Shows a table of all publication events with timestamps, dataset codes,
  * modes, record counts, and who published.
  */
-class PublicationHistoryDialog : public QDialog {
+class PublicationAuditDialog : public QDialog {
     Q_OBJECT
 
 private:
-    inline static std::string_view logger_name = "ores.qt.publication_history_dialog";
+    inline static std::string_view logger_name = "ores.qt.publication_audit_dialog";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
@@ -86,8 +86,8 @@ private:
     }
 
 public:
-    explicit PublicationHistoryDialog(ClientManager* clientManager, QWidget* parent = nullptr);
-    ~PublicationHistoryDialog() override;
+    explicit PublicationAuditDialog(ClientManager* clientManager, QWidget* parent = nullptr);
+    ~PublicationAuditDialog() override;
 
     /**
      * @brief Refresh the publication list from the server.
@@ -105,7 +105,7 @@ private:
     void setupUi();
 
     QTableView* tableView_;
-    PublicationHistoryModel* model_;
+    PublicationAuditModel* model_;
     ClientManager* clientManager_;
 
     struct FetchResult {

--- a/projects/ores.qt/refdata/include/ores.qt/PurposeTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/PurposeTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/purpose_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PurposeTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a purpose type with ability
  * to view details or revert to a previous version.
  */
-class PurposeTypeHistoryDialog final : public QWidget {
+class PurposeTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                       QWidget* parent = nullptr);
     ~PurposeTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the purpose type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::purpose_type& pt, int versionNumber);
     void revertVersionRequested(const refdata::domain::purpose_type& pt);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PurposeTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::PurposeTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::purpose_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/RoundingTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/RoundingTypeHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/rounding_type.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class RoundingTypeHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a rounding type with ability
  * to view details or revert to a previous version.
  */
-class RoundingTypeHistoryDialog final : public QWidget {
+class RoundingTypeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                        QWidget* parent = nullptr);
     ~RoundingTypeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the rounding type.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::rounding_type& type, int versionNumber);
     void revertVersionRequested(const refdata::domain::rounding_type& type);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::RoundingTypeHistoryDialog* ui_;
+    std::unique_ptr<Ui::RoundingTypeHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::rounding_type> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/SubjectAreaHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/SubjectAreaHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/subject_area.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class SubjectAreaHistoryDialog;
@@ -33,7 +34,7 @@ class SubjectAreaHistoryDialog;
 
 namespace ores::qt {
 
-class SubjectAreaHistoryDialog final : public QWidget {
+class SubjectAreaHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -52,37 +53,35 @@ public:
                                       QWidget* parent = nullptr);
     ~SubjectAreaHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the subject area.
+     */
+    [[nodiscard]] QString code() const override {
+        return name_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::subject_area& subject_area, int versionNumber);
     void revertVersionRequested(const dq::domain::subject_area& subject_area);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::SubjectAreaHistoryDialog* ui_;
+    std::unique_ptr<Ui::SubjectAreaHistoryDialog> ui_;
     QString name_;
     QString domain_name_;
     ClientManager* clientManager_;
     std::vector<dq::domain::subject_area> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/swap_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class SwapConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a swap convention with ability
  * to view details or revert to a previous version.
  */
-class SwapConventionHistoryDialog final : public QWidget {
+class SwapConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                          QWidget* parent = nullptr);
     ~SwapConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the swap convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::swap_convention& sc, int versionNumber);
     void revertVersionRequested(const refdata::domain::swap_convention& sc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::SwapConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::SwapConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::swap_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/TreatmentDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/TreatmentDimensionHistoryDialog.hpp
@@ -23,9 +23,10 @@
 #include "ores.dq.api/domain/treatment_dimension.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include "ores.qt/HistoryDialogBase.hpp"
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class TreatmentDimensionHistoryDialog;
@@ -33,7 +34,7 @@ class TreatmentDimensionHistoryDialog;
 
 namespace ores::qt {
 
-class TreatmentDimensionHistoryDialog final : public QWidget {
+class TreatmentDimensionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -51,36 +52,34 @@ public:
                                              QWidget* parent = nullptr);
     ~TreatmentDimensionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the treatment dimension.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const dq::domain::treatment_dimension& dimension, int versionNumber);
     void revertVersionRequested(const dq::domain::treatment_dimension& dimension);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::TreatmentDimensionHistoryDialog* ui_;
+    std::unique_ptr<Ui::TreatmentDimensionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<dq::domain::treatment_dimension> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/ZeroConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ZeroConventionHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/zero_convention.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class ZeroConventionHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a zero convention with ability
  * to view details or revert to a previous version.
  */
-class ZeroConventionHistoryDialog final : public QWidget {
+class ZeroConventionHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                          QWidget* parent = nullptr);
     ~ZeroConventionHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the zero convention.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::zero_convention& zc, int versionNumber);
     void revertVersionRequested(const refdata::domain::zero_convention& zc);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::ZeroConventionHistoryDialog* ui_;
+    std::unique_ptr<Ui::ZeroConventionHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::zero_convention> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/refdata/modeling/ores.qt.refdata.puml
+++ b/projects/ores.qt/refdata/modeling/ores.qt.refdata.puml
@@ -1452,14 +1452,14 @@ namespace ores #F2F2F2 {
             -deleteAction_ : QAction*
             -historyAction_ : QAction*
         }
-        class PublicationHistoryModel {
+        class PublicationAuditModel {
             +role : int
             -publications_ : vector<dq::domain::publication>
         }
-        class PublicationHistoryDialog {
+        class PublicationAuditDialog {
             +parent : QWidget*
             -tableView_ : QTableView*
-            -model_ : PublicationHistoryModel*
+            -model_ : PublicationAuditModel*
             -clientManager_ : ClientManager*
             -watcher_ : QFutureWatcher<FetchResult>*
         }

--- a/projects/ores.qt/refdata/src/BusinessDayConventionTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/BusinessDayConventionTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/BusinessDayConventionTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/business_day_convention_type_protocol.hpp"
 #include "ui_BusinessDayConventionTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -33,244 +29,79 @@ using namespace ores::logging;
 
 BusinessDayConventionTypeHistoryDialog::BusinessDayConventionTypeHistoryDialog(
     const QString& code, ClientManager* clientManager, QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BusinessDayConventionTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BusinessDayConventionTypeHistoryDialog::~BusinessDayConventionTypeHistoryDialog() {
-    delete ui_;
-}
-
-void BusinessDayConventionTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BusinessDayConventionTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BusinessDayConventionTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BusinessDayConventionTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BusinessDayConventionTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &BusinessDayConventionTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BusinessDayConventionTypeHistoryDialog::~BusinessDayConventionTypeHistoryDialog() = default;
 
 void BusinessDayConventionTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for business day convention type: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BusinessDayConventionTypeHistoryDialog> self = this;
+    trading::messaging::get_business_day_convention_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::business_day_convention_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_business_day_convention_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BusinessDayConventionTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BusinessDayConventionTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BusinessDayConventionTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BusinessDayConventionTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BusinessDayConventionTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BusinessDayConventionTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BusinessDayConventionTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BusinessDayConventionTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                        int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void BusinessDayConventionTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
@@ -280,37 +111,22 @@ void BusinessDayConventionTypeHistoryDialog::updateFullDetails(int versionIndex)
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void BusinessDayConventionTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BusinessDayConventionTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening business day convention type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BusinessDayConventionTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BusinessDayConventionTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BusinessDayConventionTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/CatalogHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CatalogHistoryDialog.cpp
@@ -19,269 +19,125 @@
  */
 #include "ores.qt/CatalogHistoryDialog.hpp"
 #include "ores.dq.api/messaging/data_organization_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_CatalogHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 CatalogHistoryDialog::CatalogHistoryDialog(const QString& name,
                                            ClientManager* clientManager,
                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CatalogHistoryDialog)
     , name_(name)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CatalogHistoryDialog::~CatalogHistoryDialog() {
-    delete ui_;
-}
-
-void CatalogHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(name_));
 
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CatalogHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CatalogHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CatalogHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &CatalogHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &CatalogHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CatalogHistoryDialog::~CatalogHistoryDialog() = default;
 
 void CatalogHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for catalog: "
+                               << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CatalogHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::catalog> versions;
-    };
+    dq::messaging::get_catalog_history_request request;
+    request.code = name_.toStdString();
 
-    auto task = [self, name = name_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_catalog_history_request request;
-        request.code = name;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void CatalogHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int CatalogHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CatalogHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CatalogHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CatalogHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    auto prevOwner = previous.owner.value_or("");
-    auto currOwner = current.owner.value_or("");
-    if (currOwner != prevOwner)
-        addChange("Owner", QString::fromStdString(prevOwner), QString::fromStdString(currOwner));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CatalogHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(name_);
 }
 
-void CatalogHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+CatalogHistoryDialog::calculateDiffAt(int current_index,
+                                      int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Owner", current.owner, previous.owner);
+
+    return diffs;
+}
+
+void CatalogHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->ownerValue->setText(version.owner ? QString::fromStdString(*version.owner) : QString());
+    ui_->ownerValue->setText(optionalText(version.owner));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
     ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CatalogHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CatalogHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening catalog version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CatalogHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CatalogHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CatalogHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/CdsConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CdsConventionHistoryDialog.cpp
@@ -18,307 +18,131 @@
  *
  */
 #include "ores.qt/CdsConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
 #include "ui_CdsConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 CdsConventionHistoryDialog::CdsConventionHistoryDialog(const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CdsConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CdsConventionHistoryDialog::~CdsConventionHistoryDialog() {
-    delete ui_;
-}
-
-void CdsConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CdsConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CdsConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CdsConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CdsConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &CdsConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CdsConventionHistoryDialog::~CdsConventionHistoryDialog() = default;
 
 void CdsConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for CDS convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for CDS convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CdsConventionHistoryDialog> self = this;
+    refdata::messaging::get_cds_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_cds_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_cds_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->cds_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.cds_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void CdsConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int CdsConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CdsConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CdsConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CdsConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
+QString CdsConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
+}
 
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+CdsConventionHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.calendar != previous.calendar) {
-        addChange("Calendar",
-                  QString::fromStdString(previous.calendar),
-                  QString::fromStdString(current.calendar));
-    }
-
-    if (current.frequency != previous.frequency) {
-        addChange("Frequency",
-                  QString::fromStdString(previous.frequency),
-                  QString::fromStdString(current.frequency));
-    }
-
-    if (current.payment_convention != previous.payment_convention) {
-        addChange("Payment Convention",
-                  QString::fromStdString(previous.payment_convention),
-                  QString::fromStdString(current.payment_convention));
-    }
-
-    if (current.rule != previous.rule) {
-        addChange(
-            "Rule", QString::fromStdString(previous.rule), QString::fromStdString(current.rule));
-    }
-
-    if (current.day_count_fraction != previous.day_count_fraction) {
-        addChange("Day Count Fraction",
-                  QString::fromStdString(previous.day_count_fraction),
-                  QString::fromStdString(current.day_count_fraction));
-    }
-
-    if (current.settlement_days != previous.settlement_days) {
-        addChange("Settlement Days",
-                  QString::number(previous.settlement_days),
-                  QString::number(current.settlement_days));
-    }
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Calendar", current.calendar, previous.calendar);
+    checkString(diffs, "Frequency", current.frequency, previous.frequency);
+    checkString(diffs, "Payment Convention", current.payment_convention,
+                previous.payment_convention);
+    checkString(diffs, "Rule", current.rule, previous.rule);
+    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
+                previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days,
+             previous.settlement_days);
 
     if (current.upfront_settlement_days != previous.upfront_settlement_days) {
-        addChange(
-            "Upfront Settlement Days",
-            previous.upfront_settlement_days ? QString::number(*previous.upfront_settlement_days) :
-                                               tr("(unset)"),
-            current.upfront_settlement_days ? QString::number(*current.upfront_settlement_days) :
-                                              tr("(unset)"));
+        diffs.append(
+            {"Upfront Settlement Days",
+             {previous.upfront_settlement_days ?
+                  QString::number(*previous.upfront_settlement_days) : tr("(unset)"),
+              current.upfront_settlement_days ?
+                  QString::number(*current.upfront_settlement_days) : tr("(unset)")}});
     }
 
-    if (current.last_period_day_count_fraction != previous.last_period_day_count_fraction) {
-        addChange("Last Period DCF",
-                  previous.last_period_day_count_fraction ?
-                      QString::fromStdString(*previous.last_period_day_count_fraction) :
-                      QString{},
-                  current.last_period_day_count_fraction ?
-                      QString::fromStdString(*current.last_period_day_count_fraction) :
-                      QString{});
-    }
+    checkString(diffs, "Last Period DCF", current.last_period_day_count_fraction,
+                previous.last_period_day_count_fraction);
 
     if (current.settles_accrual != previous.settles_accrual) {
-        addChange("Settles Accrual",
-                  previous.settles_accrual ? tr("true") : tr("false"),
-                  current.settles_accrual ? tr("true") : tr("false"));
+        diffs.append({"Settles Accrual",
+                      {previous.settles_accrual ? tr("true") : tr("false"),
+                       current.settles_accrual ? tr("true") : tr("false")}});
     }
 
     if (current.pays_at_default_time != previous.pays_at_default_time) {
-        addChange("Pays At Default Time",
-                  previous.pays_at_default_time ? tr("true") : tr("false"),
-                  current.pays_at_default_time ? tr("true") : tr("false"));
+        diffs.append({"Pays At Default Time",
+                      {previous.pays_at_default_time ? tr("true") : tr("false"),
+                       current.pays_at_default_time ? tr("true") : tr("false")}});
     }
 
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+    return diffs;
 }
 
-void CdsConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
-
-    const auto& version = versions_[versionIndex];
+void CdsConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
     ui_->calendarValue->setText(QString::fromStdString(version.calendar));
@@ -331,9 +155,7 @@ void CdsConventionHistoryDialog::updateFullDetails(int versionIndex) {
                                                  QString::number(*version.upfront_settlement_days) :
                                                  tr("(unset)"));
     ui_->lastPeriodDayCountFractionValue->setText(
-        version.last_period_day_count_fraction ?
-            QString::fromStdString(*version.last_period_day_count_fraction) :
-            QString{});
+        optionalText(version.last_period_day_count_fraction));
     ui_->settlesAccrualValue->setText(version.settles_accrual ? tr("true") : tr("false"));
     ui_->paysAtDefaultTimeValue->setText(version.pays_at_default_time ? tr("true") : tr("false"));
     ui_->versionNumberValue->setText(QString::number(version.version));
@@ -342,37 +164,22 @@ void CdsConventionHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CdsConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CdsConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening CDS convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CdsConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CdsConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CdsConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
@@ -117,14 +117,14 @@ void ChangeReasonCategoryHistoryDialog::openVersionAt(int index) {
 }
 
 void ChangeReasonCategoryHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection, stamped with the latest version number.
-    const auto& previous = versions_[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version, stamped with the latest version number.
+    const auto& selected = versions_[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version;
+                              << selected.version;
 
-    dq::domain::change_reason_category category = previous;
+    dq::domain::change_reason_category category = selected;
     category.version = versions_.front().version;
     emit revertVersionRequested(category);
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/ChangeReasonCategoryHistoryDialog.hpp"
+#include "ui_ChangeReasonCategoryHistoryDialog.h"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -44,6 +45,8 @@ ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(
                          .titleLabel = ui_->titleLabel,
                          .closeButton = ui_->closeButton});
 }
+
+ChangeReasonCategoryHistoryDialog::~ChangeReasonCategoryHistoryDialog() = default;
 
 void ChangeReasonCategoryHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading category history for: "

--- a/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
@@ -19,410 +19,114 @@
  */
 #include "ores.qt/ChangeReasonCategoryHistoryDialog.hpp"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& ChangeReasonCategoryHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
-}
-
-ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(QString code,
-                                                                     ClientManager* clientManager,
-                                                                     QWidget* parent)
-    : QWidget(parent)
+ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(
+    QString code, ClientManager* clientManager, QWidget* parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ChangeReasonCategoryHistoryDialog)
     , clientManager_(clientManager)
-    , code_(std::move(code))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , code_(std::move(code)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating category history widget for: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating category history widget for: "
+                              << code_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
-
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-}
-
-ChangeReasonCategoryHistoryDialog::~ChangeReasonCategoryHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying category history widget";
-
-    // Disconnect and cancel any active QFutureWatcher objects
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-        watcher->waitForFinished();
-    }
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
 void ChangeReasonCategoryHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading category history for: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading category history for: "
+                              << code_.toStdString();
 
-    using HistoryResult =
-        std::expected<dq::messaging::get_change_reason_category_history_response, std::string>;
-    QPointer<ChangeReasonCategoryHistoryDialog> self = this;
-    const auto code = code_.toStdString();
+    dq::messaging::get_change_reason_category_history_request request;
+    request.code = code_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, code]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        dq::messaging::get_change_reason_category_history_request request;
-        request.code = code;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->versions_ = std::move(result->versions);
-        self->onHistoryLoaded();
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void ChangeReasonCategoryHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << versions_.size() << " versions";
-
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(versions_.size());
-
-    for (int i = 0; i < static_cast<int>(versions_.size()); ++i) {
-        const auto& version = versions_[i];
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 2, modifiedByItem);
-        ui_->versionListWidget->setItem(i, 3, commentaryItem);
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!versions_.empty()) {
-        const auto& latest = versions_[0];
-        ui_->titleLabel->setText(
-            QString("Category History: %1").arg(QString::fromStdString(latest.code)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(versions_.size()));
+int ChangeReasonCategoryHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ChangeReasonCategoryHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
-
-    emit errorOccurred(QString("Failed to load category history: %1").arg(error_msg));
-    MessageBoxHelper::critical(
-        this, "History Load Error", QString("Failed to load category history:\n%1").arg(error_msg));
+HistoryDialogBase::VersionRow
+ChangeReasonCategoryHistoryDialog::versionRow(int index) const {
+    const auto& category = versions_[index];
+    return {.version = category.version,
+            .cells = {relative_time_helper::format(category.recorded_at),
+                      QString::fromStdString(category.modified_by),
+                      QString::fromStdString(category.change_commentary)}};
 }
 
-void ChangeReasonCategoryHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
+QString ChangeReasonCategoryHistoryDialog::historyTitle() const {
+    const auto& latest = versions_.front();
+    return QString("Category History: %1")
+        .arg(QString::fromStdString(latest.code));
 }
 
-void ChangeReasonCategoryHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(versions_.size()))
-        return;
-
-    const auto& current = versions_[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(versions_.size()) - 1)
-        return;
-
-    // Calculate diff with previous version
-    const auto& previous = versions_[version_index + 1];
-    auto diffs = calculateDiff(current, previous);
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        auto* oldItem = new QTableWidgetItem(old_val);
-        auto* newItem = new QTableWidgetItem(new_val);
-
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-        ui_->changesTableWidget->setItem(i, 1, oldItem);
-        ui_->changesTableWidget->setItem(i, 2, newItem);
-    }
-}
-
-void ChangeReasonCategoryHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(versions_.size()))
-        return;
-
-    const auto& category = versions_[version_index];
-
-    ui_->codeValue->setText(QString::fromStdString(category.code));
-    ui_->descriptionValue->setText(QString::fromStdString(category.description));
-    ui_->versionNumberValue->setText(QString::number(category.version));
-    ui_->modifiedByValue->setText(QString::fromStdString(category.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(category.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(category.change_commentary));
-}
-
-#define CHECK_DIFF_STRING(FIELD_NAME, FIELD)                                                    \
-    if (current.FIELD != previous.FIELD) {                                                      \
-        diffs.append(                                                                           \
-            {FIELD_NAME,                                                                        \
-             {QString::fromStdString(previous.FIELD), QString::fromStdString(current.FIELD)}}); \
-    }
-
-ChangeReasonCategoryHistoryDialog::DiffResult ChangeReasonCategoryHistoryDialog::calculateDiff(
-    const dq::domain::change_reason_category& current,
-    const dq::domain::change_reason_category& previous) {
+HistoryDialogBase::DiffResult
+ChangeReasonCategoryHistoryDialog::calculateDiffAt(int current_index,
+                                                   int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-
-    // Compare string fields
-    CHECK_DIFF_STRING("Code", code);
-    CHECK_DIFF_STRING("Description", description);
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
 
-#undef CHECK_DIFF_STRING
+void ChangeReasonCategoryHistoryDialog::displayFullDetails(int index) {
+    const auto& category = versions_[index];
 
-void ChangeReasonCategoryHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_,
-            &QAction::triggered,
-            this,
-            &ChangeReasonCategoryHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(
-        openAction_, &QAction::triggered, this, &ChangeReasonCategoryHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert category to this version");
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &ChangeReasonCategoryHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
+    ui_->codeValue->setText(QString::fromStdString(category.code));
+    ui_->descriptionValue->setText(
+        QString::fromStdString(category.description));
+    ui_->versionNumberValue->setText(QString::number(category.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(category.modified_by));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(category.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(category.change_commentary));
 }
 
-void ChangeReasonCategoryHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(versions_.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int ChangeReasonCategoryHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void ChangeReasonCategoryHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
+void ChangeReasonCategoryHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
     BOOST_LOG_SEV(lg(), info) << "Opening category version " << version.version
                               << " in read-only mode";
-
     emit openVersionRequested(version, version.version);
 }
 
-void ChangeReasonCategoryHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = versions_[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(versions_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void ChangeReasonCategoryHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection, stamped with the latest version number.
     const auto& previous = versions_[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version
-                              << " to version " << previous.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert Category",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(code_)
-            .arg(current.version)
-            .arg(previous.version),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) with the latest version number
     dq::domain::change_reason_category category = previous;
-    category.version = versions_[0].version;
+    category.version = versions_.front().version;
     emit revertVersionRequested(category);
-}
-
-void ChangeReasonCategoryHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for category history: " << code_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(code_));
-    loadHistory();
-}
-
-QSize ChangeReasonCategoryHistoryDialog::sizeHint() const {
-    // Call the base implementation first to get the minimum size required by
-    // the layout manager and its content's size policies.
-    QSize baseSize = QWidget::sizeHint();
-
-    // Define a reasonable minimum size for a history dialog. This ensures the
-    // two panes (Version List and Details/Changes) are comfortably visible.
-    const int minimumWidth = 900;
-    const int minimumHeight = 600;
-
-    // Return the maximum of the base size (to accommodate large text/UI
-    // elements) and the defined minimum size.
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void ChangeReasonCategoryHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "Category history marked as stale for: " << code_.toStdString()
-                              << ", reloading...";
-
-    emit statusChanged(QString("Category %1 was modified - reloading history...").arg(code_));
-
-    // Reload history data
-    loadHistory();
 }
 
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
@@ -133,14 +133,14 @@ void ChangeReasonHistoryDialog::openVersionAt(int index) {
 }
 
 void ChangeReasonHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection, stamped with the latest version number.
-    const auto& previous = versions_[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version, stamped with the latest version number.
+    const auto& selected = versions_[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version;
+                              << selected.version;
 
-    dq::domain::change_reason reason = previous;
+    dq::domain::change_reason reason = selected;
     reason.version = versions_.front().version;
     emit revertVersionRequested(reason);
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
@@ -19,38 +19,20 @@
  */
 #include "ores.qt/ChangeReasonHistoryDialog.hpp"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& ChangeReasonHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
-}
-
 ChangeReasonHistoryDialog::ChangeReasonHistoryDialog(QString code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ChangeReasonHistoryDialog)
     , clientManager_(clientManager)
-    , code_(std::move(code))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , code_(std::move(code)) {
 
     BOOST_LOG_SEV(lg(), info) << "Creating change reason history widget for: "
                               << code_.toStdString();
@@ -58,394 +40,109 @@ ChangeReasonHistoryDialog::ChangeReasonHistoryDialog(QString code,
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
-
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-}
-
-ChangeReasonHistoryDialog::~ChangeReasonHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying change reason history widget";
-
-    // Disconnect and cancel any active QFutureWatcher objects
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-        watcher->waitForFinished();
-    }
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
 void ChangeReasonHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading change reason history for: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading change reason history for: "
+                              << code_.toStdString();
 
-    using HistoryResult =
-        std::expected<dq::messaging::get_change_reason_history_response, std::string>;
-    QPointer<ChangeReasonHistoryDialog> self = this;
-    const auto code = code_.toStdString();
+    dq::messaging::get_change_reason_history_request request;
+    request.code = code_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, code]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        dq::messaging::get_change_reason_history_request request;
-        request.code = code;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->versions_ = std::move(result->versions);
-        self->onHistoryLoaded();
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void ChangeReasonHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << versions_.size() << " versions";
-
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(versions_.size());
-
-    for (int i = 0; i < static_cast<int>(versions_.size()); ++i) {
-        const auto& version = versions_[i];
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 2, modifiedByItem);
-        ui_->versionListWidget->setItem(i, 3, commentaryItem);
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!versions_.empty()) {
-        const auto& latest = versions_[0];
-        ui_->titleLabel->setText(
-            QString("Change Reason History: %1").arg(QString::fromStdString(latest.code)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(versions_.size()));
+int ChangeReasonHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ChangeReasonHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
-
-    emit errorOccurred(QString("Failed to load change reason history: %1").arg(error_msg));
-    MessageBoxHelper::critical(this,
-                               "History Load Error",
-                               QString("Failed to load change reason history:\n%1").arg(error_msg));
+HistoryDialogBase::VersionRow ChangeReasonHistoryDialog::versionRow(int index) const {
+    const auto& reason = versions_[index];
+    return {.version = reason.version,
+            .cells = {relative_time_helper::format(reason.recorded_at),
+                      QString::fromStdString(reason.modified_by),
+                      QString::fromStdString(reason.change_commentary)}};
 }
 
-void ChangeReasonHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
+QString ChangeReasonHistoryDialog::historyTitle() const {
+    const auto& latest = versions_.front();
+    return QString("Change Reason History: %1")
+        .arg(QString::fromStdString(latest.code));
 }
 
-void ChangeReasonHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(versions_.size()))
-        return;
-
-    const auto& current = versions_[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(versions_.size()) - 1)
-        return;
-
-    // Calculate diff with previous version
-    const auto& previous = versions_[version_index + 1];
-    auto diffs = calculateDiff(current, previous);
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        auto* oldItem = new QTableWidgetItem(old_val);
-        auto* newItem = new QTableWidgetItem(new_val);
-
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-        ui_->changesTableWidget->setItem(i, 1, oldItem);
-        ui_->changesTableWidget->setItem(i, 2, newItem);
-    }
-}
-
-void ChangeReasonHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(versions_.size()))
-        return;
-
-    const auto& reason = versions_[version_index];
-
-    ui_->codeValue->setText(QString::fromStdString(reason.code));
-    ui_->descriptionValue->setText(QString::fromStdString(reason.description));
-    ui_->categoryCodeValue->setText(QString::fromStdString(reason.category_code));
-    ui_->appliesToAmendValue->setText(reason.applies_to_amend ? "Yes" : "No");
-    ui_->appliesToDeleteValue->setText(reason.applies_to_delete ? "Yes" : "No");
-    ui_->requiresCommentaryValue->setText(reason.requires_commentary ? "Yes" : "No");
-    ui_->displayOrderValue->setText(QString::number(reason.display_order));
-    ui_->versionNumberValue->setText(QString::number(reason.version));
-    ui_->modifiedByValue->setText(QString::fromStdString(reason.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(reason.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(reason.change_commentary));
-}
-
-#define CHECK_DIFF_STRING(FIELD_NAME, FIELD)                                                    \
-    if (current.FIELD != previous.FIELD) {                                                      \
-        diffs.append(                                                                           \
-            {FIELD_NAME,                                                                        \
-             {QString::fromStdString(previous.FIELD), QString::fromStdString(current.FIELD)}}); \
-    }
-
-#define CHECK_DIFF_BOOL(FIELD_NAME, FIELD)                                                         \
-    if (current.FIELD != previous.FIELD) {                                                         \
-        diffs.append({FIELD_NAME, {previous.FIELD ? "Yes" : "No", current.FIELD ? "Yes" : "No"}}); \
-    }
-
-#define CHECK_DIFF_INT(FIELD_NAME, FIELD)                                                     \
-    if (current.FIELD != previous.FIELD) {                                                    \
-        diffs.append(                                                                         \
-            {FIELD_NAME, {QString::number(previous.FIELD), QString::number(current.FIELD)}}); \
-    }
-
-ChangeReasonHistoryDialog::DiffResult
-ChangeReasonHistoryDialog::calculateDiff(const dq::domain::change_reason& current,
-                                         const dq::domain::change_reason& previous) {
+HistoryDialogBase::DiffResult
+ChangeReasonHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-
-    // Compare string fields
-    CHECK_DIFF_STRING("Code", code);
-    CHECK_DIFF_STRING("Description", description);
-    CHECK_DIFF_STRING("Category Code", category_code);
-
-    // Compare boolean fields
-    CHECK_DIFF_BOOL("Applies to Amend", applies_to_amend);
-    CHECK_DIFF_BOOL("Applies to Delete", applies_to_delete);
-    CHECK_DIFF_BOOL("Requires Commentary", requires_commentary);
-
-    // Compare integer fields
-    CHECK_DIFF_INT("Display Order", display_order);
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Category Code", current.category_code,
+                previous.category_code);
+    checkBool(diffs, "Applies to Amend", current.applies_to_amend,
+              previous.applies_to_amend);
+    checkBool(diffs, "Applies to Delete", current.applies_to_delete,
+              previous.applies_to_delete);
+    checkBool(diffs, "Requires Commentary", current.requires_commentary,
+              previous.requires_commentary);
+    checkInt(diffs, "Display Order", current.display_order,
+             previous.display_order);
 
     return diffs;
 }
 
-#undef CHECK_DIFF_STRING
-#undef CHECK_DIFF_BOOL
-#undef CHECK_DIFF_INT
+void ChangeReasonHistoryDialog::displayFullDetails(int index) {
+    const auto& reason = versions_[index];
 
-void ChangeReasonHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_, &QAction::triggered, this, &ChangeReasonHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(openAction_, &QAction::triggered, this, &ChangeReasonHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert change reason to this version");
-    connect(revertAction_, &QAction::triggered, this, &ChangeReasonHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
+    ui_->codeValue->setText(QString::fromStdString(reason.code));
+    ui_->descriptionValue->setText(QString::fromStdString(reason.description));
+    ui_->categoryCodeValue->setText(
+        QString::fromStdString(reason.category_code));
+    ui_->appliesToAmendValue->setText(reason.applies_to_amend ? "Yes" : "No");
+    ui_->appliesToDeleteValue->setText(reason.applies_to_delete ? "Yes" : "No");
+    ui_->requiresCommentaryValue->setText(
+        reason.requires_commentary ? "Yes" : "No");
+    ui_->displayOrderValue->setText(QString::number(reason.display_order));
+    ui_->versionNumberValue->setText(QString::number(reason.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(reason.modified_by));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(reason.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(reason.change_commentary));
 }
 
-void ChangeReasonHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(versions_.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int ChangeReasonHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void ChangeReasonHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
+void ChangeReasonHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening change reason version " << version.version
-                              << " in read-only mode";
-
+    BOOST_LOG_SEV(lg(), info) << "Opening change reason version "
+                              << version.version << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
-void ChangeReasonHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(versions_.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = versions_[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(versions_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void ChangeReasonHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection, stamped with the latest version number.
     const auto& previous = versions_[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version
-                              << " to version " << previous.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert Change Reason",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(code_)
-            .arg(current.version)
-            .arg(previous.version),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) with the latest version number
     dq::domain::change_reason reason = previous;
-    reason.version = versions_[0].version;
+    reason.version = versions_.front().version;
     emit revertVersionRequested(reason);
-}
-
-void ChangeReasonHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for change reason history: "
-                              << code_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(code_));
-    loadHistory();
-}
-
-QSize ChangeReasonHistoryDialog::sizeHint() const {
-    // Call the base implementation first to get the minimum size required by
-    // the layout manager and its content's size policies.
-    QSize baseSize = QWidget::sizeHint();
-
-    // Define a reasonable minimum size for a history dialog. This ensures the
-    // two panes (Version List and Details/Changes) are comfortably visible.
-    const int minimumWidth = 900;
-    const int minimumHeight = 600;
-
-    // Return the maximum of the base size (to accommodate large text/UI
-    // elements) and the defined minimum size.
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void ChangeReasonHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "Change reason history marked as stale for: "
-                              << code_.toStdString() << ", reloading...";
-
-    emit statusChanged(QString("Change reason %1 was modified - reloading history...").arg(code_));
-
-    // Reload history data
-    loadHistory();
 }
 
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/ChangeReasonHistoryDialog.hpp"
+#include "ui_ChangeReasonHistoryDialog.h"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -45,6 +46,8 @@ ChangeReasonHistoryDialog::ChangeReasonHistoryDialog(QString code,
                          .titleLabel = ui_->titleLabel,
                          .closeButton = ui_->closeButton});
 }
+
+ChangeReasonHistoryDialog::~ChangeReasonHistoryDialog() = default;
 
 void ChangeReasonHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading change reason history for: "

--- a/projects/ores.qt/refdata/src/CodeDomainHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodeDomainHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/CodeDomainHistoryDialog.hpp"
 #include "ores.dq.api/messaging/badge_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_CodeDomainHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,245 +30,80 @@ using namespace ores::logging;
 CodeDomainHistoryDialog::CodeDomainHistoryDialog(const QString& code,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CodeDomainHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CodeDomainHistoryDialog::~CodeDomainHistoryDialog() {
-    delete ui_;
-}
-
-void CodeDomainHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CodeDomainHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CodeDomainHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CodeDomainHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CodeDomainHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &CodeDomainHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CodeDomainHistoryDialog::~CodeDomainHistoryDialog() = default;
 
 void CodeDomainHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for code domain: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for code domain: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CodeDomainHistoryDialog> self = this;
+    dq::messaging::get_code_domain_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::code_domain> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        dq::messaging::get_code_domain_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, response_result.error(), {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void CodeDomainHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int CodeDomainHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CodeDomainHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CodeDomainHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CodeDomainHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CodeDomainHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void CodeDomainHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+CodeDomainHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void CodeDomainHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -283,37 +114,22 @@ void CodeDomainHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CodeDomainHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CodeDomainHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening code domain version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CodeDomainHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CodeDomainHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CodeDomainHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/CodingSchemeAuthorityTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodingSchemeAuthorityTypeHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/CodingSchemeAuthorityTypeHistoryDialog.hpp"
 #include "ores.dq.api/messaging/coding_scheme_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_CodingSchemeAuthorityTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,213 +30,80 @@ using namespace ores::logging;
 
 CodingSchemeAuthorityTypeHistoryDialog::CodingSchemeAuthorityTypeHistoryDialog(
     const QString& code, ClientManager* clientManager, QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CodingSchemeAuthorityTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CodingSchemeAuthorityTypeHistoryDialog::~CodingSchemeAuthorityTypeHistoryDialog() {
-    delete ui_;
-}
-
-void CodingSchemeAuthorityTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CodingSchemeAuthorityTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CodingSchemeAuthorityTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CodingSchemeAuthorityTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &CodingSchemeAuthorityTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CodingSchemeAuthorityTypeHistoryDialog::~CodingSchemeAuthorityTypeHistoryDialog() = default;
 
 void CodingSchemeAuthorityTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for coding scheme authority type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CodingSchemeAuthorityTypeHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::coding_scheme_authority_type> versions;
-    };
+    dq::messaging::get_coding_scheme_authority_type_history_request request;
+    request.type = code_.toStdString();
 
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_coding_scheme_authority_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int CodingSchemeAuthorityTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CodingSchemeAuthorityTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CodingSchemeAuthorityTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+CodingSchemeAuthorityTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                        int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void CodingSchemeAuthorityTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
@@ -251,37 +113,22 @@ void CodingSchemeAuthorityTypeHistoryDialog::updateFullDetails(int versionIndex)
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CodingSchemeAuthorityTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme authority type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CodingSchemeAuthorityTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CodingSchemeAuthorityTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CodingSchemeAuthorityTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/CodingSchemeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodingSchemeHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/CodingSchemeHistoryDialog.hpp"
 #include "ores.dq.api/messaging/coding_scheme_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_CodingSchemeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,226 +31,86 @@ using namespace ores::logging;
 CodingSchemeHistoryDialog::CodingSchemeHistoryDialog(const QString& code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CodingSchemeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CodingSchemeHistoryDialog::~CodingSchemeHistoryDialog() {
-    delete ui_;
-}
-
-void CodingSchemeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CodingSchemeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CodingSchemeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CodingSchemeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CodingSchemeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &CodingSchemeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CodingSchemeHistoryDialog::~CodingSchemeHistoryDialog() = default;
 
 void CodingSchemeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for coding scheme: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CodingSchemeHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::coding_scheme> versions;
-    };
+    dq::messaging::get_coding_scheme_history_request request;
+    request.code = code_.toStdString();
 
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_coding_scheme_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void CodingSchemeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int CodingSchemeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CodingSchemeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CodingSchemeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CodingSchemeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.authority_type != previous.authority_type)
-        addChange("Authority Type",
-                  QString::fromStdString(previous.authority_type),
-                  QString::fromStdString(current.authority_type));
-    if (current.subject_area_name != previous.subject_area_name)
-        addChange("Subject Area",
-                  QString::fromStdString(previous.subject_area_name),
-                  QString::fromStdString(current.subject_area_name));
-    if (current.domain_name != previous.domain_name)
-        addChange("Domain",
-                  QString::fromStdString(previous.domain_name),
-                  QString::fromStdString(current.domain_name));
-    if (current.uri != previous.uri)
-        addChange("URI",
-                  QString::fromStdString(previous.uri.value_or("")),
-                  QString::fromStdString(current.uri.value_or("")));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CodingSchemeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void CodingSchemeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+CodingSchemeHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Authority Type", current.authority_type,
+                previous.authority_type);
+    checkString(diffs, "Subject Area", current.subject_area_name,
+                previous.subject_area_name);
+    checkString(diffs, "Domain", current.domain_name, previous.domain_name);
+    checkString(diffs, "URI", current.uri, previous.uri);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void CodingSchemeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->authorityTypeValue->setText(QString::fromStdString(version.authority_type));
@@ -269,37 +124,22 @@ void CodingSchemeHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CodingSchemeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CodingSchemeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CodingSchemeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CodingSchemeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CodingSchemeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
@@ -18,42 +18,34 @@
  *
  */
 #include "ores.qt/CountryHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
 #include <QLabel>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& CountryHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
+namespace {
+
+QString formatImageId(const std::optional<boost::uuids::uuid>& id) {
+    if (!id.has_value())
+        return QStringLiteral("(none)");
+    return QString::fromStdString(boost::uuids::to_string(*id));
+}
+
 }
 
 CountryHistoryDialog::CountryHistoryDialog(QString alpha2_code,
                                            ClientManager* clientManager,
                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CountryHistoryDialog)
     , clientManager_(clientManager)
     , imageCache_(nullptr)
-    , alpha2Code_(std::move(alpha2_code))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , alpha2Code_(std::move(alpha2_code)) {
 
     BOOST_LOG_SEV(lg(), info) << "Creating country history widget for: "
                               << alpha2Code_.toStdString();
@@ -61,246 +53,106 @@ CountryHistoryDialog::CountryHistoryDialog(QString alpha2_code,
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
-
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-}
-
-CountryHistoryDialog::~CountryHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying country history widget";
-
-    // Disconnect and cancel any active QFutureWatcher objects
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-        watcher->waitForFinished();
-    }
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
 void CountryHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading country history for: " << alpha2Code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading country history for: "
+                              << alpha2Code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_country_history_response, std::string>;
-    QPointer<CountryHistoryDialog> self = this;
-    const auto alpha2_code = alpha2Code_.toStdString();
+    refdata::messaging::get_country_history_request request;
+    request.alpha2_code = alpha2Code_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, alpha2_code]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        refdata::messaging::get_country_history_request request;
-        request.alpha2_code = alpha2_code;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->history_ = std::move(result->history);
-        self->onHistoryLoaded();
+        history_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void CountryHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << history_.size() << " versions";
+int CountryHistoryDialog::historySize() const {
+    return static_cast<int>(history_.size());
+}
 
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(history_.size());
+HistoryDialogBase::VersionRow CountryHistoryDialog::versionRow(int index) const {
+    const auto& country = history_[index];
+    return {.version = country.version,
+            .cells = {relative_time_helper::format(country.recorded_at),
+                      QString::fromStdString(country.modified_by),
+                      QString::fromStdString(country.change_reason_code),
+                      QString::fromStdString(country.change_commentary)}};
+}
 
-    for (int i = 0; i < static_cast<int>(history_.size()); ++i) {
-        const auto& country = history_[i];
+QString CountryHistoryDialog::historyTitle() const {
+    const auto& latest = history_.front();
+    return QString("Country History: %1 - %2")
+        .arg(alpha2Code_)
+        .arg(QString::fromStdString(latest.name));
+}
 
-        BOOST_LOG_SEV(lg(), trace)
-            << "Displaying version [" << i << "]: "
-            << "version=" << country.version << ", modified_by=" << country.modified_by;
+HistoryDialogBase::DiffResult
+CountryHistoryDialog::calculateDiffAt(int current_index,
+                                      int previous_index) const {
+    const auto& current = history_[current_index];
+    const auto& previous = history_[previous_index];
 
-        auto* versionItem = new QTableWidgetItem(QString::number(country.version));
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(country.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(country.modified_by));
-        auto* changeReasonItem =
-            new QTableWidgetItem(QString::fromStdString(country.change_reason_code));
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(country.change_commentary));
+    DiffResult diffs;
+    checkString(diffs, "Alpha-2 Code", current.alpha2_code, previous.alpha2_code);
+    checkString(diffs, "Alpha-3 Code", current.alpha3_code, previous.alpha3_code);
+    checkString(diffs, "Numeric Code", current.numeric_code, previous.numeric_code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Official Name", current.official_name, previous.official_name);
+    checkString(diffs, "Change Reason", current.change_reason_code,
+                previous.change_reason_code);
+    checkString(diffs, "Commentary", current.change_commentary,
+                previous.change_commentary);
 
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 2, modifiedByItem);
-        ui_->versionListWidget->setItem(i, 3, changeReasonItem);
-        ui_->versionListWidget->setItem(i, 4, commentaryItem);
+    if (current.image_id != previous.image_id) {
+        diffs.append({"Flag",
+                      {formatImageId(previous.image_id),
+                       formatImageId(current.image_id)}});
     }
 
-    if (!history_.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!history_.empty()) {
-        const auto& latest = history_[0];
-        ui_->titleLabel->setText(QString("Country History: %1 - %2")
-                                     .arg(alpha2Code_)
-                                     .arg(QString::fromStdString(latest.name)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(history_.size()));
+    return diffs;
 }
 
-void CountryHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
+QWidget* CountryHistoryDialog::changeCellWidget(const QString& field,
+                                                const QString& value) {
+    // Show flag icons instead of image UUIDs.
+    if (field != "Flag" || !imageCache_)
+        return nullptr;
 
-    emit errorOccurred(QString("Failed to load country history: %1").arg(error_msg));
-    MessageBoxHelper::critical(
-        this, "History Load Error", QString("Failed to load country history:\n%1").arg(error_msg));
-}
+    auto* label = new QLabel();
+    label->setAlignment(Qt::AlignCenter);
+    label->setFixedSize(32, 32);
 
-void CountryHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
-}
-
-void CountryHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(history_.size()))
-        return;
-
-    const auto& current = history_[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(history_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), trace) << "No previous version to diff against for oldest version";
-        return;
-    }
-
-    // Calculate diff with previous version
-    const auto& previous = history_[version_index + 1];
-
-    BOOST_LOG_SEV(lg(), trace) << "Calculating diff between version " << current.version << " and "
-                               << previous.version;
-    BOOST_LOG_SEV(lg(), trace) << "Current name: " << current.name
-                               << ", Previous name: " << previous.name;
-
-    auto diffs = calculateDiff(current, previous);
-
-    BOOST_LOG_SEV(lg(), trace) << "Found " << diffs.size() << " differences";
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-
-        // Special handling for Flag field - show SVG icons instead of UUIDs
-        if (field == "Flag" && imageCache_) {
-            // Create label widgets to show the flag icons
-            auto createFlagLabel = [this](const QString& imageIdStr) -> QWidget* {
-                auto* label = new QLabel();
-                label->setAlignment(Qt::AlignCenter);
-                label->setFixedSize(32, 32);
-
-                if (imageIdStr == "(none)") {
-                    QIcon noFlagIcon = imageCache_->getNoFlagIcon();
-                    if (!noFlagIcon.isNull()) {
-                        label->setPixmap(noFlagIcon.pixmap(24, 24));
-                    } else {
-                        label->setText("-");
-                    }
-                } else {
-                    // Get the icon using the UUID string
-                    QIcon icon = imageCache_->getIcon(imageIdStr.toStdString());
-                    if (!icon.isNull()) {
-                        label->setPixmap(icon.pixmap(24, 24));
-                    } else {
-                        label->setText("?");
-                        label->setToolTip(imageIdStr);
-                    }
-                }
-                return label;
-            };
-
-            ui_->changesTableWidget->setCellWidget(i, 1, createFlagLabel(old_val));
-            ui_->changesTableWidget->setCellWidget(i, 2, createFlagLabel(new_val));
+    if (value == "(none)") {
+        QIcon noFlagIcon = imageCache_->getNoFlagIcon();
+        if (!noFlagIcon.isNull())
+            label->setPixmap(noFlagIcon.pixmap(24, 24));
+        else
+            label->setText("-");
+    } else {
+        QIcon icon = imageCache_->getIcon(value.toStdString());
+        if (!icon.isNull()) {
+            label->setPixmap(icon.pixmap(24, 24));
         } else {
-            auto* oldItem = new QTableWidgetItem(old_val);
-            auto* newItem = new QTableWidgetItem(new_val);
-            ui_->changesTableWidget->setItem(i, 1, oldItem);
-            ui_->changesTableWidget->setItem(i, 2, newItem);
+            label->setText("?");
+            label->setToolTip(value);
         }
     }
+    return label;
 }
 
-void CountryHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(history_.size()))
-        return;
-
-    const auto& country = history_[version_index];
+void CountryHistoryDialog::displayFullDetails(int index) {
+    const auto& country = history_[index];
 
     ui_->alpha2CodeValue->setText(QString::fromStdString(country.alpha2_code));
     ui_->alpha3CodeValue->setText(QString::fromStdString(country.alpha3_code));
@@ -312,181 +164,24 @@ void CountryHistoryDialog::displayFullDetailsTab(int version_index) {
     ui_->recordedAtValue->setText(relative_time_helper::format(country.recorded_at));
 }
 
-CountryHistoryDialog::DiffResult
-CountryHistoryDialog::calculateDiff(const refdata::domain::country& current,
-                                    const refdata::domain::country& previous) {
-
-    DiffResult diffs;
-
-    // Helper to check string field differences
-    auto checkDiffString = [&diffs](const QString& fieldName,
-                                    const std::string& currentVal,
-                                    const std::string& previousVal) {
-        if (currentVal != previousVal) {
-            diffs.append(
-                {fieldName,
-                 {QString::fromStdString(previousVal), QString::fromStdString(currentVal)}});
-        }
-    };
-
-    // Compare string fields
-    checkDiffString("Alpha-2 Code", current.alpha2_code, previous.alpha2_code);
-    checkDiffString("Alpha-3 Code", current.alpha3_code, previous.alpha3_code);
-    checkDiffString("Numeric Code", current.numeric_code, previous.numeric_code);
-    checkDiffString("Name", current.name, previous.name);
-    checkDiffString("Official Name", current.official_name, previous.official_name);
-
-    // Compare change management fields
-    checkDiffString("Change Reason", current.change_reason_code, previous.change_reason_code);
-    checkDiffString("Commentary", current.change_commentary, previous.change_commentary);
-
-    // Compare image_id (flag)
-    if (current.image_id != previous.image_id) {
-        auto formatImageId = [](const std::optional<boost::uuids::uuid>& id) {
-            if (!id.has_value()) {
-                return QString("(none)");
-            }
-            return QString::fromStdString(boost::uuids::to_string(*id));
-        };
-        diffs.append({"Flag", {formatImageId(previous.image_id), formatImageId(current.image_id)}});
-    }
-
-    return diffs;
-}
-
-void CountryHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_, &QAction::triggered, this, &CountryHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(openAction_, &QAction::triggered, this, &CountryHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert country to this version");
-    connect(revertAction_, &QAction::triggered, this, &CountryHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
-}
-
-void CountryHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(history_.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int CountryHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void CountryHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
+void CountryHistoryDialog::openVersionAt(int index) {
     const auto& country = history_[index];
     BOOST_LOG_SEV(lg(), info) << "Opening country version " << country.version
                               << " in read-only mode";
-
     emit openVersionRequested(country, country.version);
 }
 
-void CountryHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = history_[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(history_.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void CountryHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection, stamped with the latest version number.
     const auto& previous = history_[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version
-                              << " to version " << previous.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert Country",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(alpha2Code_)
-            .arg(current.version)
-            .arg(previous.version),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) with the latest version number
     refdata::domain::country countryToRevert = previous;
-    countryToRevert.version = history_[0].version;
+    countryToRevert.version = history_.front().version;
     emit revertVersionRequested(countryToRevert);
-}
-
-void CountryHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for country history: "
-                              << alpha2Code_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(alpha2Code_));
-    loadHistory();
-}
-
-QSize CountryHistoryDialog::sizeHint() const {
-    QSize baseSize = QWidget::sizeHint();
-
-    const int minimumWidth = 900;
-    const int minimumHeight = 600;
-
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void CountryHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "Country history marked as stale for: "
-                              << alpha2Code_.toStdString() << ", reloading...";
-
-    emit statusChanged(QString("Country %1 was modified - reloading history...").arg(alpha2Code_));
-
-    // Reload history data
-    loadHistory();
 }
 
 void CountryHistoryDialog::setImageCache(ImageCache* imageCache) {

--- a/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/CountryHistoryDialog.hpp"
+#include "ui_CountryHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
@@ -58,6 +59,8 @@ CountryHistoryDialog::CountryHistoryDialog(QString alpha2_code,
                          .titleLabel = ui_->titleLabel,
                          .closeButton = ui_->closeButton});
 }
+
+CountryHistoryDialog::~CountryHistoryDialog() = default;
 
 void CountryHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading country history for: "

--- a/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
@@ -172,14 +172,14 @@ void CountryHistoryDialog::openVersionAt(int index) {
 }
 
 void CountryHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection, stamped with the latest version number.
-    const auto& previous = history_[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version, stamped with the latest version number.
+    const auto& selected = history_[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version;
+                              << selected.version;
 
-    refdata::domain::country countryToRevert = previous;
+    refdata::domain::country countryToRevert = selected;
     countryToRevert.version = history_.front().version;
     emit revertVersionRequested(countryToRevert);
 }

--- a/projects/ores.qt/refdata/src/CurrencyController.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyController.cpp
@@ -462,10 +462,10 @@ void CurrencyController::onNotificationReceived(const QString& eventType,
             }
         } else if (key.startsWith("history:")) {
             if (auto* historyDialog = qobject_cast<CurrencyHistoryDialog*>(window->widget())) {
-                if (entityIds.isEmpty() || entityIds.contains(historyDialog->isoCode())) {
+                if (entityIds.isEmpty() || entityIds.contains(historyDialog->code())) {
                     historyDialog->markAsStale();
                     BOOST_LOG_SEV(lg(), debug) << "Marked history dialog as stale for: "
-                                               << historyDialog->isoCode().toStdString();
+                                               << historyDialog->code().toStdString();
                 }
             }
         }

--- a/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/CurrencyHistoryDialog.hpp"
+#include "ui_CurrencyHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -63,6 +64,8 @@ CurrencyHistoryDialog::CurrencyHistoryDialog(QString iso_code,
     resize(UiPersistence::restoreSize(QLatin1String("CurrencyHistoryDialog"),
                                       sizeHint()));
 }
+
+CurrencyHistoryDialog::~CurrencyHistoryDialog() = default;
 
 void CurrencyHistoryDialog::loadHistory() {
     BOOST_LOG_SEV(lg(), info) << "Loading currency history for: "

--- a/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
@@ -196,14 +196,14 @@ void CurrencyHistoryDialog::openVersionAt(int index) {
 }
 
 void CurrencyHistoryDialog::revertToVersionAt(int index) {
-    // The base has already confirmed with the user; revert TO the version
-    // older than the selection, stamped with the latest version number.
-    const auto& previous = history_.versions[index + 1];
+    // The base has already confirmed with the user; revert TO the
+    // selected version, stamped with the latest version number.
+    const auto& selected = history_.versions[index];
 
     BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << previous.version_number;
+                              << selected.version_number;
 
-    refdata::domain::currency currency = previous.data;
+    refdata::domain::currency currency = selected.data;
     currency.version = history_.versions.front().version_number;
     emit revertVersionRequested(currency);
 }

--- a/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
@@ -18,512 +18,199 @@
  *
  */
 #include "ores.qt/CurrencyHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
-#include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
 #include <QCloseEvent>
-#include <QDateTime>
-#include <QFutureWatcher>
-#include <QIcon>
 #include <QLabel>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-const QIcon& CurrencyHistoryDialog::getHistoryIcon() const {
-    static const QIcon historyIcon =
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
-    return historyIcon;
+namespace {
+
+QString formatImageId(const std::optional<boost::uuids::uuid>& id) {
+    if (!id.has_value())
+        return QStringLiteral("(none)");
+    return QString::fromStdString(boost::uuids::to_string(*id));
+}
+
 }
 
 CurrencyHistoryDialog::CurrencyHistoryDialog(QString iso_code,
                                              ClientManager* clientManager,
                                              QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CurrencyHistoryDialog)
     , clientManager_(clientManager)
     , imageCache_(nullptr)
-    , isoCode_(std::move(iso_code))
-    , toolBar_(nullptr)
-    , reloadAction_(nullptr)
-    , openAction_(nullptr)
-    , revertAction_(nullptr) {
+    , isoCode_(std::move(iso_code)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating currency history widget for: " << isoCode_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating currency history widget for: "
+                              << isoCode_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
 
-    setupToolbar();
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 
-    connect(ui_->versionListWidget,
-            &QTableWidget::currentCellChanged,
-            this,
-            [this](int currentRow, int, int, int) { onVersionSelected(currentRow); });
-
-    // Double-click opens the version in read-only mode
-    connect(ui_->versionListWidget, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
-        onOpenClicked();
-    });
-
-    ui_->versionListWidget->setAlternatingRowColors(true);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->resizeRowsToContents();
-
-    QHeaderView* versionVerticalHeader = ui_->versionListWidget->verticalHeader();
-    QHeaderView* versionHorizontalHeader = ui_->versionListWidget->horizontalHeader();
-    versionVerticalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-    versionHorizontalHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->changesTableWidget->setColumnWidth(0, 200);
-    ui_->changesTableWidget->setColumnWidth(1, 200);
-
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-
-    updateButtonStates();
-    resize(UiPersistence::restoreSize(QLatin1String("CurrencyHistoryDialog"), sizeHint()));
-}
-
-CurrencyHistoryDialog::~CurrencyHistoryDialog() {
-    BOOST_LOG_SEV(lg(), info) << "Destroying currency history widget";
-
-    const auto watchers = findChildren<QFutureWatcherBase*>();
-    for (auto* watcher : watchers) {
-        disconnect(watcher, nullptr, this, nullptr);
-        watcher->cancel();
-    }
+    resize(UiPersistence::restoreSize(QLatin1String("CurrencyHistoryDialog"),
+                                      sizeHint()));
 }
 
 void CurrencyHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading currency history for: " << isoCode_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading currency history for: "
+                              << isoCode_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_currency_history_response, std::string>;
-    QPointer<CurrencyHistoryDialog> self = this;
-    const auto iso_code = isoCode_.toStdString();
+    refdata::messaging::get_currency_history_request request;
+    request.iso_code = isoCode_.toStdString();
 
-    QFuture<HistoryResult> future = QtConcurrent::run([self, iso_code]() -> HistoryResult {
-        if (!self->clientManager_ || !self->clientManager_->isConnected()) {
-            return std::unexpected("Disconnected from server");
-        }
-        refdata::messaging::get_currency_history_request request;
-        request.iso_code = iso_code;
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        return std::move(*result);
-    });
-
-    // Use watcher to handle results
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        if (!self)
-            return;
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            self->onHistoryLoadError(QString::fromStdString(result.error()));
-            return;
-        }
-
-        if (!result->success) {
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
             BOOST_LOG_SEV(lg(), error) << "Response was not success.";
-            self->onHistoryLoadError(QString::fromStdString(result->message));
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-
-        self->history_ = std::move(result->history);
-        self->onHistoryLoaded();
+        history_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(future);
 }
 
-void CurrencyHistoryDialog::onHistoryLoaded() {
-    BOOST_LOG_SEV(lg(), info) << "History loaded successfully: " << history_.versions.size()
-                              << " versions";
+int CurrencyHistoryDialog::historySize() const {
+    return static_cast<int>(history_.versions.size());
+}
 
-    const QIcon& cachedIcon = getHistoryIcon();
-    ui_->versionListWidget->setRowCount(0);
-    ui_->versionListWidget->setRowCount(history_.versions.size());
+HistoryDialogBase::VersionRow CurrencyHistoryDialog::versionRow(int index) const {
+    const auto& version = history_.versions[index];
+    return {.version = version.version_number,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.data.change_reason_code),
+                      QString::fromStdString(version.data.change_commentary)}};
+}
 
-    for (int i = 0; i < static_cast<int>(history_.versions.size()); ++i) {
-        const auto& version = history_.versions[i];
+QString CurrencyHistoryDialog::historyTitle() const {
+    const auto& latest = history_.versions.front();
+    return QString("Currency History: %1 - %2")
+        .arg(isoCode_)
+        .arg(QString::fromStdString(latest.data.name));
+}
 
-        BOOST_LOG_SEV(lg(), trace)
-            << "Displaying version [" << i << "]: "
-            << "version_number=" << version.version_number
-            << ", data.version=" << version.data.version << ", modified_by=" << version.modified_by;
+HistoryDialogBase::DiffResult
+CurrencyHistoryDialog::calculateDiffAt(int current_index,
+                                       int previous_index) const {
+    const auto& current = history_.versions[current_index].data;
+    const auto& previous = history_.versions[previous_index].data;
 
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version_number));
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        auto* changeReasonItem =
-            new QTableWidgetItem(QString::fromStdString(version.data.change_reason_code));
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.data.change_commentary));
+    DiffResult diffs;
+    checkString(diffs, "ISO Code", current.iso_code, previous.iso_code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Numeric Code", current.numeric_code,
+                previous.numeric_code);
+    checkString(diffs, "Symbol", current.symbol, previous.symbol);
+    checkString(diffs, "Fraction Symbol", current.fraction_symbol,
+                previous.fraction_symbol);
+    checkString(diffs, "Rounding Type", current.rounding_type,
+                previous.rounding_type);
+    checkString(diffs, "Format", current.format, previous.format);
+    checkString(diffs, "Monetary Nature", current.monetary_nature,
+                previous.monetary_nature);
+    checkString(diffs, "Market Tier", current.market_tier,
+                previous.market_tier);
+    checkInt(diffs, "Fractions Per Unit", current.fractions_per_unit,
+             previous.fractions_per_unit);
+    checkInt(diffs, "Rounding Precision", current.rounding_precision,
+             previous.rounding_precision);
+    checkString(diffs, "Change Reason", current.change_reason_code,
+                previous.change_reason_code);
+    checkString(diffs, "Commentary", current.change_commentary,
+                previous.change_commentary);
 
-        versionItem->setIcon(cachedIcon);
-
-        ui_->versionListWidget->setItem(i, 0, versionItem);
-        ui_->versionListWidget->setItem(i, 1, recordedAtItem);
-        ui_->versionListWidget->setItem(i, 2, modifiedByItem);
-        ui_->versionListWidget->setItem(i, 3, changeReasonItem);
-        ui_->versionListWidget->setItem(i, 4, commentaryItem);
+    if (current.image_id != previous.image_id) {
+        diffs.append({"Flag",
+                      {formatImageId(previous.image_id),
+                       formatImageId(current.image_id)}});
     }
 
-    if (!history_.versions.empty())
-        ui_->versionListWidget->selectRow(0);
-
-    if (!history_.versions.empty()) {
-        const auto& latest = history_.versions[0];
-        ui_->titleLabel->setText(QString("Currency History: %1 - %2")
-                                     .arg(isoCode_)
-                                     .arg(QString::fromStdString(latest.data.name)));
-    }
-
-    updateButtonStates();
-
-    emit statusChanged(QString("Loaded %1 versions").arg(history_.versions.size()));
+    return diffs;
 }
 
-void CurrencyHistoryDialog::onHistoryLoadError(const QString& error_msg) {
-    BOOST_LOG_SEV(lg(), error) << "Error loading history: " << error_msg.toStdString();
+QWidget* CurrencyHistoryDialog::changeCellWidget(const QString& field,
+                                                 const QString& value) {
+    // Show flag icons instead of image UUIDs.
+    if (field != "Flag" || !imageCache_)
+        return nullptr;
 
-    emit errorOccurred(QString("Failed to load currency history: %1").arg(error_msg));
-    MessageBoxHelper::critical(
-        this, "History Load Error", QString("Failed to load currency history:\n%1").arg(error_msg));
-}
+    auto* label = new QLabel();
+    label->setAlignment(Qt::AlignCenter);
+    label->setFixedSize(32, 32);
 
-void CurrencyHistoryDialog::onVersionSelected(int index) {
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    BOOST_LOG_SEV(lg(), trace) << "Version selected: " << index;
-
-    displayChangesTab(index);
-    displayFullDetailsTab(index);
-}
-
-void CurrencyHistoryDialog::displayChangesTab(int version_index) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (version_index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    const auto& current = history_.versions[version_index];
-
-    // If this is the first (oldest) version, there's nothing to diff against so
-    // leave the changes table empty
-    if (version_index == static_cast<int>(history_.versions.size()) - 1) {
-        BOOST_LOG_SEV(lg(), trace) << "No previous version to diff against for oldest version";
-        return;
-    }
-
-    // Calculate diff with previous version
-    const auto& previous = history_.versions[version_index + 1];
-
-    BOOST_LOG_SEV(lg(), trace) << "Calculating diff between version " << current.version_number
-                               << " and " << previous.version_number;
-    BOOST_LOG_SEV(lg(), trace) << "Current name: " << current.data.name
-                               << ", Previous name: " << previous.data.name;
-
-    auto diffs = calculateDiff(current, previous);
-
-    BOOST_LOG_SEV(lg(), trace) << "Found " << diffs.size() << " differences";
-
-    ui_->changesTableWidget->setRowCount(diffs.size());
-
-    for (int i = 0; i < diffs.size(); ++i) {
-        const auto& [field, values] = diffs[i];
-        const auto& [old_val, new_val] = values;
-
-        auto* fieldItem = new QTableWidgetItem(field);
-        ui_->changesTableWidget->setItem(i, 0, fieldItem);
-
-        // Special handling for Flag field - show SVG icons instead of UUIDs
-        if (field == "Flag" && imageCache_) {
-            // Create label widgets to show the flag icons
-            auto createFlagLabel = [this](const QString& imageIdStr) -> QWidget* {
-                auto* label = new QLabel();
-                label->setAlignment(Qt::AlignCenter);
-                label->setFixedSize(32, 32);
-
-                if (imageIdStr == "(none)") {
-                    QIcon noFlagIcon = imageCache_->getNoFlagIcon();
-                    if (!noFlagIcon.isNull()) {
-                        label->setPixmap(noFlagIcon.pixmap(24, 24));
-                    } else {
-                        label->setText("-");
-                    }
-                } else {
-                    // Get the icon using the UUID string
-                    QIcon icon = imageCache_->getIcon(imageIdStr.toStdString());
-                    if (!icon.isNull()) {
-                        label->setPixmap(icon.pixmap(24, 24));
-                    } else {
-                        label->setText("?");
-                        label->setToolTip(imageIdStr);
-                    }
-                }
-                return label;
-            };
-
-            ui_->changesTableWidget->setCellWidget(i, 1, createFlagLabel(old_val));
-            ui_->changesTableWidget->setCellWidget(i, 2, createFlagLabel(new_val));
+    if (value == "(none)") {
+        QIcon noFlagIcon = imageCache_->getNoFlagIcon();
+        if (!noFlagIcon.isNull())
+            label->setPixmap(noFlagIcon.pixmap(24, 24));
+        else
+            label->setText("-");
+    } else {
+        QIcon icon = imageCache_->getIcon(value.toStdString());
+        if (!icon.isNull()) {
+            label->setPixmap(icon.pixmap(24, 24));
         } else {
-            auto* oldItem = new QTableWidgetItem(old_val);
-            auto* newItem = new QTableWidgetItem(new_val);
-            ui_->changesTableWidget->setItem(i, 1, oldItem);
-            ui_->changesTableWidget->setItem(i, 2, newItem);
+            label->setText("?");
+            label->setToolTip(value);
         }
     }
+    return label;
 }
 
-void CurrencyHistoryDialog::displayFullDetailsTab(int version_index) {
-    if (version_index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    const auto& version = history_.versions[version_index];
+void CurrencyHistoryDialog::displayFullDetails(int index) {
+    const auto& version = history_.versions[index];
     const auto& data = version.data;
 
     ui_->isoCodeValue->setText(QString::fromStdString(data.iso_code));
     ui_->nameValue->setText(QString::fromStdString(data.name));
     ui_->numericCodeValue->setText(QString::fromStdString(data.numeric_code));
     ui_->symbolValue->setText(QString::fromStdString(data.symbol));
-    ui_->fractionSymbolValue->setText(QString::fromStdString(data.fraction_symbol));
-    ui_->fractionsPerUnitValue->setText(QString::number(data.fractions_per_unit));
+    ui_->fractionSymbolValue->setText(
+        QString::fromStdString(data.fraction_symbol));
+    ui_->fractionsPerUnitValue->setText(
+        QString::number(data.fractions_per_unit));
     ui_->versionNumberValue->setText(QString::number(version.version_number));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
 }
 
-CurrencyHistoryDialog::DiffResult
-CurrencyHistoryDialog::calculateDiff(const refdata::domain::currency_version& current,
-                                     const refdata::domain::currency_version& previous) {
-
-    DiffResult diffs;
-
-    // Helper to check string field differences
-    auto checkDiffString = [&diffs](const QString& fieldName,
-                                    const std::string& currentVal,
-                                    const std::string& previousVal) {
-        if (currentVal != previousVal) {
-            diffs.append(
-                {fieldName,
-                 {QString::fromStdString(previousVal), QString::fromStdString(currentVal)}});
-        }
-    };
-
-    // Helper to check integer field differences
-    auto checkDiffInt = [&diffs](const QString& fieldName, int currentVal, int previousVal) {
-        if (currentVal != previousVal) {
-            diffs.append({fieldName, {QString::number(previousVal), QString::number(currentVal)}});
-        }
-    };
-
-    // Compare string fields
-    checkDiffString("ISO Code", current.data.iso_code, previous.data.iso_code);
-    checkDiffString("Name", current.data.name, previous.data.name);
-    checkDiffString("Numeric Code", current.data.numeric_code, previous.data.numeric_code);
-    checkDiffString("Symbol", current.data.symbol, previous.data.symbol);
-    checkDiffString("Fraction Symbol", current.data.fraction_symbol, previous.data.fraction_symbol);
-    checkDiffString("Rounding Type", current.data.rounding_type, previous.data.rounding_type);
-    checkDiffString("Format", current.data.format, previous.data.format);
-    checkDiffString("Monetary Nature", current.data.monetary_nature, previous.data.monetary_nature);
-    checkDiffString("Market Tier", current.data.market_tier, previous.data.market_tier);
-
-    // Compare integer fields
-    checkDiffInt(
-        "Fractions Per Unit", current.data.fractions_per_unit, previous.data.fractions_per_unit);
-    checkDiffInt(
-        "Rounding Precision", current.data.rounding_precision, previous.data.rounding_precision);
-
-    // Compare change management fields
-    checkDiffString(
-        "Change Reason", current.data.change_reason_code, previous.data.change_reason_code);
-    checkDiffString("Commentary", current.data.change_commentary, previous.data.change_commentary);
-
-    // Compare image_id (flag)
-    if (current.data.image_id != previous.data.image_id) {
-        auto formatImageId = [](const std::optional<boost::uuids::uuid>& id) {
-            if (!id.has_value()) {
-                return QString("(none)");
-            }
-            return QString::fromStdString(boost::uuids::to_string(*id));
-        };
-        diffs.append(
-            {"Flag",
-             {formatImageId(previous.data.image_id), formatImageId(current.data.image_id)}});
-    }
-
-    return diffs;
-}
-
-void CurrencyHistoryDialog::setupToolbar() {
-    toolBar_ = new QToolBar(this);
-    toolBar_->setMovable(false);
-    toolBar_->setFloatable(false);
-
-    // Create Reload action
-    reloadAction_ = new QAction("Reload", this);
-    reloadAction_->setIcon(
-        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
-    reloadAction_->setToolTip("Reload history from server");
-    connect(reloadAction_, &QAction::triggered, this, &CurrencyHistoryDialog::onReloadClicked);
-    toolBar_->addAction(reloadAction_);
-
-    toolBar_->addSeparator();
-
-    // Create Open action
-    openAction_ = new QAction("Open", this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
-    openAction_->setToolTip("Open this version in read-only mode");
-    connect(openAction_, &QAction::triggered, this, &CurrencyHistoryDialog::onOpenClicked);
-    toolBar_->addAction(openAction_);
-
-    // Create Revert action
-    revertAction_ = new QAction("Revert", this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                          IconUtils::DefaultIconColor));
-    revertAction_->setToolTip("Revert currency to this version");
-    connect(revertAction_, &QAction::triggered, this, &CurrencyHistoryDialog::onRevertClicked);
-    toolBar_->addAction(revertAction_);
-
-    // Add toolbar to layout
-    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
-    if (mainLayout)
-        mainLayout->insertWidget(0, toolBar_);
-}
-
-void CurrencyHistoryDialog::updateButtonStates() {
-    const int index = selectedVersionIndex();
-    const bool hasSelection = index >= 0 && index < static_cast<int>(history_.versions.size());
-
-    if (openAction_)
-        openAction_->setEnabled(hasSelection);
-
-    if (revertAction_)
-        revertAction_->setEnabled(hasSelection);
-}
-
-int CurrencyHistoryDialog::selectedVersionIndex() const {
-    return ui_->versionListWidget->currentRow();
-}
-
-void CurrencyHistoryDialog::onOpenClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
+void CurrencyHistoryDialog::openVersionAt(int index) {
     const auto& version = history_.versions[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening currency version " << version.version_number
+    BOOST_LOG_SEV(lg(), info) << "Opening currency version "
+                              << version.version_number
                               << " in read-only mode";
-
     emit openVersionRequested(version.data, version.version_number);
 }
 
-void CurrencyHistoryDialog::onRevertClicked() {
-    const int index = selectedVersionIndex();
-    if (index < 0 || index >= static_cast<int>(history_.versions.size()))
-        return;
-
-    // Get the selected version and the previous (older) version
-    const auto& current = history_.versions[index];
-
-    // If this is the oldest version, there's no previous version to revert to
-    if (index == static_cast<int>(history_.versions.size()) - 1) {
-        BOOST_LOG_SEV(lg(), warn) << "Cannot revert oldest version - no previous version exists";
-        MessageBoxHelper::information(
-            this,
-            "Cannot Revert",
-            "This is the oldest version. There is no previous version to revert to.");
-        return;
-    }
-
-    // The "previous" version is the one we want to revert TO (the "old" side in the diff)
+void CurrencyHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the version
+    // older than the selection, stamped with the latest version number.
     const auto& previous = history_.versions[index + 1];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert from version " << current.version_number
-                              << " to version " << previous.version_number;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << previous.version_number;
 
-    // Confirm with user
-    auto reply = MessageBoxHelper::question(
-        this,
-        "Revert Currency",
-        QString("Are you sure you want to revert '%1' from version %2 back to version %3?\n\n"
-                "This will create a new version with the data from version %3.")
-            .arg(isoCode_)
-            .arg(current.version_number)
-            .arg(previous.version_number),
-        QMessageBox::Yes | QMessageBox::No);
-
-    if (reply != QMessageBox::Yes) {
-        BOOST_LOG_SEV(lg(), debug) << "Revert cancelled by user";
-        return;
-    }
-
-    // Use the PREVIOUS version's data (the "old" side of the diff) with the latest version number
     refdata::domain::currency currency = previous.data;
-    currency.version = history_.versions[0].version_number;
+    currency.version = history_.versions.front().version_number;
     emit revertVersionRequested(currency);
-}
-
-void CurrencyHistoryDialog::onReloadClicked() {
-    BOOST_LOG_SEV(lg(), info) << "Reload requested for currency history: "
-                              << isoCode_.toStdString();
-    emit statusChanged(QString("Reloading history for %1...").arg(isoCode_));
-    loadHistory();
 }
 
 void CurrencyHistoryDialog::closeEvent(QCloseEvent* event) {
     UiPersistence::saveSize(QLatin1String("CurrencyHistoryDialog"), this);
-    QWidget::closeEvent(event);
-}
-
-QSize CurrencyHistoryDialog::sizeHint() const {
-    // Call the base implementation first to get the minimum size required by
-    // the layout manager and its content's size policies.
-    QSize baseSize = QWidget::sizeHint();
-
-    // Define a reasonable minimum size for a history dialog. This ensures the
-    // two panes (Version List and Details/Changes) are comfortably visible.
-    // These numbers are chosen to fit most content without excessive manual
-    // calculation.
-    const int minimumWidth = 900;
-    const int minimumHeight = 600;
-
-    // Return the maximum of the base size (to accommodate large text/UI
-    // elements) and the defined minimum size.
-    return {qMax(baseSize.width(), minimumWidth), qMax(baseSize.height(), minimumHeight)};
-}
-
-void CurrencyHistoryDialog::markAsStale() {
-    BOOST_LOG_SEV(lg(), info) << "Currency history marked as stale for: " << isoCode_.toStdString()
-                              << ", reloading...";
-
-    emit statusChanged(QString("Currency %1 was modified - reloading history...").arg(isoCode_));
-
-    // Reload history data
-    loadHistory();
+    HistoryDialogBase::closeEvent(event);
 }
 
 void CurrencyHistoryDialog::setImageCache(ImageCache* imageCache) {

--- a/projects/ores.qt/refdata/src/CurrencyMarketTierHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyMarketTierHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/CurrencyMarketTierHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
 #include "ui_CurrencyMarketTierHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,249 +30,80 @@ using namespace ores::logging;
 CurrencyMarketTierHistoryDialog::CurrencyMarketTierHistoryDialog(const QString& code,
                                                                  ClientManager* clientManager,
                                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::CurrencyMarketTierHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-CurrencyMarketTierHistoryDialog::~CurrencyMarketTierHistoryDialog() {
-    delete ui_;
-}
-
-void CurrencyMarketTierHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void CurrencyMarketTierHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void CurrencyMarketTierHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &CurrencyMarketTierHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &CurrencyMarketTierHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &CurrencyMarketTierHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+CurrencyMarketTierHistoryDialog::~CurrencyMarketTierHistoryDialog() = default;
 
 void CurrencyMarketTierHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for currency market tier: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<CurrencyMarketTierHistoryDialog> self = this;
+    refdata::messaging::get_currency_market_tier_history_request request;
+    request.tier = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::currency_market_tier> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_currency_market_tier_history_request request;
-        request.tier = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void CurrencyMarketTierHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int CurrencyMarketTierHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void CurrencyMarketTierHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+CurrencyMarketTierHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void CurrencyMarketTierHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString CurrencyMarketTierHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void CurrencyMarketTierHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+CurrencyMarketTierHistoryDialog::calculateDiffAt(int current_index,
+                                                 int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void CurrencyMarketTierHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -287,37 +114,22 @@ void CurrencyMarketTierHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void CurrencyMarketTierHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void CurrencyMarketTierHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening currency market tier version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void CurrencyMarketTierHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void CurrencyMarketTierHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void CurrencyMarketTierHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/DataDomainHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DataDomainHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/DataDomainHistoryDialog.hpp"
 #include "ores.dq.api/messaging/data_organization_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_DataDomainHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,207 +31,79 @@ using namespace ores::logging;
 DataDomainHistoryDialog::DataDomainHistoryDialog(const QString& name,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::DataDomainHistoryDialog)
     , name_(name)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-DataDomainHistoryDialog::~DataDomainHistoryDialog() {
-    delete ui_;
-}
-
-void DataDomainHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(name_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void DataDomainHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void DataDomainHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &DataDomainHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &DataDomainHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &DataDomainHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+DataDomainHistoryDialog::~DataDomainHistoryDialog() = default;
 
 void DataDomainHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for data domain: "
+                               << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<DataDomainHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::data_domain> versions;
-    };
+    dq::messaging::get_data_domain_history_request request;
+    request.name = name_.toStdString();
 
-    auto task = [self, name = name_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_data_domain_history_request request;
-        request.name = name;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void DataDomainHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int DataDomainHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void DataDomainHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+DataDomainHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void DataDomainHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString DataDomainHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(name_);
 }
 
-void DataDomainHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+DataDomainHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void DataDomainHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
@@ -245,37 +112,22 @@ void DataDomainHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void DataDomainHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void DataDomainHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening data domain version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void DataDomainHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void DataDomainHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void DataDomainHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/DataLibrarianWindow.cpp
+++ b/projects/ores.qt/refdata/src/DataLibrarianWindow.cpp
@@ -25,7 +25,7 @@
 #include "ores.qt/DatasetViewDialog.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
-#include "ores.qt/PublicationHistoryDialog.hpp"
+#include "ores.qt/PublicationAuditDialog.hpp"
 #include "ores.qt/PublishBundleWizard.hpp"
 #include "ores.qt/PublishDatasetsDialog.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -203,9 +203,9 @@ void DataLibrarianWindow::setupToolbar() {
     publishAction_->setToolTip(tr("Publish selected datasets to production tables"));
     publishAction_->setEnabled(false);
 
-    publicationHistoryAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor), tr("History"));
-    publicationHistoryAction_->setToolTip(tr("View publication history"));
+    publicationAuditAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor), tr("Audit"));
+    publicationAuditAction_->setToolTip(tr("View publication audit"));
 
     toolbar_->addSeparator();
 
@@ -358,10 +358,10 @@ void DataLibrarianWindow::setupConnections() {
     connect(
         viewDatasetAction_, &QAction::triggered, this, &DataLibrarianWindow::onViewDatasetClicked);
     connect(publishAction_, &QAction::triggered, this, &DataLibrarianWindow::onPublishClicked);
-    connect(publicationHistoryAction_,
+    connect(publicationAuditAction_,
             &QAction::triggered,
             this,
-            &DataLibrarianWindow::onPublicationHistoryClicked);
+            &DataLibrarianWindow::onPublicationAuditClicked);
 
     connect(originDimensionsAction_,
             &QAction::triggered,
@@ -574,10 +574,10 @@ void DataLibrarianWindow::onPublishClicked() {
     dialog->exec();
 }
 
-void DataLibrarianWindow::onPublicationHistoryClicked() {
-    BOOST_LOG_SEV(lg(), debug) << "Opening publication history dialog";
+void DataLibrarianWindow::onPublicationAuditClicked() {
+    BOOST_LOG_SEV(lg(), debug) << "Opening publication audit dialog";
 
-    auto* dialog = new PublicationHistoryDialog(clientManager_, this);
+    auto* dialog = new PublicationAuditDialog(clientManager_, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->refresh();
     dialog->show();

--- a/projects/ores.qt/refdata/src/DatasetBundleHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DatasetBundleHistoryDialog.cpp
@@ -19,13 +19,9 @@
  */
 #include "ores.qt/DatasetBundleHistoryDialog.hpp"
 #include "ores.dq.api/messaging/dataset_bundle_protocol.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ui_DatasetBundleHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,246 +32,81 @@ DatasetBundleHistoryDialog::DatasetBundleHistoryDialog(const boost::uuids::uuid&
                                                        const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::DatasetBundleHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-DatasetBundleHistoryDialog::~DatasetBundleHistoryDialog() {
-    delete ui_;
-}
-
-void DatasetBundleHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void DatasetBundleHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void DatasetBundleHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &DatasetBundleHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &DatasetBundleHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &DatasetBundleHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+DatasetBundleHistoryDialog::~DatasetBundleHistoryDialog() = default;
 
 void DatasetBundleHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset bundle: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset bundle: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<DatasetBundleHistoryDialog> self = this;
+    dq::messaging::get_dataset_bundle_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::dataset_bundle> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        dq::messaging::get_dataset_bundle_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void DatasetBundleHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int DatasetBundleHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void DatasetBundleHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+DatasetBundleHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void DatasetBundleHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString DatasetBundleHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void DatasetBundleHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+DatasetBundleHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void DatasetBundleHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
@@ -286,37 +117,22 @@ void DatasetBundleHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void DatasetBundleHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void DatasetBundleHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening dataset bundle version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void DatasetBundleHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void DatasetBundleHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void DatasetBundleHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/DatasetHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DatasetHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/DatasetHistoryDialog.hpp"
 #include "ores.dq.api/messaging/dataset_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_DatasetHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -37,224 +32,90 @@ using namespace ores::logging;
 DatasetHistoryDialog::DatasetHistoryDialog(const boost::uuids::uuid& id,
                                            ClientManager* clientManager,
                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::DatasetHistoryDialog)
     , id_(id)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-DatasetHistoryDialog::~DatasetHistoryDialog() {
-    delete ui_;
-}
-
-void DatasetHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("Dataset History"));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void DatasetHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
+DatasetHistoryDialog::~DatasetHistoryDialog() = default;
 
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void DatasetHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &DatasetHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &DatasetHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &DatasetHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
+QString DatasetHistoryDialog::code() const {
+    return QString::fromStdString(boost::uuids::to_string(id_));
 }
 
 void DatasetHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset: "
+                               << boost::uuids::to_string(id_);
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<DatasetHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::dataset> versions;
-    };
+    dq::messaging::get_dataset_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_dataset_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void DatasetHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int DatasetHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void DatasetHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+DatasetHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void DatasetHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.catalog_name != previous.catalog_name)
-        addChange("Catalog",
-                  QString::fromStdString(previous.catalog_name.value_or("")),
-                  QString::fromStdString(current.catalog_name.value_or("")));
-    if (current.subject_area_name != previous.subject_area_name)
-        addChange("Subject Area",
-                  QString::fromStdString(previous.subject_area_name),
-                  QString::fromStdString(current.subject_area_name));
-    if (current.domain_name != previous.domain_name)
-        addChange("Domain",
-                  QString::fromStdString(previous.domain_name),
-                  QString::fromStdString(current.domain_name));
-    if (current.source_system_id != previous.source_system_id)
-        addChange("Source System",
-                  QString::fromStdString(previous.source_system_id),
-                  QString::fromStdString(current.source_system_id));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString DatasetHistoryDialog::historyTitle() const {
+    return QString("Dataset History");
 }
 
-void DatasetHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+DatasetHistoryDialog::calculateDiffAt(int current_index,
+                                      int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Catalog", current.catalog_name, previous.catalog_name);
+    checkString(diffs, "Subject Area", current.subject_area_name,
+                previous.subject_area_name);
+    checkString(diffs, "Domain", current.domain_name, previous.domain_name);
+    checkString(diffs, "Source System", current.source_system_id,
+                previous.source_system_id);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void DatasetHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->catalogValue->setText(QString::fromStdString(version.catalog_name.value_or("")));
     ui_->subjectAreaValue->setText(QString::fromStdString(version.subject_area_name));
@@ -267,37 +128,22 @@ void DatasetHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
-void DatasetHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void DatasetHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening dataset version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void DatasetHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void DatasetHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version. The server handles versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void DatasetHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/DayCountFractionTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DayCountFractionTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/DayCountFractionTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/day_count_fraction_type_protocol.hpp"
 #include "ui_DayCountFractionTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,284 +30,106 @@ using namespace ores::logging;
 DayCountFractionTypeHistoryDialog::DayCountFractionTypeHistoryDialog(const QString& code,
                                                                      ClientManager* clientManager,
                                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::DayCountFractionTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-DayCountFractionTypeHistoryDialog::~DayCountFractionTypeHistoryDialog() {
-    delete ui_;
-}
-
-void DayCountFractionTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void DayCountFractionTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void DayCountFractionTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &DayCountFractionTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &DayCountFractionTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &DayCountFractionTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+DayCountFractionTypeHistoryDialog::~DayCountFractionTypeHistoryDialog() = default;
 
 void DayCountFractionTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for day count fraction type: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<DayCountFractionTypeHistoryDialog> self = this;
+    trading::messaging::get_day_count_fraction_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::day_count_fraction_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_day_count_fraction_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void DayCountFractionTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int DayCountFractionTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void DayCountFractionTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+DayCountFractionTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void DayCountFractionTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString DayCountFractionTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void DayCountFractionTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+DayCountFractionTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                   int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void DayCountFractionTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void DayCountFractionTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void DayCountFractionTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening day count fraction type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void DayCountFractionTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void DayCountFractionTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void DayCountFractionTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/DepositConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DepositConventionHistoryDialog.cpp
@@ -18,342 +18,158 @@
  *
  */
 #include "ores.qt/DepositConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
 #include "ui_DepositConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+QString optionalBoolText(const std::optional<bool>& value) {
+    return value ? (*value ? QObject::tr("true") : QObject::tr("false"))
+                 : QObject::tr("(unset)");
+}
+
+QString optionalIntText(const std::optional<int>& value) {
+    return value ? QString::number(*value) : QObject::tr("(unset)");
+}
+
+}
+
 DepositConventionHistoryDialog::DepositConventionHistoryDialog(const QString& code,
                                                                ClientManager* clientManager,
                                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::DepositConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-DepositConventionHistoryDialog::~DepositConventionHistoryDialog() {
-    delete ui_;
-}
-
-void DepositConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void DepositConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void DepositConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &DepositConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &DepositConventionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &DepositConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+DepositConventionHistoryDialog::~DepositConventionHistoryDialog() = default;
 
 void DepositConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for deposit convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for deposit convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<DepositConventionHistoryDialog> self = this;
+    refdata::messaging::get_deposit_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_deposit_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_deposit_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->deposit_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.deposit_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void DepositConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int DepositConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void DepositConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+DepositConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void DepositConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
+QString DepositConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
+}
 
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+DepositConventionHistoryDialog::calculateDiffAt(int current_index,
+                                                int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.index_based != previous.index_based) {
-        addChange("Index Based",
-                  previous.index_based ? tr("true") : tr("false"),
-                  current.index_based ? tr("true") : tr("false"));
-    }
-
-    if (current.index != previous.index) {
-        addChange("Index",
-                  previous.index ? QString::fromStdString(*previous.index) : QString{},
-                  current.index ? QString::fromStdString(*current.index) : QString{});
-    }
-
-    if (current.calendar != previous.calendar) {
-        addChange("Calendar",
-                  previous.calendar ? QString::fromStdString(*previous.calendar) : QString{},
-                  current.calendar ? QString::fromStdString(*current.calendar) : QString{});
-    }
-
-    if (current.convention != previous.convention) {
-        addChange("Convention",
-                  previous.convention ? QString::fromStdString(*previous.convention) : QString{},
-                  current.convention ? QString::fromStdString(*current.convention) : QString{});
-    }
-
-    if (current.day_count_fraction != previous.day_count_fraction) {
-        addChange("Day Count Fraction",
-                  previous.day_count_fraction ?
-                      QString::fromStdString(*previous.day_count_fraction) :
-                      QString{},
-                  current.day_count_fraction ? QString::fromStdString(*current.day_count_fraction) :
-                                               QString{});
-    }
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkBool(diffs, "Index Based", current.index_based, previous.index_based);
+    checkString(diffs, "Index", current.index, previous.index);
+    checkString(diffs, "Calendar", current.calendar, previous.calendar);
+    checkString(diffs, "Convention", current.convention, previous.convention);
+    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
+                previous.day_count_fraction);
 
     if (current.end_of_month != previous.end_of_month) {
-        addChange("End Of Month",
-                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) :
-                                          tr("(unset)"),
-                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) :
-                                         tr("(unset)"));
+        diffs.append({"End Of Month",
+                      {optionalBoolText(previous.end_of_month),
+                       optionalBoolText(current.end_of_month)}});
     }
 
     if (current.settlement_days != previous.settlement_days) {
-        addChange(
-            "Settlement Days",
-            previous.settlement_days ? QString::number(*previous.settlement_days) : tr("(unset)"),
-            current.settlement_days ? QString::number(*current.settlement_days) : tr("(unset)"));
+        diffs.append({"Settlement Days",
+                      {optionalIntText(previous.settlement_days),
+                       optionalIntText(current.settlement_days)}});
     }
 
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+    return diffs;
 }
 
-void DepositConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
-
-    const auto& version = versions_[versionIndex];
+void DepositConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
     ui_->indexBasedValue->setText(version.index_based ? tr("true") : tr("false"));
-    ui_->indexValue->setText(version.index ? QString::fromStdString(*version.index) : QString{});
-    ui_->calendarValue->setText(version.calendar ? QString::fromStdString(*version.calendar) :
-                                                   QString{});
-    ui_->conventionValue->setText(version.convention ? QString::fromStdString(*version.convention) :
-                                                       QString{});
-    ui_->dayCountFractionValue->setText(version.day_count_fraction ?
-                                            QString::fromStdString(*version.day_count_fraction) :
-                                            QString{});
-    ui_->endOfMonthValue->setText(
-        version.end_of_month ? (*version.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
-    ui_->settlementDaysValue->setText(
-        version.settlement_days ? QString::number(*version.settlement_days) : tr("(unset)"));
+    ui_->indexValue->setText(optionalText(version.index));
+    ui_->calendarValue->setText(optionalText(version.calendar));
+    ui_->conventionValue->setText(optionalText(version.convention));
+    ui_->dayCountFractionValue->setText(optionalText(version.day_count_fraction));
+    ui_->endOfMonthValue->setText(optionalBoolText(version.end_of_month));
+    ui_->settlementDaysValue->setText(optionalIntText(version.settlement_days));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void DepositConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void DepositConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening deposit convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void DepositConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void DepositConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void DepositConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/FloatingIndexTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FloatingIndexTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/FloatingIndexTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/floating_index_type_protocol.hpp"
 #include "ui_FloatingIndexTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,282 +30,106 @@ using namespace ores::logging;
 FloatingIndexTypeHistoryDialog::FloatingIndexTypeHistoryDialog(const QString& code,
                                                                ClientManager* clientManager,
                                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::FloatingIndexTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-FloatingIndexTypeHistoryDialog::~FloatingIndexTypeHistoryDialog() {
-    delete ui_;
-}
-
-void FloatingIndexTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void FloatingIndexTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void FloatingIndexTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &FloatingIndexTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &FloatingIndexTypeHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &FloatingIndexTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+FloatingIndexTypeHistoryDialog::~FloatingIndexTypeHistoryDialog() = default;
 
 void FloatingIndexTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for floating index type: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<FloatingIndexTypeHistoryDialog> self = this;
+    trading::messaging::get_floating_index_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::floating_index_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_floating_index_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void FloatingIndexTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int FloatingIndexTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void FloatingIndexTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+FloatingIndexTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void FloatingIndexTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString FloatingIndexTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void FloatingIndexTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+FloatingIndexTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void FloatingIndexTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void FloatingIndexTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void FloatingIndexTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening floating index type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void FloatingIndexTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void FloatingIndexTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void FloatingIndexTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/FraConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FraConventionHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/FraConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
 #include "ui_FraConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,270 +30,106 @@ using namespace ores::logging;
 FraConventionHistoryDialog::FraConventionHistoryDialog(const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::FraConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-FraConventionHistoryDialog::~FraConventionHistoryDialog() {
-    delete ui_;
-}
-
-void FraConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void FraConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void FraConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &FraConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &FraConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &FraConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+FraConventionHistoryDialog::~FraConventionHistoryDialog() = default;
 
 void FraConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for FRA convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FRA convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<FraConventionHistoryDialog> self = this;
+    refdata::messaging::get_fra_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_fra_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_fra_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->fra_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.fra_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void FraConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int FraConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void FraConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+FraConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void FraConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.index != previous.index) {
-        addChange(
-            "Index", QString::fromStdString(previous.index), QString::fromStdString(current.index));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString FraConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void FraConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+FraConventionHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Index", current.index, previous.index);
+
+    return diffs;
+}
+
+void FraConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
     ui_->indexValue->setText(QString::fromStdString(version.index));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void FraConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void FraConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening FRA convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void FraConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void FraConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void FraConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/FxConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FxConventionHistoryDialog.cpp
@@ -18,339 +18,158 @@
  *
  */
 #include "ores.qt/FxConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
 #include "ui_FxConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+QString optionalBoolText(const std::optional<bool>& value) {
+    return value ? (*value ? QObject::tr("true") : QObject::tr("false"))
+                 : QObject::tr("(unset)");
+}
+
+}
+
 FxConventionHistoryDialog::FxConventionHistoryDialog(const QString& code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::FxConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-FxConventionHistoryDialog::~FxConventionHistoryDialog() {
-    delete ui_;
-}
-
-void FxConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void FxConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void FxConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &FxConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &FxConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &FxConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+FxConventionHistoryDialog::~FxConventionHistoryDialog() = default;
 
 void FxConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for FX convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FX convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<FxConventionHistoryDialog> self = this;
+    refdata::messaging::get_fx_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_fx_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_fx_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->fx_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.fx_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void FxConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int FxConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void FxConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+FxConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void FxConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
+QString FxConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
+}
 
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+FxConventionHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.source_currency != previous.source_currency) {
-        addChange("Source Currency",
-                  QString::fromStdString(previous.source_currency),
-                  QString::fromStdString(current.source_currency));
-    }
-
-    if (current.target_currency != previous.target_currency) {
-        addChange("Target Currency",
-                  QString::fromStdString(previous.target_currency),
-                  QString::fromStdString(current.target_currency));
-    }
-
-    if (current.spot_days != previous.spot_days) {
-        addChange(
-            "Spot Days", QString::number(previous.spot_days), QString::number(current.spot_days));
-    }
-
-    if (current.advance_calendar != previous.advance_calendar) {
-        addChange("Advance Calendar",
-                  previous.advance_calendar ? QString::fromStdString(*previous.advance_calendar) :
-                                              QString{},
-                  current.advance_calendar ? QString::fromStdString(*current.advance_calendar) :
-                                             QString{});
-    }
-
-    if (current.convention != previous.convention) {
-        addChange("Convention",
-                  previous.convention ? QString::fromStdString(*previous.convention) : QString{},
-                  current.convention ? QString::fromStdString(*current.convention) : QString{});
-    }
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Source Currency", current.source_currency,
+                previous.source_currency);
+    checkString(diffs, "Target Currency", current.target_currency,
+                previous.target_currency);
+    checkInt(diffs, "Spot Days", current.spot_days, previous.spot_days);
+    checkString(diffs, "Advance Calendar", current.advance_calendar,
+                previous.advance_calendar);
+    checkString(diffs, "Convention", current.convention, previous.convention);
 
     if (current.spot_relative != previous.spot_relative) {
-        addChange("Spot Relative",
-                  previous.spot_relative ? (*previous.spot_relative ? tr("true") : tr("false")) :
-                                           tr("(unset)"),
-                  current.spot_relative ? (*current.spot_relative ? tr("true") : tr("false")) :
-                                          tr("(unset)"));
+        diffs.append({"Spot Relative",
+                      {optionalBoolText(previous.spot_relative),
+                       optionalBoolText(current.spot_relative)}});
     }
 
     if (current.end_of_month != previous.end_of_month) {
-        addChange("End Of Month",
-                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) :
-                                          tr("(unset)"),
-                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) :
-                                         tr("(unset)"));
+        diffs.append({"End Of Month",
+                      {optionalBoolText(previous.end_of_month),
+                       optionalBoolText(current.end_of_month)}});
     }
 
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+    return diffs;
 }
 
-void FxConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
-
-    const auto& version = versions_[versionIndex];
+void FxConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->sourceCurrencyValue->setText(QString::fromStdString(version.source_currency));
-    ui_->targetCurrencyValue->setText(QString::fromStdString(version.target_currency));
+    ui_->sourceCurrencyValue->setText(
+        QString::fromStdString(version.source_currency));
+    ui_->targetCurrencyValue->setText(
+        QString::fromStdString(version.target_currency));
     ui_->spotDaysValue->setText(QString::number(version.spot_days));
-    ui_->advanceCalendarValue->setText(
-        version.advance_calendar ? QString::fromStdString(*version.advance_calendar) : QString{});
-    ui_->conventionValue->setText(version.convention ? QString::fromStdString(*version.convention) :
-                                                       QString{});
-    ui_->spotRelativeValue->setText(version.spot_relative ?
-                                        (*version.spot_relative ? tr("true") : tr("false")) :
-                                        tr("(unset)"));
-    ui_->endOfMonthValue->setText(
-        version.end_of_month ? (*version.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
+    ui_->advanceCalendarValue->setText(optionalText(version.advance_calendar));
+    ui_->conventionValue->setText(optionalText(version.convention));
+    ui_->spotRelativeValue->setText(optionalBoolText(version.spot_relative));
+    ui_->endOfMonthValue->setText(optionalBoolText(version.end_of_month));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void FxConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void FxConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening FX convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void FxConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void FxConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void FxConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/IborIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/IborIndexConventionHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/IborIndexConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
 #include "ui_IborIndexConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,304 +30,121 @@ using namespace ores::logging;
 IborIndexConventionHistoryDialog::IborIndexConventionHistoryDialog(const QString& code,
                                                                    ClientManager* clientManager,
                                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::IborIndexConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-IborIndexConventionHistoryDialog::~IborIndexConventionHistoryDialog() {
-    delete ui_;
-}
-
-void IborIndexConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void IborIndexConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void IborIndexConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &IborIndexConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &IborIndexConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &IborIndexConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+IborIndexConventionHistoryDialog::~IborIndexConventionHistoryDialog() = default;
 
 void IborIndexConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for IBOR index convention: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<IborIndexConventionHistoryDialog> self = this;
+    refdata::messaging::get_ibor_index_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_ibor_index_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_ibor_index_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->ibor_index_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.ibor_index_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void IborIndexConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int IborIndexConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void IborIndexConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+IborIndexConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void IborIndexConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.fixing_calendar != previous.fixing_calendar) {
-        addChange("Fixing Calendar",
-                  QString::fromStdString(previous.fixing_calendar),
-                  QString::fromStdString(current.fixing_calendar));
-    }
-
-    if (current.day_count_fraction != previous.day_count_fraction) {
-        addChange("Day Count Fraction",
-                  QString::fromStdString(previous.day_count_fraction),
-                  QString::fromStdString(current.day_count_fraction));
-    }
-
-    if (current.settlement_days != previous.settlement_days) {
-        addChange("Settlement Days",
-                  QString::number(previous.settlement_days),
-                  QString::number(current.settlement_days));
-    }
-
-    if (current.business_day_convention != previous.business_day_convention) {
-        addChange("Business Day Convention",
-                  QString::fromStdString(previous.business_day_convention),
-                  QString::fromStdString(current.business_day_convention));
-    }
-
-    if (current.end_of_month != previous.end_of_month) {
-        addChange("End Of Month",
-                  previous.end_of_month ? tr("true") : tr("false"),
-                  current.end_of_month ? tr("true") : tr("false"));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString IborIndexConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void IborIndexConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+IborIndexConventionHistoryDialog::calculateDiffAt(int current_index,
+                                                  int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Fixing Calendar", current.fixing_calendar,
+                previous.fixing_calendar);
+    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
+                previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days,
+             previous.settlement_days);
+    checkString(diffs, "Business Day Convention", current.business_day_convention,
+                previous.business_day_convention);
+    checkBool(diffs, "End Of Month", current.end_of_month, previous.end_of_month);
+
+    return diffs;
+}
+
+void IborIndexConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
-    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
+    ui_->fixingCalendarValue->setText(
+        QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(
+        QString::fromStdString(version.day_count_fraction));
     ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
     ui_->businessDayConventionValue->setText(
         QString::fromStdString(version.business_day_convention));
     ui_->endOfMonthValue->setText(version.end_of_month ? tr("true") : tr("false"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void IborIndexConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void IborIndexConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening IBOR index convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void IborIndexConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void IborIndexConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void IborIndexConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/LegTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/LegTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/LegTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/leg_type_protocol.hpp"
 #include "ui_LegTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,278 +30,106 @@ using namespace ores::logging;
 LegTypeHistoryDialog::LegTypeHistoryDialog(const QString& code,
                                            ClientManager* clientManager,
                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::LegTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-LegTypeHistoryDialog::~LegTypeHistoryDialog() {
-    delete ui_;
-}
-
-void LegTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void LegTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void LegTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &LegTypeHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &LegTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &LegTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+LegTypeHistoryDialog::~LegTypeHistoryDialog() = default;
 
 void LegTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for leg type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for leg type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<LegTypeHistoryDialog> self = this;
+    trading::messaging::get_leg_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::leg_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_leg_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void LegTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int LegTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void LegTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+LegTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void LegTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString LegTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void LegTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+LegTypeHistoryDialog::calculateDiffAt(int current_index,
+                                      int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void LegTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void LegTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void LegTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening leg type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void LegTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void LegTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void LegTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/MethodologyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/MethodologyHistoryDialog.cpp
@@ -19,278 +19,132 @@
  */
 #include "ores.qt/MethodologyHistoryDialog.hpp"
 #include "ores.dq.api/messaging/data_organization_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_MethodologyHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
-#include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return QString::fromStdString(value.value_or(""));
+}
+
+}
+
 MethodologyHistoryDialog::MethodologyHistoryDialog(const std::string& name,
                                                    ClientManager* clientManager,
                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::MethodologyHistoryDialog)
     , name_(name)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-MethodologyHistoryDialog::~MethodologyHistoryDialog() {
-    delete ui_;
-}
-
-void MethodologyHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("Methodology History"));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void MethodologyHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void MethodologyHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &MethodologyHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &MethodologyHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &MethodologyHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+MethodologyHistoryDialog::~MethodologyHistoryDialog() = default;
 
 void MethodologyHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for methodology: " << name_;
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<MethodologyHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::methodology> versions;
-    };
+    dq::messaging::get_methodology_history_request request;
+    request.code = name_;
 
-    auto task = [self, name = name_]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_methodology_history_request request;
-        request.code = name;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void MethodologyHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int MethodologyHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void MethodologyHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+MethodologyHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void MethodologyHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    if (current.logic_reference != previous.logic_reference)
-        addChange("Logic Reference",
-                  QString::fromStdString(previous.logic_reference.value_or("")),
-                  QString::fromStdString(current.logic_reference.value_or("")));
-    if (current.implementation_details != previous.implementation_details)
-        addChange("Implementation",
-                  QString::fromStdString(previous.implementation_details.value_or("")),
-                  QString::fromStdString(current.implementation_details.value_or("")));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString MethodologyHistoryDialog::historyTitle() const {
+    return QString("Methodology History");
 }
 
-void MethodologyHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+MethodologyHistoryDialog::calculateDiffAt(int current_index,
+                                          int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Logic Reference", current.logic_reference,
+                previous.logic_reference);
+    checkString(diffs, "Implementation", current.implementation_details,
+                previous.implementation_details);
+
+    return diffs;
+}
+
+void MethodologyHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->logicReferenceValue->setText(QString::fromStdString(version.logic_reference.value_or("")));
+    ui_->logicReferenceValue->setText(optionalText(version.logic_reference));
     ui_->implementationValue->setText(
-        QString::fromStdString(version.implementation_details.value_or("")));
+        optionalText(version.implementation_details));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void MethodologyHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void MethodologyHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening methodology version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void MethodologyHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void MethodologyHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void MethodologyHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/MonetaryNatureHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/MonetaryNatureHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/MonetaryNatureHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
 #include "ui_MonetaryNatureHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,288 +30,108 @@ using namespace ores::logging;
 MonetaryNatureHistoryDialog::MonetaryNatureHistoryDialog(const QString& code,
                                                          ClientManager* clientManager,
                                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::MonetaryNatureHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-MonetaryNatureHistoryDialog::~MonetaryNatureHistoryDialog() {
-    delete ui_;
-}
-
-void MonetaryNatureHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void MonetaryNatureHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void MonetaryNatureHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &MonetaryNatureHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &MonetaryNatureHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &MonetaryNatureHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+MonetaryNatureHistoryDialog::~MonetaryNatureHistoryDialog() = default;
 
 void MonetaryNatureHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for monetary nature: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for monetary nature: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<MonetaryNatureHistoryDialog> self = this;
+    refdata::messaging::get_monetary_nature_history_request request;
+    request.nature = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::monetary_nature> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_monetary_nature_history_request request;
-        request.nature = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void MonetaryNatureHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int MonetaryNatureHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void MonetaryNatureHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+MonetaryNatureHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void MonetaryNatureHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString MonetaryNatureHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void MonetaryNatureHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+MonetaryNatureHistoryDialog::calculateDiffAt(int current_index,
+                                             int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void MonetaryNatureHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void MonetaryNatureHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void MonetaryNatureHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening monetary nature version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void MonetaryNatureHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void MonetaryNatureHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void MonetaryNatureHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/NatureDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/NatureDimensionHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/NatureDimensionHistoryDialog.hpp"
 #include "ores.dq.api/messaging/dimension_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_NatureDimensionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,251 +31,107 @@ using namespace ores::logging;
 NatureDimensionHistoryDialog::NatureDimensionHistoryDialog(const QString& code,
                                                            ClientManager* clientManager,
                                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::NatureDimensionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-NatureDimensionHistoryDialog::~NatureDimensionHistoryDialog() {
-    delete ui_;
-}
-
-void NatureDimensionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void NatureDimensionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void NatureDimensionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &NatureDimensionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &NatureDimensionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &NatureDimensionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+NatureDimensionHistoryDialog::~NatureDimensionHistoryDialog() = default;
 
 void NatureDimensionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for nature dimension: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<NatureDimensionHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::nature_dimension> versions;
-    };
+    dq::messaging::get_nature_dimension_history_request request;
+    request.code = code_.toStdString();
 
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_nature_dimension_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void NatureDimensionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int NatureDimensionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void NatureDimensionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+NatureDimensionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void NatureDimensionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString NatureDimensionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void NatureDimensionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+NatureDimensionHistoryDialog::calculateDiffAt(int current_index,
+                                              int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void NatureDimensionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void NatureDimensionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void NatureDimensionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening nature dimension version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void NatureDimensionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void NatureDimensionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void NatureDimensionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/OisConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OisConventionHistoryDialog.cpp
@@ -18,386 +18,171 @@
  *
  */
 #include "ores.qt/OisConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
 #include "ui_OisConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 OisConventionHistoryDialog::OisConventionHistoryDialog(const QString& code,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::OisConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-OisConventionHistoryDialog::~OisConventionHistoryDialog() {
-    delete ui_;
-}
-
-void OisConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void OisConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void OisConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &OisConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &OisConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &OisConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+OisConventionHistoryDialog::~OisConventionHistoryDialog() = default;
 
 void OisConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for OIS convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for OIS convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<OisConventionHistoryDialog> self = this;
+    refdata::messaging::get_ois_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_ois_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_ois_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->ois_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.ois_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void OisConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int OisConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void OisConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+OisConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void OisConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
+QString OisConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
+}
 
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+OisConventionHistoryDialog::calculateDiffAt(int current_index,
+                                            int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.index != previous.index) {
-        addChange(
-            "Index", QString::fromStdString(previous.index), QString::fromStdString(current.index));
-    }
-
-    if (current.spot_lag != previous.spot_lag) {
-        addChange(
-            "Spot Lag", QString::number(previous.spot_lag), QString::number(current.spot_lag));
-    }
-
-    if (current.fixed_day_count_fraction != previous.fixed_day_count_fraction) {
-        addChange("Fixed Day Count Fraction",
-                  QString::fromStdString(previous.fixed_day_count_fraction),
-                  QString::fromStdString(current.fixed_day_count_fraction));
-    }
-
-    if (current.fixed_calendar != previous.fixed_calendar) {
-        addChange(
-            "Fixed Calendar",
-            previous.fixed_calendar ? QString::fromStdString(*previous.fixed_calendar) : QString{},
-            current.fixed_calendar ? QString::fromStdString(*current.fixed_calendar) : QString{});
-    }
-
-    if (current.payment_lag != previous.payment_lag) {
-        addChange("Payment Lag",
-                  previous.payment_lag ? QString::number(*previous.payment_lag) : tr("(unset)"),
-                  current.payment_lag ? QString::number(*current.payment_lag) : tr("(unset)"));
-    }
-
-    if (current.fixed_frequency != previous.fixed_frequency) {
-        addChange("Fixed Frequency",
-                  previous.fixed_frequency ? QString::fromStdString(*previous.fixed_frequency) :
-                                             QString{},
-                  current.fixed_frequency ? QString::fromStdString(*current.fixed_frequency) :
-                                            QString{});
-    }
-
-    if (current.fixed_convention != previous.fixed_convention) {
-        addChange("Fixed Convention",
-                  previous.fixed_convention ? QString::fromStdString(*previous.fixed_convention) :
-                                              QString{},
-                  current.fixed_convention ? QString::fromStdString(*current.fixed_convention) :
-                                             QString{});
-    }
-
-    if (current.fixed_payment_convention != previous.fixed_payment_convention) {
-        addChange("Fixed Payment Convention",
-                  previous.fixed_payment_convention ?
-                      QString::fromStdString(*previous.fixed_payment_convention) :
-                      QString{},
-                  current.fixed_payment_convention ?
-                      QString::fromStdString(*current.fixed_payment_convention) :
-                      QString{});
-    }
-
-    if (current.rule != previous.rule) {
-        addChange("Rule",
-                  previous.rule ? QString::fromStdString(*previous.rule) : QString{},
-                  current.rule ? QString::fromStdString(*current.rule) : QString{});
-    }
-
-    if (current.payment_calendar != previous.payment_calendar) {
-        addChange("Payment Calendar",
-                  previous.payment_calendar ? QString::fromStdString(*previous.payment_calendar) :
-                                              QString{},
-                  current.payment_calendar ? QString::fromStdString(*current.payment_calendar) :
-                                             QString{});
-    }
-
-    if (current.rate_cutoff != previous.rate_cutoff) {
-        addChange("Rate Cutoff",
-                  previous.rate_cutoff ? QString::number(*previous.rate_cutoff) : tr("(unset)"),
-                  current.rate_cutoff ? QString::number(*current.rate_cutoff) : tr("(unset)"));
-    }
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Index", current.index, previous.index);
+    checkInt(diffs, "Spot Lag", current.spot_lag, previous.spot_lag);
+    checkString(diffs, "Fixed Day Count Fraction",
+                current.fixed_day_count_fraction,
+                previous.fixed_day_count_fraction);
+    checkString(diffs, "Fixed Calendar", current.fixed_calendar,
+                previous.fixed_calendar);
+    checkInt(diffs, "Payment Lag", current.payment_lag, previous.payment_lag);
+    checkString(diffs, "Fixed Frequency", current.fixed_frequency,
+                previous.fixed_frequency);
+    checkString(diffs, "Fixed Convention", current.fixed_convention,
+                previous.fixed_convention);
+    checkString(diffs, "Fixed Payment Convention",
+                current.fixed_payment_convention,
+                previous.fixed_payment_convention);
+    checkString(diffs, "Rule", current.rule, previous.rule);
+    checkString(diffs, "Payment Calendar", current.payment_calendar,
+                previous.payment_calendar);
+    checkInt(diffs, "Rate Cutoff", current.rate_cutoff, previous.rate_cutoff);
 
     if (current.end_of_month != previous.end_of_month) {
-        addChange("End Of Month",
-                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) :
-                                          tr("(unset)"),
-                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) :
-                                         tr("(unset)"));
+        auto boolText = [this](const std::optional<bool>& v) {
+            return v ? (*v ? tr("true") : tr("false")) : tr("(unset)");
+        };
+        diffs.append({"End Of Month",
+                      {boolText(previous.end_of_month),
+                       boolText(current.end_of_month)}});
     }
 
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+    return diffs;
 }
 
-void OisConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
-
-    const auto& version = versions_[versionIndex];
+void OisConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
     ui_->indexValue->setText(QString::fromStdString(version.index));
     ui_->spotLagValue->setText(QString::number(version.spot_lag));
     ui_->fixedDayCountFractionValue->setText(
         QString::fromStdString(version.fixed_day_count_fraction));
-    ui_->fixedCalendarValue->setText(
-        version.fixed_calendar ? QString::fromStdString(*version.fixed_calendar) : QString{});
-    ui_->paymentLagValue->setText(version.payment_lag ? QString::number(*version.payment_lag) :
-                                                        tr("(unset)"));
-    ui_->fixedFrequencyValue->setText(
-        version.fixed_frequency ? QString::fromStdString(*version.fixed_frequency) : QString{});
-    ui_->fixedConventionValue->setText(
-        version.fixed_convention ? QString::fromStdString(*version.fixed_convention) : QString{});
+    ui_->fixedCalendarValue->setText(optionalText(version.fixed_calendar));
+    ui_->paymentLagValue->setText(version.payment_lag ?
+                                      QString::number(*version.payment_lag) :
+                                      tr("(unset)"));
+    ui_->fixedFrequencyValue->setText(optionalText(version.fixed_frequency));
+    ui_->fixedConventionValue->setText(optionalText(version.fixed_convention));
     ui_->fixedPaymentConventionValue->setText(
-        version.fixed_payment_convention ?
-            QString::fromStdString(*version.fixed_payment_convention) :
-            QString{});
-    ui_->ruleValue->setText(version.rule ? QString::fromStdString(*version.rule) : QString{});
-    ui_->paymentCalendarValue->setText(
-        version.payment_calendar ? QString::fromStdString(*version.payment_calendar) : QString{});
-    ui_->rateCutoffValue->setText(version.rate_cutoff ? QString::number(*version.rate_cutoff) :
-                                                        tr("(unset)"));
+        optionalText(version.fixed_payment_convention));
+    ui_->ruleValue->setText(optionalText(version.rule));
+    ui_->paymentCalendarValue->setText(optionalText(version.payment_calendar));
+    ui_->rateCutoffValue->setText(version.rate_cutoff ?
+                                      QString::number(*version.rate_cutoff) :
+                                      tr("(unset)"));
     ui_->endOfMonthValue->setText(
         version.end_of_month ? (*version.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void OisConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void OisConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening OIS convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void OisConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void OisConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void OisConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/OriginDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OriginDimensionHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/OriginDimensionHistoryDialog.hpp"
 #include "ores.dq.api/messaging/dimension_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_OriginDimensionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,280 +31,107 @@ using namespace ores::logging;
 OriginDimensionHistoryDialog::OriginDimensionHistoryDialog(const QString& code,
                                                            ClientManager* clientManager,
                                                            QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::OriginDimensionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-OriginDimensionHistoryDialog::~OriginDimensionHistoryDialog() {
-    delete ui_;
-}
-
-void OriginDimensionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void OriginDimensionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void OriginDimensionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &OriginDimensionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &OriginDimensionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &OriginDimensionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+OriginDimensionHistoryDialog::~OriginDimensionHistoryDialog() = default;
 
 void OriginDimensionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<OriginDimensionHistoryDialog> self = this;
+    dq::messaging::get_origin_dimension_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::origin_dimension> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        dq::messaging::get_origin_dimension_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void OriginDimensionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 3, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int OriginDimensionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void OriginDimensionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+OriginDimensionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void OriginDimensionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString OriginDimensionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void OriginDimensionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+OriginDimensionHistoryDialog::calculateDiffAt(int current_index,
+                                              int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void OriginDimensionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void OriginDimensionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void OriginDimensionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening origin dimension version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void OriginDimensionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void OriginDimensionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void OriginDimensionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/OvernightIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OvernightIndexConventionHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/OvernightIndexConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
 #include "ui_OvernightIndexConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -33,290 +29,115 @@ using namespace ores::logging;
 
 OvernightIndexConventionHistoryDialog::OvernightIndexConventionHistoryDialog(
     const QString& code, ClientManager* clientManager, QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::OvernightIndexConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-OvernightIndexConventionHistoryDialog::~OvernightIndexConventionHistoryDialog() {
-    delete ui_;
-}
-
-void OvernightIndexConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void OvernightIndexConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void OvernightIndexConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &OvernightIndexConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &OvernightIndexConventionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &OvernightIndexConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+OvernightIndexConventionHistoryDialog::~OvernightIndexConventionHistoryDialog() = default;
 
 void OvernightIndexConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for overnight index convention: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<OvernightIndexConventionHistoryDialog> self = this;
+    refdata::messaging::get_overnight_index_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_overnight_index_convention_history_response,
-                      std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_overnight_index_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->overnight_index_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.overnight_index_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void OvernightIndexConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int OvernightIndexConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void OvernightIndexConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+OvernightIndexConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void OvernightIndexConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.fixing_calendar != previous.fixing_calendar) {
-        addChange("Fixing Calendar",
-                  QString::fromStdString(previous.fixing_calendar),
-                  QString::fromStdString(current.fixing_calendar));
-    }
-
-    if (current.day_count_fraction != previous.day_count_fraction) {
-        addChange("Day Count Fraction",
-                  QString::fromStdString(previous.day_count_fraction),
-                  QString::fromStdString(current.day_count_fraction));
-    }
-
-    if (current.settlement_days != previous.settlement_days) {
-        addChange("Settlement Days",
-                  QString::number(previous.settlement_days),
-                  QString::number(current.settlement_days));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString OvernightIndexConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void OvernightIndexConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+OvernightIndexConventionHistoryDialog::calculateDiffAt(int current_index,
+                                                       int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Fixing Calendar", current.fixing_calendar,
+                previous.fixing_calendar);
+    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
+                previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days,
+             previous.settlement_days);
+
+    return diffs;
+}
+
+void OvernightIndexConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
-    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
+    ui_->fixingCalendarValue->setText(
+        QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(
+        QString::fromStdString(version.day_count_fraction));
     ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void OvernightIndexConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void OvernightIndexConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening overnight index convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void OvernightIndexConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void OvernightIndexConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void OvernightIndexConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/PaymentFrequencyTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/PaymentFrequencyTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/PaymentFrequencyTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/payment_frequency_type_protocol.hpp"
 #include "ui_PaymentFrequencyTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,284 +30,107 @@ using namespace ores::logging;
 PaymentFrequencyTypeHistoryDialog::PaymentFrequencyTypeHistoryDialog(const QString& code,
                                                                      ClientManager* clientManager,
                                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PaymentFrequencyTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PaymentFrequencyTypeHistoryDialog::~PaymentFrequencyTypeHistoryDialog() {
-    delete ui_;
-}
-
-void PaymentFrequencyTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PaymentFrequencyTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PaymentFrequencyTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PaymentFrequencyTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PaymentFrequencyTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &PaymentFrequencyTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PaymentFrequencyTypeHistoryDialog::~PaymentFrequencyTypeHistoryDialog() = default;
 
 void PaymentFrequencyTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for payment frequency type: "
                                << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PaymentFrequencyTypeHistoryDialog> self = this;
+    trading::messaging::get_payment_frequency_type_history_request request;
+    request.code = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::payment_frequency_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_payment_frequency_type_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PaymentFrequencyTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PaymentFrequencyTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PaymentFrequencyTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PaymentFrequencyTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PaymentFrequencyTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PaymentFrequencyTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PaymentFrequencyTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PaymentFrequencyTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                   int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void PaymentFrequencyTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PaymentFrequencyTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PaymentFrequencyTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening payment frequency type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PaymentFrequencyTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PaymentFrequencyTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PaymentFrequencyTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/PublicationAuditDialog.cpp
+++ b/projects/ores.qt/refdata/src/PublicationAuditDialog.cpp
@@ -17,7 +17,7 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.qt/PublicationHistoryDialog.hpp"
+#include "ores.qt/PublicationAuditDialog.hpp"
 #include "ores.dq.api/domain/publication_mode.hpp"
 #include "ores.dq.api/messaging/publication_protocol.hpp"
 #include "ores.qt/WidgetUtils.hpp"
@@ -33,24 +33,24 @@ namespace ores::qt {
 
 using namespace ores::logging;
 
-// PublicationHistoryModel implementation
+// PublicationAuditModel implementation
 
-PublicationHistoryModel::PublicationHistoryModel(QObject* parent)
+PublicationAuditModel::PublicationAuditModel(QObject* parent)
     : QAbstractTableModel(parent) {}
 
-int PublicationHistoryModel::rowCount(const QModelIndex& parent) const {
+int PublicationAuditModel::rowCount(const QModelIndex& parent) const {
     if (parent.isValid())
         return 0;
     return static_cast<int>(publications_.size());
 }
 
-int PublicationHistoryModel::columnCount(const QModelIndex& parent) const {
+int PublicationAuditModel::columnCount(const QModelIndex& parent) const {
     if (parent.isValid())
         return 0;
     return ColumnCount;
 }
 
-QVariant PublicationHistoryModel::data(const QModelIndex& index, int role) const {
+QVariant PublicationAuditModel::data(const QModelIndex& index, int role) const {
     if (!index.isValid() || index.row() >= static_cast<int>(publications_.size()))
         return QVariant();
 
@@ -97,7 +97,7 @@ QVariant PublicationHistoryModel::data(const QModelIndex& index, int role) const
 }
 
 QVariant
-PublicationHistoryModel::headerData(int section, Qt::Orientation orientation, int role) const {
+PublicationAuditModel::headerData(int section, Qt::Orientation orientation, int role) const {
     if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
         return QVariant();
 
@@ -123,22 +123,22 @@ PublicationHistoryModel::headerData(int section, Qt::Orientation orientation, in
     }
 }
 
-void PublicationHistoryModel::setPublications(
+void PublicationAuditModel::setPublications(
     const std::vector<dq::domain::publication>& publications) {
     beginResetModel();
     publications_ = publications;
     endResetModel();
 }
 
-void PublicationHistoryModel::clear() {
+void PublicationAuditModel::clear() {
     beginResetModel();
     publications_.clear();
     endResetModel();
 }
 
-// PublicationHistoryDialog implementation
+// PublicationAuditDialog implementation
 
-PublicationHistoryDialog::PublicationHistoryDialog(ClientManager* clientManager, QWidget* parent)
+PublicationAuditDialog::PublicationAuditDialog(ClientManager* clientManager, QWidget* parent)
     : QDialog(parent)
     , clientManager_(clientManager)
     , watcher_(new QFutureWatcher<FetchResult>(this)) {
@@ -147,21 +147,21 @@ PublicationHistoryDialog::PublicationHistoryDialog(ClientManager* clientManager,
     connect(watcher_,
             &QFutureWatcher<FetchResult>::finished,
             this,
-            &PublicationHistoryDialog::onPublicationsLoaded);
+            &PublicationAuditDialog::onPublicationsLoaded);
 }
 
-PublicationHistoryDialog::~PublicationHistoryDialog() = default;
+PublicationAuditDialog::~PublicationAuditDialog() = default;
 
-void PublicationHistoryDialog::setupUi() {
+void PublicationAuditDialog::setupUi() {
     WidgetUtils::setupComboBoxes(this);
-    setWindowTitle(tr("Publication History"));
+    setWindowTitle(tr("Publication Audit"));
     setMinimumSize(900, 500);
 
     auto* layout = new QVBoxLayout(this);
 
     // Table view
     tableView_ = new QTableView(this);
-    model_ = new PublicationHistoryModel(this);
+    model_ = new PublicationAuditModel(this);
     tableView_->setModel(model_);
     tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -176,19 +176,19 @@ void PublicationHistoryDialog::setupUi() {
     auto* refreshButton = buttonBox->addButton(tr("Refresh"), QDialogButtonBox::ActionRole);
     buttonBox->addButton(QDialogButtonBox::Close);
 
-    connect(refreshButton, &QPushButton::clicked, this, &PublicationHistoryDialog::refresh);
+    connect(refreshButton, &QPushButton::clicked, this, &PublicationAuditDialog::refresh);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
     layout->addWidget(buttonBox);
 }
 
-void PublicationHistoryDialog::refresh() {
+void PublicationAuditDialog::refresh() {
     if (!clientManager_ || !clientManager_->isConnected()) {
         BOOST_LOG_SEV(lg(), warn) << "Cannot refresh: not connected to server";
         return;
     }
 
-    BOOST_LOG_SEV(lg(), debug) << "Fetching publication history";
+    BOOST_LOG_SEV(lg(), debug) << "Fetching publication audit";
 
     auto future = QtConcurrent::run([this]() -> FetchResult {
         try {
@@ -211,7 +211,7 @@ void PublicationHistoryDialog::refresh() {
     watcher_->setFuture(future);
 }
 
-void PublicationHistoryDialog::onPublicationsLoaded() {
+void PublicationAuditDialog::onPublicationsLoaded() {
     auto result = watcher_->result();
 
     if (result.success) {
@@ -227,7 +227,7 @@ void PublicationHistoryDialog::onPublicationsLoaded() {
         emit statusMessage(tr("Loaded %1 publication records").arg(result.publications.size()));
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to load publications";
-        emit errorMessage(tr("Failed to load publication history"));
+        emit errorMessage(tr("Failed to load publication audit"));
     }
 }
 

--- a/projects/ores.qt/refdata/src/PurposeTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/PurposeTypeHistoryDialog.cpp
@@ -18,15 +18,11 @@
  *
  */
 #include "ores.qt/PurposeTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/purpose_type_protocol.hpp"
 #include "ui_PurposeTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,287 +31,110 @@ using namespace ores::logging;
 PurposeTypeHistoryDialog::PurposeTypeHistoryDialog(const QString& code,
                                                    ClientManager* clientManager,
                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PurposeTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PurposeTypeHistoryDialog::~PurposeTypeHistoryDialog() {
-    delete ui_;
-}
-
-void PurposeTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PurposeTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PurposeTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PurposeTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PurposeTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PurposeTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PurposeTypeHistoryDialog::~PurposeTypeHistoryDialog() = default;
 
 void PurposeTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for purpose type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for purpose type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PurposeTypeHistoryDialog> self = this;
+    refdata::messaging::get_purpose_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::purpose_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_purpose_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PurposeTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PurposeTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PurposeTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PurposeTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PurposeTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PurposeTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PurposeTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PurposeTypeHistoryDialog::calculateDiffAt(int current_index,
+                                          int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void PurposeTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PurposeTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PurposeTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening purpose type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PurposeTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PurposeTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PurposeTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/RoundingTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/RoundingTypeHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/RoundingTypeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/rounding_type_protocol.hpp"
 #include "ui_RoundingTypeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -34,287 +30,109 @@ using namespace ores::logging;
 RoundingTypeHistoryDialog::RoundingTypeHistoryDialog(const QString& code,
                                                      ClientManager* clientManager,
                                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::RoundingTypeHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-RoundingTypeHistoryDialog::~RoundingTypeHistoryDialog() {
-    delete ui_;
-}
-
-void RoundingTypeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void RoundingTypeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void RoundingTypeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &RoundingTypeHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &RoundingTypeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &RoundingTypeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+RoundingTypeHistoryDialog::~RoundingTypeHistoryDialog() = default;
 
 void RoundingTypeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for rounding type: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for rounding type: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<RoundingTypeHistoryDialog> self = this;
+    refdata::messaging::get_rounding_type_history_request request;
+    request.type = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::rounding_type> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_rounding_type_history_request request;
-        request.type = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void RoundingTypeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int RoundingTypeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void RoundingTypeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+RoundingTypeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void RoundingTypeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString RoundingTypeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void RoundingTypeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+RoundingTypeHistoryDialog::calculateDiffAt(int current_index,
+                                           int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void RoundingTypeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void RoundingTypeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void RoundingTypeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening rounding type version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void RoundingTypeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void RoundingTypeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void RoundingTypeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/SubjectAreaHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/SubjectAreaHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/SubjectAreaHistoryDialog.hpp"
 #include "ores.dq.api/messaging/data_organization_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_SubjectAreaHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -37,251 +32,109 @@ SubjectAreaHistoryDialog::SubjectAreaHistoryDialog(const QString& name,
                                                    const QString& domain_name,
                                                    ClientManager* clientManager,
                                                    QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::SubjectAreaHistoryDialog)
     , name_(name)
     , domain_name_(domain_name)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-SubjectAreaHistoryDialog::~SubjectAreaHistoryDialog() {
-    delete ui_;
-}
-
-void SubjectAreaHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1 (Domain: %2)").arg(name_, domain_name_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void SubjectAreaHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void SubjectAreaHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &SubjectAreaHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &SubjectAreaHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &SubjectAreaHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+SubjectAreaHistoryDialog::~SubjectAreaHistoryDialog() = default;
 
 void SubjectAreaHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for subject area: "
+                               << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<SubjectAreaHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::subject_area> versions;
-    };
+    dq::messaging::get_subject_area_history_request request;
+    request.key.name = name_.toStdString();
+    request.key.domain_name = domain_name_.toStdString();
 
-    auto task = [self,
-                 name = name_.toStdString(),
-                 domain_name = domain_name_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_subject_area_history_request request;
-        request.key.name = name;
-        request.key.domain_name = domain_name;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void SubjectAreaHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int SubjectAreaHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void SubjectAreaHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+SubjectAreaHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void SubjectAreaHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString SubjectAreaHistoryDialog::historyTitle() const {
+    return QString("History for: %1 (Domain: %2)").arg(name_, domain_name_);
 }
 
-void SubjectAreaHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+SubjectAreaHistoryDialog::calculateDiffAt(int current_index,
+                                          int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void SubjectAreaHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->domainNameValue->setText(QString::fromStdString(version.domain_name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void SubjectAreaHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void SubjectAreaHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening subject area version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void SubjectAreaHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void SubjectAreaHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void SubjectAreaHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/SwapConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/SwapConventionHistoryDialog.cpp
@@ -18,344 +18,149 @@
  *
  */
 #include "ores.qt/SwapConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
 #include "ui_SwapConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 SwapConventionHistoryDialog::SwapConventionHistoryDialog(const QString& code,
                                                          ClientManager* clientManager,
                                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::SwapConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-SwapConventionHistoryDialog::~SwapConventionHistoryDialog() {
-    delete ui_;
-}
-
-void SwapConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void SwapConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void SwapConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &SwapConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &SwapConventionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &SwapConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+SwapConventionHistoryDialog::~SwapConventionHistoryDialog() = default;
 
 void SwapConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for swap convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for swap convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<SwapConventionHistoryDialog> self = this;
+    refdata::messaging::get_swap_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_swap_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_swap_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->swap_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.swap_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void SwapConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int SwapConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void SwapConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+SwapConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void SwapConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.fixed_frequency != previous.fixed_frequency) {
-        addChange("Fixed Frequency",
-                  QString::fromStdString(previous.fixed_frequency),
-                  QString::fromStdString(current.fixed_frequency));
-    }
-
-    if (current.fixed_day_count_fraction != previous.fixed_day_count_fraction) {
-        addChange("Fixed Day Count Fraction",
-                  QString::fromStdString(previous.fixed_day_count_fraction),
-                  QString::fromStdString(current.fixed_day_count_fraction));
-    }
-
-    if (current.index != previous.index) {
-        addChange(
-            "Index", QString::fromStdString(previous.index), QString::fromStdString(current.index));
-    }
-
-    if (current.fixed_calendar != previous.fixed_calendar) {
-        addChange(
-            "Fixed Calendar",
-            previous.fixed_calendar ? QString::fromStdString(*previous.fixed_calendar) : QString{},
-            current.fixed_calendar ? QString::fromStdString(*current.fixed_calendar) : QString{});
-    }
-
-    if (current.fixed_convention != previous.fixed_convention) {
-        addChange("Fixed Convention",
-                  previous.fixed_convention ? QString::fromStdString(*previous.fixed_convention) :
-                                              QString{},
-                  current.fixed_convention ? QString::fromStdString(*current.fixed_convention) :
-                                             QString{});
-    }
-
-    if (current.float_frequency != previous.float_frequency) {
-        addChange("Float Frequency",
-                  previous.float_frequency ? QString::fromStdString(*previous.float_frequency) :
-                                             QString{},
-                  current.float_frequency ? QString::fromStdString(*current.float_frequency) :
-                                            QString{});
-    }
-
-    if (current.sub_periods_coupon_type != previous.sub_periods_coupon_type) {
-        addChange("Sub-Periods Coupon Type",
-                  previous.sub_periods_coupon_type ?
-                      QString::fromStdString(*previous.sub_periods_coupon_type) :
-                      QString{},
-                  current.sub_periods_coupon_type ?
-                      QString::fromStdString(*current.sub_periods_coupon_type) :
-                      QString{});
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString SwapConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void SwapConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+SwapConventionHistoryDialog::calculateDiffAt(int current_index,
+                                             int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Fixed Frequency", current.fixed_frequency,
+                previous.fixed_frequency);
+    checkString(diffs, "Fixed Day Count Fraction",
+                current.fixed_day_count_fraction,
+                previous.fixed_day_count_fraction);
+    checkString(diffs, "Index", current.index, previous.index);
+    checkString(diffs, "Fixed Calendar", current.fixed_calendar,
+                previous.fixed_calendar);
+    checkString(diffs, "Fixed Convention", current.fixed_convention,
+                previous.fixed_convention);
+    checkString(diffs, "Float Frequency", current.float_frequency,
+                previous.float_frequency);
+    checkString(diffs, "Sub-Periods Coupon Type",
+                current.sub_periods_coupon_type,
+                previous.sub_periods_coupon_type);
+
+    return diffs;
+}
+
+void SwapConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixedFrequencyValue->setText(QString::fromStdString(version.fixed_frequency));
+    ui_->fixedFrequencyValue->setText(
+        QString::fromStdString(version.fixed_frequency));
     ui_->fixedDayCountFractionValue->setText(
         QString::fromStdString(version.fixed_day_count_fraction));
     ui_->indexValue->setText(QString::fromStdString(version.index));
-    ui_->fixedCalendarValue->setText(
-        version.fixed_calendar ? QString::fromStdString(*version.fixed_calendar) : QString{});
-    ui_->fixedConventionValue->setText(
-        version.fixed_convention ? QString::fromStdString(*version.fixed_convention) : QString{});
-    ui_->floatFrequencyValue->setText(
-        version.float_frequency ? QString::fromStdString(*version.float_frequency) : QString{});
+    ui_->fixedCalendarValue->setText(optionalText(version.fixed_calendar));
+    ui_->fixedConventionValue->setText(optionalText(version.fixed_convention));
+    ui_->floatFrequencyValue->setText(optionalText(version.float_frequency));
     ui_->subPeriodsCouponTypeValue->setText(
-        version.sub_periods_coupon_type ? QString::fromStdString(*version.sub_periods_coupon_type) :
-                                          QString{});
+        optionalText(version.sub_periods_coupon_type));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void SwapConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void SwapConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening swap convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void SwapConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void SwapConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void SwapConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/TreatmentDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/TreatmentDimensionHistoryDialog.cpp
@@ -19,15 +19,10 @@
  */
 #include "ores.qt/TreatmentDimensionHistoryDialog.hpp"
 #include "ores.dq.api/messaging/dimension_protocol.hpp"
-#include "ores.qt/ColorConstants.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ui_TreatmentDimensionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -36,253 +31,107 @@ using namespace ores::logging;
 TreatmentDimensionHistoryDialog::TreatmentDimensionHistoryDialog(const QString& code,
                                                                  ClientManager* clientManager,
                                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::TreatmentDimensionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-TreatmentDimensionHistoryDialog::~TreatmentDimensionHistoryDialog() {
-    delete ui_;
-}
-
-void TreatmentDimensionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
     ui_->versionListWidget->setColumnCount(4);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void TreatmentDimensionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void TreatmentDimensionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &TreatmentDimensionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &TreatmentDimensionHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_,
-            &QAction::triggered,
-            this,
-            &TreatmentDimensionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+TreatmentDimensionHistoryDialog::~TreatmentDimensionHistoryDialog() = default;
 
 void TreatmentDimensionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<TreatmentDimensionHistoryDialog> self = this;
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<dq::domain::treatment_dimension> versions;
-    };
+    dq::messaging::get_treatment_dimension_history_request request;
+    request.code = code_.toStdString();
 
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_)
-            return {false, "Dialog closed", {}};
-
-        dq::messaging::get_treatment_dimension_history_request request;
-        request.code = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-        if (!response_result)
-            return {false, "Failed to communicate with server", {}};
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            emit self->errorOccurred(QString::fromStdString(result.message));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    watcher->setFuture(QtConcurrent::run(task));
 }
 
-void TreatmentDimensionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-        ui_->versionListWidget->setItem(
-            row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
-        ui_->versionListWidget->setItem(
-            row, 2, new QTableWidgetItem(QString::fromStdString(version.modified_by)));
-        ui_->versionListWidget->setItem(
-            row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
-    }
-
-    if (!versions_.empty())
-        ui_->versionListWidget->selectRow(0);
+int TreatmentDimensionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void TreatmentDimensionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+TreatmentDimensionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void TreatmentDimensionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size())
-        return;
-
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name)
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    if (current.description != previous.description)
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString TreatmentDimensionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void TreatmentDimensionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size())
-        return;
+HistoryDialogBase::DiffResult
+TreatmentDimensionHistoryDialog::calculateDiffAt(int current_index,
+                                                 int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description,
+                previous.description);
+
+    return diffs;
+}
+
+void TreatmentDimensionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void TreatmentDimensionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void TreatmentDimensionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening treatment dimension version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void TreatmentDimensionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void TreatmentDimensionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; the server handles
+    // versioning, so simply request the revert to the selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void TreatmentDimensionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/refdata/src/ZeroConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ZeroConventionHistoryDialog.cpp
@@ -18,337 +18,144 @@
  *
  */
 #include "ores.qt/ZeroConventionHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/zero_convention_protocol.hpp"
 #include "ui_ZeroConventionHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 ZeroConventionHistoryDialog::ZeroConventionHistoryDialog(const QString& code,
                                                          ClientManager* clientManager,
                                                          QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::ZeroConventionHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-ZeroConventionHistoryDialog::~ZeroConventionHistoryDialog() {
-    delete ui_;
-}
-
-void ZeroConventionHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void ZeroConventionHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void ZeroConventionHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &ZeroConventionHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &ZeroConventionHistoryDialog::onOpenVersionClicked);
-    connect(
-        revertAction_, &QAction::triggered, this, &ZeroConventionHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+ZeroConventionHistoryDialog::~ZeroConventionHistoryDialog() = default;
 
 void ZeroConventionHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for zero convention: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for zero convention: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<ZeroConventionHistoryDialog> self = this;
+    refdata::messaging::get_zero_convention_history_request request;
+    request.id = code_.toStdString();
 
-    using HistoryResult =
-        std::expected<refdata::messaging::get_zero_convention_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            refdata::messaging::get_zero_convention_history_request request;
-            request.id = code;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->zero_conventions);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.zero_conventions);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void ZeroConventionHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int ZeroConventionHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void ZeroConventionHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+ZeroConventionHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void ZeroConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.id != previous.id) {
-        addChange("Id", QString::fromStdString(previous.id), QString::fromStdString(current.id));
-    }
-
-    if (current.day_count_fraction != previous.day_count_fraction) {
-        addChange("Day Count Fraction",
-                  QString::fromStdString(previous.day_count_fraction),
-                  QString::fromStdString(current.day_count_fraction));
-    }
-
-    if (current.compounding != previous.compounding) {
-        addChange("Compounding",
-                  previous.compounding ? QString::fromStdString(*previous.compounding) : QString{},
-                  current.compounding ? QString::fromStdString(*current.compounding) : QString{});
-    }
-
-    if (current.compounding_frequency != previous.compounding_frequency) {
-        addChange("Compounding Frequency",
-                  previous.compounding_frequency ?
-                      QString::fromStdString(*previous.compounding_frequency) :
-                      QString{},
-                  current.compounding_frequency ?
-                      QString::fromStdString(*current.compounding_frequency) :
-                      QString{});
-    }
-
-    if (current.tenor_calendar != previous.tenor_calendar) {
-        addChange(
-            "Tenor Calendar",
-            previous.tenor_calendar ? QString::fromStdString(*previous.tenor_calendar) : QString{},
-            current.tenor_calendar ? QString::fromStdString(*current.tenor_calendar) : QString{});
-    }
-
-    if (current.spot_calendar != previous.spot_calendar) {
-        addChange(
-            "Spot Calendar",
-            previous.spot_calendar ? QString::fromStdString(*previous.spot_calendar) : QString{},
-            current.spot_calendar ? QString::fromStdString(*current.spot_calendar) : QString{});
-    }
-
-    if (current.roll_convention != previous.roll_convention) {
-        addChange("Roll Convention",
-                  previous.roll_convention ? QString::fromStdString(*previous.roll_convention) :
-                                             QString{},
-                  current.roll_convention ? QString::fromStdString(*current.roll_convention) :
-                                            QString{});
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString ZeroConventionHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void ZeroConventionHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+ZeroConventionHistoryDialog::calculateDiffAt(int current_index,
+                                             int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Id", current.id, previous.id);
+    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
+                previous.day_count_fraction);
+    checkString(diffs, "Compounding", current.compounding,
+                previous.compounding);
+    checkString(diffs, "Compounding Frequency", current.compounding_frequency,
+                previous.compounding_frequency);
+    checkString(diffs, "Tenor Calendar", current.tenor_calendar,
+                previous.tenor_calendar);
+    checkString(diffs, "Spot Calendar", current.spot_calendar,
+                previous.spot_calendar);
+    checkString(diffs, "Roll Convention", current.roll_convention,
+                previous.roll_convention);
+
+    return diffs;
+}
+
+void ZeroConventionHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
-    ui_->compoundingValue->setText(
-        version.compounding ? QString::fromStdString(*version.compounding) : QString{});
+    ui_->dayCountFractionValue->setText(
+        QString::fromStdString(version.day_count_fraction));
+    ui_->compoundingValue->setText(optionalText(version.compounding));
     ui_->compoundingFrequencyValue->setText(
-        version.compounding_frequency ? QString::fromStdString(*version.compounding_frequency) :
-                                        QString{});
-    ui_->tenorCalendarValue->setText(
-        version.tenor_calendar ? QString::fromStdString(*version.tenor_calendar) : QString{});
-    ui_->spotCalendarValue->setText(
-        version.spot_calendar ? QString::fromStdString(*version.spot_calendar) : QString{});
-    ui_->rollConventionValue->setText(
-        version.roll_convention ? QString::fromStdString(*version.roll_convention) : QString{});
+        optionalText(version.compounding_frequency));
+    ui_->tenorCalendarValue->setText(optionalText(version.tenor_calendar));
+    ui_->spotCalendarValue->setText(optionalText(version.spot_calendar));
+    ui_->rollConventionValue->setText(optionalText(version.roll_convention));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void ZeroConventionHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void ZeroConventionHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening zero convention version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void ZeroConventionHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void ZeroConventionHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void ZeroConventionHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionAuditDialog.hpp
+++ b/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionAuditDialog.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_QT_JOB_DEFINITION_HISTORY_DIALOG_HPP
-#define ORES_QT_JOB_DEFINITION_HISTORY_DIALOG_HPP
+#ifndef ORES_QT_JOB_DEFINITION_AUDIT_DIALOG_HPP
+#define ORES_QT_JOB_DEFINITION_AUDIT_DIALOG_HPP
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
@@ -28,23 +28,23 @@
 #include <boost/uuid/uuid.hpp>
 
 namespace Ui {
-class JobDefinitionHistoryDialog;
+class JobDefinitionAuditDialog;
 }
 
 namespace ores::qt {
 
 /**
- * @brief Dialog for viewing execution history (job_instance records) for a
+ * @brief Dialog for viewing the execution audit trail (job_instance records) for a
  * job definition.
  *
  * Shows all pg_cron run records for the given job, fetched via
  * get_job_history_request.
  */
-class JobDefinitionHistoryDialog final : public QWidget {
+class JobDefinitionAuditDialog final : public QWidget {
     Q_OBJECT
 
 private:
-    inline static std::string_view logger_name = "ores.qt.job_definition_history_dialog";
+    inline static std::string_view logger_name = "ores.qt.job_definition_audit_dialog";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
@@ -53,13 +53,13 @@ private:
     }
 
 public:
-    explicit JobDefinitionHistoryDialog(const boost::uuids::uuid& job_definition_id,
+    explicit JobDefinitionAuditDialog(const boost::uuids::uuid& job_definition_id,
                                         const QString& job_name,
                                         ClientManager* clientManager,
                                         QWidget* parent = nullptr);
-    ~JobDefinitionHistoryDialog() override;
+    ~JobDefinitionAuditDialog() override;
 
-    void loadHistory();
+    void refresh();
 
 signals:
     void statusChanged(const QString& message);
@@ -73,7 +73,7 @@ private:
     void setupConnections();
     void updateRunList();
 
-    Ui::JobDefinitionHistoryDialog* ui_;
+    Ui::JobDefinitionAuditDialog* ui_;
     boost::uuids::uuid job_definition_id_;
     QString job_name_;
     ClientManager* clientManager_;

--- a/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionController.hpp
+++ b/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionController.hpp
@@ -37,7 +37,7 @@ class DetachableMdiSubWindow;
 /**
  * @brief Controller for managing job definition windows and operations.
  *
- * Manages the lifecycle of job definition list, detail, and history windows.
+ * Manages the lifecycle of job definition list, detail, and audit windows.
  * Handles event subscriptions and coordinates between windows.
  */
 class JobDefinitionController final : public EntityController {
@@ -74,12 +74,12 @@ protected:
 private slots:
     void onShowDetails(const scheduler::domain::job_definition& definition);
     void onAddNewRequested();
-    void onShowHistory(const scheduler::domain::job_definition& definition);
+    void onShowAudit(const scheduler::domain::job_definition& definition);
 
 private:
     void showAddWindow();
     void showDetailWindow(const scheduler::domain::job_definition& definition);
-    void showHistoryWindow(const scheduler::domain::job_definition& definition);
+    void showAuditWindow(const scheduler::domain::job_definition& definition);
 
     ChangeReasonCache* changeReasonCache_;
     JobDefinitionMdiWindow* listWindow_;

--- a/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionMdiWindow.hpp
+++ b/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionMdiWindow.hpp
@@ -36,7 +36,7 @@ namespace ores::qt {
  * @brief MDI window for displaying and managing job definitions.
  *
  * Provides a table view of job definitions with toolbar actions
- * for reload, add, edit, delete, and viewing history.
+ * for reload, add, edit, delete, and viewing the execution audit.
  */
 class JobDefinitionMdiWindow final : public EntityListMdiWindow {
     Q_OBJECT
@@ -65,13 +65,13 @@ signals:
     void showDefinitionDetails(const scheduler::domain::job_definition& definition);
     void addNewRequested();
     void definitionDeleted(const QString& code);
-    void showDefinitionHistory(const scheduler::domain::job_definition& definition);
+    void showDefinitionAudit(const scheduler::domain::job_definition& definition);
 
 public slots:
     void addNew();
     void editSelected();
     void deleteSelected();
-    void viewHistorySelected();
+    void viewAuditSelected();
 
 private slots:
     void onDataLoaded();
@@ -105,7 +105,7 @@ private:
     QAction* addAction_;
     QAction* editAction_;
     QAction* deleteAction_;
-    QAction* historyAction_;
+    QAction* auditAction_;
 };
 
 }

--- a/projects/ores.qt/scheduler/modeling/ores.qt.scheduler.puml
+++ b/projects/ores.qt/scheduler/modeling/ores.qt.scheduler.puml
@@ -51,9 +51,9 @@ namespace ores #F2F2F2 {
             -username_ : string
             -definition_ : scheduler::domain::job_definition
         }
-        class JobDefinitionHistoryDialog {
+        class JobDefinitionAuditDialog {
             +parent : QWidget*
-            -ui_ : Ui::JobDefinitionHistoryDialog*
+            -ui_ : Ui::JobDefinitionAuditDialog*
             -job_definition_id_ : boost::uuids::uuid
             -job_name_ : QString
             -clientManager_ : ClientManager*

--- a/projects/ores.qt/scheduler/src/JobDefinitionAuditDialog.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionAuditDialog.cpp
@@ -17,12 +17,12 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.qt/JobDefinitionHistoryDialog.hpp"
+#include "ores.qt/JobDefinitionAuditDialog.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
 #include "ores.scheduler.api/rfl/reflectors.hpp"
-#include "ui_JobDefinitionHistoryDialog.h"
+#include "ui_JobDefinitionAuditDialog.h"
 #include <QFutureWatcher>
 #include <QHeaderView>
 #include <QtConcurrent>
@@ -58,12 +58,12 @@ QString format_duration(const scheduler::domain::job_instance& instance) {
 
 } // anonymous namespace
 
-JobDefinitionHistoryDialog::JobDefinitionHistoryDialog(const boost::uuids::uuid& job_definition_id,
+JobDefinitionAuditDialog::JobDefinitionAuditDialog(const boost::uuids::uuid& job_definition_id,
                                                        const QString& job_name,
                                                        ClientManager* clientManager,
                                                        QWidget* parent)
     : QWidget(parent)
-    , ui_(new Ui::JobDefinitionHistoryDialog)
+    , ui_(new Ui::JobDefinitionAuditDialog)
     , job_definition_id_(job_definition_id)
     , job_name_(job_name)
     , clientManager_(clientManager) {
@@ -73,15 +73,15 @@ JobDefinitionHistoryDialog::JobDefinitionHistoryDialog(const boost::uuids::uuid&
     setupConnections();
 }
 
-JobDefinitionHistoryDialog::~JobDefinitionHistoryDialog() {
+JobDefinitionAuditDialog::~JobDefinitionAuditDialog() {
     delete ui_;
 }
 
-void JobDefinitionHistoryDialog::setupUi() {
+void JobDefinitionAuditDialog::setupUi() {
     ui_->closeButton->setIcon(
         IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
-    ui_->titleLabel->setText(QString("Execution history: %1").arg(job_name_));
+    ui_->titleLabel->setText(QString("Execution audit: %1").arg(job_name_));
 
     // Columns: Run ID | Status | Start Time | End Time | Duration | Message
     ui_->versionListWidget->setColumnCount(6);
@@ -97,35 +97,35 @@ void JobDefinitionHistoryDialog::setupUi() {
     ui_->versionListWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
 }
 
-void JobDefinitionHistoryDialog::setupConnections() {
+void JobDefinitionAuditDialog::setupConnections() {
     connect(ui_->versionListWidget,
             &QTableWidget::itemSelectionChanged,
             this,
-            &JobDefinitionHistoryDialog::onRunSelected);
+            &JobDefinitionAuditDialog::onRunSelected);
     connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
         if (window())
             window()->close();
     });
 }
 
-void JobDefinitionHistoryDialog::loadHistory() {
+void JobDefinitionAuditDialog::refresh() {
     if (!clientManager_ || !clientManager_->isConnected()) {
         emit errorOccurred(tr("Not connected to server"));
         return;
     }
 
-    BOOST_LOG_SEV(lg(), debug) << "Loading execution history for: " << job_name_.toStdString();
-    emit statusChanged(tr("Loading execution history…"));
+    BOOST_LOG_SEV(lg(), debug) << "Loading execution audit for: " << job_name_.toStdString();
+    emit statusChanged(tr("Loading execution audit…"));
 
-    QPointer<JobDefinitionHistoryDialog> self = this;
+    QPointer<JobDefinitionAuditDialog> self = this;
 
-    struct HistoryResult {
+    struct AuditResult {
         bool success;
         std::string message;
         std::vector<scheduler::domain::job_instance> instances;
     };
 
-    auto task = [self, id = job_definition_id_]() -> HistoryResult {
+    auto task = [self, id = job_definition_id_]() -> AuditResult {
         if (!self || !self->clientManager_) {
             return {false, "Dialog closed", {}};
         }
@@ -146,8 +146,8 @@ void JobDefinitionHistoryDialog::loadHistory() {
                 std::move(response_result->instances)};
     };
 
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
+    auto* watcher = new QFutureWatcher<AuditResult>(self);
+    connect(watcher, &QFutureWatcher<AuditResult>::finished, self, [self, watcher]() {
         auto result = watcher->result();
         watcher->deleteLater();
 
@@ -157,16 +157,16 @@ void JobDefinitionHistoryDialog::loadHistory() {
             emit self->statusChanged(
                 QString("Loaded %1 execution record(s)").arg(self->instances_.size()));
         } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
+            BOOST_LOG_SEV(lg(), error) << "Audit load failed: " << result.message;
             emit self->errorOccurred(QString::fromStdString(result.message));
         }
     });
 
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
+    QFuture<AuditResult> future = QtConcurrent::run(task);
     watcher->setFuture(future);
 }
 
-void JobDefinitionHistoryDialog::updateRunList() {
+void JobDefinitionAuditDialog::updateRunList() {
     ui_->versionListWidget->setRowCount(0);
 
     for (const auto& inst : instances_) {
@@ -200,7 +200,7 @@ void JobDefinitionHistoryDialog::updateRunList() {
     }
 }
 
-void JobDefinitionHistoryDialog::onRunSelected() {
+void JobDefinitionAuditDialog::onRunSelected() {
     // No-op: the table is read-only; selection just highlights the row.
 }
 

--- a/projects/ores.qt/scheduler/src/JobDefinitionController.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionController.cpp
@@ -22,7 +22,7 @@
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/JobDefinitionDetailDialog.hpp"
-#include "ores.qt/JobDefinitionHistoryDialog.hpp"
+#include "ores.qt/JobDefinitionAuditDialog.hpp"
 #include "ores.qt/JobDefinitionMdiWindow.hpp"
 #include <QMdiSubWindow>
 #include <QMessageBox>
@@ -76,9 +76,9 @@ void JobDefinitionController::showListWindow() {
             this,
             &JobDefinitionController::onAddNewRequested);
     connect(listWindow_,
-            &JobDefinitionMdiWindow::showDefinitionHistory,
+            &JobDefinitionMdiWindow::showDefinitionAudit,
             this,
-            &JobDefinitionController::onShowHistory);
+            &JobDefinitionController::onShowAudit);
 
     // Create MDI subwindow
     listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
@@ -143,9 +143,9 @@ void JobDefinitionController::onAddNewRequested() {
     showAddWindow();
 }
 
-void JobDefinitionController::onShowHistory(const scheduler::domain::job_definition& definition) {
-    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << definition.job_name;
-    showHistoryWindow(definition);
+void JobDefinitionController::onShowAudit(const scheduler::domain::job_definition& definition) {
+    BOOST_LOG_SEV(lg(), debug) << "Show audit requested for: " << definition.job_name;
+    showAuditWindow(definition);
 }
 
 void JobDefinitionController::showAddWindow() {
@@ -257,64 +257,64 @@ void JobDefinitionController::showDetailWindow(
     show_managed_window(detailWindow, listMdiSubWindow_);
 }
 
-void JobDefinitionController::showHistoryWindow(
+void JobDefinitionController::showAuditWindow(
     const scheduler::domain::job_definition& definition) {
     const QString code = QString::fromStdString(definition.job_name);
-    BOOST_LOG_SEV(lg(), info) << "Opening history window for job definition: "
+    BOOST_LOG_SEV(lg(), info) << "Opening audit window for job definition: "
                               << definition.job_name;
 
-    const QString windowKey = build_window_key("history", code);
+    const QString windowKey = build_window_key("audit", code);
 
     // Try to reuse existing window
     if (try_reuse_window(windowKey)) {
-        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: " << definition.job_name;
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing audit window for: " << definition.job_name;
         return;
     }
 
-    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: " << definition.job_name;
+    BOOST_LOG_SEV(lg(), info) << "Creating new audit window for: " << definition.job_name;
 
-    auto* historyDialog =
-        new JobDefinitionHistoryDialog(definition.id, code, clientManager_, mainWindow_);
-    // No revert/open-version signals — execution history is read-only
+    auto* auditDialog =
+        new JobDefinitionAuditDialog(definition.id, code, clientManager_, mainWindow_);
+    // No revert/open-version signals — the execution audit is read-only
 
-    connect(historyDialog,
-            &JobDefinitionHistoryDialog::statusChanged,
+    connect(auditDialog,
+            &JobDefinitionAuditDialog::statusChanged,
             this,
             [self = QPointer<JobDefinitionController>(this)](const QString& message) {
                 if (!self)
                     return;
                 emit self->statusMessage(message);
             });
-    connect(historyDialog,
-            &JobDefinitionHistoryDialog::errorOccurred,
+    connect(auditDialog,
+            &JobDefinitionAuditDialog::errorOccurred,
             this,
             [self = QPointer<JobDefinitionController>(this)](const QString& message) {
                 if (!self)
                     return;
                 emit self->errorMessage(message);
             });
-    // Load history data
-    historyDialog->loadHistory();
+    // Load audit data
+    auditDialog->refresh();
 
-    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
-    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
-    historyWindow->setWidget(historyDialog);
-    historyWindow->setWindowTitle(QString("Job Definition History: %1").arg(code));
-    historyWindow->setWindowIcon(
+    auto* auditWindow = new DetachableMdiSubWindow(mainWindow_);
+    auditWindow->setAttribute(Qt::WA_DeleteOnClose);
+    auditWindow->setWidget(auditDialog);
+    auditWindow->setWindowTitle(QString("Job Definition Audit: %1").arg(code));
+    auditWindow->setWindowIcon(
         IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor));
 
-    // Track this history window
-    track_window(windowKey, historyWindow);
-    register_detachable_window(historyWindow);
+    // Track this audit window
+    track_window(windowKey, auditWindow);
+    register_detachable_window(auditWindow);
 
     QPointer<JobDefinitionController> self = this;
-    connect(historyWindow, &QObject::destroyed, this, [self, windowKey]() {
+    connect(auditWindow, &QObject::destroyed, this, [self, windowKey]() {
         if (self) {
             self->untrack_window(windowKey);
         }
     });
 
-    show_managed_window(historyWindow, listMdiSubWindow_);
+    show_managed_window(auditWindow, listMdiSubWindow_);
 }
 
 

--- a/projects/ores.qt/scheduler/src/JobDefinitionMdiWindow.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionMdiWindow.cpp
@@ -49,7 +49,7 @@ JobDefinitionMdiWindow::JobDefinitionMdiWindow(ClientManager* clientManager,
     , addAction_(nullptr)
     , editAction_(nullptr)
     , deleteAction_(nullptr)
-    , historyAction_(nullptr) {
+    , auditAction_(nullptr) {
 
     setupUi();
     setupConnections();
@@ -106,12 +106,12 @@ void JobDefinitionMdiWindow::setupToolbar() {
     deleteAction_->setEnabled(false);
     connect(deleteAction_, &QAction::triggered, this, &JobDefinitionMdiWindow::deleteSelected);
 
-    historyAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor), tr("History"));
-    historyAction_->setToolTip(tr("View job definition history"));
-    historyAction_->setEnabled(false);
+    auditAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor), tr("Audit"));
+    auditAction_->setToolTip(tr("View job execution audit"));
+    auditAction_->setEnabled(false);
     connect(
-        historyAction_, &QAction::triggered, this, &JobDefinitionMdiWindow::viewHistorySelected);
+        auditAction_, &QAction::triggered, this, &JobDefinitionMdiWindow::viewAuditSelected);
 }
 
 void JobDefinitionMdiWindow::setupTable() {
@@ -210,7 +210,7 @@ void JobDefinitionMdiWindow::updateActionStates() {
     const bool hasSelection = tableView_->selectionModel()->hasSelection();
     editAction_->setEnabled(hasSelection);
     deleteAction_->setEnabled(hasSelection);
-    historyAction_->setEnabled(hasSelection);
+    auditAction_->setEnabled(hasSelection);
 }
 
 void JobDefinitionMdiWindow::addNew() {
@@ -231,18 +231,18 @@ void JobDefinitionMdiWindow::editSelected() {
     }
 }
 
-void JobDefinitionMdiWindow::viewHistorySelected() {
+void JobDefinitionMdiWindow::viewAuditSelected() {
     const auto selected = tableView_->selectionModel()->selectedRows();
     if (selected.isEmpty()) {
-        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        BOOST_LOG_SEV(lg(), warn) << "View audit requested but no row selected";
         return;
     }
 
     auto sourceIndex = proxyModel_->mapToSource(selected.first());
     if (auto* definition = model_->getDefinition(sourceIndex.row())) {
         BOOST_LOG_SEV(lg(), debug)
-            << "Emitting showDefinitionHistory for code: " << definition->job_name;
-        emit showDefinitionHistory(*definition);
+            << "Emitting showDefinitionAudit for code: " << definition->job_name;
+        emit showDefinitionAudit(*definition);
     }
 }
 

--- a/projects/ores.qt/scheduler/ui/JobDefinitionAuditDialog.ui
+++ b/projects/ores.qt/scheduler/ui/JobDefinitionAuditDialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>JobDefinitionHistoryDialog</class>
- <widget class="QWidget" name="JobDefinitionHistoryDialog">
+ <class>JobDefinitionAuditDialog</class>
+ <widget class="QWidget" name="JobDefinitionAuditDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Job Execution History</string>
+   <string>Job Execution Audit</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -23,7 +23,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Job Execution History</string>
+      <string>Job Execution Audit</string>
      </property>
     </widget>
    </item>

--- a/projects/ores.qt/trading/include/ores.qt/BookHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/BookHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/book.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BookHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a book with ability
  * to view details or revert to a previous version.
  */
-class BookHistoryDialog final : public QWidget {
+class BookHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                QWidget* parent = nullptr);
     ~BookHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the book.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::book& book, int versionNumber);
     void revertVersionRequested(const refdata::domain::book& book);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BookHistoryDialog* ui_;
+    std::unique_ptr<Ui::BookHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::book> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/trading/include/ores.qt/BookStatusHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/BookStatusHistoryDialog.hpp
@@ -22,10 +22,11 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/book_status.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class BookStatusHistoryDialog;
@@ -39,7 +40,7 @@ namespace ores::qt {
  * Shows all historical versions of a book status with ability
  * to view details or revert to a previous version.
  */
-class BookStatusHistoryDialog final : public QWidget {
+class BookStatusHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -57,36 +58,34 @@ public:
                                      QWidget* parent = nullptr);
     ~BookStatusHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the book status.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::book_status& status, int versionNumber);
     void revertVersionRequested(const refdata::domain::book_status& status);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::BookStatusHistoryDialog* ui_;
+    std::unique_ptr<Ui::BookStatusHistoryDialog> ui_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::book_status> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/trading/include/ores.qt/PortfolioHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/PortfolioHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.refdata.api/domain/portfolio.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class PortfolioHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a portfolio with ability
  * to view details or revert to a previous version.
  */
-class PortfolioHistoryDialog final : public QWidget {
+class PortfolioHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                     QWidget* parent = nullptr);
     ~PortfolioHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the portfolio.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const refdata::domain::portfolio& portfolio, int versionNumber);
     void revertVersionRequested(const refdata::domain::portfolio& portfolio);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::PortfolioHistoryDialog* ui_;
+    std::unique_ptr<Ui::PortfolioHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<refdata::domain::portfolio> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/trading/include/ores.qt/TradeHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/TradeHistoryDialog.hpp
@@ -22,11 +22,12 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.trading.api/domain/trade.hpp"
-#include <QTableWidget>
-#include <QToolBar>
-#include <QWidget>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class TradeHistoryDialog;
@@ -40,7 +41,7 @@ namespace ores::qt {
  * Shows all historical versions of a trade with ability
  * to view details or revert to a previous version.
  */
-class TradeHistoryDialog final : public QWidget {
+class TradeHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
@@ -59,37 +60,35 @@ public:
                                 QWidget* parent = nullptr);
     ~TradeHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
+
+    /**
+     * @brief Returns the identifier of the trade.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
-    void statusChanged(const QString& message);
-    void errorOccurred(const QString& error_message);
     void openVersionRequested(const trading::domain::trade& trade, int versionNumber);
     void revertVersionRequested(const trading::domain::trade& trade);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::TradeHistoryDialog* ui_;
+    std::unique_ptr<Ui::TradeHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<trading::domain::trade> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/trading/src/BookHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/BookHistoryDialog.cpp
@@ -18,15 +18,11 @@
  *
  */
 #include "ores.qt/BookHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/book_protocol.hpp"
 #include "ui_BookHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -37,257 +33,82 @@ BookHistoryDialog::BookHistoryDialog(const boost::uuids::uuid& id,
                                      const QString& code,
                                      ClientManager* clientManager,
                                      QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BookHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BookHistoryDialog::~BookHistoryDialog() {
-    delete ui_;
-}
-
-void BookHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BookHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BookHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BookHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &BookHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &BookHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BookHistoryDialog::~BookHistoryDialog() = default;
 
 void BookHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
     BOOST_LOG_SEV(lg(), debug) << "Loading history for book: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BookHistoryDialog> self = this;
+    refdata::messaging::get_book_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::book> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_book_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {
-            response_result->success, response_result->message, std::move(response_result->books)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.books);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BookHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BookHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BookHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow BookHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BookHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.ledger_ccy != previous.ledger_ccy) {
-        addChange("Ledger Currency",
-                  QString::fromStdString(previous.ledger_ccy),
-                  QString::fromStdString(current.ledger_ccy));
-    }
-
-    if (current.gl_account_ref != previous.gl_account_ref) {
-        addChange("GL Account Ref",
-                  QString::fromStdString(previous.gl_account_ref),
-                  QString::fromStdString(current.gl_account_ref));
-    }
-
-    if (current.cost_center != previous.cost_center) {
-        addChange("Cost Center",
-                  QString::fromStdString(previous.cost_center),
-                  QString::fromStdString(current.cost_center));
-    }
-
-    if (current.book_status != previous.book_status) {
-        addChange("Status",
-                  QString::fromStdString(previous.book_status),
-                  QString::fromStdString(current.book_status));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BookHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BookHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BookHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Ledger Currency", current.ledger_ccy, previous.ledger_ccy);
+    checkString(diffs, "GL Account Ref", current.gl_account_ref,
+                previous.gl_account_ref);
+    checkString(diffs, "Cost Center", current.cost_center, previous.cost_center);
+    checkString(diffs, "Status", current.book_status, previous.book_status);
+
+    return diffs;
+}
+
+void BookHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->ledgerCcyValue->setText(QString::fromStdString(version.ledger_ccy));
@@ -296,41 +117,28 @@ void BookHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->bookStatusValue->setText(QString::fromStdString(version.book_status));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void BookHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BookHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening book version " << version.version
+                              << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BookHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BookHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BookHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/trading/src/BookStatusHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/BookStatusHistoryDialog.cpp
@@ -18,15 +18,11 @@
  *
  */
 #include "ores.qt/BookStatusHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/book_status_protocol.hpp"
 #include "ui_BookStatusHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 
 namespace ores::qt {
 
@@ -35,286 +31,109 @@ using namespace ores::logging;
 BookStatusHistoryDialog::BookStatusHistoryDialog(const QString& code,
                                                  ClientManager* clientManager,
                                                  QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::BookStatusHistoryDialog)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-BookStatusHistoryDialog::~BookStatusHistoryDialog() {
-    delete ui_;
-}
-
-void BookStatusHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void BookStatusHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void BookStatusHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &BookStatusHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &BookStatusHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &BookStatusHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+BookStatusHistoryDialog::~BookStatusHistoryDialog() = default;
 
 void BookStatusHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for book status: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for book status: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<BookStatusHistoryDialog> self = this;
+    refdata::messaging::get_book_status_history_request request;
+    request.status = code_.toStdString();
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::book_status> versions;
-    };
-
-    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_book_status_history_request request;
-        request.status = code;
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void BookStatusHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int BookStatusHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void BookStatusHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+BookStatusHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void BookStatusHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.code != previous.code) {
-        addChange(
-            "Code", QString::fromStdString(previous.code), QString::fromStdString(current.code));
-    }
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString BookStatusHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void BookStatusHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+BookStatusHistoryDialog::calculateDiffAt(int current_index,
+                                         int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Code", current.code, previous.code);
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+
+    return diffs;
+}
+
+void BookStatusHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void BookStatusHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void BookStatusHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening book status version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void BookStatusHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void BookStatusHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void BookStatusHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/trading/src/PortfolioHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/PortfolioHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/PortfolioHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/portfolio_protocol.hpp"
 #include "ui_PortfolioHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -36,289 +32,112 @@ PortfolioHistoryDialog::PortfolioHistoryDialog(const boost::uuids::uuid& id,
                                                const QString& code,
                                                ClientManager* clientManager,
                                                QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::PortfolioHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-PortfolioHistoryDialog::~PortfolioHistoryDialog() {
-    delete ui_;
-}
-
-void PortfolioHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void PortfolioHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void PortfolioHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &PortfolioHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &PortfolioHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &PortfolioHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+PortfolioHistoryDialog::~PortfolioHistoryDialog() = default;
 
 void PortfolioHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for portfolio: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for portfolio: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<PortfolioHistoryDialog> self = this;
+    refdata::messaging::get_portfolio_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<refdata::domain::portfolio> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        refdata::messaging::get_portfolio_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->history)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.history);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void PortfolioHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int PortfolioHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void PortfolioHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+PortfolioHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void PortfolioHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.purpose_type != previous.purpose_type) {
-        addChange("Purpose Type",
-                  QString::fromStdString(previous.purpose_type),
-                  QString::fromStdString(current.purpose_type));
-    }
-
-    if (current.aggregation_ccy != previous.aggregation_ccy) {
-        addChange("Aggregation Currency",
-                  QString::fromStdString(previous.aggregation_ccy),
-                  QString::fromStdString(current.aggregation_ccy));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString PortfolioHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void PortfolioHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+PortfolioHistoryDialog::calculateDiffAt(int current_index,
+                                        int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Purpose Type", current.purpose_type,
+                previous.purpose_type);
+    checkString(diffs, "Aggregation Currency", current.aggregation_ccy,
+                previous.aggregation_ccy);
+
+    return diffs;
+}
+
+void PortfolioHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->purposeTypeValue->setText(QString::fromStdString(version.purpose_type));
-    ui_->aggregationCcyValue->setText(QString::fromStdString(version.aggregation_ccy));
+    ui_->aggregationCcyValue->setText(
+        QString::fromStdString(version.aggregation_ccy));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void PortfolioHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void PortfolioHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening portfolio version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void PortfolioHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void PortfolioHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void PortfolioHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/trading/src/TradeHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/TradeHistoryDialog.cpp
@@ -18,347 +18,159 @@
  *
  */
 #include "ores.qt/TradeHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.trading.api/messaging/trade_protocol.hpp"
 #include "ui_TradeHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+QString optionalText(const std::optional<std::string>& value) {
+    return value ? QString::fromStdString(*value) : QString{};
+}
+
+}
+
 TradeHistoryDialog::TradeHistoryDialog(const boost::uuids::uuid& id,
                                        const QString& code,
                                        ClientManager* clientManager,
                                        QWidget* parent)
-    : QWidget(parent)
+    : HistoryDialogBase(parent)
     , ui_(new Ui::TradeHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-TradeHistoryDialog::~TradeHistoryDialog() {
-    delete ui_;
-}
-
-void TradeHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void TradeHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void TradeHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &TradeHistoryDialog::onVersionSelected);
-    connect(
-        openVersionAction_, &QAction::triggered, this, &TradeHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &TradeHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+TradeHistoryDialog::~TradeHistoryDialog() = default;
 
 void TradeHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for trade: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for trade: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<TradeHistoryDialog> self = this;
+    trading::messaging::get_trade_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    struct HistoryResult {
-        bool success;
-        std::string message;
-        std::vector<trading::domain::trade> versions;
-    };
-
-    auto task = [self, id = id_]() -> HistoryResult {
-        if (!self || !self->clientManager_) {
-            return {false, "Dialog closed", {}};
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
+            return;
         }
-
-        trading::messaging::get_trade_history_request request;
-        request.id = boost::uuids::to_string(id);
-        auto response_result =
-            self->clientManager_->process_authenticated_request(std::move(request));
-
-        if (!response_result) {
-            return {false, "Failed to communicate with server", {}};
-        }
-
-
-        return {response_result->success,
-                response_result->message,
-                std::move(response_result->versions)};
-    };
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (result.success) {
-            self->versions_ = std::move(result.versions);
-            self->updateVersionList();
-            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
-        } else {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.message;
-            emit self->errorOccurred(QString::fromStdString(result.message));
-        }
+        versions_ = std::move(response.versions);
+        historyLoaded();
     });
-
-    QFuture<HistoryResult> future = QtConcurrent::run(task);
-    watcher->setFuture(future);
 }
 
-void TradeHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.identity.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.audit.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem =
-            new QTableWidgetItem(QString::fromStdString(version.audit.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem =
-            new QTableWidgetItem(QString::fromStdString(version.audit.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.audit.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int TradeHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void TradeHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow TradeHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.identity.version,
+            .cells = {relative_time_helper::format(version.audit.recorded_at),
+                      QString::fromStdString(version.audit.modified_by),
+                      QString::fromStdString(version.audit.performed_by),
+                      QString::fromStdString(version.audit.change_commentary)}};
 }
 
-void TradeHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
-
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
-
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.identity.external_id != previous.identity.external_id) {
-        addChange("External ID",
-                  QString::fromStdString(previous.identity.external_id),
-                  QString::fromStdString(current.identity.external_id));
-    }
-
-    if (current.classification.trade_type != previous.classification.trade_type) {
-        addChange("Trade Type",
-                  QString::fromStdString(previous.classification.trade_type),
-                  QString::fromStdString(current.classification.trade_type));
-    }
-
-    if (current.classification.activity_type_code != previous.classification.activity_type_code) {
-        addChange("Lifecycle Event",
-                  QString::fromStdString(previous.classification.activity_type_code),
-                  QString::fromStdString(current.classification.activity_type_code));
-    }
-
-    if (current.classification.netting_set_id != previous.classification.netting_set_id) {
-        addChange("Netting Set",
-                  QString::fromStdString(previous.classification.netting_set_id),
-                  QString::fromStdString(current.classification.netting_set_id));
-    }
-
-    if (current.lifecycle.trade_date != previous.lifecycle.trade_date) {
-        addChange("Trade Date",
-                  QString::fromStdString(previous.lifecycle.trade_date.value_or("")),
-                  QString::fromStdString(current.lifecycle.trade_date.value_or("")));
-    }
-
-    if (current.lifecycle.effective_date != previous.lifecycle.effective_date) {
-        addChange("Effective Date",
-                  QString::fromStdString(previous.lifecycle.effective_date.value_or("")),
-                  QString::fromStdString(current.lifecycle.effective_date.value_or("")));
-    }
-
-    if (current.lifecycle.termination_date != previous.lifecycle.termination_date) {
-        addChange("Termination Date",
-                  QString::fromStdString(previous.lifecycle.termination_date.value_or("")),
-                  QString::fromStdString(current.lifecycle.termination_date.value_or("")));
-    }
-
-    if (current.lifecycle.execution_timestamp != previous.lifecycle.execution_timestamp) {
-        addChange("Execution Timestamp",
-                  QString::fromStdString(previous.lifecycle.execution_timestamp.value_or("")),
-                  QString::fromStdString(current.lifecycle.execution_timestamp.value_or("")));
-    }
-
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+QString TradeHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
 }
 
-void TradeHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+TradeHistoryDialog::calculateDiffAt(int current_index,
+                                    int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    const auto& version = versions_[versionIndex];
+    DiffResult diffs;
+    checkString(diffs, "External ID", current.identity.external_id,
+                previous.identity.external_id);
+    checkString(diffs, "Trade Type", current.classification.trade_type,
+                previous.classification.trade_type);
+    checkString(diffs, "Lifecycle Event",
+                current.classification.activity_type_code,
+                previous.classification.activity_type_code);
+    checkString(diffs, "Netting Set", current.classification.netting_set_id,
+                previous.classification.netting_set_id);
+    checkString(diffs, "Trade Date", current.lifecycle.trade_date,
+                previous.lifecycle.trade_date);
+    checkString(diffs, "Effective Date", current.lifecycle.effective_date,
+                previous.lifecycle.effective_date);
+    checkString(diffs, "Termination Date", current.lifecycle.termination_date,
+                previous.lifecycle.termination_date);
+    checkString(diffs, "Execution Timestamp",
+                current.lifecycle.execution_timestamp,
+                previous.lifecycle.execution_timestamp);
 
-    ui_->externalIdValue->setText(QString::fromStdString(version.identity.external_id));
-    ui_->tradeTypeValue->setText(QString::fromStdString(version.classification.trade_type));
+    return diffs;
+}
+
+void TradeHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
+
+    ui_->externalIdValue->setText(
+        QString::fromStdString(version.identity.external_id));
+    ui_->tradeTypeValue->setText(
+        QString::fromStdString(version.classification.trade_type));
     ui_->lifecycleEventValue->setText(
         QString::fromStdString(version.classification.activity_type_code));
-    ui_->nettingSetIdValue->setText(QString::fromStdString(version.classification.netting_set_id));
-    ui_->tradeDateValue->setText(QString::fromStdString(version.lifecycle.trade_date.value_or("")));
+    ui_->nettingSetIdValue->setText(
+        QString::fromStdString(version.classification.netting_set_id));
+    ui_->tradeDateValue->setText(optionalText(version.lifecycle.trade_date));
     ui_->effectiveDateValue->setText(
-        QString::fromStdString(version.lifecycle.effective_date.value_or("")));
+        optionalText(version.lifecycle.effective_date));
     ui_->terminationDateValue->setText(
-        QString::fromStdString(version.lifecycle.termination_date.value_or("")));
+        optionalText(version.lifecycle.termination_date));
     ui_->executionTimestampValue->setText(
-        QString::fromStdString(version.lifecycle.execution_timestamp.value_or("")));
+        optionalText(version.lifecycle.execution_timestamp));
     ui_->versionNumberValue->setText(QString::number(version.identity.version));
-    ui_->modifiedByValue->setText(QString::fromStdString(version.audit.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.audit.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.audit.change_commentary));
+    ui_->modifiedByValue->setText(
+        QString::fromStdString(version.audit.modified_by));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.audit.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.audit.change_commentary));
 }
 
-void TradeHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void TradeHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening trade version "
+                              << version.identity.version
+                              << " in read-only mode";
+    emit openVersionRequested(version, version.identity.version);
 }
 
-void TradeHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void TradeHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.identity.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].identity.version);
-}
-
-void TradeHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }

--- a/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
+++ b/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
@@ -24,9 +24,10 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.workspace.api/domain/workspace.hpp"
-#include <QTableWidget>
-#include <QToolBar>
+#include <QString>
 #include <boost/uuid/uuid.hpp>
+#include <memory>
+#include <vector>
 
 namespace Ui {
 class WorkspaceHistoryDialog;
@@ -60,36 +61,34 @@ public:
     ~WorkspaceHistoryDialog() override;
 
     void loadHistory() override;
-    void markAsStale() override;
-    [[nodiscard]] QString code() const override;
+
+    /**
+     * @brief Returns the identifier of the workspace.
+     */
+    [[nodiscard]] QString code() const override {
+        return code_;
+    }
 
 signals:
     void openVersionRequested(const workspace::domain::workspace& workspace, int versionNumber);
     void revertVersionRequested(const workspace::domain::workspace& workspace);
 
-private slots:
-    void onVersionSelected();
-    void onOpenVersionClicked();
-    void onRevertClicked();
+protected:
+    [[nodiscard]] int historySize() const override;
+    [[nodiscard]] VersionRow versionRow(int index) const override;
+    [[nodiscard]] QString historyTitle() const override;
+    [[nodiscard]] DiffResult
+    calculateDiffAt(int current_index, int previous_index) const override;
+    void displayFullDetails(int index) override;
+    void openVersionAt(int index) override;
+    void revertToVersionAt(int index) override;
 
 private:
-    void setupUi();
-    void setupToolbar();
-    void setupConnections();
-    void updateVersionList();
-    void updateChangesTable(int currentVersionIndex);
-    void updateFullDetails(int versionIndex);
-    void updateActionStates();
-
-    Ui::WorkspaceHistoryDialog* ui_;
+    std::unique_ptr<Ui::WorkspaceHistoryDialog> ui_;
     boost::uuids::uuid id_;
     QString code_;
     ClientManager* clientManager_;
     std::vector<workspace::domain::workspace> versions_;
-
-    QToolBar* toolbar_;
-    QAction* openVersionAction_;
-    QAction* revertAction_;
 };
 
 }

--- a/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
+++ b/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
@@ -59,7 +59,7 @@ public:
                                     QWidget* parent = nullptr);
     ~WorkspaceHistoryDialog() override;
 
-    void loadHistory();
+    void loadHistory() override;
     void markAsStale() override;
     [[nodiscard]] QString code() const override;
 

--- a/projects/ores.qt/workspace/src/WorkspaceHistoryDialog.cpp
+++ b/projects/ores.qt/workspace/src/WorkspaceHistoryDialog.cpp
@@ -18,14 +18,10 @@
  *
  */
 #include "ores.qt/WorkspaceHistoryDialog.hpp"
-#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.workspace.api/messaging/workspace_protocol.hpp"
 #include "ui_WorkspaceHistoryDialog.h"
-#include <QFutureWatcher>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QtConcurrent>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
@@ -40,312 +36,134 @@ WorkspaceHistoryDialog::WorkspaceHistoryDialog(const boost::uuids::uuid& id,
     , ui_(new Ui::WorkspaceHistoryDialog)
     , id_(id)
     , code_(code)
-    , clientManager_(clientManager)
-    , toolbar_(nullptr)
-    , openVersionAction_(nullptr)
-    , revertAction_(nullptr) {
+    , clientManager_(clientManager) {
 
     ui_->setupUi(this);
-    setupUi();
-    setupToolbar();
-    setupConnections();
-}
-
-WorkspaceHistoryDialog::~WorkspaceHistoryDialog() {
-    delete ui_;
-}
-
-void WorkspaceHistoryDialog::markAsStale() {
-    loadHistory();
-}
-
-QString WorkspaceHistoryDialog::code() const {
-    return code_;
-}
-
-void WorkspaceHistoryDialog::setupUi() {
-    ui_->closeButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 
     ui_->titleLabel->setText(QString("History for: %1").arg(code_));
 
-    // Setup version list table
     ui_->versionListWidget->setColumnCount(5);
     ui_->versionListWidget->setHorizontalHeaderLabels(
         {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
-    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
-    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    // Setup changes table
-    ui_->changesTableWidget->setColumnCount(3);
-    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
-    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+    initializeHistoryUi({.versionList = ui_->versionListWidget,
+                         .changesTable = ui_->changesTableWidget,
+                         .titleLabel = ui_->titleLabel,
+                         .closeButton = ui_->closeButton});
 }
 
-void WorkspaceHistoryDialog::setupToolbar() {
-    toolbar_ = new QToolBar(this);
-    toolbar_->setMovable(false);
-    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolbar_->setIconSize(QSize(20, 20));
-
-    openVersionAction_ = toolbar_->addAction(
-        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor), tr("Open"));
-    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
-    openVersionAction_->setEnabled(false);
-
-    revertAction_ =
-        toolbar_->addAction(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
-                                                           IconUtils::DefaultIconColor),
-                            tr("Revert"));
-    revertAction_->setToolTip(tr("Revert to this version"));
-    revertAction_->setEnabled(false);
-
-    // Insert toolbar at the top of the layout
-    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
-    if (layout) {
-        layout->insertWidget(0, toolbar_);
-    }
-}
-
-void WorkspaceHistoryDialog::setupConnections() {
-    connect(ui_->versionListWidget,
-            &QTableWidget::itemSelectionChanged,
-            this,
-            &WorkspaceHistoryDialog::onVersionSelected);
-    connect(openVersionAction_,
-            &QAction::triggered,
-            this,
-            &WorkspaceHistoryDialog::onOpenVersionClicked);
-    connect(revertAction_, &QAction::triggered, this, &WorkspaceHistoryDialog::onRevertClicked);
-    connect(ui_->closeButton, &QPushButton::clicked, this, [this]() {
-        if (window())
-            window()->close();
-    });
-}
+WorkspaceHistoryDialog::~WorkspaceHistoryDialog() = default;
 
 void WorkspaceHistoryDialog::loadHistory() {
-    if (!clientManager_ || !clientManager_->isConnected()) {
-        emit errorOccurred("Not connected to server");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for workspace: " << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for workspace: "
+                               << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
-    QPointer<WorkspaceHistoryDialog> self = this;
+    workspace::messaging::get_workspace_history_request request;
+    request.id = boost::uuids::to_string(id_);
 
-    using HistoryResult =
-        std::expected<workspace::messaging::get_workspace_history_response, std::string>;
-
-    QFuture<HistoryResult> future =
-        QtConcurrent::run([self, id_str = boost::uuids::to_string(id_)]() -> HistoryResult {
-            if (!self || !self->clientManager_)
-                return std::unexpected("Dialog closed");
-            workspace::messaging::get_workspace_history_request request;
-            request.id = id_str;
-            auto result = self->clientManager_->process_authenticated_request(std::move(request));
-            if (!result)
-                return std::unexpected(result.error());
-            return std::move(*result);
-        });
-
-    auto* watcher = new QFutureWatcher<HistoryResult>(self);
-    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
-        auto result = watcher->result();
-        watcher->deleteLater();
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
-            emit self->errorOccurred(QString::fromStdString(result.error()));
+    runHistoryRequest(clientManager_, std::move(request), [this](auto response) {
+        if (!response.success) {
+            BOOST_LOG_SEV(lg(), error) << "Response was not success.";
+            historyLoadFailed(QString::fromStdString(response.message));
             return;
         }
-        if (!result->success) {
-            emit self->errorOccurred(QString::fromStdString(result->message));
-            return;
-        }
-        self->versions_ = std::move(result->workspaces);
-        self->updateVersionList();
-        emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        versions_ = std::move(response.workspaces);
+        historyLoaded();
     });
-    watcher->setFuture(future);
 }
 
-void WorkspaceHistoryDialog::updateVersionList() {
-    ui_->versionListWidget->setRowCount(0);
-
-    for (const auto& version : versions_) {
-        int row = ui_->versionListWidget->rowCount();
-        ui_->versionListWidget->insertRow(row);
-
-        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
-        versionItem->setTextAlignment(Qt::AlignCenter);
-        ui_->versionListWidget->setItem(row, 0, versionItem);
-
-        auto* recordedAtItem =
-            new QTableWidgetItem(relative_time_helper::format(version.recorded_at));
-        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
-
-        auto* modifiedByItem = new QTableWidgetItem(QString::fromStdString(version.modified_by));
-        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
-
-        auto* performedByItem = new QTableWidgetItem(QString::fromStdString(version.performed_by));
-        ui_->versionListWidget->setItem(row, 3, performedByItem);
-
-        auto* commentaryItem =
-            new QTableWidgetItem(QString::fromStdString(version.change_commentary));
-        ui_->versionListWidget->setItem(row, 4, commentaryItem);
-    }
-
-    // Select the first (most recent) version
-    if (!versions_.empty()) {
-        ui_->versionListWidget->selectRow(0);
-    }
+int WorkspaceHistoryDialog::historySize() const {
+    return static_cast<int>(versions_.size());
 }
 
-void WorkspaceHistoryDialog::onVersionSelected() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty()) {
-        updateActionStates();
-        return;
-    }
-
-    int row = selected.first()->row();
-    updateChangesTable(row);
-    updateFullDetails(row);
-    updateActionStates();
+HistoryDialogBase::VersionRow
+WorkspaceHistoryDialog::versionRow(int index) const {
+    const auto& version = versions_[index];
+    return {.version = version.version,
+            .cells = {relative_time_helper::format(version.recorded_at),
+                      QString::fromStdString(version.modified_by),
+                      QString::fromStdString(version.performed_by),
+                      QString::fromStdString(version.change_commentary)}};
 }
 
-void WorkspaceHistoryDialog::updateChangesTable(int currentVersionIndex) {
-    ui_->changesTableWidget->setRowCount(0);
+QString WorkspaceHistoryDialog::historyTitle() const {
+    return QString("History for: %1").arg(code_);
+}
 
-    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
-        return;
-    }
+HistoryDialogBase::DiffResult
+WorkspaceHistoryDialog::calculateDiffAt(int current_index,
+                                        int previous_index) const {
+    const auto& current = versions_[current_index];
+    const auto& previous = versions_[previous_index];
 
-    // Get the next older version to compare against
-    int previousVersionIndex = currentVersionIndex + 1;
-    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
-        // This is the first version, no changes to show
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-        return;
-    }
-
-    const auto& current = versions_[currentVersionIndex];
-    const auto& previous = versions_[previousVersionIndex];
-
-    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
-        int row = ui_->changesTableWidget->rowCount();
-        ui_->changesTableWidget->insertRow(row);
-        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
-        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
-        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
-    };
-
-    if (current.name != previous.name) {
-        addChange(
-            "Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
-    }
-
-    if (current.description != previous.description) {
-        addChange("Description",
-                  QString::fromStdString(previous.description),
-                  QString::fromStdString(current.description));
-    }
-
-    if (current.source_path != previous.source_path) {
-        addChange("Source Path",
-                  QString::fromStdString(previous.source_path),
-                  QString::fromStdString(current.source_path));
-    }
+    DiffResult diffs;
+    checkString(diffs, "Name", current.name, previous.name);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Source Path", current.source_path,
+                previous.source_path);
 
     if (current.parent_workspace_id != previous.parent_workspace_id) {
-        {
-            auto _to_s = [](const std::optional<boost::uuids::uuid>& o) {
-                return o ? QString::fromStdString(boost::uuids::to_string(*o)) : QString{};
-            };
-            addChange(
-                "Parent", _to_s(previous.parent_workspace_id), _to_s(current.parent_workspace_id));
-        }
+        auto to_s = [](const std::optional<boost::uuids::uuid>& o) {
+            return o ? QString::fromStdString(boost::uuids::to_string(*o))
+                     : QString{};
+        };
+        diffs.append({"Parent",
+                      {to_s(previous.parent_workspace_id),
+                       to_s(current.parent_workspace_id)}});
     }
 
     if (current.owner_id != previous.owner_id) {
-        addChange("Owner",
-                  QString::fromStdString(boost::uuids::to_string(previous.owner_id)),
-                  QString::fromStdString(boost::uuids::to_string(current.owner_id)));
+        diffs.append(
+            {"Owner",
+             {QString::fromStdString(boost::uuids::to_string(previous.owner_id)),
+              QString::fromStdString(
+                  boost::uuids::to_string(current.owner_id))}});
     }
 
-    if (current.status_code != previous.status_code) {
-        addChange("Status",
-                  QString::fromStdString(previous.status_code),
-                  QString::fromStdString(current.status_code));
-    }
+    checkString(diffs, "Status", current.status_code, previous.status_code);
 
-
-    if (ui_->changesTableWidget->rowCount() == 0) {
-        ui_->changesTableWidget->insertRow(0);
-        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
-        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
-        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
-    }
+    return diffs;
 }
 
-void WorkspaceHistoryDialog::updateFullDetails(int versionIndex) {
-    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) {
-        return;
-    }
-
-    const auto& version = versions_[versionIndex];
+void WorkspaceHistoryDialog::displayFullDetails(int index) {
+    const auto& version = versions_[index];
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->sourcePathValue->setText(QString::fromStdString(version.source_path));
     ui_->parentValue->setText(
         version.parent_workspace_id ?
-            QString::fromStdString(boost::uuids::to_string(*version.parent_workspace_id)) :
+            QString::fromStdString(
+                boost::uuids::to_string(*version.parent_workspace_id)) :
             QString{});
-    ui_->ownerValue->setText(QString::fromStdString(boost::uuids::to_string(version.owner_id)));
+    ui_->ownerValue->setText(
+        QString::fromStdString(boost::uuids::to_string(version.owner_id)));
     ui_->statusValue->setText(QString::fromStdString(version.status_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(
+        relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
 }
 
-void WorkspaceHistoryDialog::updateActionStates() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    bool hasSelection = !selected.isEmpty();
-    bool isNotLatest = hasSelection && selected.first()->row() > 0;
-
-    openVersionAction_->setEnabled(hasSelection);
-    revertAction_->setEnabled(isNotLatest);
+void WorkspaceHistoryDialog::openVersionAt(int index) {
+    const auto& version = versions_[index];
+    BOOST_LOG_SEV(lg(), info) << "Opening workspace version "
+                              << version.version << " in read-only mode";
+    emit openVersionRequested(version, version.version);
 }
 
-void WorkspaceHistoryDialog::onOpenVersionClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
+void WorkspaceHistoryDialog::revertToVersionAt(int index) {
+    // The base has already confirmed with the user; revert TO the
+    // selected version.
+    const auto& selected = versions_[index];
 
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
+                              << selected.version;
 
-    emit openVersionRequested(versions_[row], versions_[row].version);
-}
-
-void WorkspaceHistoryDialog::onRevertClicked() {
-    auto selected = ui_->versionListWidget->selectedItems();
-    if (selected.isEmpty())
-        return;
-
-    int row = selected.first()->row();
-    if (static_cast<size_t>(row) >= versions_.size())
-        return;
-
-    emit revertVersionRequested(versions_[row]);
+    emit revertVersionRequested(selected);
 }
 
 }


### PR DESCRIPTION
## Summary

Grows `HistoryDialogBase` from a stub into the shared pipeline for every version-history dialog, migrates all 64 dialogs onto it, and renames the three event-log "history" screens to **Audit** so /history/ has a single meaning in the codebase. Net effect: **−10,600 lines** (4,939 added, 15,573 removed).

## The grown base

`HistoryDialogBase` now owns everything the dialogs previously duplicated:

- The **Reload / Open / Revert toolbar** and its action states.
- **Version-list population** via an ordered-cells `VersionRow` — dialogs vary between 3 and 6 columns (change reason, commentary, performed by, enabled), and the cell list adapts without per-shape heuristics.
- The **changes-tab diff flow** with `(Initial version)` / `(No field changes)` placeholder rows, calling the `calculateDiffAt()` hook — the interim seam until server-side diffs land.
- `checkString` / `checkInt` / `checkBool` **diff helpers**, including `std::optional` overloads.
- **Async request plumbing** (`runHistoryRequest`: QtConcurrent + QFutureWatcher with QPointer guard) and watcher cleanup on destruction.
- `markAsStale()` / `code()` for controller stale-notification filtering.

Derived dialogs shrink to entity-specific hooks: `historySize`, `versionRow`, `historyTitle`, `calculateDiffAt`, `displayFullDetails`, `openVersionAt`, `revertToVersionAt`, plus optional `changeCellWidget` (e.g. flag icons for Country/Currency).

## Unified revert semantics

The two dialog families disagreed on what Revert means: hand-rolled dialogs reverted to the version *older* than the selection (with confirmation); generated dialogs reverted *to* the selected version (without confirmation). The unified behaviour takes the best of both — **Revert restores the selected version as a new current version, after confirmation**, and is disabled on the latest version. Recorded in the UX language doc.

## Migrations (64 dialogs)

- **6 hand-rolled diff dialogs**: Country, Currency, ChangeReason, ChangeReasonCategory (refdata), Account, SystemSetting (admin) — eliminating the four competing diff idioms (free function, per-call lambdas, `CHECK_DIFF_*` macros, inline if-blocks).
- **ZeroConvention** as the generated-family exemplar, then the **57 remaining generated-pattern dialogs** across admin (4), analytics (4), compute (6), party (9), refdata (29), trading (4) and workspace (1) — one commit per component. Entity-specific request/response shapes, optional-field formatting (including bespoke `(unset)` rendering) and `WidgetUtils` calls preserved faithfully.

## History vs Audit

Three screens are event logs, not version histories, so they stay off the base and are renamed instead:

- `SessionHistoryDialog` → `SessionAuditDialog` (login-session telemetry)
- `PublicationHistoryDialog` → `PublicationAuditDialog` (dataset publications)
- `JobDefinitionHistoryDialog` → `JobDefinitionAuditDialog` (job executions)

User-visible titles, menu options and tooltips follow, as do the plumbing identifiers. The distinction — *History = versioned entity; Audit = read-only event log* — is recorded in the UX language doc. The wire name `get_job_history_request` is deliberately untouched.

## Notes / Decisions

- A pre-existing `AppVersionHistoryDialog` bug (diff rows mislabelled: "Name" diffs `wrapper_version`, "Description" diffs `engine_version`) was preserved verbatim to keep the migration behaviour-neutral, and filed as an inbox capture.
- App/AppVersion previously collapsed all load failures into a generic message; they now surface the server message via the base.
- Full build green; `ores.qt.api.tests` (14) and `ores.qt.tests` (6) pass.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Consolidate history dialogs onto HistoryDialogBase](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.html) | 037B474D-84ED-4888-9054-D58AB1FB10D2 |
| Task | [Grow HistoryDialogBase and migrate the six hand-rolled dialogs](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.html) | E9348344-C7A1-4B4A-969D-BDB56C96DE9A |
| Capture | [AppVersionHistoryDialog diff rows mislabelled](https://orestudio.github.io/OreStudio/doc/agile/product_backlog/inbox/appversion-history-diff-mislabelled.html) | FC2EF34E-F873-4793-BA38-4026BD78E7FE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)