### PR TITLE
[ores.compass] Add pr pillar with checks verb

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -33,7 +33,7 @@ with traceability, merge) as follow-on tasks.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Review verbs shipped (PR #1078). Extending list to conversation comments. |
+| Now           | Conversation layer shipped (PR #1081). Adding compass pr checks. |
 | Waiting on    | Nothing.                               |
 | Next          | Conversation-comments gap, then the pr pillar verbs: checks, create, merge. |
 | Last touched  | 2026-06-05                               |
@@ -68,8 +68,8 @@ with traceability, merge) as follow-on tasks.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The four review-round verbs (list, reply, resolve, pending) wrapping gh; --owner/--repo from git remote. PR #1078. |
-| [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | STARTED | 2026-06-05 | | Include PR conversation comments so gh pr view --comments is no longer needed. |
-| [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | BACKLOG | | | Wrap gh pr checks as compass pr checks <N> [--watch]; update runbook + recipes. |
+| [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | DONE | 2026-06-05 | 2026-06-05 | Conversation section in review list; gh pr view --comments retired. PR #1081. |
+| [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | STARTED | 2026-06-05 | | Wrap gh pr checks as compass pr checks <N> [--watch]; update runbook + recipes. |
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | BACKLOG | | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | BACKLOG | | | Refuse on unresolved threads or red CI; merge, delete branch, prompt close-out. |
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -70,7 +70,7 @@ with traceability, merge) as follow-on tasks.
 | [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The four review-round verbs (list, reply, resolve, pending) wrapping gh; --owner/--repo from git remote. PR #1078. |
 | [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | DONE | 2026-06-05 | 2026-06-05 | Conversation section in review list; gh pr view --comments retired. PR #1081. |
 | [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | STARTED | 2026-06-05 | | Wrap gh pr checks as compass pr checks <N> [--watch]; update runbook + recipes. |
-| [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | BACKLOG | | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. |
+| [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | STARTED | 2026-06-05 | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. pr record (first slice) shipped with #1084. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | BACKLOG | | | Refuse on unresolved threads or red CI; merge, delete branch, prompt close-out. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
@@ -19,7 +19,13 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add the PR pillar's first verb: =compass pr checks [<pr>]= wrapping
+=gh pr checks= (default: the current branch's PR), with =--watch=,
+=--fail-fast=, =--required=, and =--interval= passed through. Output
+streams live and the exit code follows gh (0 green, non-zero on
+failing/pending) so runbooks can gate on it. Retire the raw =gh pr
+checks= invocations from the review-round runbook and the monitor,
+fix-CI, create-PR, and merge recipes.
 
 * Status
 
@@ -34,7 +40,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- =compass pr checks [<pr>] [--watch] [--fail-fast] [--required]
+  [--interval N]= streams CI status with gh's exit semantics.
+- No =gh pr checks= references remain in recipes or runbooks.
+- =compass --help= documents the PR pillar.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
@@ -63,6 +63,8 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | if args.interval: drops explicit 0 | compass_pr.py | Accepted | is not None; d0f3c6708 |
+| 2 | --interval default should be None | compass_pr.py | Accepted | d0f3c6708 |
+| 3 | Validate --interval: non-negative, only with --watch | compass_pr.py | Accepted | ap.error; d0f3c6708 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-pr-checks
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,7 +25,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-pr-checks
-#+pr:
+#+pr: 1084
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -57,7 +57,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1084][#1084]] | [ores.compass] Add pr pillar with checks verb |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -25,9 +25,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Not yet started.                       |
+| Now          | pr record (auto-record slice) shipped with #1084; create itself next. |
 | Waiting on   | Nothing.                               |
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-05                               |
@@ -43,6 +43,13 @@ distilled into the parent story's =* Decisions= and cleared when the
 task closes. Plans do not outlive their task.)
 
 * Notes
+
+2026-06-05: first slice landed ahead of create itself — =compass pr
+record [<pr>]= finds the task by matching =#+branch:= against the
+current branch (or =--task=), sets =#+pr:=, and appends the =* PRs=
+row from the PR's live title; idempotent when already recorded. The
+create-PR recipe's record step is now one command. Shipped on the
+pr-checks branch (PR #1084).
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_review_conversation_comments.org
@@ -30,11 +30,11 @@ review surface.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -68,3 +68,9 @@ task closes. Plans do not outlive their task.)
 | 2 | submitted_at null (pending reviews) → same TypeError | compass_review.py | Accepted | or ""; b378ad8a1 |
 
 * Result
+
+Shipped in PR [[https://github.com/OreStudio/OreStudio/pull/1081][#1081]] (merged 2026-06-05): =review list= shows line
+threads plus a Conversation section (issue comments and review
+summaries, chronological, null-timestamp safe); =--detail= and json
+({line, conversation}) cover both. The runbook and recipe dropped
+their last =gh pr view --comments= reference.

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -30,7 +30,7 @@ In execution order:
 2. /Check CI status./ Before reading comments, inspect the current CI state:
 
    #+begin_src sh :results verbatim
-   gh pr checks <N>
+   compass pr checks <N>
    #+end_src
 
    - If any check is *failing*, identify and fix the root cause first — as a separate commit — before looking at review comments. A CI failure may explain or supersede some review comments.
@@ -45,7 +45,7 @@ In execution order:
 
 6. /Push./ =git push=.
 
-7. /Verify CI is green./ Re-run =gh pr checks <N>= and wait until no checks are pending. If any check fails, fix, commit, push, and repeat this step. Do not reply to review comments while CI is red.
+7. /Verify CI is green./ Re-run =compass pr checks <N>= (or =--watch= to poll) and wait until no checks are pending. If any check fails, fix, commit, push, and repeat this step. Do not reply to review comments while CI is red.
 
 8. /Reply to every comment./ Accepted: "Fixed in commit <sha> — <description>." Declined: "Not changed. <reason>." Use =compass review reply <N> <comment-id> "<message>"= per the recipe.
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :github:pr:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-24
+#+updated: 2026-06-05
 
 The body content should be assembled via [[id:1882D6DF-4012-4C6E-BF62-0D943EF805B0][How do I generate a PR
 summary?]] before running the =gh= command here.
@@ -55,16 +55,15 @@ EOF
 3. /Confirm the PR URL/ that =gh= prints; verify the title format
    matches =[COMPONENT] Description=.
 
-4. /Record the PR in the task./ Open the task's =* PRs= table and add
-   a row with the PR number (as a URL link) and title. The table carries
-   the canonical record — =compass where --prs= reads it to fetch live
-   status:
+4. /Record the PR in the task./ One command — it finds the task by
+   matching =#+branch:= against the current branch, sets =#+pr:=, and
+   adds the =* PRs= table row (the canonical record =compass where
+   --prs= reads):
 
-   #+begin_example
-   | PR | Title                            |
-   |----+----------------------------------|
-   | [[https://github.com/OreStudio/OreStudio/pull/123][#123]] | [component] One-line description |
-   #+end_example
+   #+begin_src sh :results verbatim
+   ./compass.sh pr record            # current branch's PR
+   ./compass.sh pr record 123        # explicit PR number
+   #+end_src
 
 * Conventions
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -97,7 +97,7 @@ login=) once per checkout.
 
 * Tested by
 
-Manual. Reviewers verify the PR shape; =gh pr checks= reports CI.
+Manual. Reviewers verify the PR shape; =compass pr checks= reports CI.
 
 * See also
 

--- a/doc/recipes/github/how_do_i_fix_a_failing_ci_check.org
+++ b/doc/recipes/github/how_do_i_fix_a_failing_ci_check.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :github:pr:ci:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-05
 
 This is one branch of the [[id:F6E88DCC-9240-4632-A9A3-9F36F79C9262][PR monitoring loop]]. The other branch is
 [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][addressing review comments]].
@@ -19,11 +19,11 @@ and push the fix?
 
 * Answer
 
-1. /Identify the failing check/. =gh pr checks= shows the overall
+1. /Identify the failing check/. =compass pr checks= shows the overall
    status; =gh run list= drills into the runs for the branch:
 
    #+begin_src sh :results verbatim
-   gh pr checks
+   ./compass.sh pr checks
    gh run list --branch "$(git branch --show-current)"
    #+end_src
 

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -22,7 +22,7 @@ How do I merge a green, approved PR and delete its feature branch?
 1. /Verify CI is green/. Never merge a yellow or red PR.
 
    #+begin_src sh :results verbatim
-   gh pr checks
+   ./compass.sh pr checks
    #+end_src
 
 2. /Verify all review threads are resolved/ — see the resolve loop

--- a/doc/recipes/github/how_do_i_monitor_a_pr_until_green.org
+++ b/doc/recipes/github/how_do_i_monitor_a_pr_until_green.org
@@ -2,7 +2,7 @@
 :ID: F6E88DCC-9240-4632-A9A3-9F36F79C9262
 :END:
 #+title: How do I monitor a PR until green?
-#+description: Drive a PR to green CI and zero unresolved review threads — via the pr-watch background script, or by hand with gh pr checks.
+#+description: Drive a PR to green CI and zero unresolved review threads — via the pr-watch background script, or by hand with compass pr checks.
 #+type: recipe
 #+level: cross
 #+filetags: :github:pr:ci:gh:recipe:
@@ -55,7 +55,7 @@ When the script is unavailable, run the loop yourself:
    build:
 
    #+begin_src sh :results verbatim
-   gh pr checks
+   ./compass.sh pr checks --watch
    #+end_src
 
    - All green or pending → step 2.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -3200,7 +3200,8 @@ def main():
                                "'review pending [--since 24h]'; 'review --help'")
     subparsers.add_parser("pr",
                           help="PR: pull-request lifecycle verbs via gh — "
-                               "'pr checks [<pr>] [--watch]'; 'pr --help'")
+                               "'pr checks [<pr>] [--watch]', 'pr record [<pr>]'; "
+                               "'pr --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2622,6 +2622,12 @@ def _tr_find_suite_log(log_dir, project_name):
     return None
 
 
+def cmd_pr(argv):
+    """compass pr — PR pillar: pull-request lifecycle verbs via gh."""
+    import compass_pr
+    return compass_pr.run(argv, PROJECT_ROOT)
+
+
 def cmd_review(argv):
     """compass review — Review pillar: PR review-round verbs via gh."""
     import compass_review
@@ -3084,6 +3090,8 @@ def main():
         sys.exit(cmd_build(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "review":
         sys.exit(cmd_review(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "pr":
+        sys.exit(cmd_pr(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ("bearings", "orient"):
         sys.exit(cmd_bearings(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ALL_BUCKETS:
@@ -3094,7 +3102,8 @@ def main():
         _KNOWN_COMMANDS = [
             "index", "search", "find", "debug", "where", "status", "fleet",
             "list", "show", "add", "sprint", "story", "task", "journal",
-            "env", "nats", "test", "build", "review", "bearings", "orient",
+            "env", "nats", "test", "build", "review", "pr", "bearings",
+            "orient",
             "capture",
             "inbox", "next", "deferred", "discarded", "backlog",
         ]
@@ -3119,6 +3128,7 @@ def main():
         "  Test:      test\n"
         "  Build:     build\n"
         "  Review:    review\n"
+        "  PR:        pr\n"
         "  Bearings:  bearings (alias: orient)\n"
         "\n"
         "Entity commands (sub-subcommands span pillars):\n"
@@ -3188,6 +3198,9 @@ def main():
                           help="Review: PR review-round verbs via gh — 'review list <pr>', "
                                "'review reply <pr> <id> <msg>', 'review resolve <pr>', "
                                "'review pending [--since 24h]'; 'review --help'")
+    subparsers.add_parser("pr",
+                          help="PR: pull-request lifecycle verbs via gh — "
+                               "'pr checks [<pr>] [--watch]'; 'pr --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -33,7 +33,7 @@ def _cmd_checks(args, project_root):
         cmd.append("--fail-fast")
     if args.required:
         cmd.append("--required")
-    if args.interval:
+    if args.interval is not None:
         cmd += ["--interval", str(args.interval)]
     try:
         # Stream straight through so --watch updates live; gh's exit
@@ -136,7 +136,7 @@ def run(argv, project_root):
                     help="With --watch, exit on the first failure")
     cp.add_argument("--required", action="store_true",
                     help="Only show checks marked required")
-    cp.add_argument("--interval", type=int, default=0,
+    cp.add_argument("--interval", type=int, default=None,
                     help="Polling interval in seconds for --watch "
                          "(default: gh's 10)")
 
@@ -150,6 +150,11 @@ def run(argv, project_root):
                          "against the current branch)")
 
     args = ap.parse_args(argv)
+    if args.subcmd == "checks" and args.interval is not None:
+        if args.interval < 0:
+            ap.error("argument --interval: must be a non-negative integer")
+        if not args.watch:
+            ap.error("argument --interval: only allowed with --watch")
     if args.subcmd == "checks":
         return _cmd_checks(args, project_root)
     if args.subcmd == "record":

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""compass pr — PR pillar: pull-request lifecycle verbs wrapping the gh CLI.
+
+Subcommands:
+  checks [pr]   CI status for a PR (default: the current branch's PR).
+                --watch polls until checks settle; the exit code follows
+                gh (0 green, non-zero on failing/pending checks) so
+                runbooks can gate on it.
+
+The review-round verbs (list, reply, resolve, pending) live in the
+Review pillar: compass review --help.
+"""
+
+import argparse
+import subprocess
+import sys
+
+
+def _cmd_checks(args, project_root):
+    cmd = ["gh", "pr", "checks"]
+    if args.pr:
+        cmd.append(str(args.pr))
+    if args.watch:
+        cmd.append("--watch")
+    if args.fail_fast:
+        cmd.append("--fail-fast")
+    if args.required:
+        cmd.append("--required")
+    if args.interval:
+        cmd += ["--interval", str(args.interval)]
+    try:
+        # Stream straight through so --watch updates live; gh's exit
+        # code (0 green, non-zero otherwise) is the gating signal.
+        return subprocess.run(cmd, cwd=str(project_root)).returncode
+    except FileNotFoundError:
+        print("❌ gh CLI not found on PATH.", file=sys.stderr)
+        return 127
+
+
+def run(argv, project_root):
+    """Entry point: compass pr <subcommand>."""
+    ap = argparse.ArgumentParser(
+        prog="compass pr",
+        description="PR pillar: pull-request lifecycle verbs wrapping "
+                    "the gh CLI.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+
+    cp = sub.add_parser("checks", help="CI status for a PR")
+    cp.add_argument("pr", nargs="?", default="",
+                    help="PR number (default: the current branch's PR)")
+    cp.add_argument("--watch", action="store_true",
+                    help="Poll until all checks settle")
+    cp.add_argument("--fail-fast", action="store_true",
+                    help="With --watch, exit on the first failure")
+    cp.add_argument("--required", action="store_true",
+                    help="Only show checks marked required")
+    cp.add_argument("--interval", type=int, default=0,
+                    help="Polling interval in seconds for --watch "
+                         "(default: gh's 10)")
+
+    args = ap.parse_args(argv)
+    if args.subcmd == "checks":
+        return _cmd_checks(args, project_root)
+    return 1

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -6,14 +6,21 @@ Subcommands:
                 --watch polls until checks settle; the exit code follows
                 gh (0 green, non-zero on failing/pending checks) so
                 runbooks can gate on it.
+  record [pr]   Record a PR on its task doc: set #+pr: and add the row
+                to the * PRs table. The task is found by matching
+                #+branch: against the current branch (override with
+                --task); idempotent when the PR is already recorded.
 
 The review-round verbs (list, reply, resolve, pending) live in the
 Review pillar: compass review --help.
 """
 
 import argparse
+import json
+import re
 import subprocess
 import sys
+from pathlib import Path
 
 
 def _cmd_checks(args, project_root):
@@ -37,6 +44,81 @@ def _cmd_checks(args, project_root):
         return 127
 
 
+def _current_branch(project_root):
+    p = subprocess.run(["git", "symbolic-ref", "--short", "HEAD"],
+                       capture_output=True, text=True, cwd=str(project_root))
+    return p.stdout.strip() if p.returncode == 0 else ""
+
+
+def _find_task_doc(project_root, branch, task_ref):
+    """Find the task doc to record on.
+
+    With TASK_REF, match a task file by UUID or slug. Otherwise match
+    #+branch: BRANCH across doc/agile task docs, preferring a STARTED
+    task when several share the branch.
+    """
+    base = Path(project_root) / "doc" / "agile"
+    candidates = []
+    for path in base.rglob("task_*.org"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if task_ref:
+            if (task_ref.upper() in text[:200]
+                    or path.stem == f"task_{task_ref}"):
+                candidates.append((path, text))
+            continue
+        if re.search(rf"^#\+branch: {re.escape(branch)}\s*$", text, re.M):
+            candidates.append((path, text))
+    if len(candidates) > 1:
+        started = [c for c in candidates
+                   if re.search(r"^\| State\s*\|\s*STARTED", c[1], re.M)]
+        if len(started) == 1:
+            return started[0]
+    return candidates[0] if candidates else (None, None)
+
+
+def _cmd_record(args, project_root):
+    # Resolve the PR: explicit number or the current branch's PR.
+    sel = [str(args.pr)] if args.pr else []
+    p = subprocess.run(
+        ["gh", "pr", "view", *sel, "--json", "number,title,url"],
+        capture_output=True, text=True, cwd=str(project_root))
+    if p.returncode != 0:
+        print(p.stderr.strip() or "❌ gh pr view failed.", file=sys.stderr)
+        return p.returncode
+    pr = json.loads(p.stdout)
+    number, title, url = pr["number"], pr["title"], pr["url"]
+
+    branch = _current_branch(project_root)
+    path, text = _find_task_doc(project_root, branch, args.task)
+    if path is None:
+        print(f"❌ No task doc found for branch '{branch}' "
+              "(set #+branch: on the task, or pass --task).",
+              file=sys.stderr)
+        return 1
+    rel = path.relative_to(project_root)
+
+    if f"/pull/{number}]" in text:
+        print(f"✅ PR #{number} already recorded in {rel}")
+        return 0
+
+    text = re.sub(r"^#\+pr:.*$", f"#+pr: {number}", text,
+                  count=1, flags=re.M)
+    row = f"| [[{url}][#{number}]] | {title} |"
+    empty = "| PR | Title |\n|----+-------|\n|    |       |"
+    if empty in text:
+        text = text.replace(empty, f"| PR | Title |\n|----+-------|\n{row}")
+    else:
+        text = text.replace("| PR | Title |\n|----+-------|",
+                            f"| PR | Title |\n|----+-------|\n{row}")
+    path.write_text(text, encoding="utf-8")
+    print(f"✅ PR #{number} recorded in {rel}")
+    print(f"   #+pr: {number}  +  * PRs row: {title}")
+    return 0
+
+
 def run(argv, project_root):
     """Entry point: compass pr <subcommand>."""
     ap = argparse.ArgumentParser(
@@ -58,7 +140,18 @@ def run(argv, project_root):
                     help="Polling interval in seconds for --watch "
                          "(default: gh's 10)")
 
+    rp = sub.add_parser("record",
+                        help="Record a PR on its task doc (#+pr: and the "
+                             "* PRs table)")
+    rp.add_argument("pr", nargs="?", type=int, default=0,
+                    help="PR number (default: the current branch's PR)")
+    rp.add_argument("--task", default="",
+                    help="Task UUID or slug (default: match #+branch: "
+                         "against the current branch)")
+
     args = ap.parse_args(argv)
     if args.subcmd == "checks":
         return _cmd_checks(args, project_root)
+    if args.subcmd == "record":
+        return _cmd_record(args, project_root)
     return 1


### PR DESCRIPTION
## Summary

Third task of the PR-management story: `compass pr checks` — the PR pillar's first verb — so CI gating no longer needs raw `gh pr checks`.

## Changes

- New `compass_pr.py` module dispatched as `compass pr`; `checks [<pr>]` defaults to the current branch's PR, passes through `--watch`, `--fail-fast`, `--required`, `--interval`, streams live, and keeps gh's exit semantics (0 green) so runbooks can gate on it.
- Raw `gh pr checks` removed from the review-round runbook and the monitor, fix-CI, create-PR, and merge recipes.
- Close out the conversation-comments task (shipped in #1081); start this one.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [Add compass pr checks: CI status for a PR](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.html) | DCC5B3B1-9262-47A3-8C27-61F12D136922 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)