### PR TITLE
[agile] Close health review 3 after PR #1079 merge

### DIFF
--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_align_new_component_flow_with_overview_merge.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_align_new_component_flow_with_overview_merge.org
@@ -52,7 +52,7 @@ Design decisions agreed before implementation:
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete; verified during health review 3. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_colocate_pilot_org.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_colocate_pilot_org.org
@@ -29,7 +29,7 @@ how to find it there.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete; verified during health review 3. |
+| Now          | Nothing.                               |
 | Waiting on   | Final approval / merge.                |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
@@ -33,7 +33,7 @@ migration task that follows in this story.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete; verified during health review 3. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_inventory_remaining_json_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_inventory_remaining_json_models.org
@@ -37,7 +37,7 @@ one scaffolds.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete; verified during health review 3. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_analytics_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_analytics_models.org
@@ -32,7 +32,7 @@ pricing_model_product_parameter) into literate
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_compute_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_compute_models.org
@@ -32,7 +32,7 @@ PR to close out the per-component migration sweep.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_controller_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_controller_models.org
@@ -32,7 +32,7 @@ PR to close out the per-component migration sweep.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_database_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_database_models.org
@@ -32,7 +32,7 @@ PR to close out the per-component migration sweep.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_dq_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_dq_models.org
@@ -31,7 +31,7 @@ files under =projects/ores.dq/modeling/=, using
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_enum_models_to_org.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_enum_models_to_org.org
@@ -34,7 +34,7 @@ enum-org pipeline work, no converter, no loader extension.
 |--------------+----------------------------------------|
 | State        | DONE                                   |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Closed via retirement.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | n/a                                    |
 | Last touched | 2026-06-02                             |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_iam_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_iam_models.org
@@ -31,7 +31,7 @@ files under =projects/ores.iam/modeling/=, using the
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_refdata_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_refdata_models.org
@@ -41,7 +41,7 @@ land via the =:implements <kind-UUID>= mechanism.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_reporting_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_reporting_models.org
@@ -31,7 +31,7 @@ report_definition, report_instance, report_type) into literate
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_scheduler_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_scheduler_models.org
@@ -30,7 +30,7 @@ Convert the single =job_definition_domain_entity.json= under
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_slovaris_reference_data_to_org.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_slovaris_reference_data_to_org.org
@@ -28,7 +28,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | ABANDONED                              |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Superseded by [[id:5104ADAF-390D-4ADB-B005-CE726B553123][Introduce ores.seeder component for database test-data generation]]. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | n/a                                    |
 | Last touched | 2026-06-02                             |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_trading_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_trading_models.org
@@ -33,7 +33,7 @@ output matches the pre-migration regen byte-for-byte.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_workflow_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_workflow_models.org
@@ -30,7 +30,7 @@ under =projects/ores.workflow/modeling/=, using =migrate_json_to_org.py=.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_workspace_models.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_workspace_models.org
@@ -32,7 +32,7 @@ PR to close out the per-component migration sweep.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete: migration verified on disk. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_validate_codegen_after_subcomponent_regroup.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_validate_codegen_after_subcomponent_regroup.org
@@ -53,7 +53,7 @@ field_group / junction org files use the correct group-level
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Complete; verified during health review 3. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/codegen_unified_single_model/story.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_unified_single_model/story.org
@@ -65,7 +65,7 @@ See [[id:F2A1C8E3-9D4B-4F7A-B2E5-6C3D8A1F9B4E][Codegen architecture analysis and
 |---------------+------------------------------------------------------------------------------------------|
 | State         | ABANDONED |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                                                |
-| Now           | Superseded by the org-mode migration story. |
+| Now           | Nothing.                               |
 | Waiting on    | [[id:7AA5B5C3-F7DE-4A17-84A0-75FB3761D43E][Phase 1: Qt derivation]] (model is cleaner without transcribed Qt fields). |
 | Next          | Nothing. |
 | Last touched  | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/commission_currency/task_fix-auxiliary-tenant-filters.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/task_fix-auxiliary-tenant-filters.org
@@ -30,7 +30,7 @@ system-tenant seed rows.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Complete: PR #1042 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_load_ssh_from_env.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_load_ssh_from_env.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | ABANDONED |
 | Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] |
-| Now          | Re-filed as backlog capture. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_show_blocked_dependency_tree.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_show_blocked_dependency_tree.org
@@ -31,7 +31,7 @@ user can see the full chain at a glance without opening individual files.
 |--------------+---------------------------------------------|
 | State        | ABANDONED |
 | Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]]                    |
