### PR TITLE
[trading,qt,ore] Decompose scripted/composite; delete the flat-instrument era

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
@@ -27,9 +27,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Implementation complete; awaiting build + PR. |
+| Now          | PR #1085 in review.                    |
 | Waiting on   | Nothing.                               |
-| Next         | Verify build, raise PR.                |
+| Next         | Review round; rebase once #1083 merges. |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -48,7 +48,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1085][#1085]] | [trading,qt,ore] Decompose scripted/composite; delete the flat-instrument era |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
@@ -54,6 +54,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Gemini: guard empty workspace_id before lexical_cast (2 mappers) | scripted/composite mappers | Decline | Column is NOT NULL DEFAULT in the DDL — empty values cannot exist; guarding would diverge from the ~30 sibling mappers using the identical cast. Cross-cutting defensive parsing would be a capture, not a one-off |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: B6B2BC7A-255F-4E23-A16E-F4537E2D8E1E
+:END:
+#+title: Task: Decompose scripted, composite and composite_leg into nested structs
+#+description: scripted_instrument (17 fields) sits in the same Mode 2 risk band as equity_position (17, already decomposed); composite_instrument and composite_leg (12 each) follow for symmetry. Completing the family lets the FlatInstrument dual concept and all flat/nested if-constexpr dispatch branches be deleted.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-scripted-composite-c1202-nested-structs
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | Implementation complete; awaiting build + PR. |
+| Waiting on   | Nothing.                               |
+| Next         | Verify build, raise PR.                |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.ore/core/src/domain/composite_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/composite_instrument_mapper.cpp
@@ -36,11 +36,11 @@ namespace {
 
 composite_instrument make_base(const std::string& trade_type_code) {
     composite_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.identity.trade_type_code = trade_type_code;
+    r.audit.modified_by = "ores";
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -119,15 +119,15 @@ currencyCode parse_currency_code(const std::string& s) {
 
 composite_leg make_composite_leg(const compositeTradeComponents_Trade_t& comp, int seq) {
     composite_leg leg;
-    leg.leg_sequence = seq;
+    leg.identity.leg_sequence = seq;
     if (comp.id)
         leg.constituent_trade_id = std::string(*comp.id);
     else
         leg.constituent_trade_id = to_string(comp.TradeType);
-    leg.modified_by = "ores";
-    leg.performed_by = "ores";
-    leg.change_reason_code = "system.external_data_import";
-    leg.change_commentary = "Imported from ORE XML";
+    leg.audit.modified_by = "ores";
+    leg.audit.performed_by = "ores";
+    leg.audit.change_reason_code = "system.external_data_import";
+    leg.audit.change_commentary = "Imported from ORE XML";
     return leg;
 }
 

--- a/projects/ores.ore/core/src/domain/scripted_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/scripted_instrument_mapper.cpp
@@ -32,11 +32,11 @@ namespace {
 
 scripted_instrument make_base(const std::string& trade_type_code) {
     scripted_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.identity.trade_type_code = trade_type_code;
+    r.audit.modified_by = "ores";
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 

--- a/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
+++ b/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
@@ -330,18 +330,13 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
                         },
                         r);
                 } else if constexpr (std::is_same_v<T, composite_instrument_data>) {
-                    REQUIRE(r.instrument.trade_id.has_value());
-                    CHECK(*r.instrument.trade_id == item.trade.identity.id);
-                    ++checked;
-                } else if constexpr (ores::trading::domain::NestedInstrument<T>) {
-                    // bond/credit/commodity — nested identity
-                    REQUIRE(r.identity.trade_id.has_value());
-                    CHECK(*r.identity.trade_id == item.trade.identity.id);
+                    REQUIRE(r.instrument.identity.trade_id.has_value());
+                    CHECK(*r.instrument.identity.trade_id == item.trade.identity.id);
                     ++checked;
                 } else {
-                    // scripted — direct trade_id field
-                    REQUIRE(r.trade_id.has_value());
-                    CHECK(*r.trade_id == item.trade.identity.id);
+                    // bond/credit/commodity/scripted — all nested now.
+                    REQUIRE(r.identity.trade_id.has_value());
+                    CHECK(*r.identity.trade_id == item.trade.identity.id);
                     ++checked;
                 }
             },

--- a/projects/ores.ore/core/tests/xml_composite_scripted_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_composite_scripted_mapper_roundtrip_tests.cpp
@@ -83,7 +83,7 @@ TEST_CASE("scripted_mapper_roundtrip_asian_basket_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_scripted("Scripted_BasketOption.xml");
 
-    CHECK(r.trade_type_code == "ScriptedTrade");
+    CHECK(r.identity.trade_type_code == "ScriptedTrade");
     CHECK(r.script_name == "AsianBasketOption");
     CHECK(!r.underlyings_json.empty());
     CHECK(!r.parameters_json.empty());
@@ -100,7 +100,7 @@ TEST_CASE("scripted_mapper_roundtrip_average_strike_basket_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_scripted("Scripted_BasketOption2.xml");
 
-    CHECK(r.trade_type_code == "ScriptedTrade");
+    CHECK(r.identity.trade_type_code == "ScriptedTrade");
     CHECK(!r.underlyings_json.empty());
 
     BOOST_LOG_SEV(lg, info) << "ScriptedTrade (AverageStrikeBasketOption) "
@@ -111,7 +111,7 @@ TEST_CASE("composite_mapper_roundtrip_composite_trade", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_composite("Hybrid_CompositeTrade.xml");
 
-    CHECK(r.instrument.trade_type_code == "CompositeTrade");
+    CHECK(r.instrument.identity.trade_type_code == "CompositeTrade");
 
     const auto rt = composite_instrument_mapper::reverse_composite_trade(r.instrument);
     REQUIRE(rt.CompositeTradeData.operator bool());
@@ -127,13 +127,13 @@ TEST_CASE("composite_mapper_components_populate_legs", tags) {
     REQUIRE(r.legs.size() == 2);
 
     // Legs are 1-based and ordered.
-    CHECK(r.legs[0].leg_sequence == 1);
-    CHECK(r.legs[1].leg_sequence == 2);
+    CHECK(r.legs[0].identity.leg_sequence == 1);
+    CHECK(r.legs[1].identity.leg_sequence == 2);
 
     // Each leg carries a constituent trade identifier.
     for (const auto& leg : r.legs) {
         CHECK(!leg.constituent_trade_id.empty());
-        CHECK(leg.change_reason_code == "system.external_data_import");
+        CHECK(leg.audit.change_reason_code == "system.external_data_import");
     }
 
     BOOST_LOG_SEV(lg, info) << "CompositeTrade legs populated: " << r.legs.size();

--- a/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -265,7 +265,7 @@ TEST_CASE("double_digital_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_scripted("Exotic_Double_Digital_Option.xml");
 
-    CHECK(r.trade_type_code == "DoubleDigitalOption");
+    CHECK(r.identity.trade_type_code == "DoubleDigitalOption");
     CHECK(!r.underlyings_json.empty());
     CHECK(!r.parameters_json.empty());
 
@@ -291,7 +291,7 @@ TEST_CASE("performance_option_01_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_scripted("Exotic_PerformanceOption_01_FX.xml");
 
-    CHECK(r.trade_type_code == "PerformanceOption_01");
+    CHECK(r.identity.trade_type_code == "PerformanceOption_01");
     CHECK(!r.underlyings_json.empty());
     CHECK(!r.parameters_json.empty());
 
@@ -317,7 +317,7 @@ TEST_CASE("knock_out_swap_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_scripted("Exotic_KnockOutSwap.xml");
 
-    CHECK(r.trade_type_code == "KnockOutSwap");
+    CHECK(r.identity.trade_type_code == "KnockOutSwap");
     CHECK(!r.parameters_json.empty());
 
     BOOST_LOG_SEV(lg, info) << "KnockOutSwap forward test passed. "
@@ -342,7 +342,7 @@ TEST_CASE("total_return_swap_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_composite("Hybrid_GenericTRS_with_Bond.xml");
 
-    CHECK(r.instrument.trade_type_code == "TotalReturnSwap");
+    CHECK(r.instrument.identity.trade_type_code == "TotalReturnSwap");
     CHECK(!r.instrument.description.empty());
 
     BOOST_LOG_SEV(lg, info) << "TotalReturnSwap forward test passed. "
@@ -367,7 +367,7 @@ TEST_CASE("contract_for_difference_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_composite("Hybrid_CFD.xml");
 
-    CHECK(r.instrument.trade_type_code == "ContractForDifference");
+    CHECK(r.instrument.identity.trade_type_code == "ContractForDifference");
 
     BOOST_LOG_SEV(lg, info) << "ContractForDifference forward test passed";
 }

--- a/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
+++ b/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
@@ -231,8 +231,8 @@ TEST_CASE("parse_trade_instrument_dispatches_commodity", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_scripted", tags) {
     scripted_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "ScriptedTrade";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "ScriptedTrade";
 
     auto json = make_response_json(make_test_trade(product_type::scripted, "ScriptedTrade"),
                                    trade_instrument{instr});
@@ -243,7 +243,7 @@ TEST_CASE("parse_trade_instrument_dispatches_scripted", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::scripted);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
 }
 
 // =============================================================================

--- a/projects/ores.qt/trading/src/CompositeInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/CompositeInstrumentForm.cpp
@@ -68,7 +68,7 @@ void CompositeInstrumentForm::clear() {
 void CompositeInstrumentForm::setTradeType(const QString& code,
                                            bool /*has_options*/,
                                            bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     const auto idx = ui_->tradeTypeCombo->findText(code.trimmed());
     if (idx >= 0)
         ui_->tradeTypeCombo->setCurrentIndex(idx);
@@ -89,16 +89,17 @@ bool CompositeInstrumentForm::isLoaded() const {
 
 void CompositeInstrumentForm::setChangeReason(const std::string& code,
                                               const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void CompositeInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code = ui_->tradeTypeCombo->currentText().trimmed().toStdString();
+    instrument_.identity.trade_type_code =
+        ui_->tradeTypeCombo->currentText().trimmed().toStdString();
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     legs_ = ui_->legsWidget->legs();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void CompositeInstrumentForm::populate(const trading::domain::composite_instrument& instr,
@@ -118,7 +119,7 @@ void CompositeInstrumentForm::populateFromInstrument() {
     ui_->legsWidget->blockSignals(true);
 
     const auto idx =
-        ui_->tradeTypeCombo->findText(QString::fromStdString(instrument_.trade_type_code));
+        ui_->tradeTypeCombo->findText(QString::fromStdString(instrument_.identity.trade_type_code));
     if (idx >= 0)
         ui_->tradeTypeCombo->setCurrentIndex(idx);
     ui_->descriptionEdit->setPlainText(QString::fromStdString(instrument_.description));
@@ -131,12 +132,12 @@ void CompositeInstrumentForm::populateFromInstrument() {
 
 void CompositeInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -182,7 +183,7 @@ void CompositeInstrumentForm::saveInstrument(std::function<void(const std::strin
             BOOST_LOG_SEV(lg(), info) << "Composite instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/CompositeLegsWidget.cpp
+++ b/projects/ores.qt/trading/src/CompositeLegsWidget.cpp
@@ -61,7 +61,8 @@ void CompositeLegsWidget::setLegs(const std::vector<trading::domain::composite_l
     for (const auto& leg : legs) {
         const int row = ui_->legsTable->rowCount();
         ui_->legsTable->insertRow(row);
-        ui_->legsTable->setItem(row, 0, new QTableWidgetItem(QString::number(leg.leg_sequence)));
+        ui_->legsTable->setItem(
+            row, 0, new QTableWidgetItem(QString::number(leg.identity.leg_sequence)));
         ui_->legsTable->setItem(
             row, 1, new QTableWidgetItem(QString::fromStdString(leg.constituent_trade_id)));
     }
@@ -79,7 +80,7 @@ std::vector<trading::domain::composite_leg> CompositeLegsWidget::legs() const {
         if (tradeId.isEmpty())
             continue;
         trading::domain::composite_leg leg;
-        leg.leg_sequence = seqItem ? seqItem->text().toInt() : (row + 1);
+        leg.identity.leg_sequence = seqItem ? seqItem->text().toInt() : (row + 1);
         leg.constituent_trade_id = tradeId.toStdString();
         result.push_back(std::move(leg));
     }

--- a/projects/ores.qt/trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt/trading/src/ImportTradeDialog.cpp
@@ -612,14 +612,12 @@ void ImportTradeDialog::onImportClicked() {
                             },
                             r);
                     } else if constexpr (std::is_same_v<T, composite_instrument_data>) {
-                        r.instrument.instrument_id = instr_id;
-                        r.instrument.trade_id = tti.trade.identity.id;
-                    } else if constexpr (trading::domain::NestedInstrument<T>) {
+                        r.instrument.identity.instrument_id = instr_id;
+                        r.instrument.identity.trade_id = tti.trade.identity.id;
+                    } else {
+                        // bond/credit/commodity/scripted — all nested now.
                         r.identity.instrument_id = instr_id;
                         r.identity.trade_id = tti.trade.identity.id;
-                    } else {
-                        r.instrument_id = instr_id;
-                        r.trade_id = tti.trade.identity.id;
                     }
                 }
             },

--- a/projects/ores.qt/trading/src/ScriptedInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/ScriptedInstrumentForm.cpp
@@ -70,7 +70,7 @@ void ScriptedInstrumentForm::clear() {
 void ScriptedInstrumentForm::setTradeType(const QString& code,
                                           bool /*has_options*/,
                                           bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
 }
 
 void ScriptedInstrumentForm::setReadOnly(bool readOnly) {
@@ -92,20 +92,20 @@ bool ScriptedInstrumentForm::isLoaded() const {
 
 void ScriptedInstrumentForm::setChangeReason(const std::string& code,
                                              const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void ScriptedInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code = ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
+    instrument_.identity.trade_type_code = ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.script_name = ui_->scriptNameEdit->text().trimmed().toStdString();
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.script_body = ui_->scriptBodyEdit->toPlainText().toStdString();
     instrument_.events_json = ui_->eventsJsonEdit->toPlainText().toStdString();
     instrument_.underlyings_json = ui_->underlyingsJsonEdit->toPlainText().toStdString();
     instrument_.parameters_json = ui_->parametersJsonEdit->toPlainText().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void ScriptedInstrumentForm::populate(const trading::domain::scripted_instrument& instr) {
@@ -129,7 +129,7 @@ void ScriptedInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     ui_->scriptNameEdit->setText(QString::fromStdString(instrument_.script_name));
     ui_->descriptionEdit->setPlainText(QString::fromStdString(instrument_.description));
     ui_->scriptBodyEdit->setPlainText(QString::fromStdString(instrument_.script_body));
@@ -141,12 +141,12 @@ void ScriptedInstrumentForm::populateFromInstrument() {
 
 void ScriptedInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -191,7 +191,7 @@ void ScriptedInstrumentForm::saveInstrument(std::function<void(const std::string
             BOOST_LOG_SEV(lg(), info) << "Scripted instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.trading/api/include/ores.trading.api/domain/composite_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/composite_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_COMPOSITE_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_COMPOSITE_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -36,67 +34,14 @@ namespace ores::trading::domain {
  * in composite_leg records keyed by this instrument's instrument_id.
  */
 struct composite_instrument final {
-    /**
-     * @brief Version number for optimistic locking and change tracking.
-     */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this composite instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the associated trade record.
-     *
-     * Soft FK to ores_trading_trades_tbl. Absent for standalone instruments.
-     */
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code (CompositeTrade, MultiLegOption).
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief Optional free-text description.
      */
     std::string description;
 
-    /**
-     * @brief Username of the person who last modified this record.
-     */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/composite_leg.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/composite_leg.hpp
@@ -20,12 +20,26 @@
 #ifndef ORES_TRADING_DOMAIN_COMPOSITE_LEG_HPP
 #define ORES_TRADING_DOMAIN_COMPOSITE_LEG_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
 #include <boost/uuid/uuid.hpp>
-#include <chrono>
 #include <string>
 
 namespace ores::trading::domain {
+
+// Decomposed into plain nested sub-structs (≤9 fields each) so that
+// rfl::internal::no_duplicate_field_names never sees more than 9 field names
+// at once, staying below MSVC's C1202 template-graph limit.
+// See doc/investigations/msvc_c1202_rfl_complexity.org for full analysis.
+
+struct composite_leg_identity final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+    boost::uuids::uuid id;
+    boost::uuids::uuid party_id;
+    boost::uuids::uuid instrument_id;
+    int leg_sequence = 1;
+};
 
 /**
  * @brief One constituent trade of a composite instrument (CompositeTrade,
@@ -33,69 +47,23 @@ namespace ores::trading::domain {
  *
  * The leg_sequence field provides 1-based ordering of the constituent trades
  * within the parent composite instrument.
+ *
+ * Access fields via the sub-struct members:
+ *   cl.identity.id, cl.identity.leg_sequence
+ *   cl.constituent_trade_id
+ *   cl.audit.modified_by, cl.audit.recorded_at
+ *
+ * JSON wire format is nested: {"identity":{...},"audit":{...}}.
  */
 struct composite_leg final {
-    /**
-     * @brief Version number for optimistic locking and change tracking.
-     */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this composite leg.
-     */
-    boost::uuids::uuid id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the parent composite instrument.
-     *
-     * Soft FK to ores_trading_composite_instruments_tbl.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Leg ordering within the instrument (1-based).
-     */
-    int leg_sequence = 1;
+    composite_leg_identity identity;
 
     /**
      * @brief UUID string identifying the constituent trade.
      */
     std::string constituent_trade_id;
 
-    /**
-     * @brief Username of the person who last modified this record.
-     */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/instrument.hpp
@@ -32,22 +32,18 @@
 
 namespace ores::trading::domain {
 
-// Instruments decomposed with instrument_identity (rates types after task 12).
+// Every instrument type carries instrument_identity + audit_record; the
+// flat-field era (and the FlatInstrument concept that bridged the
+// incremental migration in tasks 12-15) is over.
 template <typename T>
-concept NestedInstrument = requires(T t) {
+concept Instrument = requires(T t) {
     { t.identity.instrument_id } -> std::convertible_to<boost::uuids::uuid>;
     { t.identity.trade_id } -> std::convertible_to<std::optional<boost::uuids::uuid>>;
 };
 
-// Instruments still using flat fields (FX, equity, bond — tasks 13-15 pending).
+// Retained as an alias for call sites written during the migration.
 template <typename T>
-concept FlatInstrument = requires(T t) {
-    { t.instrument_id } -> std::convertible_to<boost::uuids::uuid>;
-    { t.trade_id } -> std::convertible_to<std::optional<boost::uuids::uuid>>;
-};
-
-template <typename T>
-concept Instrument = NestedInstrument<T> || FlatInstrument<T>;
+concept NestedInstrument = Instrument<T>;
 
 template <typename T, typename Leg>
 struct with_legs {
@@ -60,13 +56,8 @@ using composite_instrument_data = with_legs<composite_instrument, composite_leg>
 
 template <Instrument T>
 void stamp_ids(T& instr, boost::uuids::uuid instrument_id, boost::uuids::uuid trade_id) {
-    if constexpr (NestedInstrument<T>) {
-        instr.identity.instrument_id = instrument_id;
-        instr.identity.trade_id = trade_id;
-    } else {
-        instr.instrument_id = instrument_id;
-        instr.trade_id = trade_id;
-    }
+    instr.identity.instrument_id = instrument_id;
+    instr.identity.trade_id = trade_id;
 }
 
 template <typename... Ts>
@@ -82,12 +73,8 @@ void stamp_ids(with_legs<T, Leg>& data,
                boost::uuids::uuid instrument_id,
                boost::uuids::uuid trade_id) {
     stamp_ids(data.instrument, instrument_id, trade_id);
-    for (auto& leg : data.legs) {
-        if constexpr (std::is_same_v<Leg, swap_leg>)
-            leg.identity.instrument_id = instrument_id;
-        else
-            leg.instrument_id = instrument_id;
-    }
+    for (auto& leg : data.legs)
+        leg.identity.instrument_id = instrument_id;
 }
 
 } // namespace ores::trading::domain

--- a/projects/ores.trading/api/include/ores.trading.api/domain/scripted_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/scripted_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_SCRIPTED_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_SCRIPTED_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -38,36 +36,9 @@ namespace ores::trading::domain {
  */
 struct scripted_instrument final {
     /**
-     * @brief Version number for optimistic locking and change tracking.
+     * @brief Common identity fields shared by all instrument types.
      */
-    int version = 0;
-
-    /**
-     * @brief Tenant identifier for multi-tenancy isolation.
-     */
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this scripted instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    /**
-     * @brief Party that owns this instrument.
-     */
-    boost::uuids::uuid party_id;
-
-    /**
-     * @brief UUID of the associated trade record.
-     *
-     * Soft FK to ores_trading_trades_tbl. Absent for standalone instruments.
-     */
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code (ScriptedTrade, Autocallable_01, etc.).
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE script name identifying the payoff script.
@@ -100,29 +71,9 @@ struct scripted_instrument final {
     std::string description;
 
     /**
-     * @brief Username of the person who last modified this record.
+     * @brief Provenance and audit trail for this record.
      */
-    std::string modified_by;
-
-    /**
-     * @brief Username of the account that performed this action.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Code identifying the reason for the change.
-     */
-    std::string change_reason_code;
-
-    /**
-     * @brief Free-text commentary explaining the change.
-     */
-    std::string change_commentary;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded.
-     */
-    std::chrono::system_clock::time_point recorded_at;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/src/domain/composite_instrument_table.cpp
+++ b/projects/ores.trading/api/src/domain/composite_instrument_table.cpp
@@ -31,8 +31,8 @@ std::string convert_to_table(const std::vector<composite_instrument>& v) {
           << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.instrument_id) << t.trade_type_code << t.description
-              << t.modified_by << t.version << fort::endr;
+        table << boost::uuids::to_string(t.identity.instrument_id) << t.identity.trade_type_code
+              << t.description << t.audit.modified_by << t.identity.version << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/api/src/domain/composite_leg_table.cpp
+++ b/projects/ores.trading/api/src/domain/composite_leg_table.cpp
@@ -31,9 +31,9 @@ std::string convert_to_table(const std::vector<composite_leg>& v) {
           << "Modified By" << "Version" << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.id) << boost::uuids::to_string(t.instrument_id)
-              << t.leg_sequence << t.constituent_trade_id << t.modified_by << t.version
-              << fort::endr;
+        table << boost::uuids::to_string(t.identity.id)
+              << boost::uuids::to_string(t.identity.instrument_id) << t.identity.leg_sequence
+              << t.constituent_trade_id << t.audit.modified_by << t.identity.version << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/api/src/domain/scripted_instrument_table.cpp
+++ b/projects/ores.trading/api/src/domain/scripted_instrument_table.cpp
@@ -31,8 +31,9 @@ std::string convert_to_table(const std::vector<scripted_instrument>& v) {
           << "Modified By" << "Version" << fort::endr;
 
     for (const auto& t : v) {
-        table << boost::uuids::to_string(t.instrument_id) << t.trade_type_code << t.script_name
-              << t.description << t.modified_by << t.version << fort::endr;
+        table << boost::uuids::to_string(t.identity.instrument_id) << t.identity.trade_type_code
+              << t.script_name << t.description << t.audit.modified_by << t.identity.version
+              << fort::endr;
     }
     return table.to_string();
 }

--- a/projects/ores.trading/api/src/generators/composite_instrument_generator.cpp
+++ b/projects/ores.trading/api/src/generators/composite_instrument_generator.cpp
@@ -31,15 +31,15 @@ generate_synthetic_composite_instrument(utility::generation::generation_context&
     const auto modified_by = ctx.env().get_or(std::string(generation_keys::modified_by), "system");
 
     domain::composite_instrument r;
-    r.version = 1;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.trade_type_code = "CompositeTrade";
+    r.identity.version = 1;
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.trade_type_code = "CompositeTrade";
     r.description = std::string(faker::lorem::sentence());
-    r.modified_by = modified_by;
-    r.performed_by = modified_by;
-    r.change_reason_code = "system.test";
-    r.change_commentary = "Synthetic test data";
-    r.recorded_at = ctx.past_timepoint();
+    r.audit.modified_by = modified_by;
+    r.audit.performed_by = modified_by;
+    r.audit.change_reason_code = "system.test";
+    r.audit.change_commentary = "Synthetic test data";
+    r.audit.recorded_at = ctx.past_timepoint();
     return r;
 }
 

--- a/projects/ores.trading/api/src/generators/composite_leg_generator.cpp
+++ b/projects/ores.trading/api/src/generators/composite_leg_generator.cpp
@@ -33,16 +33,16 @@ generate_synthetic_composite_leg(const boost::uuids::uuid& instrument_id,
     const auto modified_by = ctx.env().get_or(std::string(generation_keys::modified_by), "system");
 
     domain::composite_leg r;
-    r.version = 1;
-    r.id = boost::uuids::random_generator()();
-    r.instrument_id = instrument_id;
-    r.leg_sequence = leg_sequence;
+    r.identity.version = 1;
+    r.identity.id = boost::uuids::random_generator()();
+    r.identity.instrument_id = instrument_id;
+    r.identity.leg_sequence = leg_sequence;
     r.constituent_trade_id = boost::uuids::to_string(boost::uuids::random_generator()());
-    r.modified_by = modified_by;
-    r.performed_by = modified_by;
-    r.change_reason_code = "system.test";
-    r.change_commentary = "Synthetic test data";
-    r.recorded_at = ctx.past_timepoint();
+    r.audit.modified_by = modified_by;
+    r.audit.performed_by = modified_by;
+    r.audit.change_reason_code = "system.test";
+    r.audit.change_commentary = "Synthetic test data";
+    r.audit.recorded_at = ctx.past_timepoint();
     return r;
 }
 

--- a/projects/ores.trading/api/src/generators/scripted_instrument_generator.cpp
+++ b/projects/ores.trading/api/src/generators/scripted_instrument_generator.cpp
@@ -31,16 +31,16 @@ generate_synthetic_scripted_instrument(utility::generation::generation_context& 
     const auto modified_by = ctx.env().get_or(std::string(generation_keys::modified_by), "system");
 
     domain::scripted_instrument r;
-    r.version = 1;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.trade_type_code = "ScriptedTrade";
+    r.identity.version = 1;
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.trade_type_code = "ScriptedTrade";
     r.script_name = "Autocallable";
     r.description = std::string(faker::lorem::sentence());
-    r.modified_by = modified_by;
-    r.performed_by = modified_by;
-    r.change_reason_code = "system.test";
-    r.change_commentary = "Synthetic test data";
-    r.recorded_at = ctx.past_timepoint();
+    r.audit.modified_by = modified_by;
+    r.audit.performed_by = modified_by;
+    r.audit.change_reason_code = "system.test";
+    r.audit.change_commentary = "Synthetic test data";
+    r.audit.recorded_at = ctx.past_timepoint();
     return r;
 }
 

--- a/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -232,7 +232,8 @@ private:
         if (!composite_ids.empty()) {
             service::composite_instrument_service comp_svc(ctx);
             for (auto& leg : comp_svc.get_legs_batch(composite_ids))
-                comp_legs_map[boost::uuids::to_string(leg.instrument_id)].push_back(std::move(leg));
+                comp_legs_map[boost::uuids::to_string(leg.identity.instrument_id)].push_back(
+                    std::move(leg));
         }
 
         // Phase 3: batch-fetch instruments, build lookup map
@@ -244,16 +245,10 @@ private:
                                           std::vector<ores::trading::domain::swap_leg>{};
         };
 
-        // Single-table types (bond/credit/commodity are nested; scripted
-        // is still flat — key through whichever shape the type has).
+        // Single-table types (bond, credit, commodity, scripted).
         auto add_flat = [&](auto&& results) {
-            for (auto& v : results) {
-                using T = std::decay_t<decltype(v)>;
-                if constexpr (ores::trading::domain::NestedInstrument<T>)
-                    imap[boost::uuids::to_string(v.identity.instrument_id)] = std::move(v);
-                else
-                    imap[boost::uuids::to_string(v.instrument_id)] = std::move(v);
-            }
+            for (auto& v : results)
+                imap[boost::uuids::to_string(v.identity.instrument_id)] = std::move(v);
         };
 
         if (!bond_ids.empty()) {
@@ -275,7 +270,7 @@ private:
         if (!composite_ids.empty()) {
             service::composite_instrument_service svc(ctx);
             for (auto& v : svc.get_composite_instruments(composite_ids)) {
-                const auto id = boost::uuids::to_string(v.instrument_id);
+                const auto id = boost::uuids::to_string(v.identity.instrument_id);
                 composite_instrument_data data;
                 data.instrument = std::move(v);
                 auto it = comp_legs_map.find(id);

--- a/projects/ores.trading/core/include/ores.trading.core/repository/composite_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/composite_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct composite_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/scripted_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/scripted_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct scripted_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/src/repository/composite_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/composite_instrument_mapper.cpp
@@ -33,20 +33,21 @@ composite_instrument_mapper::map(const composite_instrument_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::composite_instrument r;
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.version = v.version;
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.version = v.version;
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -57,18 +58,20 @@ composite_instrument_mapper::map(const domain::composite_instrument& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     composite_instrument_entity r;
-    r.id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/composite_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/composite_instrument_repository.cpp
@@ -39,7 +39,7 @@ std::string composite_instrument_repository::sql() {
 }
 
 void composite_instrument_repository::write(context ctx, const domain::composite_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing composite_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing composite_instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         composite_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/composite_leg_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/composite_leg_mapper.cpp
@@ -32,18 +32,18 @@ domain::composite_leg composite_leg_mapper::map(const composite_leg_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::composite_leg r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id);
-    r.leg_sequence = v.leg_sequence;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id);
+    r.identity.leg_sequence = v.leg_sequence;
     r.constituent_trade_id = v.constituent_trade_id;
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -53,17 +53,17 @@ composite_leg_entity composite_leg_mapper::map(const domain::composite_leg& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     composite_leg_entity r;
-    r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.leg_sequence = v.leg_sequence;
+    r.id = boost::uuids::to_string(v.identity.id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.leg_sequence = v.identity.leg_sequence;
     r.constituent_trade_id = v.constituent_trade_id;
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/composite_leg_repository.cpp
+++ b/projects/ores.trading/core/src/repository/composite_leg_repository.cpp
@@ -39,7 +39,7 @@ std::string composite_leg_repository::sql() {
 }
 
 void composite_leg_repository::write(context ctx, const domain::composite_leg& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing composite leg: " << v.id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing composite leg: " << v.identity.id;
     execute_write_query(
         ctx, composite_leg_mapper::map(v), lg(), "Writing composite leg to database.");
 }

--- a/projects/ores.trading/core/src/repository/scripted_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/scripted_instrument_mapper.cpp
@@ -32,25 +32,26 @@ domain::scripted_instrument scripted_instrument_mapper::map(const scripted_instr
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::scripted_instrument r;
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.version = v.version;
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.version = v.version;
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.script_name = v.script_name;
     r.script_body = v.script_body.value_or("");
     r.events_json = v.events_json.value_or("");
     r.underlyings_json = v.underlyings_json.value_or("");
     r.parameters_json = v.parameters_json.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -60,13 +61,15 @@ scripted_instrument_entity scripted_instrument_mapper::map(const domain::scripte
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     scripted_instrument_entity r;
-    r.id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.version = v.version;
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.version = v.identity.version;
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.script_name = v.script_name;
     r.script_body = v.script_body.empty() ? std::nullopt : std::optional(v.script_body);
     r.events_json = v.events_json.empty() ? std::nullopt : std::optional(v.events_json);
@@ -74,10 +77,10 @@ scripted_instrument_entity scripted_instrument_mapper::map(const domain::scripte
         v.underlyings_json.empty() ? std::nullopt : std::optional(v.underlyings_json);
     r.parameters_json = v.parameters_json.empty() ? std::nullopt : std::optional(v.parameters_json);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/scripted_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/scripted_instrument_repository.cpp
@@ -39,7 +39,7 @@ std::string scripted_instrument_repository::sql() {
 }
 
 void scripted_instrument_repository::write(context ctx, const domain::scripted_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing scripted_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing scripted_instrument: " << v.identity.instrument_id;
     execute_write_query(
         ctx, scripted_instrument_mapper::map(v), lg(), "Writing scripted_instrument to database.");
 }

--- a/projects/ores.trading/core/src/service/composite_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/composite_instrument_service.cpp
@@ -68,24 +68,24 @@ composite_instrument_service::get_legs(const std::string& instrument_id) {
 void composite_instrument_service::save_composite_instrument(
     const domain::composite_instrument& v, const std::vector<domain::composite_leg>& legs) {
     auto t = v;
-    if (t.instrument_id.is_nil()) {
+    if (t.identity.instrument_id.is_nil()) {
         static boost::uuids::random_generator gen;
-        t.instrument_id = gen();
+        t.identity.instrument_id = gen();
     }
-    const auto id_str = boost::uuids::to_string(t.instrument_id);
-    BOOST_LOG_SEV(lg(), debug) << "Saving composite_instrument: " << t.instrument_id << " with "
-                               << legs.size() << " legs";
+    const auto id_str = boost::uuids::to_string(t.identity.instrument_id);
+    BOOST_LOG_SEV(lg(), debug) << "Saving composite_instrument: " << t.identity.instrument_id
+                               << " with " << legs.size() << " legs";
     stamp(t, ctx_);
     // Replace-on-save: remove the existing leg set before writing the new
     // one so that updates do not accumulate stale legs.
     leg_repo_.remove_by_instrument(ctx_, id_str);
     repo_.write(ctx_, t);
     for (auto leg : legs) {
-        leg.instrument_id = t.instrument_id;
+        leg.identity.instrument_id = t.identity.instrument_id;
         stamp(leg, ctx_);
         leg_repo_.write(ctx_, leg);
     }
-    BOOST_LOG_SEV(lg(), info) << "Saved composite_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved composite_instrument: " << t.identity.instrument_id;
 }
 
 void composite_instrument_service::remove_composite_instrument(const std::string& id) {

--- a/projects/ores.trading/core/src/service/scripted_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/scripted_instrument_service.cpp
@@ -58,14 +58,14 @@ scripted_instrument_service::get_scripted_instrument(const std::string& id) {
 
 void scripted_instrument_service::save_scripted_instrument(const domain::scripted_instrument& v) {
     auto t = v;
-    if (t.instrument_id.is_nil()) {
+    if (t.identity.instrument_id.is_nil()) {
         static boost::uuids::random_generator gen;
-        t.instrument_id = gen();
+        t.identity.instrument_id = gen();
     }
-    BOOST_LOG_SEV(lg(), debug) << "Saving scripted_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving scripted_instrument: " << t.identity.instrument_id;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved scripted_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved scripted_instrument: " << t.identity.instrument_id;
 }
 
 void scripted_instrument_service::remove_scripted_instrument(const std::string& id) {


### PR DESCRIPTION
## Summary

Closes out the C1202 instrument decomposition. Builds on #1083 (bond/credit/commodity) — once that merges, this rebases to just the scripted/composite delta.

**Why scripted:** at 17 fields it sits in the same Mode 2 risk band as `equity_position` (17, decomposed in #1075) — a latent C1202 waiting to fire. Composite (12) and `composite_leg` (12) follow for symmetry.

- `scripted_instrument`: `identity` + 6 flat type-specific + `audit` (top level 8) — full vertical including generator, fort table, Qt form, ores.ore mapper, round-trip + parse-dispatch tests
- `composite_instrument`: `identity` + description + `audit` (top level 3)
- `composite_leg`: new `composite_leg_identity` sub-struct (mirrors `swap_leg`'s structure; carries `party_id`/`leg_sequence`) + `audit`
- Entities stay flat; scripted/composite gain `workspace_id`

**The payoff — migration scaffolding deleted:** with no flat instruments left, `FlatInstrument` is gone, `Instrument` now *requires* `identity` (`NestedInstrument` kept as an alias), `stamp_ids` is single-path, and `trade_handler`/`ImportTradeDialog`/planner-test drop their flat/nested `if constexpr` branches. Every instrument and leg type in the system speaks one shape: `identity` + type-specific + `audit`.

## Test plan

- Full local `linux-clang-debug-make` build green (0 errors, 100%)
- CI exercises gcc/msvc/AppleClang

🤖 Generated with [Claude Code](https://claude.com/claude-code)