### PR TITLE
[agile] Close the three remaining RFL decomposition tasks

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_extract_shared_instrument_sub_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_extract_shared_instrument_sub_structs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Not yet started.                       |
+| Now          | Complete: delivered in PR #1047.       |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-04                               |
 
 * Acceptance
@@ -57,3 +57,7 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Delivered as part of PR #1047 (task 11 commit): audit_record (now in
+ores.dq.api after #1070) and instrument_identity extracted and adopted
+by every instrument family through tasks 12-15.

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_complex_instrument_c1202_nested_structs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Designing sub-struct groupings for bond/credit/commodity. |
+| Now          | Complete: PR #1083 merged.             |
 | Waiting on   | Nothing.                               |
-| Next         | Apply groupings + identity/audit; update all callers per the FX/equity playbook. |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -88,3 +88,10 @@ split, parse dispatch + planner tests, JSON snapshots.
 |   |                 |      |          |       |
 
 * Result
+
+bond, credit and commodity decomposed with type-specific sub-structs
+(all Literals <=9 fields: bond terms/features/option, credit
+terms/schedule/index/option/tranche, commodity
+terms/option/pricing/exotic) plus identity/audit. Entities flat +
+workspace_id. Shared dispatch via NestedInstrument concept. Clean
+review round. PR #1083 merged.

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_scripted_composite_c1202_nested_structs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | PR #1085 in review.                    |
+| Now          | Complete: PR #1085 merged.             |
 | Waiting on   | Nothing.                               |
-| Next         | Review round; rebase once #1083 merges. |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -57,3 +57,11 @@ task closes. Plans do not outlive their task.)
 | 1 | Gemini: guard empty workspace_id before lexical_cast (2 mappers) | scripted/composite mappers | Decline | Column is NOT NULL DEFAULT in the DDL — empty values cannot exist; guarding would diverge from the ~30 sibling mappers using the identical cast. Cross-cutting defensive parsing would be a capture, not a one-off |
 
 * Result
+
+scripted (17 fields, same Mode 2 band as equity_position),
+composite_instrument and composite_leg decomposed; flat-instrument
+era deleted: FlatInstrument concept removed, Instrument requires
+identity, stamp_ids single-path, flat/nested if-constexpr branches
+gone from trade_handler/ImportTradeDialog/planner test. Review round
+1: empty-workspace_id guards declined (NOT NULL DEFAULT in DDL).
+PR #1085 merged.


### PR DESCRIPTION
Bookkeeping: closes the bond/credit/commodity task (#1083 merged), the scripted/composite task (#1085 merged), and the extract-shared-sub-structs task (delivered in #1047, never closed). With these, all decomposition work in the "Fix rfl complexity failure" story is DONE; the story's acceptance rides on the post-#1085 Windows/macOS runs on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)