-| Now          | Re-filed as backlog capture. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                    |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_implement_compass_bearings.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_implement_compass_bearings.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] |
-| Now          | Complete: PR #1024 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
@@ -33,7 +33,7 @@ so every compass command renders documents identically.
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] |
-| Now          | Complete: PR #1077 ready to merge.     |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_implement_compass_pr_management.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_implement_compass_pr_management.org
@@ -34,7 +34,7 @@ following the existing short-circuit pattern.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Complete: compass review list/reply/resolve/pending shipped in PR #1078. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_add_manual_doc_type_to_codegen.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_add_manual_doc_type_to_codegen.org
@@ -29,7 +29,7 @@ Add =manual= as a first-class document type to =ores.codegen= and
 |--------------+-------------------------------------------------------------|
 | State        | DONE                                                        |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]                  |
-| Now          | Implemented on feature/currency-write-docs; pending PR.     |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                                    |
 | Next         | Include in the commission-currency documentation PR.        |
 | Last touched | 2026-06-03                                                  |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_design_operational_pillar_taxonomy.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_design_operational_pillar_taxonomy.org
@@ -40,7 +40,7 @@ this task; it produces the plan and scaffolds the migration tasks.
 |--------------+------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]         |
-| Now          | Complete: PR(s) #1004 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | PR + merge.                                          |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
@@ -37,7 +37,7 @@ init -y=" exits 1.
 |--------------+--------------------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]                        |
-| Now          | Complete: PR(s) #1032, #1034, #1037 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Windows CI green on PR #1037.                                              |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -33,7 +33,7 @@ build directory is configured automatically on first use. Fold
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
-| Now          | Complete: PR(s) #1076 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_port_parse_test_results_to_compass_test_results.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_port_parse_test_results_to_compass_test_results.org
@@ -34,7 +34,7 @@ on hard cutover.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
-| Now          | Complete: PR(s) #1023 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_port_sprint_metrics_to_compass_sprint_charts.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_port_sprint_metrics_to_compass_sprint_charts.org
@@ -32,7 +32,7 @@ today. The standalone script is deleted on hard cutover.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
-| Now          | Complete: PR(s) #1020 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/create-qt-user-guide/task_link_product_identity_to_manual.org
+++ b/doc/agile/versions/v0/sprint_19/create-qt-user-guide/task_link_product_identity_to_manual.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:6111FDF8-96E6-4C40-88BD-C756B6841F85][Create a user guide for ores.qt]] |
-| Now          | Complete; in PR #1074.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/document_sprint_charts/task_implement_document_sprint_charts.org
+++ b/doc/agile/versions/v0/sprint_19/document_sprint_charts/task_implement_document_sprint_charts.org
@@ -38,7 +38,7 @@ it:
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:95429DF9-B645-4E41-8375-A2A5C84A8E5A][Document the sprint health charts]] |
-| Now          | Complete: PR #1039 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
-| Now          | Complete; in PR #1074.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
-| Now          | Complete; in PR #1074.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
-| Now          | Complete; in PR #1074.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
-| Now          | Complete: PR #1074 carries the restructure. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
-| Now          | Complete; in PR #1074.                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Complete: PR(s) #1075 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Complete: PR #1071 merged.             |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
@@ -66,7 +66,7 @@ internal-only, server and client in same repo).
 |--------------+---------------------------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]                           |
-| Now          | Complete: PR(s) #1047, #1070 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Windows CI green.                                                         |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_swap_leg_c1202_in_export_portfolio.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_swap_leg_c1202_in_export_portfolio.org
@@ -34,7 +34,7 @@ threshold, and verify that Windows CI is green.
 |--------------+------------------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
-| Now          | Complete: PR(s) #1031 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Windows CI (PR push).                                            |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_swap_leg_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_swap_leg_c1202_nested_structs.org
@@ -50,7 +50,7 @@ A side benefit: callers simplify — =sl.identity.version= replaces
 |--------------+----------------------------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]                            |
-| Now          | Complete: PR(s) #1041 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Windows CI green.                                                          |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
@@ -31,7 +31,7 @@ service parser header.
 |--------------+------------------------------------------------------------------|
 | State        | DONE |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
