### PR TITLE
[ores.compass] Extend review list to conversation-level comments

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -33,7 +33,7 @@ with traceability, merge) as follow-on tasks.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Implementing the review commands (list, reply, resolve). |
+| Now           | Review verbs shipped (PR #1078). Extending list to conversation comments. |
 | Waiting on    | Nothing.                               |
 | Next          | Conversation-comments gap, then the pr pillar verbs: checks, create, merge. |
 | Last touched  | 2026-06-05                               |
@@ -67,8 +67,8 @@ with traceability, merge) as follow-on tasks.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The three review-round verbs wrapping gh api; --owner/--repo from git remote. |
-| [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | BACKLOG | | | Include PR conversation comments so gh pr view --comments is no longer needed. |
+| [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The four review-round verbs (list, reply, resolve, pending) wrapping gh; --owner/--repo from git remote. PR #1078. |
+| [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | STARTED | 2026-06-05 | | Include PR conversation comments so gh pr view --comments is no longer needed. |
 | [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | BACKLOG | | | Wrap gh pr checks as compass pr checks <N> [--watch]; update runbook + recipes. |
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | BACKLOG | | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | BACKLOG | | | Refuse on unresolved threads or red CI; merge, delete branch, prompt close-out. |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_implement_compass_pr_management.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_implement_compass_pr_management.org
@@ -32,12 +32,12 @@ following the existing short-circuit pattern.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE |
+| State        | DONE                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Complete: compass review list/reply/resolve/pending shipped in PR #1078. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing. |
-| Last touched | 2026-06-05 |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-05                               |
 
 * Acceptance
 
@@ -106,3 +106,11 @@ another worktree) and six merged PRs with forgotten threads.
 |   |                 |      |          |       |
 
 * Result
+
+Shipped in PR [[https://github.com/OreStudio/OreStudio/pull/1078][#1078]] (merged 2026-06-05): the compass Review pillar —
+=review list= (pretty/json, =--detail=), =review reply=, =review
+resolve= (=--dry-run=), and =review pending= (severity triage with
+worktree ownership and story/task hints). Recipes and the review-round
+runbook lead with the compass verbs; a new recipe documents =pending=.
+All verbs exercised against real PRs, including a nine-comment sweep
+across six merged PRs recorded in Notes above.

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
@@ -64,6 +64,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | created_at null in JSON bypasses dict.get default → sort TypeError | compass_review.py | Accepted | or ""; b378ad8a1 |
+| 2 | submitted_at null (pending reviews) → same TypeError | compass_review.py | Accepted | or ""; b378ad8a1 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-review-conversation
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,7 +25,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-review-conversation
-#+pr:
+#+pr: 1081
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -58,7 +58,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1081][#1081]] | [ores.compass] Extend review list to conversation-level comments |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
@@ -19,7 +19,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+=compass review list= only showed line-level review comments, so the
+review-round runbook still needed =gh pr view --comments= for review
+summaries and bot banners. Extend =list= with a Conversation section
+sourced from the PR's issue comments and review summaries (state-only
+reviews with no body are dropped), so one command reads the whole
+review surface.
 
 * Status
 
@@ -34,7 +39,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- =compass review list <pr>= shows line comments and conversation
+  items (issue comments + review summaries with bodies), in
+  chronological order, with =--detail= and =--format json= covering
+  both.
+- The review-round runbook and the address-review-comments recipe no
+  longer reference =gh pr view --comments=.
 
 * Plan
 

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -37,7 +37,7 @@ In execution order:
    - If checks are *pending / running*, notify the user and proceed to step 3; CI will be re-verified after fixes are pushed (step 7).
    - If CI is *green*, proceed immediately.
 
-3. /Read the comments./ =compass review list <N> --detail= for the line comments; =gh pr view <N> --comments= for conversation-level review summaries. See [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] step 1.
+3. /Read the comments./ =compass review list <N> --detail= — line-level threads and conversation-level comments/review summaries in one view. See [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] step 1.
 
 4. /Decide per comment./ For each comment, make an explicit accept/decline decision. Never silently ignore a comment.
 

--- a/doc/recipes/cmake/how_do_i_build_the_system.org
+++ b/doc/recipes/cmake/how_do_i_build_the_system.org
@@ -2,12 +2,12 @@
 :ID: F176FCA1-68D5-420D-B076-75A65FEE5EBB
 :END:
 #+title: How do I build the system?
-#+description: Build ORE Studio with the build.sh wrapper or directly with `cmake --build --preset`.
+#+description: Build ORE Studio with compass build (preset from .env), or directly with `cmake --build --preset`.
 #+type: recipe
 #+level: cross
 #+filetags: :cmake:build:recipe:
 #+created: 2026-05-18
-#+updated: 2026-05-18
+#+updated: 2026-06-05
 
 Configure first if you haven't (see [[id:7C44751E-54C0-4CB7-B489-1D3EC609A4E3][How do I configure the project?]]).
 For preset / output / parallelism details, see [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]].
@@ -18,55 +18,35 @@ How do I build ORE Studio?
 
 * Answer
 
-** Day-to-day with the wrapper (Make preset)
+** Day-to-day with compass
 
-The fastest path for local builds:
+=compass build= resolves the checkout's preset from =ORES_PRESET= in
+=.env= and configures the build directory automatically on first use:
 
 #+begin_src sh :results verbatim
-build/scripts/build.sh
+./compass.sh build                          # everything
+./compass.sh build ores.iam.core            # specific target(s)
+./compass.sh build site                     # friendly alias (deploy_site)
+./compass.sh build --preset linux-clang-release-make   # preset override
+./compass.sh build -j 4 --dry-run           # jobs / print-only
 #+end_src
 
-Build only specific targets:
+Friendly aliases: =site= → =deploy_site=, =manual= → =deploy_manual=,
+=org-roam-db-sync= → =org_roam_db_sync=; any raw cmake target is also
+accepted.
+
+** Direct CMake
+
+The underlying invocation, for when you need to drive cmake yourself:
 
 #+begin_src sh :results verbatim
-build/scripts/build.sh ores.iam.core ores.service
-#+end_src
-
-Switch to the release preset:
-
-#+begin_src sh :results verbatim
-ORES_BUILD_PRESET=linux-clang-release-make build/scripts/build.sh
-#+end_src
-
-The wrapper requires the preset's build directory to exist — run
-=cmake --preset= first.
-
-** Direct CMake (Ninja preset)
-
-For the Ninja preset, the standard CMake invocation:
-
-#+begin_src sh :results verbatim
-cmake --build --preset linux-clang-debug-ninja
-#+end_src
-
-For release:
-
-#+begin_src sh :results verbatim
-cmake --build --preset linux-clang-release-ninja
-#+end_src
-
-** Single target
-
-To build one target (any preset):
-
-#+begin_src sh :results verbatim
-cmake --build --preset linux-clang-debug-ninja --target <target_name>
+cmake --build --preset <preset> [--target <target_name>]
 #+end_src
 
 * Script
 
-=build/scripts/build.sh= for the Make path; =cmake --build --preset
-...= for the Ninja path.
+=compass build= (=projects/ores.compass/src/compass.py=) wrapping
+=cmake --build --preset=.
 
 * Tested by
 

--- a/doc/recipes/compass/how_do_i_index_notes_for_compass.org
+++ b/doc/recipes/compass/how_do_i_index_notes_for_compass.org
@@ -7,11 +7,12 @@
 #+level: cross
 #+filetags: :compass:search:index:recipe:bearings:
 #+created: 2026-05-24
-#+updated: 2026-05-24
+#+updated: 2026-06-05
 
 Prerequisite for the [[id:BDA8F7FB-5CEC-42D8-BC78-766BBC8D4285][search]] pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]]. Indexing
-reads =org-roam.db=, so sync it first in Emacs with =M-x
-org-roam-db-sync=.
+reads =.org-roam.db=; pass =--org-roam-db-sync= to regenerate it
+first, or sync it any other way (=compass build org-roam-db-sync=,
+=M-x org-roam-db-sync= in Emacs).
 
 * Question
 
@@ -24,8 +25,13 @@ writes an FTS5 cache to =.compass.db= (git-ignored), updating only files
 whose mtime changed:
 
 #+begin_src sh :results verbatim
-./projects/ores.compass/compass.sh index
+./compass.sh index                       # incremental, by mtime
+./compass.sh index --org-roam-db-sync    # regenerate .org-roam.db first
 #+end_src
+
+=compass search= (pretty format) reports the age of both databases —
+green under 1h, warning over 5h, critical over 24h — with the refresh
+command to run, so a stale cache announces itself.
 
 To discard the cache and rebuild from scratch (e.g. after large
 renames or an org-roam schema change):
@@ -41,8 +47,8 @@ Inspect what is indexed with =debug=:
 ./projects/ores.compass/compass.sh debug -f glossary
 #+end_src
 
-If =org-roam.db= is missing, compass tells you to run
-=M-x org-roam-db-sync= first.
+If =.org-roam.db= is missing entirely, =index --org-roam-db-sync=
+creates it (emacs batch; packages from =./.packages=).
 
 * Script
 

--- a/doc/recipes/github/how_do_i_address_pr_review_comments.org
+++ b/doc/recipes/github/how_do_i_address_pr_review_comments.org
@@ -52,9 +52,10 @@ Then, for each PR that needs a round in this checkout:
    ./compass.sh review list <pr_number> --detail   # full bodies
    #+end_src
 
-   (=--format json= for machine consumption. Conversation-level
-   comments — review summaries, bot banners — are not line comments;
-   see them with =gh pr view <pr_number> --comments=.)
+   The output has two sections: line-level threads (the ones that
+   take replies and resolution) and conversation-level comments —
+   review summaries and bot banners. =--format json= for machine
+   consumption.
 
 2. /Decide on each comment/. For every comment, make an explicit
    accept/decline decision before touching any code:

--- a/projects/ores.compass/src/compass_review.py
+++ b/projects/ores.compass/src/compass_review.py
@@ -106,7 +106,7 @@ def _fetch_conversation(owner, repo, pr):
             "kind": "comment",
             "id": c["id"],
             "author": (c.get("user") or {}).get("login", "?"),
-            "created_at": c.get("created_at", ""),
+            "created_at": c.get("created_at") or "",
             "state": None,
             "body": c.get("body") or "",
         })
