### PR TITLE
[trading,qt,ore] Decompose bond, credit and commodity into nested structs

### DIFF
--- a/doc/agile/product_backlog/inbox/journal_log_newest_first.org
+++ b/doc/agile/product_backlog/inbox/journal_log_newest_first.org
@@ -1,0 +1,38 @@
+:PROPERTIES:
+:ID: B2C9B2C4-3596-4995-95C1-A837DEB09711
+:END:
+#+title: compass journal log: newest-first with --limit
+#+description: journal log prints oldest-first so fresh entries drown at the bottom (and head-clipping shows stale entries). Default to newest-first like git log, add --limit N / -n N to clip, and --chronological to restore oldest-first.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Make =compass journal log= print newest-first by default (matching
+=git log= semantics), add =--limit N= (short =-n N=) to clip to the N
+most recent entries, and =--chronological= to restore oldest-first
+for reading history as a narrative. =journal where= is unaffected (it
+already shows only the last entry).
+
+* Why
+
+Marco spotted the journal "looking stale" mid-session (2026-06-05):
+=journal log= appends and prints chronologically, so the freshest
+entry sits at the bottom of an ever-growing wall — and any
+head-clipping (terminal cut-off, =| head=) surfaces the OLDEST
+entries, which reads as stale state. Newest-first plus a limit makes
+the common question — "where were we just now?" — the zero-effort
+default.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
@@ -79,7 +79,7 @@ split, parse dispatch + planner tests, JSON snapshots.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1083][#1083]] | [trading,qt,ore] Decompose bond, credit and commodity into nested structs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
@@ -25,12 +25,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Not yet started.                       |
+| Now          | Designing sub-struct groupings for bond/credit/commodity. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-04                               |
+| Next         | Apply groupings + identity/audit; update all callers per the FX/equity playbook. |
+| Last touched | 2026-06-05                               |
 
 * Acceptance
 
@@ -38,9 +38,40 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Unlike rates/FX/equity, identity+audit alone leaves these Literals
+over the threshold; each type gets cohesive sub-structs (all =<=9=
+fields, defined in the same header — not shared across types):
+
+- bond (top level 6: identity, terms, features, option, description,
+  audit): =bond_terms= (9: security_id, issuer, currency, face_value,
+  coupon_rate, coupon_frequency_code, day_count_code, issue_date,
+  maturity_date); =bond_features= (6: settlement_days, call_date,
+  conversion_ratio, future_expiry_date, trs_return_type,
+  trs_funding_leg_code); =bond_option= (4: option_type,
+  option_expiry_date, option_strike, ascot_option_type).
+- credit (top level 8: identity, terms, schedule, index, option,
+  tranche, description, audit): =credit_terms= (8: reference_entity,
+  currency, notional, spread, recovery_rate, seniority,
+  restructuring, linked_asset_code); =credit_schedule= (5: tenor,
+  start_date, maturity_date, day_count_code, payment_frequency_code);
+  =credit_index= (2); =credit_option= (3); =credit_tranche= (2).
+- commodity (top level 7: identity, terms, option, pricing, exotic,
+  description, audit): =commodity_terms= (9: commodity_code,
+  currency, quantity, unit, start_date, maturity_date, fixed_price,
+  day_count_code, payment_frequency_code); =commodity_option= (4:
+  option_type, strike_price, exercise_type, swaption_expiry_date);
+  =commodity_pricing= (6: average_type, averaging_start_date,
+  averaging_end_date, spread_commodity_code, spread_amount,
+  strip_frequency_code); =commodity_exotic= (7: variance_strike,
+  accumulation_amount, knock_out_barrier, barrier_type,
+  lower_barrier, upper_barrier, basket_json).
+
+Entities stay flat (+workspace_id per the all-tables decision);
+mappers translate flat ↔ nested. One vertical agent per type owns
+header, entity, mapper, repository, service, Qt form, ores.ore
+mapper + roundtrip tests, repo tests. Shared by hand: trade_handler
+add_flat split (scripted stays flat), ImportTradeDialog else-branch
+split, parse dispatch + planner tests, JSON snapshots.
 
 * Notes
 

--- a/projects/ores.ore/core/src/domain/bond_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/bond_instrument_mapper.cpp
@@ -33,11 +33,11 @@ namespace {
 
 bond_instrument make_base(const std::string& trade_type_code) {
     bond_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.identity.trade_type_code = trade_type_code;
+    r.audit.modified_by = "ores";
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -54,36 +54,36 @@ std::string first_tenor(const xsd::optional<scheduleData>& sd) {
 // ---------------------------------------------------------------------------
 
 void bond_instrument_mapper::map_bond_data(const bondData& bd, bond_instrument& instr) {
-    instr.security_id = std::string(bd.SecurityId);
+    instr.terms.security_id = std::string(bd.SecurityId);
     if (bd.IssuerId)
-        instr.issuer = std::string(*bd.IssuerId);
+        instr.terms.issuer = std::string(*bd.IssuerId);
     if (bd.IssueDate)
-        instr.issue_date = std::string(*bd.IssueDate);
+        instr.terms.issue_date = std::string(*bd.IssueDate);
     if (bd.SettlementDays) {
         const std::string settlement_days_str(*bd.SettlementDays);
         if (!settlement_days_str.empty())
-            instr.settlement_days = std::stoi(settlement_days_str);
+            instr.features.settlement_days = std::stoi(settlement_days_str);
     }
 
     if (!bd.LegData.empty()) {
         const auto& ld = bd.LegData.front();
         if (ld.Currency)
-            instr.currency = std::string(*ld.Currency);
+            instr.terms.currency = std::string(*ld.Currency);
         if (ld.Notionals && !ld.Notionals->Notional.empty())
-            instr.face_value = static_cast<double>(ld.Notionals->Notional.front());
+            instr.terms.face_value = static_cast<double>(ld.Notionals->Notional.front());
         if (ld.DayCounter)
-            instr.day_count_code = to_string(*ld.DayCounter);
-        instr.coupon_frequency_code = first_tenor(ld.ScheduleData);
+            instr.terms.day_count_code = to_string(*ld.DayCounter);
+        instr.terms.coupon_frequency_code = first_tenor(ld.ScheduleData);
 
         if (ld.legDataType && ld.legDataType->FixedLegData &&
             !ld.legDataType->FixedLegData->Rates.Rate.empty())
-            instr.coupon_rate =
+            instr.terms.coupon_rate =
                 static_cast<double>(ld.legDataType->FixedLegData->Rates.Rate.front());
 
         if (ld.ScheduleData && !ld.ScheduleData->Rules.empty()) {
             const auto& rule = ld.ScheduleData->Rules.front();
             if (rule.EndDate)
-                instr.maturity_date = std::string(*rule.EndDate);
+                instr.terms.maturity_date = std::string(*rule.EndDate);
         }
     }
 }
@@ -95,50 +95,50 @@ void bond_instrument_mapper::map_bond_data(const bondData& bd, bond_instrument& 
 bondData bond_instrument_mapper::reverse_bond_data(const bond_instrument& instr) {
     bondData bd;
 
-    static_cast<std::string&>(bd.SecurityId) = instr.security_id;
-    if (!instr.issuer.empty()) {
+    static_cast<std::string&>(bd.SecurityId) = instr.terms.security_id;
+    if (!instr.terms.issuer.empty()) {
         bondData_IssuerId_t id;
-        static_cast<std::string&>(id) = instr.issuer;
+        static_cast<std::string&>(id) = instr.terms.issuer;
         bd.IssuerId = std::move(id);
     }
-    if (!instr.issue_date.empty()) {
+    if (!instr.terms.issue_date.empty()) {
         bondData_IssueDate_t d;
-        static_cast<std::string&>(d) = instr.issue_date;
+        static_cast<std::string&>(d) = instr.terms.issue_date;
         bd.IssueDate = std::move(d);
     }
-    if (instr.settlement_days != 0) {
+    if (instr.features.settlement_days != 0) {
         bondData_SettlementDays_t sd;
-        static_cast<std::string&>(sd) = std::to_string(instr.settlement_days);
+        static_cast<std::string&>(sd) = std::to_string(instr.features.settlement_days);
         bd.SettlementDays = std::move(sd);
     }
 
-    if (!instr.currency.empty() || instr.face_value != 0.0) {
+    if (!instr.terms.currency.empty() || instr.terms.face_value != 0.0) {
         legData ld;
         ld.LegType = legType::Fixed;
 
-        if (!instr.currency.empty())
-            ld.Currency = instr.currency;
+        if (!instr.terms.currency.empty())
+            ld.Currency = instr.terms.currency;
 
-        if (instr.face_value != 0.0) {
+        if (instr.terms.face_value != 0.0) {
             legData_Notionals_t n;
             legData_Notionals_t_Notional_t nv;
-            static_cast<float&>(nv) = static_cast<float>(instr.face_value);
+            static_cast<float&>(nv) = static_cast<float>(instr.terms.face_value);
             n.Notional.push_back(nv);
             ld.Notionals = std::move(n);
         }
 
-        if (!instr.maturity_date.empty() || !instr.coupon_frequency_code.empty()) {
+        if (!instr.terms.maturity_date.empty() || !instr.terms.coupon_frequency_code.empty()) {
             scheduleData_Rules_t rule;
-            if (!instr.maturity_date.empty()) {
+            if (!instr.terms.maturity_date.empty()) {
                 domain::date d;
-                static_cast<std::string&>(d) = instr.maturity_date;
+                static_cast<std::string&>(d) = instr.terms.maturity_date;
                 rule.EndDate = xsd::optional<domain::date>(d);
             }
-            if (!instr.coupon_frequency_code.empty())
-                static_cast<std::string&>(rule.Tenor) = instr.coupon_frequency_code;
-            if (!instr.issue_date.empty()) {
+            if (!instr.terms.coupon_frequency_code.empty())
+                static_cast<std::string&>(rule.Tenor) = instr.terms.coupon_frequency_code;
+            if (!instr.terms.issue_date.empty()) {
                 domain::date sd;
-                static_cast<std::string&>(sd) = instr.issue_date;
+                static_cast<std::string&>(sd) = instr.terms.issue_date;
                 rule.StartDate = xsd::optional<domain::date>(sd);
             }
             scheduleData sched;
@@ -146,10 +146,10 @@ bondData bond_instrument_mapper::reverse_bond_data(const bond_instrument& instr)
             ld.ScheduleData = std::move(sched);
         }
 
-        if (instr.coupon_rate != 0.0) {
+        if (instr.terms.coupon_rate != 0.0) {
             _FixedLegData_t fld;
             _FixedLegData_t_Rates_t_Rate_t rate;
-            static_cast<float&>(rate) = static_cast<float>(instr.coupon_rate);
+            static_cast<float&>(rate) = static_cast<float>(instr.terms.coupon_rate);
             fld.Rates.Rate.push_back(rate);
             legDataType_group_t ldt;
             ldt.FixedLegData = std::move(fld);
@@ -279,15 +279,15 @@ trading::domain::bond_instrument bond_instrument_mapper::forward_bond_option(con
 
     // Option fields
     if (d.OptionData.OptionType)
-        result.option_type = std::string(*d.OptionData.OptionType);
+        result.option.option_type = std::string(*d.OptionData.OptionType);
     if (d.OptionData.exerciseDatesGroup && d.OptionData.exerciseDatesGroup->ExerciseDates &&
         !d.OptionData.exerciseDatesGroup->ExerciseDates->ExerciseDate.empty())
-        result.option_expiry_date =
+        result.option.option_expiry_date =
             std::string(d.OptionData.exerciseDatesGroup->ExerciseDates->ExerciseDate.front());
     if (d.strikeGroup.Strike) {
         const std::string s(*d.strikeGroup.Strike);
         if (!s.empty())
-            result.option_strike = std::stod(s);
+            result.option.option_strike = std::stod(s);
     }
 
     return result;
@@ -306,15 +306,16 @@ trading::domain::bond_instrument bond_instrument_mapper::forward_bond_trs(const 
 
     map_bond_data(d.BondData, result);
 
-    result.trs_return_type = "TotalReturn";
+    result.features.trs_return_type = "TotalReturn";
 
     // Funding leg: capture index if floating, otherwise note fixed rate
     const auto& ld = d.FundingData.LegData;
     if (ld.legDataType) {
         if (ld.legDataType->FloatingLegData)
-            result.trs_funding_leg_code = std::string(ld.legDataType->FloatingLegData->Index);
+            result.features.trs_funding_leg_code =
+                std::string(ld.legDataType->FloatingLegData->Index);
         else if (ld.legDataType->FixedLegData && !ld.legDataType->FixedLegData->Rates.Rate.empty())
-            result.trs_funding_leg_code = "Fixed";
+            result.features.trs_funding_leg_code = "Fixed";
     }
 
     return result;
@@ -330,23 +331,23 @@ trade bond_instrument_mapper::reverse_bond_option(const bond_instrument& instr) 
     t.TradeType = oreTradeType::BondOption;
     bondOptionData d;
     d.BondData = reverse_bond_data(instr);
-    if (!instr.option_type.empty()) {
+    if (!instr.option.option_type.empty()) {
         optionData_OptionType_t ot;
-        static_cast<std::string&>(ot) = instr.option_type;
+        static_cast<std::string&>(ot) = instr.option.option_type;
         d.OptionData.OptionType = std::move(ot);
     }
-    if (!instr.option_expiry_date.empty()) {
+    if (!instr.option.option_expiry_date.empty()) {
         _ExerciseDates_t exd;
         date ed;
-        static_cast<std::string&>(ed) = instr.option_expiry_date;
+        static_cast<std::string&>(ed) = instr.option.option_expiry_date;
         exd.ExerciseDate.push_back(ed);
         exerciseDatesGroup_group_t eg;
         eg.ExerciseDates = std::move(exd);
         d.OptionData.exerciseDatesGroup = std::move(eg);
     }
-    if (instr.option_strike) {
+    if (instr.option.option_strike) {
         _Strike_t s;
-        static_cast<std::string&>(s) = std::to_string(*instr.option_strike);
+        static_cast<std::string&>(s) = std::to_string(*instr.option.option_strike);
         d.strikeGroup.Strike = std::move(s);
     }
     t.BondOptionData = std::move(d);
@@ -369,12 +370,13 @@ trade bond_instrument_mapper::reverse_bond_trs(const bond_instrument& instr) {
     d.TotalReturnData.PriceType = std::move(pt);
     // Reconstruct funding leg from captured code.
     d.FundingData.LegData.Payer = false;
-    if (instr.trs_funding_leg_code.empty() || instr.trs_funding_leg_code == "Fixed") {
+    if (instr.features.trs_funding_leg_code.empty() ||
+        instr.features.trs_funding_leg_code == "Fixed") {
         d.FundingData.LegData.LegType = legType::Fixed;
     } else {
         d.FundingData.LegData.LegType = legType::Floating;
         _FloatingLegData_t fld;
-        static_cast<std::string&>(fld.Index) = instr.trs_funding_leg_code;
+        static_cast<std::string&>(fld.Index) = instr.features.trs_funding_leg_code;
         legDataType_group_t ldt;
         ldt.FloatingLegData = std::move(fld);
         d.FundingData.LegData.legDataType = std::move(ldt);
@@ -396,9 +398,9 @@ trading::domain::bond_instrument bond_instrument_mapper::forward_bond_repo(const
     map_bond_data(d.BondData, result);
     // Repo leg: capture payment frequency from leg type
     if (d.RepoData.LegData.LegType == legType::Floating) {
-        result.coupon_frequency_code = "Quarterly";
+        result.terms.coupon_frequency_code = "Quarterly";
     } else {
-        result.coupon_frequency_code = "Maturity";
+        result.terms.coupon_frequency_code = "Maturity";
     }
     return result;
 }

--- a/projects/ores.ore/core/src/domain/commodity_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/commodity_instrument_mapper.cpp
@@ -34,11 +34,11 @@ namespace {
 
 commodity_instrument make_base(const std::string& trade_type_code) {
     commodity_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.identity.trade_type_code = trade_type_code;
+    r.audit.modified_by = "ores";
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -189,20 +189,20 @@ swap_leg_info extract_floating_leg_info(const xsd::vector<legData>& legs) {
 optionData make_option_data(const commodity_instrument& instr) {
     optionData od;
     static_cast<std::string&>(od.LongShort) = "Long";
-    if (!instr.option_type.empty()) {
+    if (!instr.option.option_type.empty()) {
         optionData_OptionType_t ot;
-        static_cast<std::string&>(ot) = instr.option_type;
+        static_cast<std::string&>(ot) = instr.option.option_type;
         od.OptionType = std::move(ot);
     }
-    if (!instr.exercise_type.empty()) {
+    if (!instr.option.exercise_type.empty()) {
         optionData_Style_t st;
-        static_cast<std::string&>(st) = instr.exercise_type;
+        static_cast<std::string&>(st) = instr.option.exercise_type;
         od.Style = std::move(st);
     }
-    if (!instr.maturity_date.empty()) {
+    if (!instr.terms.maturity_date.empty()) {
         _ExerciseDates_t exd;
         date ed;
-        static_cast<std::string&>(ed) = instr.maturity_date;
+        static_cast<std::string&>(ed) = instr.terms.maturity_date;
         exd.ExerciseDate.push_back(ed);
         exerciseDatesGroup_group_t eg;
         eg.ExerciseDates = std::move(exd);
@@ -225,11 +225,11 @@ commodity_instrument_mapper::forward_commodity_forward(const trade& t) {
         return result;
     const auto& d = *t.CommodityForwardData;
 
-    result.commodity_code = std::string(d.Name);
-    result.currency = to_string(d.Currency);
-    result.quantity = static_cast<double>(d.Quantity);
-    result.fixed_price = static_cast<double>(d.Strike);
-    result.maturity_date = std::string(d.Maturity);
+    result.terms.commodity_code = std::string(d.Name);
+    result.terms.currency = to_string(d.Currency);
+    result.terms.quantity = static_cast<double>(d.Quantity);
+    result.terms.fixed_price = static_cast<double>(d.Strike);
+    result.terms.maturity_date = std::string(d.Maturity);
     return result;
 }
 
@@ -245,13 +245,13 @@ commodity_instrument_mapper::forward_commodity_option(const trade& t) {
         return result;
     const auto& d = *t.CommodityOptionData;
 
-    result.commodity_code = std::string(d.Name);
-    result.currency = to_string(d.Currency);
-    result.quantity = static_cast<double>(d.Quantity);
-    result.strike_price = static_cast<double>(d.Strike);
-    result.option_type = extract_option_type(d.OptionData);
-    result.exercise_type = extract_exercise_style(d.OptionData);
-    result.maturity_date = first_exercise_date(d.OptionData);
+    result.terms.commodity_code = std::string(d.Name);
+    result.terms.currency = to_string(d.Currency);
+    result.terms.quantity = static_cast<double>(d.Quantity);
+    result.option.strike_price = static_cast<double>(d.Strike);
+    result.option.option_type = extract_option_type(d.OptionData);
+    result.option.exercise_type = extract_exercise_style(d.OptionData);
+    result.terms.maturity_date = first_exercise_date(d.OptionData);
     return result;
 }
 
@@ -268,10 +268,10 @@ commodity_instrument_mapper::forward_commodity_swap(const trade& t) {
     const auto& d = *t.SwapData;
 
     const auto info = extract_floating_leg_info(d.LegData);
-    result.commodity_code = info.commodity_code;
-    result.currency = info.currency;
-    result.start_date = info.start_date;
-    result.maturity_date = info.maturity_date;
+    result.terms.commodity_code = info.commodity_code;
+    result.terms.currency = info.currency;
+    result.terms.start_date = info.start_date;
+    result.terms.maturity_date = info.maturity_date;
     return result;
 }
 
@@ -287,12 +287,12 @@ commodity_instrument_mapper::forward_commodity_swaption(const trade& t) {
         return result;
     const auto& d = *t.CommoditySwaptionData;
 
-    result.swaption_expiry_date = first_exercise_date(d.OptionData);
+    result.option.swaption_expiry_date = first_exercise_date(d.OptionData);
     const auto info = extract_floating_leg_info(d.LegData);
-    result.commodity_code = info.commodity_code;
-    result.currency = info.currency;
-    result.start_date = info.start_date;
-    result.maturity_date = info.maturity_date;
+    result.terms.commodity_code = info.commodity_code;
+    result.terms.currency = info.currency;
+    result.terms.start_date = info.start_date;
+    result.terms.maturity_date = info.maturity_date;
     return result;
 }
 
@@ -308,12 +308,12 @@ commodity_instrument_mapper::forward_commodity_variance_swap(const trade& t) {
         return result;
     const auto& d = *t.CommodityVarianceSwapData;
 
-    result.commodity_code = extract_underlying_name(d.underlyingTypes);
-    result.currency = to_string(d.Currency);
-    result.start_date = std::string(d.StartDate);
-    result.maturity_date = std::string(d.EndDate);
-    result.variance_strike = static_cast<double>(d.Strike);
-    result.quantity = static_cast<double>(d.Notional);
+    result.terms.commodity_code = extract_underlying_name(d.underlyingTypes);
+    result.terms.currency = to_string(d.Currency);
+    result.terms.start_date = std::string(d.StartDate);
+    result.terms.maturity_date = std::string(d.EndDate);
+    result.exotic.variance_strike = static_cast<double>(d.Strike);
+    result.terms.quantity = static_cast<double>(d.Notional);
     return result;
 }
 
@@ -330,16 +330,16 @@ commodity_instrument_mapper::forward_commodity_apo(const trade& t) {
         return result;
     const auto& d = *t.CommodityAveragePriceOptionData;
 
-    result.commodity_code = std::string(d.Name);
-    result.currency = to_string(d.Currency);
-    result.quantity = static_cast<double>(d.Quantity);
-    result.strike_price = static_cast<double>(d.Strike);
-    result.option_type = extract_option_type(d.OptionData);
-    result.exercise_type = extract_exercise_style(d.OptionData);
-    result.maturity_date = first_exercise_date(d.OptionData);
-    result.averaging_start_date = std::string(d.StartDate);
-    result.averaging_end_date = std::string(d.EndDate);
-    result.average_type = to_string(d.PriceType);
+    result.terms.commodity_code = std::string(d.Name);
+    result.terms.currency = to_string(d.Currency);
+    result.terms.quantity = static_cast<double>(d.Quantity);
+    result.option.strike_price = static_cast<double>(d.Strike);
+    result.option.option_type = extract_option_type(d.OptionData);
+    result.option.exercise_type = extract_exercise_style(d.OptionData);
+    result.terms.maturity_date = first_exercise_date(d.OptionData);
+    result.pricing.averaging_start_date = std::string(d.StartDate);
+    result.pricing.averaging_end_date = std::string(d.EndDate);
+    result.pricing.average_type = to_string(d.PriceType);
     return result;
 }
 
@@ -358,12 +358,13 @@ commodity_instrument_mapper::forward_commodity_option_strip(const trade& t) {
     // Extract commodity code from the leg's floating data
     if (d.LegData.legDataType && d.LegData.legDataType->CommodityFloatingLegData) {
         const auto& fl = *d.LegData.legDataType->CommodityFloatingLegData;
-        result.commodity_code = std::string(fl.Name);
+        result.terms.commodity_code = std::string(fl.Name);
     }
     if (d.LegData.Currency)
-        result.currency = std::string(*d.LegData.Currency);
+        result.terms.currency = std::string(*d.LegData.Currency);
     if (d.LegData.ScheduleData && !d.LegData.ScheduleData->Rules.empty())
-        result.strip_frequency_code = std::string(d.LegData.ScheduleData->Rules.front().Tenor);
+        result.pricing.strip_frequency_code =
+            std::string(d.LegData.ScheduleData->Rules.front().Tenor);
     return result;
 }
 
@@ -377,11 +378,11 @@ trade commodity_instrument_mapper::reverse_commodity_forward(const commodity_ins
     t.TradeType = oreTradeType::CommodityForward;
     commodityForwardData d;
     d.Position = longShort::Long;
-    static_cast<std::string&>(d.Maturity) = instr.maturity_date;
-    static_cast<std::string&>(d.Name) = instr.commodity_code;
-    d.Currency = parse_currency_code(instr.currency);
-    d.Strike = static_cast<float>(instr.fixed_price.value_or(0.0));
-    d.Quantity = static_cast<float>(instr.quantity);
+    static_cast<std::string&>(d.Maturity) = instr.terms.maturity_date;
+    static_cast<std::string&>(d.Name) = instr.terms.commodity_code;
+    d.Currency = parse_currency_code(instr.terms.currency);
+    d.Strike = static_cast<float>(instr.terms.fixed_price.value_or(0.0));
+    d.Quantity = static_cast<float>(instr.terms.quantity);
     t.CommodityForwardData = std::move(d);
     return t;
 }
@@ -396,10 +397,10 @@ trade commodity_instrument_mapper::reverse_commodity_option(const commodity_inst
     t.TradeType = oreTradeType::CommodityOption;
     commodityOptionData d;
     d.OptionData = make_option_data(instr);
-    static_cast<std::string&>(d.Name) = instr.commodity_code;
-    d.Currency = parse_currency_code(instr.currency);
-    d.Strike = static_cast<float>(instr.strike_price.value_or(0.0));
-    d.Quantity = static_cast<float>(instr.quantity);
+    static_cast<std::string&>(d.Name) = instr.terms.commodity_code;
+    d.Currency = parse_currency_code(instr.terms.currency);
+    d.Strike = static_cast<float>(instr.option.strike_price.value_or(0.0));
+    d.Quantity = static_cast<float>(instr.terms.quantity);
     t.CommodityOptionData = std::move(d);
     return t;
 }
@@ -418,8 +419,8 @@ trade commodity_instrument_mapper::reverse_commodity_swap(const commodity_instru
     legData fixedLeg;
     fixedLeg.LegType = legType::CommodityFixed;
     fixedLeg.Payer = false;
-    if (!instr.currency.empty())
-        fixedLeg.Currency = instr.currency;
+    if (!instr.terms.currency.empty())
+        fixedLeg.Currency = instr.terms.currency;
     _CommodityFixedLegData_t fl;
     pricesType_Price_t price;
     static_cast<float&>(price) = 0.0f;
@@ -433,21 +434,21 @@ trade commodity_instrument_mapper::reverse_commodity_swap(const commodity_instru
     legData floatLeg;
     floatLeg.LegType = legType::CommodityFloating;
     floatLeg.Payer = true;
-    if (!instr.currency.empty())
-        floatLeg.Currency = instr.currency;
+    if (!instr.terms.currency.empty())
+        floatLeg.Currency = instr.terms.currency;
     _CommodityFloatingLegData_t cfl;
-    static_cast<std::string&>(cfl.Name) = instr.commodity_code;
+    static_cast<std::string&>(cfl.Name) = instr.terms.commodity_code;
     cfl.PriceType = priceType::FutureSettlement;
     legDataType_group_t flt2;
     flt2.CommodityFloatingLegData = std::move(cfl);
     floatLeg.legDataType = std::move(flt2);
-    if (!instr.start_date.empty()) {
+    if (!instr.terms.start_date.empty()) {
         scheduleData sd;
         scheduleData_Rules_t rule;
-        static_cast<std::string&>(rule.StartDate) = instr.start_date;
-        if (!instr.maturity_date.empty()) {
+        static_cast<std::string&>(rule.StartDate) = instr.terms.start_date;
+        if (!instr.terms.maturity_date.empty()) {
             date ed;
-            static_cast<std::string&>(ed) = instr.maturity_date;
+            static_cast<std::string&>(ed) = instr.terms.maturity_date;
             rule.EndDate = std::move(ed);
         }
         static_cast<std::string&>(rule.Tenor) = "1M";
@@ -472,10 +473,10 @@ trade commodity_instrument_mapper::reverse_commodity_swaption(const commodity_in
 
     optionData od;
     static_cast<std::string&>(od.LongShort) = "Long";
-    if (!instr.swaption_expiry_date.empty()) {
+    if (!instr.option.swaption_expiry_date.empty()) {
         _ExerciseDates_t exd;
         date ed;
-        static_cast<std::string&>(ed) = instr.swaption_expiry_date;
+        static_cast<std::string&>(ed) = instr.option.swaption_expiry_date;
         exd.ExerciseDate.push_back(ed);
         exerciseDatesGroup_group_t eg;
         eg.ExerciseDates = std::move(exd);
@@ -487,10 +488,10 @@ trade commodity_instrument_mapper::reverse_commodity_swaption(const commodity_in
     legData floatLeg;
     floatLeg.LegType = legType::CommodityFloating;
     floatLeg.Payer = false;
-    if (!instr.currency.empty())
-        floatLeg.Currency = instr.currency;
+    if (!instr.terms.currency.empty())
+        floatLeg.Currency = instr.terms.currency;
     _CommodityFloatingLegData_t cfl;
-    static_cast<std::string&>(cfl.Name) = instr.commodity_code;
+    static_cast<std::string&>(cfl.Name) = instr.terms.commodity_code;
     cfl.PriceType = priceType::FutureSettlement;
     legDataType_group_t ldt;
     ldt.CommodityFloatingLegData = std::move(cfl);
@@ -511,16 +512,16 @@ trade commodity_instrument_mapper::reverse_commodity_variance_swap(
     trade t;
     t.TradeType = oreTradeType::CommodityVarianceSwap;
     varianceSwapData d;
-    static_cast<std::string&>(d.StartDate) = instr.start_date;
-    static_cast<std::string&>(d.EndDate) = instr.maturity_date;
-    d.Currency = parse_currency_code(instr.currency);
+    static_cast<std::string&>(d.StartDate) = instr.terms.start_date;
+    static_cast<std::string&>(d.EndDate) = instr.terms.maturity_date;
+    d.Currency = parse_currency_code(instr.terms.currency);
     // Set underlying via Name field of underlyingTypes_group_t
     _Name_t n;
-    static_cast<std::string&>(n) = instr.commodity_code;
+    static_cast<std::string&>(n) = instr.terms.commodity_code;
     d.underlyingTypes.Name = std::move(n);
     static_cast<std::string&>(d.LongShort) = "Long";
-    d.Strike = static_cast<float>(instr.variance_strike.value_or(0.0));
-    d.Notional = static_cast<float>(instr.quantity);
+    d.Strike = static_cast<float>(instr.exotic.variance_strike.value_or(0.0));
+    d.Notional = static_cast<float>(instr.terms.quantity);
     static_cast<std::string&>(d.Calendar) = "USD";
     t.CommodityVarianceSwapData = std::move(d);
     return t;
@@ -536,13 +537,13 @@ trade commodity_instrument_mapper::reverse_commodity_apo(const commodity_instrum
     t.TradeType = oreTradeType::CommodityAveragePriceOption;
     commodityAveragePriceOptionData d;
     d.OptionData = make_option_data(instr);
-    static_cast<std::string&>(d.Name) = instr.commodity_code;
-    d.Currency = parse_currency_code(instr.currency);
-    d.Quantity = static_cast<float>(instr.quantity);
-    d.Strike = static_cast<float>(instr.strike_price.value_or(0.0));
+    static_cast<std::string&>(d.Name) = instr.terms.commodity_code;
+    d.Currency = parse_currency_code(instr.terms.currency);
+    d.Quantity = static_cast<float>(instr.terms.quantity);
+    d.Strike = static_cast<float>(instr.option.strike_price.value_or(0.0));
     d.PriceType = priceType::FutureSettlement;
-    static_cast<std::string&>(d.StartDate) = instr.averaging_start_date;
-    static_cast<std::string&>(d.EndDate) = instr.averaging_end_date;
+    static_cast<std::string&>(d.StartDate) = instr.pricing.averaging_start_date;
+    static_cast<std::string&>(d.EndDate) = instr.pricing.averaging_end_date;
     static_cast<std::string&>(d.PaymentCalendar) = "US-NYSE";
     static_cast<std::string&>(d.PaymentLag) = "5";
     d.PaymentConvention = businessDayConvention::Following;
@@ -565,18 +566,18 @@ trade commodity_instrument_mapper::reverse_commodity_option_strip(
     legData leg;
     leg.LegType = legType::CommodityFloating;
     leg.Payer = false;
-    if (!instr.currency.empty())
-        leg.Currency = instr.currency;
+    if (!instr.terms.currency.empty())
+        leg.Currency = instr.terms.currency;
     _CommodityFloatingLegData_t cfl;
-    static_cast<std::string&>(cfl.Name) = instr.commodity_code;
+    static_cast<std::string&>(cfl.Name) = instr.terms.commodity_code;
     cfl.PriceType = priceType::FutureSettlement;
     legDataType_group_t ldt;
     ldt.CommodityFloatingLegData = std::move(cfl);
     leg.legDataType = std::move(ldt);
-    if (!instr.strip_frequency_code.empty()) {
+    if (!instr.pricing.strip_frequency_code.empty()) {
         scheduleData sd;
         scheduleData_Rules_t rule;
-        static_cast<std::string&>(rule.Tenor) = instr.strip_frequency_code;
+        static_cast<std::string&>(rule.Tenor) = instr.pricing.strip_frequency_code;
         sd.Rules.push_back(std::move(rule));
         leg.ScheduleData = std::move(sd);
     }

--- a/projects/ores.ore/core/src/domain/credit_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/credit_instrument_mapper.cpp
@@ -32,11 +32,11 @@ namespace {
 
 credit_instrument make_base(const std::string& trade_type_code) {
     credit_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.identity.trade_type_code = trade_type_code;
+    r.audit.modified_by = "ores";
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -58,21 +58,21 @@ std::string first_exercise_date(const optionData& opt) {
 
 void credit_instrument_mapper::map_cds_leg(const legData& ld, credit_instrument& instr) {
     if (ld.Currency)
-        instr.currency = std::string(*ld.Currency);
+        instr.terms.currency = std::string(*ld.Currency);
     if (ld.Notionals && !ld.Notionals->Notional.empty())
-        instr.notional = static_cast<double>(ld.Notionals->Notional.front());
+        instr.terms.notional = static_cast<double>(ld.Notionals->Notional.front());
     if (ld.DayCounter)
-        instr.day_count_code = to_string(*ld.DayCounter);
+        instr.schedule.day_count_code = to_string(*ld.DayCounter);
     if (ld.legDataType && ld.legDataType->FixedLegData &&
         !ld.legDataType->FixedLegData->Rates.Rate.empty())
-        instr.spread = static_cast<double>(ld.legDataType->FixedLegData->Rates.Rate.front());
+        instr.terms.spread = static_cast<double>(ld.legDataType->FixedLegData->Rates.Rate.front());
     if (!ld.ScheduleData || ld.ScheduleData->Rules.empty())
         return;
     const auto& rule = ld.ScheduleData->Rules.front();
-    instr.start_date = std::string(rule.StartDate);
+    instr.schedule.start_date = std::string(rule.StartDate);
     if (rule.EndDate)
-        instr.maturity_date = std::string(*rule.EndDate);
-    instr.payment_frequency_code = std::string(rule.Tenor);
+        instr.schedule.maturity_date = std::string(*rule.EndDate);
+    instr.schedule.payment_frequency_code = std::string(rule.Tenor);
 }
 
 // ---------------------------------------------------------------------------
@@ -83,38 +83,38 @@ legData credit_instrument_mapper::reverse_cds_leg(const credit_instrument& instr
     legData ld;
     ld.LegType = legType::Fixed;
     ld.Payer = true;
-    if (!instr.currency.empty())
-        ld.Currency = instr.currency;
-    if (instr.notional != 0.0) {
+    if (!instr.terms.currency.empty())
+        ld.Currency = instr.terms.currency;
+    if (instr.terms.notional != 0.0) {
         legData_Notionals_t n;
         legData_Notionals_t_Notional_t nv;
-        static_cast<float&>(nv) = static_cast<float>(instr.notional);
+        static_cast<float&>(nv) = static_cast<float>(instr.terms.notional);
         n.Notional.push_back(nv);
         ld.Notionals = std::move(n);
     }
-    if (instr.spread != 0.0) {
+    if (instr.terms.spread != 0.0) {
         _FixedLegData_t fld;
         _FixedLegData_t_Rates_t_Rate_t rate;
-        static_cast<float&>(rate) = static_cast<float>(instr.spread);
+        static_cast<float&>(rate) = static_cast<float>(instr.terms.spread);
         fld.Rates.Rate.push_back(rate);
         legDataType_group_t ldt;
         ldt.FixedLegData = std::move(fld);
         ld.legDataType = std::move(ldt);
     }
-    if (!instr.start_date.empty() || !instr.maturity_date.empty()) {
+    if (!instr.schedule.start_date.empty() || !instr.schedule.maturity_date.empty()) {
         scheduleData_Rules_t rule;
-        if (!instr.start_date.empty()) {
+        if (!instr.schedule.start_date.empty()) {
             date sd;
-            static_cast<std::string&>(sd) = instr.start_date;
+            static_cast<std::string&>(sd) = instr.schedule.start_date;
             rule.StartDate = xsd::optional<date>(sd);
         }
-        if (!instr.maturity_date.empty()) {
+        if (!instr.schedule.maturity_date.empty()) {
             date ed;
-            static_cast<std::string&>(ed) = instr.maturity_date;
+            static_cast<std::string&>(ed) = instr.schedule.maturity_date;
             rule.EndDate = xsd::optional<date>(ed);
         }
-        if (!instr.payment_frequency_code.empty())
-            static_cast<std::string&>(rule.Tenor) = instr.payment_frequency_code;
+        if (!instr.schedule.payment_frequency_code.empty())
+            static_cast<std::string&>(rule.Tenor) = instr.schedule.payment_frequency_code;
         scheduleData sched;
         sched.Rules.push_back(std::move(rule));
         ld.ScheduleData = std::move(sched);
@@ -133,11 +133,11 @@ trading::domain::credit_instrument credit_instrument_mapper::forward_cds(const t
         return result;
     const auto& d = *t.CreditDefaultSwapData;
     if (d.IssuerId)
-        result.reference_entity = std::string(*d.IssuerId);
+        result.terms.reference_entity = std::string(*d.IssuerId);
     else if (d.creditCurveIdType.CreditCurveId)
-        result.reference_entity = std::string(*d.creditCurveIdType.CreditCurveId);
+        result.terms.reference_entity = std::string(*d.creditCurveIdType.CreditCurveId);
     if (d.FixedRecoveryRate)
-        result.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
+        result.terms.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
     map_cds_leg(d.LegData, result);
     return result;
 }
@@ -152,8 +152,8 @@ trading::domain::credit_instrument credit_instrument_mapper::forward_index_cds(c
     if (!t.IndexCreditDefaultSwapData)
         return result;
     const auto& d = *t.IndexCreditDefaultSwapData;
-    result.reference_entity = std::string(d.CreditCurveId);
-    result.index_name = std::string(d.CreditCurveId);
+    result.terms.reference_entity = std::string(d.CreditCurveId);
+    result.index.index_name = std::string(d.CreditCurveId);
     map_cds_leg(d.LegData, result);
     return result;
 }
@@ -170,11 +170,11 @@ credit_instrument_mapper::forward_index_cds_option(const trade& t) {
     if (!t.IndexCreditDefaultSwapOptionData)
         return result;
     const auto& d = *t.IndexCreditDefaultSwapOptionData;
-    result.reference_entity = std::string(d.IndexCreditDefaultSwapData.CreditCurveId);
-    result.index_name = std::string(d.IndexCreditDefaultSwapData.CreditCurveId);
+    result.terms.reference_entity = std::string(d.IndexCreditDefaultSwapData.CreditCurveId);
+    result.index.index_name = std::string(d.IndexCreditDefaultSwapData.CreditCurveId);
     if (d.Strike)
-        result.option_strike = static_cast<double>(*d.Strike);
-    result.option_expiry_date = first_exercise_date(d.OptionData);
+        result.option.option_strike = static_cast<double>(*d.Strike);
+    result.option.option_expiry_date = first_exercise_date(d.OptionData);
     map_cds_leg(d.IndexCreditDefaultSwapData.LegData, result);
     return result;
 }
@@ -190,10 +190,10 @@ credit_instrument_mapper::forward_credit_linked_swap(const trade& t) {
     if (!t.CreditLinkedSwapData)
         return result;
     const auto& d = *t.CreditLinkedSwapData;
-    result.reference_entity = std::string(d.CreditCurveId);
-    result.linked_asset_code = std::string(d.CreditCurveId);
+    result.terms.reference_entity = std::string(d.CreditCurveId);
+    result.terms.linked_asset_code = std::string(d.CreditCurveId);
     if (d.FixedRecoveryRate)
-        result.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
+        result.terms.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
     // Extract currency/notional from first contingent payment leg if available.
     if (d.ContingentPayments && !d.ContingentPayments->LegData.empty())
         map_cds_leg(d.ContingentPayments->LegData.front(), result);
@@ -210,12 +210,12 @@ trading::domain::credit_instrument credit_instrument_mapper::forward_synthetic_c
     if (!t.CdoData)
         return result;
     const auto& d = *t.CdoData;
-    result.reference_entity = std::string(d.Qualifier);
-    result.start_date = std::string(d.ProtectionStart);
-    result.tranche_attachment = static_cast<double>(d.AttachmentPoint);
-    result.tranche_detachment = static_cast<double>(d.DetachmentPoint);
+    result.terms.reference_entity = std::string(d.Qualifier);
+    result.schedule.start_date = std::string(d.ProtectionStart);
+    result.tranche.tranche_attachment = static_cast<double>(d.AttachmentPoint);
+    result.tranche.tranche_detachment = static_cast<double>(d.DetachmentPoint);
     if (d.FixedRecoveryRate)
-        result.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
+        result.terms.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
     map_cds_leg(d.LegData, result);
     return result;
 }
@@ -231,13 +231,13 @@ trading::domain::credit_instrument credit_instrument_mapper::forward_rpa(const t
     if (!t.RiskParticipationAgreementData)
         return result;
     const auto& d = *t.RiskParticipationAgreementData;
-    result.reference_entity = std::string(d.CreditCurveId);
+    result.terms.reference_entity = std::string(d.CreditCurveId);
     if (d.IssuerId)
-        result.reference_entity = std::string(*d.IssuerId);
-    result.start_date = std::string(d.ProtectionStart);
-    result.maturity_date = std::string(d.ProtectionEnd);
+        result.terms.reference_entity = std::string(*d.IssuerId);
+    result.schedule.start_date = std::string(d.ProtectionStart);
+    result.schedule.maturity_date = std::string(d.ProtectionEnd);
     if (d.FixedRecoveryRate)
-        result.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
+        result.terms.recovery_rate = static_cast<double>(*d.FixedRecoveryRate);
     return result;
 }
 
@@ -250,13 +250,13 @@ trade credit_instrument_mapper::reverse_cds(const credit_instrument& instr) {
     trade t;
     t.TradeType = oreTradeType::CreditDefaultSwap;
     creditDefaultSwapData d;
-    if (!instr.reference_entity.empty()) {
+    if (!instr.terms.reference_entity.empty()) {
         _CreditCurveId_t cid;
-        static_cast<std::string&>(cid) = instr.reference_entity;
+        static_cast<std::string&>(cid) = instr.terms.reference_entity;
         d.creditCurveIdType.CreditCurveId = std::move(cid);
     }
-    if (instr.recovery_rate != 0.0)
-        d.FixedRecoveryRate = static_cast<float>(instr.recovery_rate);
+    if (instr.terms.recovery_rate != 0.0)
+        d.FixedRecoveryRate = static_cast<float>(instr.terms.recovery_rate);
     d.LegData = reverse_cds_leg(instr);
     t.CreditDefaultSwapData = std::move(d);
     return t;
@@ -271,7 +271,7 @@ trade credit_instrument_mapper::reverse_index_cds(const credit_instrument& instr
     trade t;
     t.TradeType = oreTradeType::IndexCreditDefaultSwap;
     indexCreditDefaultSwapData d;
-    static_cast<std::string&>(d.CreditCurveId) = instr.reference_entity;
+    static_cast<std::string&>(d.CreditCurveId) = instr.terms.reference_entity;
     d.LegData = reverse_cds_leg(instr);
     t.IndexCreditDefaultSwapData = std::move(d);
     return t;
@@ -286,14 +286,15 @@ trade credit_instrument_mapper::reverse_index_cds_option(const credit_instrument
     trade t;
     t.TradeType = oreTradeType::IndexCreditDefaultSwapOption;
     indexCreditDefaultSwapOptionData d;
-    static_cast<std::string&>(d.IndexCreditDefaultSwapData.CreditCurveId) = instr.reference_entity;
+    static_cast<std::string&>(d.IndexCreditDefaultSwapData.CreditCurveId) =
+        instr.terms.reference_entity;
     d.IndexCreditDefaultSwapData.LegData = reverse_cds_leg(instr);
-    if (instr.option_strike)
-        d.Strike = static_cast<float>(*instr.option_strike);
-    if (!instr.option_expiry_date.empty()) {
+    if (instr.option.option_strike)
+        d.Strike = static_cast<float>(*instr.option.option_strike);
+    if (!instr.option.option_expiry_date.empty()) {
         _ExerciseDates_t exd;
         date ed;
-        static_cast<std::string&>(ed) = instr.option_expiry_date;
+        static_cast<std::string&>(ed) = instr.option.option_expiry_date;
         exd.ExerciseDate.push_back(ed);
         exerciseDatesGroup_group_t eg;
         eg.ExerciseDates = std::move(exd);
@@ -312,10 +313,10 @@ trade credit_instrument_mapper::reverse_credit_linked_swap(const credit_instrume
     trade t;
     t.TradeType = oreTradeType::CreditLinkedSwap;
     creditLinkedSwapData d;
-    static_cast<std::string&>(d.CreditCurveId) = instr.reference_entity;
-    if (instr.recovery_rate != 0.0)
-        d.FixedRecoveryRate = static_cast<float>(instr.recovery_rate);
-    if (!instr.currency.empty() || instr.notional != 0.0) {
+    static_cast<std::string&>(d.CreditCurveId) = instr.terms.reference_entity;
+    if (instr.terms.recovery_rate != 0.0)
+        d.FixedRecoveryRate = static_cast<float>(instr.terms.recovery_rate);
+    if (!instr.terms.currency.empty() || instr.terms.notional != 0.0) {
         creditLinkedSwapData_ContingentPayments_t cp;
         cp.LegData.push_back(reverse_cds_leg(instr));
         d.ContingentPayments = std::move(cp);
@@ -333,15 +334,15 @@ trade credit_instrument_mapper::reverse_synthetic_cdo(const credit_instrument& i
     trade t;
     t.TradeType = oreTradeType::SyntheticCDO;
     cdoData d;
-    static_cast<std::string&>(d.Qualifier) = instr.reference_entity;
-    if (!instr.start_date.empty())
-        static_cast<std::string&>(d.ProtectionStart) = instr.start_date;
-    if (instr.tranche_attachment)
-        d.AttachmentPoint = static_cast<float>(*instr.tranche_attachment);
-    if (instr.tranche_detachment)
-        d.DetachmentPoint = static_cast<float>(*instr.tranche_detachment);
-    if (instr.recovery_rate != 0.0)
-        d.FixedRecoveryRate = static_cast<float>(instr.recovery_rate);
+    static_cast<std::string&>(d.Qualifier) = instr.terms.reference_entity;
+    if (!instr.schedule.start_date.empty())
+        static_cast<std::string&>(d.ProtectionStart) = instr.schedule.start_date;
+    if (instr.tranche.tranche_attachment)
+        d.AttachmentPoint = static_cast<float>(*instr.tranche.tranche_attachment);
+    if (instr.tranche.tranche_detachment)
+        d.DetachmentPoint = static_cast<float>(*instr.tranche.tranche_detachment);
+    if (instr.terms.recovery_rate != 0.0)
+        d.FixedRecoveryRate = static_cast<float>(instr.terms.recovery_rate);
     d.LegData = reverse_cds_leg(instr);
     t.CdoData = std::move(d);
     return t;
@@ -356,13 +357,13 @@ trade credit_instrument_mapper::reverse_rpa(const credit_instrument& instr) {
     trade t;
     t.TradeType = oreTradeType::RiskParticipationAgreement;
     rpaData d;
-    static_cast<std::string&>(d.CreditCurveId) = instr.reference_entity;
-    if (!instr.start_date.empty())
-        static_cast<std::string&>(d.ProtectionStart) = instr.start_date;
-    if (!instr.maturity_date.empty())
-        static_cast<std::string&>(d.ProtectionEnd) = instr.maturity_date;
-    if (instr.recovery_rate != 0.0)
-        d.FixedRecoveryRate = static_cast<float>(instr.recovery_rate);
+    static_cast<std::string&>(d.CreditCurveId) = instr.terms.reference_entity;
+    if (!instr.schedule.start_date.empty())
+        static_cast<std::string&>(d.ProtectionStart) = instr.schedule.start_date;
+    if (!instr.schedule.maturity_date.empty())
+        static_cast<std::string&>(d.ProtectionEnd) = instr.schedule.maturity_date;
+    if (instr.terms.recovery_rate != 0.0)
+        d.FixedRecoveryRate = static_cast<float>(instr.terms.recovery_rate);
     t.RiskParticipationAgreementData = std::move(d);
     return t;
 }

--- a/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
+++ b/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
@@ -28,6 +28,7 @@
 #include "ores.ore.core/domain/swap_instrument_mapper.hpp"
 #include "ores.ore.core/planner/ore_import_planner.hpp"
 #include "ores.testing/project_root.hpp"
+#include "ores.trading.api/domain/instrument.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -332,8 +333,13 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
                     REQUIRE(r.instrument.trade_id.has_value());
                     CHECK(*r.instrument.trade_id == item.trade.identity.id);
                     ++checked;
+                } else if constexpr (ores::trading::domain::NestedInstrument<T>) {
+                    // bond/credit/commodity — nested identity
+                    REQUIRE(r.identity.trade_id.has_value());
+                    CHECK(*r.identity.trade_id == item.trade.identity.id);
+                    ++checked;
                 } else {
-                    // bond/credit/commodity/scripted — direct trade_id field
+                    // scripted — direct trade_id field
                     REQUIRE(r.trade_id.has_value());
                     CHECK(*r.trade_id == item.trade.identity.id);
                     ++checked;

--- a/projects/ores.ore/core/tests/xml_bond_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_bond_mapper_roundtrip_tests.cpp
@@ -69,14 +69,14 @@ TEST_CASE("mapper_roundtrip_bond_forward", tags) {
     const auto result = bond_instrument_mapper::forward_bond(t);
     const auto& instr = result;
 
-    CHECK(instr.trade_type_code == "Bond");
-    CHECK(instr.issuer == "CPTY_C");
-    CHECK(instr.issue_date == "2025-02-03");
-    CHECK(instr.currency == "EUR");
-    CHECK(instr.face_value == Approx(10000000.0).epsilon(0.001));
-    CHECK(instr.coupon_rate == Approx(0.05).epsilon(0.0001));
-    CHECK(instr.maturity_date == "2035-02-03");
-    CHECK(instr.coupon_frequency_code == "1Y");
+    CHECK(instr.identity.trade_type_code == "Bond");
+    CHECK(instr.terms.issuer == "CPTY_C");
+    CHECK(instr.terms.issue_date == "2025-02-03");
+    CHECK(instr.terms.currency == "EUR");
+    CHECK(instr.terms.face_value == Approx(10000000.0).epsilon(0.001));
+    CHECK(instr.terms.coupon_rate == Approx(0.05).epsilon(0.0001));
+    CHECK(instr.terms.maturity_date == "2035-02-03");
+    CHECK(instr.terms.coupon_frequency_code == "1Y");
     BOOST_LOG_SEV(lg, info) << "Bond forward-mapper test passed";
 }
 
@@ -130,10 +130,10 @@ TEST_CASE("mapper_roundtrip_forward_bond_forward", tags) {
     const auto result = bond_instrument_mapper::forward_forward_bond(t);
     const auto& instr = result;
 
-    CHECK(instr.trade_type_code == "ForwardBond");
-    CHECK(instr.issuer == "CPTY_C");
-    CHECK(instr.currency == "EUR");
-    CHECK(instr.face_value == Approx(10000000.0).epsilon(0.001));
+    CHECK(instr.identity.trade_type_code == "ForwardBond");
+    CHECK(instr.terms.issuer == "CPTY_C");
+    CHECK(instr.terms.currency == "EUR");
+    CHECK(instr.terms.face_value == Approx(10000000.0).epsilon(0.001));
     BOOST_LOG_SEV(lg, info) << "ForwardBond forward-mapper test passed";
 }
 
@@ -162,9 +162,10 @@ TEST_CASE("mapper_roundtrip_convertible_bond_forward", tags) {
     const auto result = bond_instrument_mapper::forward_convertible_bond(t);
     const auto& instr = result;
 
-    CHECK(instr.trade_type_code == "ConvertibleBond");
+    CHECK(instr.identity.trade_type_code == "ConvertibleBond");
     BOOST_LOG_SEV(lg, info) << "ConvertibleBond forward-mapper test passed, "
-                            << "issuer=" << instr.issuer << " currency=" << instr.currency;
+                            << "issuer=" << instr.terms.issuer
+                            << " currency=" << instr.terms.currency;
 }
 
 TEST_CASE("mapper_roundtrip_convertible_bond_reverse", tags) {
@@ -184,9 +185,9 @@ TEST_CASE("mapper_roundtrip_convertible_bond_reverse", tags) {
     CHECK(!cbd.BondData.IssueDate);
 
     // Instrument fields should round-trip consistently with the forward pass
-    CHECK(instr.currency.empty());
-    CHECK(instr.issuer.empty());
-    CHECK(instr.face_value == Approx(0.0).epsilon(0.001));
+    CHECK(instr.terms.currency.empty());
+    CHECK(instr.terms.issuer.empty());
+    CHECK(instr.terms.face_value == Approx(0.0).epsilon(0.001));
 
     BOOST_LOG_SEV(lg, info) << "ConvertibleBond reverse-mapper test passed";
 }

--- a/projects/ores.ore/core/tests/xml_bond_option_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_bond_option_mapper_roundtrip_tests.cpp
@@ -69,21 +69,21 @@ TEST_CASE("bond_option_mapper_roundtrip_bond_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_BondOption.xml");
 
-    CHECK(r.trade_type_code == "BondOption");
-    CHECK(!r.security_id.empty());
+    CHECK(r.identity.trade_type_code == "BondOption");
+    CHECK(!r.terms.security_id.empty());
 
     // Reverse roundtrip
     const auto rt = bond_instrument_mapper::reverse_bond_option(r);
     REQUIRE(rt.BondOptionData);
 
-    BOOST_LOG_SEV(lg, info) << "BondOption roundtrip passed. SecurityId: " << r.security_id;
+    BOOST_LOG_SEV(lg, info) << "BondOption roundtrip passed. SecurityId: " << r.terms.security_id;
 }
 
 TEST_CASE("bond_option_mapper_roundtrip_bond_option_strike", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("BondOption_StrikePrice_StrikeYield.xml");
 
-    CHECK(r.trade_type_code == "BondOption");
+    CHECK(r.identity.trade_type_code == "BondOption");
 
     // Reverse roundtrip
     const auto rt = bond_instrument_mapper::reverse_bond_option(r);
@@ -96,8 +96,8 @@ TEST_CASE("bond_option_mapper_roundtrip_bond_trs", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_Bond_TRS.xml");
 
-    CHECK(r.trade_type_code == "BondTRS");
-    CHECK(!r.trs_return_type.empty());
+    CHECK(r.identity.trade_type_code == "BondTRS");
+    CHECK(!r.features.trs_return_type.empty());
 
     // Reverse roundtrip
     const auto rt = bond_instrument_mapper::reverse_bond_trs(r);
@@ -105,5 +105,6 @@ TEST_CASE("bond_option_mapper_roundtrip_bond_trs", tags) {
     const bool has_price_type = !std::string(rt.BondTRSData->TotalReturnData.PriceType).empty();
     CHECK(has_price_type);
 
-    BOOST_LOG_SEV(lg, info) << "BondTRS roundtrip passed. Return type: " << r.trs_return_type;
+    BOOST_LOG_SEV(lg, info) << "BondTRS roundtrip passed. Return type: "
+                            << r.features.trs_return_type;
 }

--- a/projects/ores.ore/core/tests/xml_commodity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_commodity_mapper_roundtrip_tests.cpp
@@ -69,115 +69,117 @@ TEST_CASE("commodity_mapper_roundtrip_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Forward.xml");
 
-    CHECK(r.trade_type_code == "CommodityForward");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.currency.empty());
-    CHECK(r.quantity > 0.0);
-    CHECK(r.fixed_price.has_value());
-    CHECK(*r.fixed_price > 0.0);
-    CHECK(!r.maturity_date.empty());
+    CHECK(r.identity.trade_type_code == "CommodityForward");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(r.terms.quantity > 0.0);
+    CHECK(r.terms.fixed_price.has_value());
+    CHECK(*r.terms.fixed_price > 0.0);
+    CHECK(!r.terms.maturity_date.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_forward(r);
     REQUIRE(rt.CommodityForwardData.operator bool());
 
-    BOOST_LOG_SEV(lg, info) << "CommodityForward roundtrip passed. " << r.commodity_code;
+    BOOST_LOG_SEV(lg, info) << "CommodityForward roundtrip passed. " << r.terms.commodity_code;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Option.xml");
 
-    CHECK(r.trade_type_code == "CommodityOption");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.currency.empty());
-    CHECK(r.quantity > 0.0);
-    CHECK(r.strike_price.has_value());
-    CHECK(!r.option_type.empty());
-    CHECK(!r.maturity_date.empty());
+    CHECK(r.identity.trade_type_code == "CommodityOption");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(r.terms.quantity > 0.0);
+    CHECK(r.option.strike_price.has_value());
+    CHECK(!r.option.option_type.empty());
+    CHECK(!r.terms.maturity_date.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_option(r);
     REQUIRE(rt.CommodityOptionData.operator bool());
 
-    BOOST_LOG_SEV(lg, info) << "CommodityOption roundtrip passed. Strike: " << *r.strike_price;
+    BOOST_LOG_SEV(lg, info) << "CommodityOption roundtrip passed. Strike: "
+                            << *r.option.strike_price;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Swap_NYMEX_A7Q.xml");
 
-    CHECK(r.trade_type_code == "CommoditySwap");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.currency.empty());
-    CHECK(!r.start_date.empty());
-    CHECK(!r.maturity_date.empty());
+    CHECK(r.identity.trade_type_code == "CommoditySwap");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(!r.terms.start_date.empty());
+    CHECK(!r.terms.maturity_date.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_swap(r);
     REQUIRE(rt.SwapData.operator bool());
 
-    BOOST_LOG_SEV(lg, info) << "CommoditySwap roundtrip passed. " << r.commodity_code;
+    BOOST_LOG_SEV(lg, info) << "CommoditySwap roundtrip passed. " << r.terms.commodity_code;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_swaption", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Swaption_NYMEX_NG.xml");
 
-    CHECK(r.trade_type_code == "CommoditySwaption");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.swaption_expiry_date.empty());
+    CHECK(r.identity.trade_type_code == "CommoditySwaption");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.option.swaption_expiry_date.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_swaption(r);
     REQUIRE(rt.CommoditySwaptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "CommoditySwaption roundtrip passed. Expiry: "
-                            << r.swaption_expiry_date;
+                            << r.option.swaption_expiry_date;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_variance_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Variance_Swap.xml");
 
-    CHECK(r.trade_type_code == "CommodityVarianceSwap");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.currency.empty());
-    CHECK(!r.start_date.empty());
-    CHECK(!r.maturity_date.empty());
-    CHECK(r.variance_strike.has_value());
+    CHECK(r.identity.trade_type_code == "CommodityVarianceSwap");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(!r.terms.start_date.empty());
+    CHECK(!r.terms.maturity_date.empty());
+    CHECK(r.exotic.variance_strike.has_value());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_variance_swap(r);
     REQUIRE(rt.CommodityVarianceSwapData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "CommodityVarianceSwap roundtrip passed. Strike: "
-                            << *r.variance_strike;
+                            << *r.exotic.variance_strike;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_apo", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_APO_NYMEX_CL.xml");
 
-    CHECK(r.trade_type_code == "CommodityAveragePriceOption");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.currency.empty());
-    CHECK(r.quantity > 0.0);
-    CHECK(r.strike_price.has_value());
-    CHECK(!r.averaging_start_date.empty());
-    CHECK(!r.averaging_end_date.empty());
+    CHECK(r.identity.trade_type_code == "CommodityAveragePriceOption");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(r.terms.quantity > 0.0);
+    CHECK(r.option.strike_price.has_value());
+    CHECK(!r.pricing.averaging_start_date.empty());
+    CHECK(!r.pricing.averaging_end_date.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_apo(r);
     REQUIRE(rt.CommodityAveragePriceOptionData.operator bool());
 
-    BOOST_LOG_SEV(lg, info) << "CommodityAveragePriceOption roundtrip passed. " << r.commodity_code;
+    BOOST_LOG_SEV(lg, info) << "CommodityAveragePriceOption roundtrip passed. "
+                            << r.terms.commodity_code;
 }
 
 TEST_CASE("commodity_mapper_roundtrip_option_strip", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Commodity_Option_Strip_NYMEX_NG.xml");
 
-    CHECK(r.trade_type_code == "CommodityOptionStrip");
-    CHECK(!r.commodity_code.empty());
-    CHECK(!r.strip_frequency_code.empty());
+    CHECK(r.identity.trade_type_code == "CommodityOptionStrip");
+    CHECK(!r.terms.commodity_code.empty());
+    CHECK(!r.pricing.strip_frequency_code.empty());
 
     const auto rt = commodity_instrument_mapper::reverse_commodity_option_strip(r);
     REQUIRE(rt.CommodityOptionStripData.operator bool());
 
-    BOOST_LOG_SEV(lg, info) << "CommodityOptionStrip roundtrip passed. " << r.commodity_code;
+    BOOST_LOG_SEV(lg, info) << "CommodityOptionStrip roundtrip passed. " << r.terms.commodity_code;
 }

--- a/projects/ores.ore/core/tests/xml_credit_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_credit_mapper_roundtrip_tests.cpp
@@ -69,79 +69,80 @@ TEST_CASE("credit_mapper_roundtrip_cds", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_Default_Swap.xml");
 
-    CHECK(r.trade_type_code == "CreditDefaultSwap");
-    CHECK(!r.reference_entity.empty());
-    CHECK(!r.currency.empty());
-    CHECK(r.notional > 0.0);
-    CHECK(r.spread > 0.0);
-    CHECK(!r.start_date.empty());
-    CHECK(!r.maturity_date.empty());
+    CHECK(r.identity.trade_type_code == "CreditDefaultSwap");
+    CHECK(!r.terms.reference_entity.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(r.terms.notional > 0.0);
+    CHECK(r.terms.spread > 0.0);
+    CHECK(!r.schedule.start_date.empty());
+    CHECK(!r.schedule.maturity_date.empty());
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_cds(r);
     REQUIRE(rt.CreditDefaultSwapData);
     CHECK(rt.CreditDefaultSwapData->creditCurveIdType.CreditCurveId);
 
-    BOOST_LOG_SEV(lg, info) << "CDS roundtrip passed. Reference: " << r.reference_entity;
+    BOOST_LOG_SEV(lg, info) << "CDS roundtrip passed. Reference: " << r.terms.reference_entity;
 }
 
 TEST_CASE("credit_mapper_roundtrip_index_cds", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_Index_Credit_Default_Swap.xml");
 
-    CHECK(r.trade_type_code == "IndexCreditDefaultSwap");
-    CHECK(!r.reference_entity.empty());
-    CHECK(!r.index_name.empty());
-    CHECK(!r.currency.empty());
-    CHECK(r.notional > 0.0);
+    CHECK(r.identity.trade_type_code == "IndexCreditDefaultSwap");
+    CHECK(!r.terms.reference_entity.empty());
+    CHECK(!r.index.index_name.empty());
+    CHECK(!r.terms.currency.empty());
+    CHECK(r.terms.notional > 0.0);
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_index_cds(r);
     REQUIRE(rt.IndexCreditDefaultSwapData);
 
-    BOOST_LOG_SEV(lg, info) << "IndexCDS roundtrip passed. Index: " << r.index_name;
+    BOOST_LOG_SEV(lg, info) << "IndexCDS roundtrip passed. Index: " << r.index.index_name;
 }
 
 TEST_CASE("credit_mapper_roundtrip_index_cds_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_Index_CDS_Option.xml");
 
-    CHECK(r.trade_type_code == "IndexCreditDefaultSwapOption");
-    CHECK(!r.reference_entity.empty());
-    CHECK(!r.option_expiry_date.empty());
-    CHECK(r.option_strike.has_value());
+    CHECK(r.identity.trade_type_code == "IndexCreditDefaultSwapOption");
+    CHECK(!r.terms.reference_entity.empty());
+    CHECK(!r.option.option_expiry_date.empty());
+    CHECK(r.option.option_strike.has_value());
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_index_cds_option(r);
     REQUIRE(rt.IndexCreditDefaultSwapOptionData);
     CHECK(rt.IndexCreditDefaultSwapOptionData->Strike);
 
-    BOOST_LOG_SEV(lg, info) << "IndexCDSOption roundtrip passed. Expiry: " << r.option_expiry_date;
+    BOOST_LOG_SEV(lg, info) << "IndexCDSOption roundtrip passed. Expiry: "
+                            << r.option.option_expiry_date;
 }
 
 TEST_CASE("credit_mapper_roundtrip_credit_linked_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_CreditLinkedSwap.xml");
 
-    CHECK(r.trade_type_code == "CreditLinkedSwap");
-    CHECK(!r.reference_entity.empty());
-    CHECK(!r.linked_asset_code.empty());
+    CHECK(r.identity.trade_type_code == "CreditLinkedSwap");
+    CHECK(!r.terms.reference_entity.empty());
+    CHECK(!r.terms.linked_asset_code.empty());
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_credit_linked_swap(r);
     REQUIRE(rt.CreditLinkedSwapData);
 
     BOOST_LOG_SEV(lg, info) << "CreditLinkedSwap roundtrip passed. Reference: "
-                            << r.reference_entity;
+                            << r.terms.reference_entity;
 }
 
 TEST_CASE("credit_mapper_roundtrip_synthetic_cdo", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_Synthetic_CDO_refdata.xml");
 
-    CHECK(r.trade_type_code == "SyntheticCDO");
-    CHECK(r.tranche_attachment.has_value());
-    CHECK(r.tranche_detachment.has_value());
+    CHECK(r.identity.trade_type_code == "SyntheticCDO");
+    CHECK(r.tranche.tranche_attachment.has_value());
+    CHECK(r.tranche.tranche_detachment.has_value());
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_synthetic_cdo(r);
@@ -151,21 +152,21 @@ TEST_CASE("credit_mapper_roundtrip_synthetic_cdo", tags) {
     CHECK(has_tranche);
 
     BOOST_LOG_SEV(lg, info) << "SyntheticCDO roundtrip passed. Attachment: "
-                            << *r.tranche_attachment;
+                            << *r.tranche.tranche_attachment;
 }
 
 TEST_CASE("credit_mapper_roundtrip_rpa", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Credit_RiskParticipationAgreement_on_Vanilla_Swap.xml");
 
-    CHECK(r.trade_type_code == "RiskParticipationAgreement");
-    CHECK(!r.reference_entity.empty());
-    CHECK(!r.start_date.empty());
-    CHECK(!r.maturity_date.empty());
+    CHECK(r.identity.trade_type_code == "RiskParticipationAgreement");
+    CHECK(!r.terms.reference_entity.empty());
+    CHECK(!r.schedule.start_date.empty());
+    CHECK(!r.schedule.maturity_date.empty());
 
     // Reverse roundtrip
     const auto rt = credit_instrument_mapper::reverse_rpa(r);
     REQUIRE(rt.RiskParticipationAgreementData);
 
-    BOOST_LOG_SEV(lg, info) << "RPA roundtrip passed. Reference: " << r.reference_entity;
+    BOOST_LOG_SEV(lg, info) << "RPA roundtrip passed. Reference: " << r.terms.reference_entity;
 }

--- a/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -390,11 +390,11 @@ TEST_CASE("bond_repo_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_bond("Cash_BondRepo_and_Bond.xml", 0);
 
-    CHECK(r.trade_type_code == "BondRepo");
-    CHECK(!r.security_id.empty());
+    CHECK(r.identity.trade_type_code == "BondRepo");
+    CHECK(!r.terms.security_id.empty());
 
     BOOST_LOG_SEV(lg, info) << "BondRepo forward test passed. "
-                            << "security_id=" << r.security_id;
+                            << "security_id=" << r.terms.security_id;
 }
 
 TEST_CASE("bond_repo_reverse", tags) {

--- a/projects/ores.ore/core/tests/xml_trade_import_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_trade_import_tests.cpp
@@ -337,13 +337,13 @@ TEST_CASE("import_portfolio_with_context_bond_has_instrument", tags) {
     item.trade.classification.instrument_id = instr_uuid;
 
     const auto& r = std::get<bond_instrument>(item.instrument);
-    CHECK(r.instrument_id != item.trade.identity.id);
-    CHECK(r.trade_id == item.trade.identity.id);
-    CHECK(item.trade.classification.instrument_id == r.instrument_id);
+    CHECK(r.identity.instrument_id != item.trade.identity.id);
+    CHECK(r.identity.trade_id == item.trade.identity.id);
+    CHECK(item.trade.classification.instrument_id == r.identity.instrument_id);
     CHECK(item.trade.classification.product_type == ores::trading::domain::product_type::bond);
-    CHECK(!r.issuer.empty());
+    CHECK(!r.terms.issuer.empty());
 
-    BOOST_LOG_SEV(lg, info) << "Bond instrument mapped. Issuer: " << r.issuer;
+    BOOST_LOG_SEV(lg, info) << "Bond instrument mapped. Issuer: " << r.terms.issuer;
 }
 
 TEST_CASE("import_portfolio_with_context_unmapped_type_is_monostate", tags) {

--- a/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
+++ b/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
@@ -167,8 +167,8 @@ struct EquityForwardPopulator : ores::qt::IInstrumentFormPopulator {
 
 TEST_CASE("parse_trade_instrument_dispatches_bond", tags) {
     bond_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "Bond";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "Bond";
 
     auto json =
         make_response_json(make_test_trade(product_type::bond, "Bond"), trade_instrument{instr});
@@ -179,8 +179,8 @@ TEST_CASE("parse_trade_instrument_dispatches_bond", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::bond);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
-    CHECK(pop.got.trade_type_code == "Bond");
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
+    CHECK(pop.got.identity.trade_type_code == "Bond");
 }
 
 // =============================================================================
@@ -189,8 +189,8 @@ TEST_CASE("parse_trade_instrument_dispatches_bond", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_credit", tags) {
     credit_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "CreditDefaultSwap";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "CreditDefaultSwap";
 
     auto json = make_response_json(make_test_trade(product_type::credit, "CreditDefaultSwap"),
                                    trade_instrument{instr});
@@ -201,7 +201,7 @@ TEST_CASE("parse_trade_instrument_dispatches_credit", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::credit);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
 }
 
 // =============================================================================
@@ -210,8 +210,8 @@ TEST_CASE("parse_trade_instrument_dispatches_credit", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_commodity", tags) {
     commodity_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "Commodity";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "Commodity";
 
     auto json = make_response_json(make_test_trade(product_type::commodity, "Commodity"),
                                    trade_instrument{instr});
@@ -222,7 +222,7 @@ TEST_CASE("parse_trade_instrument_dispatches_commodity", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::commodity);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
 }
 
 // =============================================================================

--- a/projects/ores.qt/trading/src/BondInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/BondInstrumentForm.cpp
@@ -122,7 +122,7 @@ void BondInstrumentForm::populateCurrencies() {
         cb->addItem(QString());
         for (const auto& c : codes)
             cb->addItem(QString::fromStdString(c));
-        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.terms.currency);
         cb->blockSignals(false);
         if (self->imageCache_)
             apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
@@ -146,7 +146,7 @@ void BondInstrumentForm::clear() {
 void BondInstrumentForm::setTradeType(const QString& code,
                                       bool /*has_options*/,
                                       bool has_extension) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
@@ -181,36 +181,39 @@ bool BondInstrumentForm::isLoaded() const {
 }
 
 void BondInstrumentForm::setChangeReason(const std::string& code, const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void BondInstrumentForm::writeUiToInstrument() {
-    instrument_.issuer = ui_->issuerEdit->text().trimmed().toStdString();
-    instrument_.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
-    instrument_.face_value = ui_->faceValueSpinBox->value();
-    instrument_.coupon_rate = ui_->couponRateSpinBox->value();
-    instrument_.coupon_frequency_code =
+    instrument_.terms.issuer = ui_->issuerEdit->text().trimmed().toStdString();
+    instrument_.terms.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
+    instrument_.terms.face_value = ui_->faceValueSpinBox->value();
+    instrument_.terms.coupon_rate = ui_->couponRateSpinBox->value();
+    instrument_.terms.coupon_frequency_code =
         InstrumentFormUtils::getComboValue(ui_->couponFrequencyCombo);
-    instrument_.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
-    instrument_.issue_date = ui_->issueDateEdit->isoDate();
-    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
-    instrument_.settlement_days = ui_->settlementDaysSpinBox->value();
-    instrument_.call_date = ui_->callDateEdit->isoDate();
-    instrument_.conversion_ratio = ui_->conversionRatioSpinBox->value();
+    instrument_.terms.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
+    instrument_.terms.issue_date = ui_->issueDateEdit->isoDate();
+    instrument_.terms.maturity_date = ui_->maturityDateEdit->isoDate();
+    instrument_.features.settlement_days = ui_->settlementDaysSpinBox->value();
+    instrument_.features.call_date = ui_->callDateEdit->isoDate();
+    instrument_.features.conversion_ratio = ui_->conversionRatioSpinBox->value();
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.future_expiry_date = ui_->futureExpiryDateEdit->isoDate();
-    instrument_.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
-    instrument_.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
+    instrument_.features.future_expiry_date = ui_->futureExpiryDateEdit->isoDate();
+    instrument_.option.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
+    instrument_.option.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
     {
         const double s = ui_->optionStrikeSpinBox->value();
-        instrument_.option_strike = (s > 0.0) ? std::optional<double>(s) : std::nullopt;
+        instrument_.option.option_strike = (s > 0.0) ? std::optional<double>(s) : std::nullopt;
     }
-    instrument_.trs_return_type = InstrumentFormUtils::getComboValue(ui_->trsReturnTypeCombo);
-    instrument_.trs_funding_leg_code = ui_->trsFundingLegCodeEdit->text().trimmed().toStdString();
-    instrument_.ascot_option_type = InstrumentFormUtils::getComboValue(ui_->ascotOptionTypeCombo);
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.features.trs_return_type =
+        InstrumentFormUtils::getComboValue(ui_->trsReturnTypeCombo);
+    instrument_.features.trs_funding_leg_code =
+        ui_->trsFundingLegCodeEdit->text().trimmed().toStdString();
+    instrument_.option.ascot_option_type =
+        InstrumentFormUtils::getComboValue(ui_->ascotOptionTypeCombo);
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void BondInstrumentForm::populate(const trading::domain::bond_instrument& instr) {
@@ -246,38 +249,41 @@ void BondInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
-    ui_->issuerEdit->setText(QString::fromStdString(instrument_.issuer));
-    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
-    ui_->faceValueSpinBox->setValue(instrument_.face_value);
-    ui_->couponRateSpinBox->setValue(instrument_.coupon_rate);
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
+    ui_->issuerEdit->setText(QString::fromStdString(instrument_.terms.issuer));
+    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.terms.currency);
+    ui_->faceValueSpinBox->setValue(instrument_.terms.face_value);
+    ui_->couponRateSpinBox->setValue(instrument_.terms.coupon_rate);
     InstrumentFormUtils::setComboValue(ui_->couponFrequencyCombo,
-                                       instrument_.coupon_frequency_code);
-    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.day_count_code);
-    ui_->issueDateEdit->setIsoDate(instrument_.issue_date);
-    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
-    ui_->settlementDaysSpinBox->setValue(instrument_.settlement_days);
-    ui_->callDateEdit->setIsoDate(instrument_.call_date);
-    ui_->conversionRatioSpinBox->setValue(instrument_.conversion_ratio);
+                                       instrument_.terms.coupon_frequency_code);
+    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.terms.day_count_code);
+    ui_->issueDateEdit->setIsoDate(instrument_.terms.issue_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.terms.maturity_date);
+    ui_->settlementDaysSpinBox->setValue(instrument_.features.settlement_days);
+    ui_->callDateEdit->setIsoDate(instrument_.features.call_date);
+    ui_->conversionRatioSpinBox->setValue(instrument_.features.conversion_ratio);
     ui_->descriptionEdit->setPlainText(QString::fromStdString(instrument_.description));
-    ui_->futureExpiryDateEdit->setIsoDate(instrument_.future_expiry_date);
-    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option_type);
-    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option_expiry_date);
-    ui_->optionStrikeSpinBox->setValue(instrument_.option_strike.value_or(0.0));
-    InstrumentFormUtils::setComboValue(ui_->trsReturnTypeCombo, instrument_.trs_return_type);
-    ui_->trsFundingLegCodeEdit->setText(QString::fromStdString(instrument_.trs_funding_leg_code));
-    InstrumentFormUtils::setComboValue(ui_->ascotOptionTypeCombo, instrument_.ascot_option_type);
+    ui_->futureExpiryDateEdit->setIsoDate(instrument_.features.future_expiry_date);
+    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option.option_type);
+    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option.option_expiry_date);
+    ui_->optionStrikeSpinBox->setValue(instrument_.option.option_strike.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->trsReturnTypeCombo,
+                                       instrument_.features.trs_return_type);
+    ui_->trsFundingLegCodeEdit->setText(
+        QString::fromStdString(instrument_.features.trs_funding_leg_code));
+    InstrumentFormUtils::setComboValue(ui_->ascotOptionTypeCombo,
+                                       instrument_.option.ascot_option_type);
     block(false);
 }
 
 void BondInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -322,7 +328,7 @@ void BondInstrumentForm::saveInstrument(std::function<void(const std::string&)> 
             BOOST_LOG_SEV(lg(), info) << "Bond instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/CommodityInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/CommodityInstrumentForm.cpp
@@ -146,7 +146,7 @@ void CommodityInstrumentForm::populateCurrencies() {
         cb->addItem(QString());
         for (const auto& c : codes)
             cb->addItem(QString::fromStdString(c));
-        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.terms.currency);
         cb->blockSignals(false);
         if (self->imageCache_)
             apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
@@ -170,7 +170,7 @@ void CommodityInstrumentForm::clear() {
 void CommodityInstrumentForm::setTradeType(const QString& code,
                                            bool /*has_options*/,
                                            bool has_extension) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
@@ -214,66 +214,68 @@ bool CommodityInstrumentForm::isLoaded() const {
 
 void CommodityInstrumentForm::setChangeReason(const std::string& code,
                                               const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void CommodityInstrumentForm::writeUiToInstrument() {
-    instrument_.commodity_code = ui_->commodityCodeEdit->text().trimmed().toStdString();
-    instrument_.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
-    instrument_.quantity = ui_->quantitySpinBox->value();
-    instrument_.unit = ui_->unitEdit->text().trimmed().toStdString();
-    instrument_.start_date = ui_->startDateEdit->isoDate();
-    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
+    instrument_.terms.commodity_code = ui_->commodityCodeEdit->text().trimmed().toStdString();
+    instrument_.terms.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
+    instrument_.terms.quantity = ui_->quantitySpinBox->value();
+    instrument_.terms.unit = ui_->unitEdit->text().trimmed().toStdString();
+    instrument_.terms.start_date = ui_->startDateEdit->isoDate();
+    instrument_.terms.maturity_date = ui_->maturityDateEdit->isoDate();
     {
         const double v = ui_->fixedPriceSpinBox->value();
-        instrument_.fixed_price = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.terms.fixed_price = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
-    instrument_.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
+    instrument_.option.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     {
         const double v = ui_->strikePriceSpinBox->value();
-        instrument_.strike_price = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.option.strike_price = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
-    instrument_.exercise_type = InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
-    instrument_.average_type = InstrumentFormUtils::getComboValue(ui_->averageTypeCombo);
-    instrument_.averaging_start_date = ui_->averagingStartDateEdit->isoDate();
-    instrument_.averaging_end_date = ui_->averagingEndDateEdit->isoDate();
-    instrument_.spread_commodity_code =
+    instrument_.option.exercise_type = InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
+    instrument_.pricing.average_type = InstrumentFormUtils::getComboValue(ui_->averageTypeCombo);
+    instrument_.pricing.averaging_start_date = ui_->averagingStartDateEdit->isoDate();
+    instrument_.pricing.averaging_end_date = ui_->averagingEndDateEdit->isoDate();
+    instrument_.pricing.spread_commodity_code =
         ui_->spreadCommodityCodeEdit->text().trimmed().toStdString();
     {
         const double v = ui_->spreadAmountSpinBox->value();
-        instrument_.spread_amount = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.pricing.spread_amount = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
-    instrument_.strip_frequency_code = InstrumentFormUtils::getComboValue(ui_->stripFrequencyCombo);
+    instrument_.pricing.strip_frequency_code =
+        InstrumentFormUtils::getComboValue(ui_->stripFrequencyCombo);
     {
         const double v = ui_->varianceStrikeSpinBox->value();
-        instrument_.variance_strike = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.exotic.variance_strike = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     {
         const double v = ui_->accumulationAmountSpinBox->value();
-        instrument_.accumulation_amount = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.exotic.accumulation_amount =
+            (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     {
         const double v = ui_->knockOutBarrierSpinBox->value();
-        instrument_.knock_out_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.exotic.knock_out_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
-    instrument_.barrier_type = InstrumentFormUtils::getComboValue(ui_->barrierTypeCombo);
+    instrument_.exotic.barrier_type = InstrumentFormUtils::getComboValue(ui_->barrierTypeCombo);
     {
         const double v = ui_->lowerBarrierSpinBox->value();
-        instrument_.lower_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.exotic.lower_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     {
         const double v = ui_->upperBarrierSpinBox->value();
-        instrument_.upper_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
+        instrument_.exotic.upper_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
-    instrument_.basket_json = ui_->basketJsonEdit->toPlainText().trimmed().toStdString();
-    instrument_.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
-    instrument_.payment_frequency_code =
+    instrument_.exotic.basket_json = ui_->basketJsonEdit->toPlainText().trimmed().toStdString();
+    instrument_.terms.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
+    instrument_.terms.payment_frequency_code =
         InstrumentFormUtils::getComboValue(ui_->paymentFrequencyCombo);
-    instrument_.swaption_expiry_date = ui_->swaptionExpiryDateEdit->isoDate();
+    instrument_.option.swaption_expiry_date = ui_->swaptionExpiryDateEdit->isoDate();
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void CommodityInstrumentForm::populate(const trading::domain::commodity_instrument& instr) {
@@ -317,47 +319,48 @@ void CommodityInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
-    ui_->commodityCodeEdit->setText(QString::fromStdString(instrument_.commodity_code));
-    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
-    ui_->quantitySpinBox->setValue(instrument_.quantity);
-    ui_->unitEdit->setText(QString::fromStdString(instrument_.unit));
-    ui_->startDateEdit->setIsoDate(instrument_.start_date);
-    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
-    ui_->fixedPriceSpinBox->setValue(instrument_.fixed_price.value_or(0.0));
-    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option_type);
-    ui_->strikePriceSpinBox->setValue(instrument_.strike_price.value_or(0.0));
-    InstrumentFormUtils::setComboValue(ui_->exerciseTypeCombo, instrument_.exercise_type);
-    InstrumentFormUtils::setComboValue(ui_->averageTypeCombo, instrument_.average_type);
-    ui_->averagingStartDateEdit->setIsoDate(instrument_.averaging_start_date);
-    ui_->averagingEndDateEdit->setIsoDate(instrument_.averaging_end_date);
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
+    ui_->commodityCodeEdit->setText(QString::fromStdString(instrument_.terms.commodity_code));
+    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.terms.currency);
+    ui_->quantitySpinBox->setValue(instrument_.terms.quantity);
+    ui_->unitEdit->setText(QString::fromStdString(instrument_.terms.unit));
+    ui_->startDateEdit->setIsoDate(instrument_.terms.start_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.terms.maturity_date);
+    ui_->fixedPriceSpinBox->setValue(instrument_.terms.fixed_price.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option.option_type);
+    ui_->strikePriceSpinBox->setValue(instrument_.option.strike_price.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->exerciseTypeCombo, instrument_.option.exercise_type);
+    InstrumentFormUtils::setComboValue(ui_->averageTypeCombo, instrument_.pricing.average_type);
+    ui_->averagingStartDateEdit->setIsoDate(instrument_.pricing.averaging_start_date);
+    ui_->averagingEndDateEdit->setIsoDate(instrument_.pricing.averaging_end_date);
     ui_->spreadCommodityCodeEdit->setText(
-        QString::fromStdString(instrument_.spread_commodity_code));
-    ui_->spreadAmountSpinBox->setValue(instrument_.spread_amount.value_or(0.0));
-    InstrumentFormUtils::setComboValue(ui_->stripFrequencyCombo, instrument_.strip_frequency_code);
-    ui_->varianceStrikeSpinBox->setValue(instrument_.variance_strike.value_or(0.0));
-    ui_->accumulationAmountSpinBox->setValue(instrument_.accumulation_amount.value_or(0.0));
-    ui_->knockOutBarrierSpinBox->setValue(instrument_.knock_out_barrier.value_or(0.0));
-    InstrumentFormUtils::setComboValue(ui_->barrierTypeCombo, instrument_.barrier_type);
-    ui_->lowerBarrierSpinBox->setValue(instrument_.lower_barrier.value_or(0.0));
-    ui_->upperBarrierSpinBox->setValue(instrument_.upper_barrier.value_or(0.0));
-    ui_->basketJsonEdit->setPlainText(QString::fromStdString(instrument_.basket_json));
-    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.day_count_code);
+        QString::fromStdString(instrument_.pricing.spread_commodity_code));
+    ui_->spreadAmountSpinBox->setValue(instrument_.pricing.spread_amount.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->stripFrequencyCombo,
+                                       instrument_.pricing.strip_frequency_code);
+    ui_->varianceStrikeSpinBox->setValue(instrument_.exotic.variance_strike.value_or(0.0));
+    ui_->accumulationAmountSpinBox->setValue(instrument_.exotic.accumulation_amount.value_or(0.0));
+    ui_->knockOutBarrierSpinBox->setValue(instrument_.exotic.knock_out_barrier.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->barrierTypeCombo, instrument_.exotic.barrier_type);
+    ui_->lowerBarrierSpinBox->setValue(instrument_.exotic.lower_barrier.value_or(0.0));
+    ui_->upperBarrierSpinBox->setValue(instrument_.exotic.upper_barrier.value_or(0.0));
+    ui_->basketJsonEdit->setPlainText(QString::fromStdString(instrument_.exotic.basket_json));
+    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.terms.day_count_code);
     InstrumentFormUtils::setComboValue(ui_->paymentFrequencyCombo,
-                                       instrument_.payment_frequency_code);
-    ui_->swaptionExpiryDateEdit->setIsoDate(instrument_.swaption_expiry_date);
+                                       instrument_.terms.payment_frequency_code);
+    ui_->swaptionExpiryDateEdit->setIsoDate(instrument_.option.swaption_expiry_date);
     ui_->descriptionEdit->setPlainText(QString::fromStdString(instrument_.description));
     block(false);
 }
 
 void CommodityInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -403,7 +406,7 @@ void CommodityInstrumentForm::saveInstrument(std::function<void(const std::strin
             BOOST_LOG_SEV(lg(), info) << "Commodity instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/CreditInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/CreditInstrumentForm.cpp
@@ -130,7 +130,7 @@ void CreditInstrumentForm::populateCurrencies() {
         cb->addItem(QString());
         for (const auto& c : codes)
             cb->addItem(QString::fromStdString(c));
-        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.terms.currency);
         cb->blockSignals(false);
         if (self->imageCache_)
             apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
@@ -154,7 +154,7 @@ void CreditInstrumentForm::clear() {
 void CreditInstrumentForm::setTradeType(const QString& code,
                                         bool /*has_options*/,
                                         bool has_extension) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
@@ -191,44 +191,46 @@ bool CreditInstrumentForm::isLoaded() const {
 }
 
 void CreditInstrumentForm::setChangeReason(const std::string& code, const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void CreditInstrumentForm::writeUiToInstrument() {
-    instrument_.reference_entity = ui_->referenceEntityEdit->text().trimmed().toStdString();
-    instrument_.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
-    instrument_.notional = ui_->notionalSpinBox->value();
-    instrument_.spread = ui_->spreadSpinBox->value();
-    instrument_.recovery_rate = ui_->recoveryRateSpinBox->value();
-    instrument_.tenor = ui_->tenorEdit->text().trimmed().toStdString();
-    instrument_.start_date = ui_->startDateEdit->isoDate();
-    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
-    instrument_.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
-    instrument_.payment_frequency_code =
+    instrument_.terms.reference_entity = ui_->referenceEntityEdit->text().trimmed().toStdString();
+    instrument_.terms.currency = InstrumentFormUtils::getComboValue(ui_->currencyCombo);
+    instrument_.terms.notional = ui_->notionalSpinBox->value();
+    instrument_.terms.spread = ui_->spreadSpinBox->value();
+    instrument_.terms.recovery_rate = ui_->recoveryRateSpinBox->value();
+    instrument_.schedule.tenor = ui_->tenorEdit->text().trimmed().toStdString();
+    instrument_.schedule.start_date = ui_->startDateEdit->isoDate();
+    instrument_.schedule.maturity_date = ui_->maturityDateEdit->isoDate();
+    instrument_.schedule.day_count_code = InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
+    instrument_.schedule.payment_frequency_code =
         InstrumentFormUtils::getComboValue(ui_->paymentFrequencyCombo);
-    instrument_.index_name = ui_->indexNameEdit->text().trimmed().toStdString();
-    instrument_.index_series = ui_->indexSeriesSpinBox->value();
-    instrument_.seniority = InstrumentFormUtils::getComboValue(ui_->seniorityCombo);
-    instrument_.restructuring = InstrumentFormUtils::getComboValue(ui_->restructuringCombo);
+    instrument_.index.index_name = ui_->indexNameEdit->text().trimmed().toStdString();
+    instrument_.index.index_series = ui_->indexSeriesSpinBox->value();
+    instrument_.terms.seniority = InstrumentFormUtils::getComboValue(ui_->seniorityCombo);
+    instrument_.terms.restructuring = InstrumentFormUtils::getComboValue(ui_->restructuringCombo);
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
-    instrument_.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
+    instrument_.option.option_type = InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
+    instrument_.option.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
     {
         const double s = ui_->optionStrikeSpinBox->value();
-        instrument_.option_strike = (s > 0.0) ? std::optional<double>(s) : std::nullopt;
+        instrument_.option.option_strike = (s > 0.0) ? std::optional<double>(s) : std::nullopt;
     }
-    instrument_.linked_asset_code = ui_->linkedAssetCodeEdit->text().trimmed().toStdString();
+    instrument_.terms.linked_asset_code = ui_->linkedAssetCodeEdit->text().trimmed().toStdString();
     {
         const double a = ui_->trancheAttachmentSpinBox->value();
-        instrument_.tranche_attachment = (a > 0.0) ? std::optional<double>(a) : std::nullopt;
+        instrument_.tranche.tranche_attachment =
+            (a > 0.0) ? std::optional<double>(a) : std::nullopt;
     }
     {
         const double d = ui_->trancheDetachmentSpinBox->value();
-        instrument_.tranche_detachment = (d > 0.0) ? std::optional<double>(d) : std::nullopt;
+        instrument_.tranche.tranche_detachment =
+            (d > 0.0) ? std::optional<double>(d) : std::nullopt;
     }
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void CreditInstrumentForm::populate(const trading::domain::credit_instrument& instr) {
@@ -266,40 +268,40 @@ void CreditInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
-    ui_->referenceEntityEdit->setText(QString::fromStdString(instrument_.reference_entity));
-    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
-    ui_->notionalSpinBox->setValue(instrument_.notional);
-    ui_->spreadSpinBox->setValue(instrument_.spread);
-    ui_->recoveryRateSpinBox->setValue(instrument_.recovery_rate);
-    ui_->tenorEdit->setText(QString::fromStdString(instrument_.tenor));
-    ui_->startDateEdit->setIsoDate(instrument_.start_date);
-    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
-    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.day_count_code);
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
+    ui_->referenceEntityEdit->setText(QString::fromStdString(instrument_.terms.reference_entity));
+    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.terms.currency);
+    ui_->notionalSpinBox->setValue(instrument_.terms.notional);
+    ui_->spreadSpinBox->setValue(instrument_.terms.spread);
+    ui_->recoveryRateSpinBox->setValue(instrument_.terms.recovery_rate);
+    ui_->tenorEdit->setText(QString::fromStdString(instrument_.schedule.tenor));
+    ui_->startDateEdit->setIsoDate(instrument_.schedule.start_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.schedule.maturity_date);
+    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, instrument_.schedule.day_count_code);
     InstrumentFormUtils::setComboValue(ui_->paymentFrequencyCombo,
-                                       instrument_.payment_frequency_code);
-    ui_->indexNameEdit->setText(QString::fromStdString(instrument_.index_name));
-    ui_->indexSeriesSpinBox->setValue(instrument_.index_series);
-    InstrumentFormUtils::setComboValue(ui_->seniorityCombo, instrument_.seniority);
-    InstrumentFormUtils::setComboValue(ui_->restructuringCombo, instrument_.restructuring);
+                                       instrument_.schedule.payment_frequency_code);
+    ui_->indexNameEdit->setText(QString::fromStdString(instrument_.index.index_name));
+    ui_->indexSeriesSpinBox->setValue(instrument_.index.index_series);
+    InstrumentFormUtils::setComboValue(ui_->seniorityCombo, instrument_.terms.seniority);
+    InstrumentFormUtils::setComboValue(ui_->restructuringCombo, instrument_.terms.restructuring);
     ui_->descriptionEdit->setPlainText(QString::fromStdString(instrument_.description));
-    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option_type);
-    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option_expiry_date);
-    ui_->optionStrikeSpinBox->setValue(instrument_.option_strike.value_or(0.0));
-    ui_->linkedAssetCodeEdit->setText(QString::fromStdString(instrument_.linked_asset_code));
-    ui_->trancheAttachmentSpinBox->setValue(instrument_.tranche_attachment.value_or(0.0));
-    ui_->trancheDetachmentSpinBox->setValue(instrument_.tranche_detachment.value_or(0.0));
+    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option.option_type);
+    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option.option_expiry_date);
+    ui_->optionStrikeSpinBox->setValue(instrument_.option.option_strike.value_or(0.0));
+    ui_->linkedAssetCodeEdit->setText(QString::fromStdString(instrument_.terms.linked_asset_code));
+    ui_->trancheAttachmentSpinBox->setValue(instrument_.tranche.tranche_attachment.value_or(0.0));
+    ui_->trancheDetachmentSpinBox->setValue(instrument_.tranche.tranche_detachment.value_or(0.0));
     block(false);
 }
 
 void CreditInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -344,7 +346,7 @@ void CreditInstrumentForm::saveInstrument(std::function<void(const std::string&)
             BOOST_LOG_SEV(lg(), info) << "Credit instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt/trading/src/ImportTradeDialog.cpp
@@ -22,6 +22,7 @@
 #include "ores.ore.core/xml/importer.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.refdata.api/messaging/counterparty_protocol.hpp"
+#include "ores.trading.api/domain/instrument.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 #include "ores.trading.api/messaging/trade_protocol.hpp"
 #include <QDateTime>
@@ -613,6 +614,9 @@ void ImportTradeDialog::onImportClicked() {
                     } else if constexpr (std::is_same_v<T, composite_instrument_data>) {
                         r.instrument.instrument_id = instr_id;
                         r.instrument.trade_id = tti.trade.identity.id;
+                    } else if constexpr (trading::domain::NestedInstrument<T>) {
+                        r.identity.instrument_id = instr_id;
+                        r.identity.trade_id = tti.trade.identity.id;
                     } else {
                         r.instrument_id = instr_id;
                         r.trade_id = tti.trade.identity.id;

--- a/projects/ores.trading/api/include/ores.trading.api/domain/bond_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/bond_instrument.hpp
@@ -20,56 +20,20 @@
 #ifndef ORES_TRADING_DOMAIN_BOND_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_BOND_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
 namespace ores::trading::domain {
 
 /**
- * @brief Bond instrument economics for Bond, ForwardBond, CallableBond,
- * ConvertibleBond, and BondRepo trades.
+ * @brief Core economic terms of a bond.
  *
- * Discriminated by trade_type_code. Optional fields (call_date,
- * conversion_ratio) are empty/zero for non-applicable product types.
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
  */
-struct bond_instrument final {
-    /**
-     * @brief Version number for optimistic locking and change tracking.
-     */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this bond instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the associated trade record.
-     *
-     * Soft FK to ores_trading_trades_tbl. Absent for standalone instruments.
-     */
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code (Bond, ForwardBond, CallableBond,
-     * ConvertibleBond, BondRepo, BondFuture, BondOption, BondTRS,
-     * BondPosition, Ascot).
-     */
-    std::string trade_type_code;
-
+struct bond_terms final {
     /**
      * @brief Security identifier (e.g. ISIN) for the bond.
      */
@@ -114,7 +78,15 @@ struct bond_instrument final {
      * @brief Maturity date (ISO 8601 date string, e.g. 2036-01-15).
      */
     std::string maturity_date;
+};
 
+/**
+ * @brief Optional and product-specific bond features.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct bond_features final {
     /**
      * @brief Optional number of settlement days. Zero means not specified.
      */
@@ -133,44 +105,29 @@ struct bond_instrument final {
     double conversion_ratio = 0.0;
 
     /**
-     * @brief Optional free-text description.
-     */
-    std::string description;
-
-    /**
-     * @brief Username of the person who last modified this record.
-     */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
-
-    // -------------------------------------------------------------------------
-    // Phase 7 extensions: BondFuture, BondOption, BondTRS, Ascot
-    // -------------------------------------------------------------------------
-
-    /**
      * @brief Delivery date for BondFuture. Empty for other types.
      */
     std::string future_expiry_date;
 
+    /**
+     * @brief Return type for BondTRS: "TotalReturn" or "PriceReturn".
+     * Empty otherwise.
+     */
+    std::string trs_return_type;
+
+    /**
+     * @brief Funding leg floating index code for BondTRS. Empty otherwise.
+     */
+    std::string trs_funding_leg_code;
+};
+
+/**
+ * @brief Option-related fields for BondOption and Ascot products.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct bond_option final {
     /**
      * @brief Option type for BondOption: "Call" or "Put". Empty otherwise.
      */
@@ -187,20 +144,33 @@ struct bond_instrument final {
     std::optional<double> option_strike;
 
     /**
-     * @brief Return type for BondTRS: "TotalReturn" or "PriceReturn".
-     * Empty otherwise.
-     */
-    std::string trs_return_type;
-
-    /**
-     * @brief Funding leg floating index code for BondTRS. Empty otherwise.
-     */
-    std::string trs_funding_leg_code;
-
-    /**
      * @brief ASCOT option type. Empty for non-Ascot products.
      */
     std::string ascot_option_type;
+};
+
+/**
+ * @brief Bond instrument economics for Bond, ForwardBond, CallableBond,
+ * ConvertibleBond, and BondRepo trades.
+ *
+ * Discriminated by trade_type_code. Optional fields (call_date,
+ * conversion_ratio) are empty/zero for non-applicable product types.
+ */
+struct bond_instrument final {
+    instrument_identity identity;
+
+    bond_terms terms;
+
+    bond_features features;
+
+    bond_option option;
+
+    /**
+     * @brief Optional free-text description.
+     */
+    std::string description;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/commodity_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/commodity_instrument.hpp
@@ -20,64 +20,20 @@
 #ifndef ORES_TRADING_DOMAIN_COMMODITY_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_COMMODITY_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
 namespace ores::trading::domain {
 
 /**
- * @brief Commodity instrument economics for all commodity ORE product types.
+ * @brief Core economic terms common to commodity products.
  *
- * Discriminated by trade_type_code. Optional fields are empty/zero when not
- * applicable to the specific sub-type:
- *   option_type/strike_price/exercise_type: CommodityOption* products
- *   barrier_type/lower_barrier/upper_barrier: barrier option products
- *   average_type/averaging_start_date/averaging_end_date: Asian/average-price
- *   spread_commodity_code/spread_amount: CommoditySpreadOption
- *   strip_frequency_code: CommodityOptionStrip
- *   variance_strike: CommodityVarianceSwap and variants
- *   accumulation_amount/knock_out_barrier: CommodityAccumulator, CommodityTaRF
- *   basket_json: CommodityBasketOption, CommodityRainbowOption,
- *                CommodityWorstOfBasketSwap
- *   day_count_code/payment_frequency_code: CommoditySwap
- *   swaption_expiry_date: CommoditySwaption
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
  */
-struct commodity_instrument final {
-    /**
-     * @brief Version number for optimistic locking and change tracking.
-     */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this commodity instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the associated trade record.
-     *
-     * Soft FK to ores_trading_trades_tbl. Absent for standalone instruments.
-     */
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code (CommodityForward, CommodityOption, etc.).
-     */
-    std::string trade_type_code;
-
+struct commodity_terms final {
     /**
      * @brief Commodity identifier code (e.g. NGAS, WTI, GOLD).
      */
@@ -114,6 +70,24 @@ struct commodity_instrument final {
     std::optional<double> fixed_price;
 
     /**
+     * @brief Day count fraction code for swap products.
+     */
+    std::string day_count_code;
+
+    /**
+     * @brief Payment frequency code for swap products.
+     */
+    std::string payment_frequency_code;
+};
+
+/**
+ * @brief Vanilla option terms for commodity option products.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct commodity_option final {
+    /**
      * @brief Option type: 'Call' or 'Put'. Empty for non-option products.
      */
     std::string option_type;
@@ -128,6 +102,19 @@ struct commodity_instrument final {
      */
     std::string exercise_type;
 
+    /**
+     * @brief Swaption expiry date for CommoditySwaption products.
+     */
+    std::string swaption_expiry_date;
+};
+
+/**
+ * @brief Averaging and spread pricing terms for commodity products.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct commodity_pricing final {
     /**
      * @brief Averaging type for Asian options: 'Arithmetic' or 'Geometric'.
      */
@@ -157,7 +144,15 @@ struct commodity_instrument final {
      * @brief Strip frequency code for option strips (e.g. Monthly, Quarterly).
      */
     std::string strip_frequency_code;
+};
 
+/**
+ * @brief Exotic and barrier terms for structured commodity products.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below
+ * the MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct commodity_exotic final {
     /**
      * @brief Strike variance for variance swap products. Nullopt when not applicable.
      */
@@ -192,51 +187,38 @@ struct commodity_instrument final {
      * @brief JSON array of {code, weight} constituents for basket products.
      */
     std::string basket_json;
+};
 
-    /**
-     * @brief Day count fraction code for swap products.
-     */
-    std::string day_count_code;
-
-    /**
-     * @brief Payment frequency code for swap products.
-     */
-    std::string payment_frequency_code;
-
-    /**
-     * @brief Swaption expiry date for CommoditySwaption products.
-     */
-    std::string swaption_expiry_date;
+/**
+ * @brief Commodity instrument economics for all commodity ORE product types.
+ *
+ * Discriminated by trade_type_code. Optional fields are empty/zero when not
+ * applicable to the specific sub-type:
+ *   option_type/strike_price/exercise_type: CommodityOption* products
+ *   barrier_type/lower_barrier/upper_barrier: barrier option products
+ *   average_type/averaging_start_date/averaging_end_date: Asian/average-price
+ *   spread_commodity_code/spread_amount: CommoditySpreadOption
+ *   strip_frequency_code: CommodityOptionStrip
+ *   variance_strike: CommodityVarianceSwap and variants
+ *   accumulation_amount/knock_out_barrier: CommodityAccumulator, CommodityTaRF
+ *   basket_json: CommodityBasketOption, CommodityRainbowOption,
+ *                CommodityWorstOfBasketSwap
+ *   day_count_code/payment_frequency_code: CommoditySwap
+ *   swaption_expiry_date: CommoditySwaption
+ */
+struct commodity_instrument final {
+    instrument_identity identity;
+    commodity_terms terms;
+    commodity_option option;
+    commodity_pricing pricing;
+    commodity_exotic exotic;
 
     /**
      * @brief Optional free-text description.
      */
     std::string description;
 
-    /**
-     * @brief Username of the person who last modified this record.
-     */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/credit_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/credit_instrument.hpp
@@ -20,55 +20,20 @@
 #ifndef ORES_TRADING_DOMAIN_CREDIT_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_CREDIT_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
 namespace ores::trading::domain {
 
 /**
- * @brief Credit instrument economics for CreditDefaultSwap, CDSIndex,
- * SyntheticCDO, CreditDefaultSwapOption, IndexCreditDefaultSwapOption,
- * CreditLinkedSwap, and CBO trades.
+ * @brief Economic terms of a credit instrument.
  *
- * Discriminated by trade_type_code. Optional fields are empty/zero for
- * non-applicable product types.
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below the
+ * MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
  */
-struct credit_instrument final {
-    /**
-     * @brief Version number for optimistic locking and change tracking.
-     */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this credit instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the associated trade record.
-     *
-     * Soft FK to ores_trading_trades_tbl. Absent for standalone instruments.
-     */
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code (CreditDefaultSwap, CDSIndex, SyntheticCDO).
-     */
-    std::string trade_type_code;
-
+struct credit_terms final {
     /**
      * @brief Name or identifier of the reference entity.
      */
@@ -95,6 +60,31 @@ struct credit_instrument final {
     double recovery_rate = 0.0;
 
     /**
+     * @brief Optional seniority (e.g. "Senior", "Subordinated"). Empty if not
+     * applicable.
+     */
+    std::string seniority;
+
+    /**
+     * @brief Optional restructuring clause (e.g. "MM", "MR", "CR", "XR").
+     * Empty if not applicable.
+     */
+    std::string restructuring;
+
+    /**
+     * @brief Reference asset code for CreditLinkedSwap. Empty otherwise.
+     */
+    std::string linked_asset_code;
+};
+
+/**
+ * @brief Schedule and date conventions of a credit instrument.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below the
+ * MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct credit_schedule final {
+    /**
      * @brief Tenor of the instrument (e.g. "5Y", "3Y").
      */
     std::string tenor;
@@ -118,7 +108,15 @@ struct credit_instrument final {
      * @brief Payment frequency code (e.g. Quarterly, SemiAnnual).
      */
     std::string payment_frequency_code;
+};
 
+/**
+ * @brief Index identification for CDSIndex-style credit instruments.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below the
+ * MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct credit_index final {
     /**
      * @brief Optional index name for CDSIndex trades (e.g. "CDX.NA.IG").
      * Empty for non-index products.
@@ -130,53 +128,15 @@ struct credit_instrument final {
      * specified.
      */
     int index_series = 0;
+};
 
-    /**
-     * @brief Optional seniority (e.g. "Senior", "Subordinated"). Empty if not
-     * applicable.
-     */
-    std::string seniority;
-
-    /**
-     * @brief Optional restructuring clause (e.g. "MM", "MR", "CR", "XR").
-     * Empty if not applicable.
-     */
-    std::string restructuring;
-
-    /**
-     * @brief Optional free-text description.
-     */
-    std::string description;
-
-    /**
-     * @brief Username of the person who last modified this record.
-     */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
-
-    // -------------------------------------------------------------------------
-    // Phase 7 extensions: CreditDefaultSwapOption, CreditLinkedSwap, CBO
-    // -------------------------------------------------------------------------
-
+/**
+ * @brief Optionality of CreditDefaultSwapOption-style credit instruments.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below the
+ * MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct credit_option final {
     /**
      * @brief Option type: "Call" or "Put" — CreditDefaultSwapOption.
      * Empty otherwise.
@@ -192,12 +152,15 @@ struct credit_instrument final {
      * @brief Option strike spread in bps for CDS options. Null when not set.
      */
     std::optional<double> option_strike;
+};
 
-    /**
-     * @brief Reference asset code for CreditLinkedSwap. Empty otherwise.
-     */
-    std::string linked_asset_code;
-
+/**
+ * @brief Tranche attachment/detachment for CBO and SyntheticCDO instruments.
+ *
+ * Extracted as a plain nested sub-struct to keep each rfl::Literal below the
+ * MSVC C1202 threshold. See doc/investigations/msvc_c1202_rfl_complexity.org.
+ */
+struct credit_tranche final {
     /**
      * @brief CBO tranche attachment point as decimal. Null when not set.
      */
@@ -207,6 +170,30 @@ struct credit_instrument final {
      * @brief CBO tranche detachment point as decimal. Null when not set.
      */
     std::optional<double> tranche_detachment;
+};
+
+/**
+ * @brief Credit instrument economics for CreditDefaultSwap, CDSIndex,
+ * SyntheticCDO, CreditDefaultSwapOption, IndexCreditDefaultSwapOption,
+ * CreditLinkedSwap, and CBO trades.
+ *
+ * Discriminated by trade_type_code. Optional fields are empty/zero for
+ * non-applicable product types.
+ */
+struct credit_instrument final {
+    instrument_identity identity;
+    credit_terms terms;
+    credit_schedule schedule;
+    credit_index index;
+    credit_option option;
+    credit_tranche tranche;
+
+    /**
+     * @brief Optional free-text description.
+     */
+    std::string description;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/src/domain/bond_instrument_table.cpp
+++ b/projects/ores.trading/api/src/domain/bond_instrument_table.cpp
@@ -32,9 +32,10 @@ std::string convert_to_table(const std::vector<bond_instrument>& v) {
           << "Modified By" << "Version" << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.instrument_id) << t.trade_type_code << t.issuer
-              << t.currency << std::to_string(t.face_value) << std::to_string(t.coupon_rate)
-              << t.maturity_date << t.modified_by << t.version << fort::endr;
+        table << boost::uuids::to_string(t.identity.instrument_id) << t.identity.trade_type_code
+              << t.terms.issuer << t.terms.currency << std::to_string(t.terms.face_value)
+              << std::to_string(t.terms.coupon_rate) << t.terms.maturity_date << t.audit.modified_by
+              << t.identity.version << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/api/src/domain/commodity_instrument_table.cpp
+++ b/projects/ores.trading/api/src/domain/commodity_instrument_table.cpp
@@ -31,9 +31,10 @@ std::string convert_to_table(const std::vector<commodity_instrument>& v) {
           << "Quantity" << "Unit" << "Maturity" << "Modified By" << "Version" << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.instrument_id) << t.trade_type_code << t.commodity_code
-              << t.currency << std::to_string(t.quantity) << t.unit << t.maturity_date
-              << t.modified_by << t.version << fort::endr;
+        table << boost::uuids::to_string(t.identity.instrument_id) << t.identity.trade_type_code
+              << t.terms.commodity_code << t.terms.currency << std::to_string(t.terms.quantity)
+              << t.terms.unit << t.terms.maturity_date << t.audit.modified_by << t.identity.version
+              << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/api/src/domain/credit_instrument_table.cpp
+++ b/projects/ores.trading/api/src/domain/credit_instrument_table.cpp
@@ -32,9 +32,10 @@ std::string convert_to_table(const std::vector<credit_instrument>& v) {
           << "Modified By" << "Version" << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.instrument_id) << t.trade_type_code << t.reference_entity
-              << t.currency << std::to_string(t.notional) << std::to_string(t.spread) << t.tenor
-              << t.modified_by << t.version << fort::endr;
+        table << boost::uuids::to_string(t.identity.instrument_id) << t.identity.trade_type_code
+              << t.terms.reference_entity << t.terms.currency << std::to_string(t.terms.notional)
+              << std::to_string(t.terms.spread) << t.schedule.tenor << t.audit.modified_by
+              << t.identity.version << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -30,6 +30,7 @@
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
 #include "ores.storage/net/storage_transfer.hpp"
+#include "ores.trading.api/domain/instrument.hpp"
 #include "ores.trading.api/messaging/trade_protocol.hpp"
 #include "ores.trading.core/export.hpp"
 #include "ores.trading.core/service/activity_type_service.hpp"
@@ -243,10 +244,16 @@ private:
                                           std::vector<ores::trading::domain::swap_leg>{};
         };
 
-        // Flat / single-table types
+        // Single-table types (bond/credit/commodity are nested; scripted
+        // is still flat — key through whichever shape the type has).
         auto add_flat = [&](auto&& results) {
-            for (auto& v : results)
-                imap[boost::uuids::to_string(v.instrument_id)] = std::move(v);
+            for (auto& v : results) {
+                using T = std::decay_t<decltype(v)>;
+                if constexpr (ores::trading::domain::NestedInstrument<T>)
+                    imap[boost::uuids::to_string(v.identity.instrument_id)] = std::move(v);
+                else
+                    imap[boost::uuids::to_string(v.instrument_id)] = std::move(v);
+            }
         };
 
         if (!bond_ids.empty()) {

--- a/projects/ores.trading/core/include/ores.trading.core/repository/bond_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/bond_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct bond_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/commodity_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/commodity_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct commodity_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/credit_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/credit_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct credit_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/src/repository/bond_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/bond_instrument_mapper.cpp
@@ -32,38 +32,39 @@ domain::bond_instrument bond_instrument_mapper::map(const bond_instrument_entity
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::bond_instrument r;
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.version = v.version;
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.issuer = v.issuer;
-    r.currency = v.currency;
-    r.face_value = v.face_value;
-    r.coupon_rate = v.coupon_rate;
-    r.coupon_frequency_code = v.coupon_frequency_code;
-    r.day_count_code = v.day_count_code;
-    r.issue_date = v.issue_date;
-    r.maturity_date = v.maturity_date;
-    r.settlement_days = v.settlement_days.value_or(0);
-    r.call_date = v.call_date.value_or("");
-    r.conversion_ratio = v.conversion_ratio.value_or(0.0);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.version = v.version;
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
+    r.terms.issuer = v.issuer;
+    r.terms.currency = v.currency;
+    r.terms.face_value = v.face_value;
+    r.terms.coupon_rate = v.coupon_rate;
+    r.terms.coupon_frequency_code = v.coupon_frequency_code;
+    r.terms.day_count_code = v.day_count_code;
+    r.terms.issue_date = v.issue_date;
+    r.terms.maturity_date = v.maturity_date;
+    r.features.settlement_days = v.settlement_days.value_or(0);
+    r.features.call_date = v.call_date.value_or("");
+    r.features.conversion_ratio = v.conversion_ratio.value_or(0.0);
     r.description = v.description.value_or("");
-    r.future_expiry_date = v.future_expiry_date.value_or("");
-    r.option_type = v.option_type.value_or("");
-    r.option_expiry_date = v.option_expiry_date.value_or("");
-    r.option_strike = v.option_strike;
-    r.trs_return_type = v.trs_return_type.value_or("");
-    r.trs_funding_leg_code = v.trs_funding_leg_code.value_or("");
-    r.ascot_option_type = v.ascot_option_type.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.features.future_expiry_date = v.future_expiry_date.value_or("");
+    r.option.option_type = v.option_type.value_or("");
+    r.option.option_expiry_date = v.option_expiry_date.value_or("");
+    r.option.option_strike = v.option_strike;
+    r.features.trs_return_type = v.trs_return_type.value_or("");
+    r.features.trs_funding_leg_code = v.trs_funding_leg_code.value_or("");
+    r.option.ascot_option_type = v.ascot_option_type.value_or("");
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -73,41 +74,52 @@ bond_instrument_entity bond_instrument_mapper::map(const domain::bond_instrument
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     bond_instrument_entity r;
-    r.id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.issuer = v.issuer;
-    r.currency = v.currency;
-    r.face_value = v.face_value;
-    r.coupon_rate = v.coupon_rate;
-    r.coupon_frequency_code = v.coupon_frequency_code;
-    r.day_count_code = v.day_count_code;
-    r.issue_date = v.issue_date;
-    r.maturity_date = v.maturity_date;
-    r.settlement_days = v.settlement_days == 0 ? std::nullopt : std::optional(v.settlement_days);
-    r.call_date = v.call_date.empty() ? std::nullopt : std::optional(v.call_date);
-    r.conversion_ratio =
-        v.conversion_ratio == 0.0 ? std::nullopt : std::optional(v.conversion_ratio);
+    r.id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
+    r.issuer = v.terms.issuer;
+    r.currency = v.terms.currency;
+    r.face_value = v.terms.face_value;
+    r.coupon_rate = v.terms.coupon_rate;
+    r.coupon_frequency_code = v.terms.coupon_frequency_code;
+    r.day_count_code = v.terms.day_count_code;
+    r.issue_date = v.terms.issue_date;
+    r.maturity_date = v.terms.maturity_date;
+    r.settlement_days =
+        v.features.settlement_days == 0 ? std::nullopt : std::optional(v.features.settlement_days);
+    r.call_date = v.features.call_date.empty() ? std::nullopt : std::optional(v.features.call_date);
+    r.conversion_ratio = v.features.conversion_ratio == 0.0 ?
+                             std::nullopt :
+                             std::optional(v.features.conversion_ratio);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.future_expiry_date =
-        v.future_expiry_date.empty() ? std::nullopt : std::optional(v.future_expiry_date);
-    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
-    r.option_expiry_date =
-        v.option_expiry_date.empty() ? std::nullopt : std::optional(v.option_expiry_date);
-    r.option_strike = v.option_strike;
-    r.trs_return_type = v.trs_return_type.empty() ? std::nullopt : std::optional(v.trs_return_type);
-    r.trs_funding_leg_code =
-        v.trs_funding_leg_code.empty() ? std::nullopt : std::optional(v.trs_funding_leg_code);
-    r.ascot_option_type =
-        v.ascot_option_type.empty() ? std::nullopt : std::optional(v.ascot_option_type);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.future_expiry_date = v.features.future_expiry_date.empty() ?
+                               std::nullopt :
+                               std::optional(v.features.future_expiry_date);
+    r.option_type =
+        v.option.option_type.empty() ? std::nullopt : std::optional(v.option.option_type);
+    r.option_expiry_date = v.option.option_expiry_date.empty() ?
+                               std::nullopt :
+                               std::optional(v.option.option_expiry_date);
+    r.option_strike = v.option.option_strike;
+    r.trs_return_type = v.features.trs_return_type.empty() ?
+                            std::nullopt :
+                            std::optional(v.features.trs_return_type);
+    r.trs_funding_leg_code = v.features.trs_funding_leg_code.empty() ?
+                                 std::nullopt :
+                                 std::optional(v.features.trs_funding_leg_code);
+    r.ascot_option_type = v.option.ascot_option_type.empty() ?
+                              std::nullopt :
+                              std::optional(v.option.ascot_option_type);
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/bond_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/bond_instrument_repository.cpp
@@ -39,7 +39,7 @@ std::string bond_instrument_repository::sql() {
 }
 
 void bond_instrument_repository::write(context ctx, const domain::bond_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing bond_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing bond_instrument: " << v.identity.instrument_id;
     execute_write_query(
         ctx, bond_instrument_mapper::map(v), lg(), "Writing bond_instrument to database.");
 }

--- a/projects/ores.trading/core/src/repository/commodity_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/commodity_instrument_mapper.cpp
@@ -33,46 +33,47 @@ commodity_instrument_mapper::map(const commodity_instrument_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::commodity_instrument r;
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.version = v.version;
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.commodity_code = v.commodity_code;
-    r.currency = v.currency;
-    r.quantity = v.quantity;
-    r.unit = v.unit;
-    r.start_date = v.start_date.value_or("");
-    r.maturity_date = v.maturity_date.value_or("");
-    r.fixed_price = v.fixed_price;
-    r.option_type = v.option_type.value_or("");
-    r.strike_price = v.strike_price;
-    r.exercise_type = v.exercise_type.value_or("");
-    r.average_type = v.average_type.value_or("");
-    r.averaging_start_date = v.averaging_start_date.value_or("");
-    r.averaging_end_date = v.averaging_end_date.value_or("");
-    r.spread_commodity_code = v.spread_commodity_code.value_or("");
-    r.spread_amount = v.spread_amount;
-    r.strip_frequency_code = v.strip_frequency_code.value_or("");
-    r.variance_strike = v.variance_strike;
-    r.accumulation_amount = v.accumulation_amount;
-    r.knock_out_barrier = v.knock_out_barrier;
-    r.barrier_type = v.barrier_type.value_or("");
-    r.lower_barrier = v.lower_barrier;
-    r.upper_barrier = v.upper_barrier;
-    r.basket_json = v.basket_json.value_or("");
-    r.day_count_code = v.day_count_code.value_or("");
-    r.payment_frequency_code = v.payment_frequency_code.value_or("");
-    r.swaption_expiry_date = v.swaption_expiry_date.value_or("");
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.version = v.version;
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
+    r.terms.commodity_code = v.commodity_code;
+    r.terms.currency = v.currency;
+    r.terms.quantity = v.quantity;
+    r.terms.unit = v.unit;
+    r.terms.start_date = v.start_date.value_or("");
+    r.terms.maturity_date = v.maturity_date.value_or("");
+    r.terms.fixed_price = v.fixed_price;
+    r.terms.day_count_code = v.day_count_code.value_or("");
+    r.terms.payment_frequency_code = v.payment_frequency_code.value_or("");
+    r.option.option_type = v.option_type.value_or("");
+    r.option.strike_price = v.strike_price;
+    r.option.exercise_type = v.exercise_type.value_or("");
+    r.option.swaption_expiry_date = v.swaption_expiry_date.value_or("");
+    r.pricing.average_type = v.average_type.value_or("");
+    r.pricing.averaging_start_date = v.averaging_start_date.value_or("");
+    r.pricing.averaging_end_date = v.averaging_end_date.value_or("");
+    r.pricing.spread_commodity_code = v.spread_commodity_code.value_or("");
+    r.pricing.spread_amount = v.spread_amount;
+    r.pricing.strip_frequency_code = v.strip_frequency_code.value_or("");
+    r.exotic.variance_strike = v.variance_strike;
+    r.exotic.accumulation_amount = v.accumulation_amount;
+    r.exotic.knock_out_barrier = v.knock_out_barrier;
+    r.exotic.barrier_type = v.barrier_type.value_or("");
+    r.exotic.lower_barrier = v.lower_barrier;
+    r.exotic.upper_barrier = v.upper_barrier;
+    r.exotic.basket_json = v.basket_json.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -83,50 +84,65 @@ commodity_instrument_mapper::map(const domain::commodity_instrument& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     commodity_instrument_entity r;
-    r.id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.commodity_code = v.commodity_code;
-    r.currency = v.currency;
-    r.quantity = v.quantity;
-    r.unit = v.unit;
-    r.start_date = v.start_date.empty() ? std::nullopt : std::optional(v.start_date);
-    r.maturity_date = v.maturity_date.empty() ? std::nullopt : std::optional(v.maturity_date);
-    r.fixed_price = v.fixed_price;
-    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
-    r.strike_price = v.strike_price;
-    r.exercise_type = v.exercise_type.empty() ? std::nullopt : std::optional(v.exercise_type);
-    r.average_type = v.average_type.empty() ? std::nullopt : std::optional(v.average_type);
-    r.averaging_start_date =
-        v.averaging_start_date.empty() ? std::nullopt : std::optional(v.averaging_start_date);
-    r.averaging_end_date =
-        v.averaging_end_date.empty() ? std::nullopt : std::optional(v.averaging_end_date);
-    r.spread_commodity_code =
-        v.spread_commodity_code.empty() ? std::nullopt : std::optional(v.spread_commodity_code);
-    r.spread_amount = v.spread_amount;
-    r.strip_frequency_code =
-        v.strip_frequency_code.empty() ? std::nullopt : std::optional(v.strip_frequency_code);
-    r.variance_strike = v.variance_strike;
-    r.accumulation_amount = v.accumulation_amount;
-    r.knock_out_barrier = v.knock_out_barrier;
-    r.barrier_type = v.barrier_type.empty() ? std::nullopt : std::optional(v.barrier_type);
-    r.lower_barrier = v.lower_barrier;
-    r.upper_barrier = v.upper_barrier;
-    r.basket_json = v.basket_json.empty() ? std::nullopt : std::optional(v.basket_json);
-    r.day_count_code = v.day_count_code.empty() ? std::nullopt : std::optional(v.day_count_code);
-    r.payment_frequency_code =
-        v.payment_frequency_code.empty() ? std::nullopt : std::optional(v.payment_frequency_code);
-    r.swaption_expiry_date =
-        v.swaption_expiry_date.empty() ? std::nullopt : std::optional(v.swaption_expiry_date);
+    r.id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
+    r.commodity_code = v.terms.commodity_code;
+    r.currency = v.terms.currency;
+    r.quantity = v.terms.quantity;
+    r.unit = v.terms.unit;
+    r.start_date = v.terms.start_date.empty() ? std::nullopt : std::optional(v.terms.start_date);
+    r.maturity_date =
+        v.terms.maturity_date.empty() ? std::nullopt : std::optional(v.terms.maturity_date);
+    r.fixed_price = v.terms.fixed_price;
+    r.day_count_code =
+        v.terms.day_count_code.empty() ? std::nullopt : std::optional(v.terms.day_count_code);
+    r.payment_frequency_code = v.terms.payment_frequency_code.empty() ?
+                                   std::nullopt :
+                                   std::optional(v.terms.payment_frequency_code);
+    r.option_type =
+        v.option.option_type.empty() ? std::nullopt : std::optional(v.option.option_type);
+    r.strike_price = v.option.strike_price;
+    r.exercise_type =
+        v.option.exercise_type.empty() ? std::nullopt : std::optional(v.option.exercise_type);
+    r.swaption_expiry_date = v.option.swaption_expiry_date.empty() ?
+                                 std::nullopt :
+                                 std::optional(v.option.swaption_expiry_date);
+    r.average_type =
+        v.pricing.average_type.empty() ? std::nullopt : std::optional(v.pricing.average_type);
+    r.averaging_start_date = v.pricing.averaging_start_date.empty() ?
+                                 std::nullopt :
+                                 std::optional(v.pricing.averaging_start_date);
+    r.averaging_end_date = v.pricing.averaging_end_date.empty() ?
+                               std::nullopt :
+                               std::optional(v.pricing.averaging_end_date);
+    r.spread_commodity_code = v.pricing.spread_commodity_code.empty() ?
+                                  std::nullopt :
+                                  std::optional(v.pricing.spread_commodity_code);
+    r.spread_amount = v.pricing.spread_amount;
+    r.strip_frequency_code = v.pricing.strip_frequency_code.empty() ?
+                                 std::nullopt :
+                                 std::optional(v.pricing.strip_frequency_code);
+    r.variance_strike = v.exotic.variance_strike;
+    r.accumulation_amount = v.exotic.accumulation_amount;
+    r.knock_out_barrier = v.exotic.knock_out_barrier;
+    r.barrier_type =
+        v.exotic.barrier_type.empty() ? std::nullopt : std::optional(v.exotic.barrier_type);
+    r.lower_barrier = v.exotic.lower_barrier;
+    r.upper_barrier = v.exotic.upper_barrier;
+    r.basket_json =
+        v.exotic.basket_json.empty() ? std::nullopt : std::optional(v.exotic.basket_json);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/commodity_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/commodity_instrument_repository.cpp
@@ -39,7 +39,7 @@ std::string commodity_instrument_repository::sql() {
 }
 
 void commodity_instrument_repository::write(context ctx, const domain::commodity_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing commodity_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing commodity_instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         commodity_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/credit_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/credit_instrument_mapper.cpp
@@ -32,40 +32,41 @@ domain::credit_instrument credit_instrument_mapper::map(const credit_instrument_
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::credit_instrument r;
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.version = v.version;
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.reference_entity = v.reference_entity;
-    r.currency = v.currency;
-    r.notional = v.notional;
-    r.spread = v.spread;
-    r.recovery_rate = v.recovery_rate;
-    r.tenor = v.tenor;
-    r.start_date = v.start_date;
-    r.maturity_date = v.maturity_date;
-    r.day_count_code = v.day_count_code;
-    r.payment_frequency_code = v.payment_frequency_code;
-    r.index_name = v.index_name.value_or("");
-    r.index_series = v.index_series.value_or(0);
-    r.seniority = v.seniority.value_or("");
-    r.restructuring = v.restructuring.value_or("");
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.version = v.version;
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
+    r.terms.reference_entity = v.reference_entity;
+    r.terms.currency = v.currency;
+    r.terms.notional = v.notional;
+    r.terms.spread = v.spread;
+    r.terms.recovery_rate = v.recovery_rate;
+    r.schedule.tenor = v.tenor;
+    r.schedule.start_date = v.start_date;
+    r.schedule.maturity_date = v.maturity_date;
+    r.schedule.day_count_code = v.day_count_code;
+    r.schedule.payment_frequency_code = v.payment_frequency_code;
+    r.index.index_name = v.index_name.value_or("");
+    r.index.index_series = v.index_series.value_or(0);
+    r.terms.seniority = v.seniority.value_or("");
+    r.terms.restructuring = v.restructuring.value_or("");
     r.description = v.description.value_or("");
-    r.option_type = v.option_type.value_or("");
-    r.option_expiry_date = v.option_expiry_date.value_or("");
-    r.option_strike = v.option_strike;
-    r.linked_asset_code = v.linked_asset_code.value_or("");
-    r.tranche_attachment = v.tranche_attachment;
-    r.tranche_detachment = v.tranche_detachment;
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.option.option_type = v.option_type.value_or("");
+    r.option.option_expiry_date = v.option_expiry_date.value_or("");
+    r.option.option_strike = v.option_strike;
+    r.terms.linked_asset_code = v.linked_asset_code.value_or("");
+    r.tranche.tranche_attachment = v.tranche_attachment;
+    r.tranche.tranche_detachment = v.tranche_detachment;
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -75,40 +76,45 @@ credit_instrument_entity credit_instrument_mapper::map(const domain::credit_inst
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     credit_instrument_entity r;
-    r.id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
-    r.reference_entity = v.reference_entity;
-    r.currency = v.currency;
-    r.notional = v.notional;
-    r.spread = v.spread;
-    r.recovery_rate = v.recovery_rate;
-    r.tenor = v.tenor;
-    r.start_date = v.start_date;
-    r.maturity_date = v.maturity_date;
-    r.day_count_code = v.day_count_code;
-    r.payment_frequency_code = v.payment_frequency_code;
-    r.index_name = v.index_name.empty() ? std::nullopt : std::optional(v.index_name);
-    r.index_series = v.index_series == 0 ? std::nullopt : std::optional(v.index_series);
-    r.seniority = v.seniority.empty() ? std::nullopt : std::optional(v.seniority);
-    r.restructuring = v.restructuring.empty() ? std::nullopt : std::optional(v.restructuring);
+    r.id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
+    r.reference_entity = v.terms.reference_entity;
+    r.currency = v.terms.currency;
+    r.notional = v.terms.notional;
+    r.spread = v.terms.spread;
+    r.recovery_rate = v.terms.recovery_rate;
+    r.tenor = v.schedule.tenor;
+    r.start_date = v.schedule.start_date;
+    r.maturity_date = v.schedule.maturity_date;
+    r.day_count_code = v.schedule.day_count_code;
+    r.payment_frequency_code = v.schedule.payment_frequency_code;
+    r.index_name = v.index.index_name.empty() ? std::nullopt : std::optional(v.index.index_name);
+    r.index_series = v.index.index_series == 0 ? std::nullopt : std::optional(v.index.index_series);
+    r.seniority = v.terms.seniority.empty() ? std::nullopt : std::optional(v.terms.seniority);
+    r.restructuring =
+        v.terms.restructuring.empty() ? std::nullopt : std::optional(v.terms.restructuring);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
-    r.option_expiry_date =
-        v.option_expiry_date.empty() ? std::nullopt : std::optional(v.option_expiry_date);
-    r.option_strike = v.option_strike;
+    r.option_type =
+        v.option.option_type.empty() ? std::nullopt : std::optional(v.option.option_type);
+    r.option_expiry_date = v.option.option_expiry_date.empty() ?
+                               std::nullopt :
+                               std::optional(v.option.option_expiry_date);
+    r.option_strike = v.option.option_strike;
     r.linked_asset_code =
-        v.linked_asset_code.empty() ? std::nullopt : std::optional(v.linked_asset_code);
-    r.tranche_attachment = v.tranche_attachment;
-    r.tranche_detachment = v.tranche_detachment;
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+        v.terms.linked_asset_code.empty() ? std::nullopt : std::optional(v.terms.linked_asset_code);
+    r.tranche_attachment = v.tranche.tranche_attachment;
+    r.tranche_detachment = v.tranche.tranche_detachment;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/credit_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/credit_instrument_repository.cpp
@@ -39,7 +39,7 @@ std::string credit_instrument_repository::sql() {
 }
 
 void credit_instrument_repository::write(context ctx, const domain::credit_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing credit_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing credit_instrument: " << v.identity.instrument_id;
     execute_write_query(
         ctx, credit_instrument_mapper::map(v), lg(), "Writing credit_instrument to database.");
 }

--- a/projects/ores.trading/core/src/service/bond_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/bond_instrument_service.cpp
@@ -57,13 +57,13 @@ bond_instrument_service::get_bond_instrument(const std::string& id) {
 }
 
 void bond_instrument_service::save_bond_instrument(const domain::bond_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Bond instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving bond_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving bond_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved bond_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved bond_instrument: " << t.identity.instrument_id;
 }
 
 void bond_instrument_service::remove_bond_instrument(const std::string& id) {

--- a/projects/ores.trading/core/src/service/commodity_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/commodity_instrument_service.cpp
@@ -61,14 +61,14 @@ commodity_instrument_service::get_commodity_instrument(const std::string& id) {
 void commodity_instrument_service::save_commodity_instrument(
     const domain::commodity_instrument& v) {
     auto t = v;
-    if (t.instrument_id.is_nil()) {
+    if (t.identity.instrument_id.is_nil()) {
         boost::uuids::random_generator gen;
-        t.instrument_id = gen();
+        t.identity.instrument_id = gen();
     }
-    BOOST_LOG_SEV(lg(), debug) << "Saving commodity_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving commodity_instrument: " << t.identity.instrument_id;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved commodity_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved commodity_instrument: " << t.identity.instrument_id;
 }
 
 void commodity_instrument_service::remove_commodity_instrument(const std::string& id) {

--- a/projects/ores.trading/core/src/service/credit_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/credit_instrument_service.cpp
@@ -57,13 +57,13 @@ credit_instrument_service::get_credit_instrument(const std::string& id) {
 }
 
 void credit_instrument_service::save_credit_instrument(const domain::credit_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Credit instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving credit_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving credit_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved credit_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved credit_instrument: " << t.identity.instrument_id;
 }
 
 void credit_instrument_service::remove_credit_instrument(const std::string& id) {


### PR DESCRIPTION
## Summary

Task 15 (final decomposition task) of the C1202 story. Bond (31 fields), credit (32) and commodity (38) exceed the MSVC C1202 threshold by too much for the identity/audit split alone — each gains cohesive type-specific sub-structs, all ≤9 fields, defined in the instrument's own header:

| Type | Sub-structs | Top-level fields |
|---|---|---|
| bond | `terms` (9), `features` (6), `option` (4) | 6 |
| credit | `terms` (8), `schedule` (5), `index` (2), `option` (3), `tranche` (2) | 8 |
| commodity | `terms` (9), `option` (4), `pricing` (6), `exotic` (7) | 7 |

Plus the standard moves from #1047/#1071/#1075: `instrument_identity identity`, fully-qualified `ores::dq::domain::audit_record audit`, entities stay flat and gain `workspace_id`, mappers translate flat ↔ nested.

Notable:
- Shared dispatch sites (`trade_handler` `add_flat`, `ImportTradeDialog`, planner test) now branch on the `NestedInstrument` concept — the three types key through `identity`, scripted stays flat
- fort table printers (`bond/credit/commodity_instrument_table.cpp`) re-routed — a caller class the earlier tasks didn't have
- ores.ore XML mappers re-routed across all product types (Bond/ForwardBond/Callable/Convertible/BondOption/BondTRS/BondRepo; all credit; 7 forward + 7 reverse commodity)

With this, every instrument family is nested except scripted and composite, which sit below the threshold by design.

## Test plan

- Full local `linux-clang-debug-make` build green (0 errors)
- Round-trip and repository tests updated alongside; CI exercises gcc/msvc/AppleClang

🤖 Generated with [Claude Code](https://claude.com/claude-code)