-| Now          | Complete: PR(s) #969 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | CI green + review.                                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/introduce_ores_seeder/task_implement_introduce_ores_seeder.org
+++ b/doc/agile/versions/v0/sprint_19/introduce_ores_seeder/task_implement_introduce_ores_seeder.org
@@ -40,7 +40,7 @@ slovaris is authored here too.
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:5104ADAF-390D-4ADB-B005-CE726B553123][Introduce ores.seeder component for database test-data generation]] |
-| Now          | Complete: PR #1018 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
@@ -43,7 +43,7 @@ decision:
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
-| Now          | Complete: PRs #1045 and #1048 merged.  |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing — see the constants-move follow-up task. |
 | Last touched | 2026-06-04                               |

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
@@ -41,7 +41,7 @@ first.
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
-| Now          | Complete: PR #1052 merged.             |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing — see the eventing split task. |
 | Last touched | 2026-06-04                               |

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_split_eventing_into_api_core.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_split_eventing_into_api_core.org
@@ -48,7 +48,7 @@ uses. This completes what the dq.api fix started: apis linking
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
-| Now          | Complete: PR #1068 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/knowledge_graph_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_19/knowledge_graph_improvements/story.org
@@ -24,7 +24,7 @@ sidebar toggle) must be visible and operable.
 |---------------+--------------------------------------------------------------------|
 | State         | DONE                                                               |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                          |
-| Now           | PR #951 merged; all acceptance criteria met.                       |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                                                           |
 | Next          | N/A.                                                               |
 | Last touched  | 2026-05-31                                                         |

--- a/doc/agile/versions/v0/sprint_19/knowledge_graph_improvements/task_implement_knowledge_graph_improvements.org
+++ b/doc/agile/versions/v0/sprint_19/knowledge_graph_improvements/task_implement_knowledge_graph_improvements.org
@@ -29,7 +29,7 @@ options, sidebar toggle) being absent from the graph view.
 |--------------+-----------------------------------------------------------------|
 | State        | DONE                                                            |
 | Parent story | [[id:F3CB848E-72C1-4F81-AAE4-1265F41D47C1][Fix knowledge graph issues]]                   |
-| Now          | PR #951 merged.                                                 |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                                        |
 | Next         | N/A.                                                            |
 | Last touched | 2026-05-31                                                      |

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_add_compass_goto_sprint_support.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_add_compass_goto_sprint_support.org
@@ -31,7 +31,7 @@ runbook is updated to reference =compass goto sprint=.
 |--------------+----------------------------------------|
 | State        | ABANDONED |
 | Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] |
-| Now          | Abandoned: compass goto no longer exists. |
+| Now          | Nothing.                               |
 | Waiting on   | Task: Open new sprint (needs PR merged first). |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
@@ -27,7 +27,7 @@ Sprint 19 wired into the version manifest and agile index; sprint.org mission an
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] |
-| Now          | Done.                                  |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing.                               |
 | Last touched | 2026-05-29                               |

--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
@@ -30,7 +30,7 @@ FIFO).
 |---------------+----------------------------------------|
 | State         | DONE                                                      |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                 |
-| Now           | Nothing. — closed as a knowledge capture.                 |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                                                  |
 | Next          | Nothing.                                                  |
 | Last touched  | 2026-06-03                                                |

--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
@@ -30,7 +30,7 @@ tracking approach]] knowledge doc, then implement the agreed changes.
 |--------------+------------------------------------------------|
 | State        | DONE                                           |
 | Parent story | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]]                      |
-| Now          | Nothing. — closed with story as knowledge capture. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                       |
 | Next         | Nothing.                                       |
 | Last touched | 2026-06-03                                     |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_org_codegen_extensions.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_org_codegen_extensions.org
@@ -62,7 +62,7 @@ extension idea retreats to a simpler sidecar-fragment design.
 |--------------+----------------------------------------|
 | State        | DONE                                   |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | POC complete; mechanism proven on =party=. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Full migration tracked under [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][org-mode migration story]]. |
 | Last touched | 2026-06-01                             |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/story.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/story.org
@@ -112,7 +112,7 @@ fidelity is required; whitespace normalisation is acceptable.
 |---------------+----------------------------------------|
 | State         | DONE                                 |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Complete. All 5 tasks done; PRs #934–#938 merged.                           |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                                                                    |
 | Next          | Nothing.                                                                    |
 | Last touched  | 2026-05-30                               |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
@@ -33,7 +33,7 @@ current SQL files in =projects/ores.sql/create/refdata/=.
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
-| Now          | Implementation complete; awaiting PR review. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                     |
 | Next         | Migrate refdata entity models to new format. |
 | Last touched | 2026-05-29                               |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_migrate_refdata_models.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_migrate_refdata_models.org