@@ -126,7 +126,7 @@ def _fetch_conversation(owner, repo, pr):
             "kind": "review",
             "id": r["id"],
             "author": (r.get("user") or {}).get("login", "?"),
-            "created_at": r.get("submitted_at", ""),
+            "created_at": r.get("submitted_at") or "",
             "state": r.get("state"),
             "body": r["body"],
         })

--- a/projects/ores.compass/src/compass_review.py
+++ b/projects/ores.compass/src/compass_review.py
@@ -2,9 +2,10 @@
 """compass review — Review pillar: PR review-round verbs wrapping the gh CLI.
 
 Subcommands:
-  list <pr>                      List review comments: id, file, line,
-                                 author, and a body preview (--detail for
-                                 full bodies; --format json for machines).
+  list <pr>                      List review comments — line-level threads
+                                 plus conversation-level comments and
+                                 review summaries (--detail for full
+                                 bodies; --format json for machines).
   reply <pr> <comment-id> <msg>  Reply to a specific review comment.
   resolve <pr>                   Resolve all unresolved review threads
                                  (--dry-run to preview).
@@ -82,11 +83,71 @@ def _fetch_comments(owner, repo, pr):
     return 0, comments
 
 
+def _fetch_conversation(owner, repo, pr):
+    """Fetch conversation-level comments and review summaries for PR.
+
+    Returns (rc, list) where each entry carries kind ('comment' for an
+    issue comment, 'review' for a review summary), id, author,
+    created_at, state (reviews only), and body. State-only reviews
+    with no body (bare approvals) are dropped.
+    """
+    rc, out, err = _run_gh([
+        "api", f"repos/{owner}/{repo}/issues/{pr}/comments",
+        "--paginate", "--jq", ".[]"])
+    if rc != 0:
+        print(err.strip() or "❌ gh api call failed.", file=sys.stderr)
+        return rc, []
+    entries = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        c = json.loads(line)
+        entries.append({
+            "kind": "comment",
+            "id": c["id"],
+            "author": (c.get("user") or {}).get("login", "?"),
+            "created_at": c.get("created_at", ""),
+            "state": None,
+            "body": c.get("body") or "",
+        })
+    rc, out, err = _run_gh([
+        "api", f"repos/{owner}/{repo}/pulls/{pr}/reviews",
+        "--paginate", "--jq", ".[]"])
+    if rc != 0:
+        print(err.strip() or "❌ gh api call failed.", file=sys.stderr)
+        return rc, []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        if not (r.get("body") or "").strip():
+            continue
+        entries.append({
+            "kind": "review",
+            "id": r["id"],
+            "author": (r.get("user") or {}).get("login", "?"),
+            "created_at": r.get("submitted_at", ""),
+            "state": r.get("state"),
+            "body": r["body"],
+        })
+    entries.sort(key=lambda e: e["created_at"])
+    return 0, entries
+
+
 def _preview(body, width=100):
     """First line of BODY squashed to WIDTH chars, image markup stripped."""
     text = re.sub(r"!\[[^]]*\]\([^)]*\)", "", body or "")  # strip images
     text = " ".join(text.split())
     return text[:width] + ("…" if len(text) > width else "")
+
+
+def _print_body(body, detail):
+    """Print BODY indented — full when DETAIL, one-line preview otherwise."""
+    if detail:
+        for body_line in (body or "").splitlines():
+            print(f"    {body_line}")
+    else:
+        print(f"    {_preview(body)}")
 
 
 def _cmd_list(args, project_root):
@@ -96,35 +157,46 @@ def _cmd_list(args, project_root):
     rc, comments = _fetch_comments(owner, repo, args.pr)
     if rc != 0:
         return rc
+    rc, conversation = _fetch_conversation(owner, repo, args.pr)
+    if rc != 0:
+        return rc
 
     if args.format == "json":
         keep = ("id", "in_reply_to_id", "path", "line", "side",
                 "html_url", "body")
-        print(json.dumps(
-            [{k: c.get(k) for k in keep}
-             | {"author": (c.get("user") or {}).get("login", "")}
-             for c in comments], indent=2))
+        print(json.dumps({
+            "line": [{k: c.get(k) for k in keep}
+                     | {"author": (c.get("user") or {}).get("login", "")}
+                     for c in comments],
+            "conversation": conversation,
+        }, indent=2))
         return 0
 
     print(f"🧭 ores.compass — review comments: "
           f"PR #{args.pr} ({owner}/{repo})\n")
-    if not comments:
-        print("  (no review comments)")
-        return 0
+
+    print("Line comments:\n" if comments else "Line comments: (none)\n")
     for c in comments:
         author = (c.get("user") or {}).get("login", "?")
         line = c.get("line") or c.get("original_line") or "?"
         reply_to = c.get("in_reply_to_id")
         marker = f"  ↳ reply to #{reply_to}" if reply_to else ""
         print(f"#{c['id']}  {c.get('path', '?')}:{line}  {author}{marker}")
-        if args.detail:
-            for body_line in (c.get("body") or "").splitlines():
-                print(f"    {body_line}")
-        else:
-            print(f"    {_preview(c.get('body'))}")
+        _print_body(c.get("body"), args.detail)
         print()
+
+    print("Conversation:\n" if conversation else "Conversation: (none)\n")
+    for e in conversation:
+        kind = (f"review summary ({e['state']})" if e["kind"] == "review"
+                else "comment")
+        when = (e["created_at"] or "")[:10]
+        print(f"#{e['id']}  {e['author']}  {when}  [{kind}]")
+        _print_body(e["body"], args.detail)
+        print()
+
     top = sum(1 for c in comments if not c.get("in_reply_to_id"))
-    print(f"{len(comments)} comment(s), {top} top-level.")
+    print(f"{len(comments)} line comment(s) ({top} top-level), "
+          f"{len(conversation)} conversation item(s).")
     return 0
 
 


### PR DESCRIPTION
## Summary

`compass review list` only showed line-level review comments, so the review-round runbook still needed `gh pr view --comments` for review summaries and bot banners. This extends `list` with a Conversation section so one command reads the whole review surface.

## Changes

- `review list <pr>` gains a Conversation section: the PR's issue comments plus review summaries with bodies (state-only approvals dropped), chronologically sorted, covered by `--detail` and `--format json` (now `{line, conversation}`).
- The review-round runbook and the address-review-comments recipe drop their last `gh pr view --comments` reference.
- Close out the review-commands task (shipped in #1078) and start this one in the story.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [Extend compass review list to conversation-level comments](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.html) | 5C9B5256-9246-48D4-9763-4C9098904072 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)