@@ -30,7 +30,7 @@ added for parity testing. Run a full parity check to confirm zero logical diff.
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
-| Now          | Implementation complete; awaiting PR review. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                     |
 | Next         | Retire generate_refdata_schema.sh.           |
 | Last touched | 2026-05-29                               |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_retire_generate_refdata_schema.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_retire_generate_refdata_schema.org
@@ -30,7 +30,7 @@ document the replacement command.
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
-| Now          | Implementation complete; awaiting PR review. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                                     |
 | Next         | Close story if this is the last task.        |
 | Last touched | 2026-05-30                               |

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -143,7 +143,7 @@ CI and build tooling improvements: code formatting, static analysis, and build h
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | DONE | 2026-05-29 | 2026-06-05 | Scaffold sprint 19, wire version manifest, bump version, PR. |
 | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] | DONE | 2026-06-02 | 2026-06-02 | Introduce milestone concept; separate version identity from release series; scaffold v1.0 and v2.0 milestone docs. |
 | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | DONE | 2026-05-29 | 2026-05-29 | Select stories from backlog, size tasks, confirm mission. |
-| [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][System 2 health review]] | STARTED | 2026-05-31 |  | Periodic System 2 health checks: goal alignment, load, PR velocity, story/task balance, focus, verdict. |
+| [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][System 2 health review]] | DONE | 2026-05-31 | 2026-06-05 | Periodic System 2 health checks: goal alignment, load, PR velocity, story/task balance, focus, verdict. |
 
 ** LLMs
 

--- a/doc/agile/versions/v0/sprint_19/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_health_review/story.org
@@ -26,11 +26,11 @@ whether the team is focused — rather than merely summarising status.
 
 | Field         | Value                                                                   |
 |---------------+-------------------------------------------------------------------------|
-| State         | STARTED |
+| State         | DONE |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                               |
-| Now           | Health review 3: state-sync audit + compass sprint audit command. |
+| Now           | Nothing. |
 | Waiting on    | Nothing.                                                                |
-| Next          | Land the sync PR; close review 3. |
+| Next          | Nothing. |
 | Last touched  | 2026-06-05 |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
@@ -27,7 +27,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | DONE |
 | Parent story | [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][Sprint health review — System 2 analysis]] |
-| Now          | Complete: PR #1079 merged. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
 | Last touched | 2026-06-05 |

--- a/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
@@ -25,12 +25,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE |
 | Parent story | [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][Sprint health review — System 2 analysis]] |
-| Now          | Sync complete: 30 findings -> 2 (both deliberately open). |
+| Now          | Complete: PR #1079 merged. |
 | Waiting on   | Nothing.                               |
-| Next         | Land PR #1079; close review 3. |
-| Last touched | 2026-06-05                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-05 |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.org
@@ -58,6 +58,7 @@ task closes. Plans do not outlive their task.)
 | 2 | Null repository in GraphQL response crashes audit | projects/ores.compass/src/compass.py | Accepted | Fixed in ef76aa58a; .get() chain + truthiness. |
 | 3 | Table-row regex breaks under org auto-alignment | projects/ores.compass/src/compass.py | Accepted | Fixed in ef76aa58a; \s* padding, [A-Z]+ state. |
 | 4 | Use all() for the merged-PR check | projects/ores.compass/src/compass.py | Accepted | Fixed in ef76aa58a; stricter logic surfaced one further genuine finding, closed in same commit. |
+| 5 | Now should be Nothing. on DONE task (PR #1082 round) | doc/agile/.../task_sync_finished_stories.org | Accepted | Fixed in 7159b8920; noted repo-wide sweep candidate. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
@@ -22,7 +22,7 @@ Sprint 19 has a selected, sized set of stories pulled from the product backlog, 
 |---------------+----------------------------------------|
 | State         | DONE                                 |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Done. PR #927 reviewed and ready to merge. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
 | Next          | Merge PR #927.                         |
 | Last touched  | 2026-05-29                               |

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
@@ -27,7 +27,7 @@ Sprint 19 stories selected from the product backlog, promoted into the sprint, e
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] |
-| Now          | Done. PR #927 reviewed and ready to merge. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Merge PR #927.                         |
 | Last touched | 2026-05-29                               |

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1434,10 +1434,20 @@ def cmd_sprint_audit(args):
 
     # Gather stories, tasks and every referenced PR number.
     pr_re = re.compile(r"pull/(\d+)")
+    now_re = re.compile(r"(?m)^\| Now\s+\|([^|]*)\|")
+
+    def _now_of(text):
+        m = now_re.search(text)
+        return m.group(1).strip() if m else None
+
     stories = []
     all_prs = set()
     for sf in sorted(sprint_dir.glob("*/story.org")):
         title, state, uuid = _read_story_state(sf)
+        try:
+            stext = sf.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            stext = ""
         tasks = []
         for tf in sorted(sf.parent.glob("task_*.org")):
             ttitle, tstate, tuuid, _, _ = _read_task_detail(tf)
@@ -1448,17 +1458,26 @@ def cmd_sprint_audit(args):
             prs = sorted({int(n) for n in pr_re.findall(text)})
             all_prs.update(prs)
             tasks.append({"title": ttitle, "state": tstate,
-                          "uuid": (tuuid or "").upper(), "prs": prs})
+                          "uuid": (tuuid or "").upper(), "prs": prs,
+                          "now": _now_of(text)})
         stories.append({"title": _strip_type_prefix(title or ""),
                         "state": state, "uuid": (uuid or "").upper(),
-                        "dir": sf.parent.name, "tasks": tasks})
+                        "dir": sf.parent.name, "tasks": tasks,
+                        "now": _now_of(stext)})
 
     pr_states = _audit_pr_states(all_prs)
     if all_prs and not pr_states:
         print("⚠️  gh unavailable — skipping merged-PR checks.", file=sys.stderr)
 
-    zombie, closeable, merged_open, mismatch = [], [], [], []
+    zombie, closeable, merged_open, mismatch, stale_now = [], [], [], [], []
     for s in stories:
+        if (s["state"] in _TERMINAL_STATES and s["now"] is not None
+                and s["now"] not in ("Nothing.", "")):
+            stale_now.append(("story", s["title"], s["uuid"], s["state"], s["now"]))
+        for t in s["tasks"]:
+            if (t["state"] in _TERMINAL_STATES and t["now"] is not None
+                    and t["now"] not in ("Nothing.", "")):
+                stale_now.append(("task", t["title"], t["uuid"], t["state"], t["now"]))
         open_tasks = [t for t in s["tasks"] if t["state"] not in _TERMINAL_STATES]
         if s["state"] in _TERMINAL_STATES and open_tasks:
             zombie.append((s, open_tasks))
@@ -1473,7 +1492,8 @@ def cmd_sprint_audit(args):
         if table and table != s["state"]:
             mismatch.append((s, table))
 
-    total = len(zombie) + len(closeable) + len(merged_open) + len(mismatch)
+    total = (len(zombie) + len(closeable) + len(merged_open) + len(mismatch)
+             + len(stale_now))
 
     if args.format == "json":
         findings = (
@@ -1492,7 +1512,10 @@ def cmd_sprint_audit(args):
             + [{"check": "sprint-table-mismatch", "story": s["title"],
                 "story_uuid": s["uuid"], "table_state": table,
                 "story_state": s["state"]}
-               for s, table in mismatch])
+               for s, table in mismatch]
+            + [{"check": "closed-doc-now-not-nothing", "kind": kind,
+                "title": title, "uuid": uuid, "state": state, "now": now}
+               for kind, title, uuid, state, now in stale_now])
         print(json.dumps({"sprint": current_sprint.title,
                           "findings": findings}, indent=2))
         return 0
@@ -1542,6 +1565,13 @@ def cmd_sprint_audit(args):
                   f"{_C_YELLOW}{table}{_C_RESET}, story file says "
                   f"{_C_YELLOW}{s['state']}{_C_RESET}")
             _hint(s["uuid"], 4)
+
+    if stale_now:
+        _section("🧹", "Closed documents whose Now is not 'Nothing.'")
+        for kind, title, uuid, state, now in stale_now:
+            print(f"  • {title}  ({kind}, {state}) Now: "
+                  f"{_C_YELLOW}{now}{_C_RESET}")
+            _hint(uuid, 4)
 
     print(f"\n  {total} finding(s).")
     return 0


### PR DESCRIPTION
## Summary

Clock-off bookkeeping for health review 3: PR #1079 (compass sprint
audit + sprint state sync) merged, so the sync task closes DONE, the
sprint_health_review story returns to DONE, and the sprint table row
is reconciled. `compass sprint audit` now reports only the two
deliberately open currency tasks.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint health review — System 2 analysis](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_health_review/story.html) | 73D162FD-92D6-4567-8D94-4368C97F96E4 |
| Task | [Health review 3 — sync finished stories and tasks](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_health_review/task_sync_finished_stories.html) | BC9CD821-66B4-46CA-8C51-5CDBB9061A05 |