### PR TITLE
[ores.compass] Add pr create: open PRs with conventions built in

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -33,7 +33,7 @@ with traceability, merge) as follow-on tasks.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Conversation layer shipped (PR #1081). Adding compass pr checks. |
+| Now           | pr checks + record shipped (PR #1084). Implementing pr create. |
 | Waiting on    | Nothing.                               |
 | Next          | Conversation-comments gap, then the pr pillar verbs: checks, create, merge. |
 | Last touched  | 2026-06-05                               |
@@ -69,7 +69,7 @@ with traceability, merge) as follow-on tasks.
 |------+-------+-------+-----+-------------|
 | [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The four review-round verbs (list, reply, resolve, pending) wrapping gh; --owner/--repo from git remote. PR #1078. |
 | [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | DONE | 2026-06-05 | 2026-06-05 | Conversation section in review list; gh pr view --comments retired. PR #1081. |
-| [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | STARTED | 2026-06-05 | | Wrap gh pr checks as compass pr checks <N> [--watch]; update runbook + recipes. |
+| [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | DONE | 2026-06-05 | 2026-06-05 | compass pr checks with gh exit semantics; raw gh pr checks retired from docs. PR #1084. |
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | STARTED | 2026-06-05 | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. pr record (first slice) shipped with #1084. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | BACKLOG | | | Refuse on unresolved threads or red CI; merge, delete branch, prompt close-out. |
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_checks.org
@@ -31,11 +31,11 @@ fix-CI, create-PR, and merge recipes.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -68,3 +68,9 @@ task closes. Plans do not outlive their task.)
 | 3 | Validate --interval: non-negative, only with --watch | compass_pr.py | Accepted | ap.error; d0f3c6708 |
 
 * Result
+
+Shipped in PR [[https://github.com/OreStudio/OreStudio/pull/1084][#1084]] (merged 2026-06-05): =compass pr checks= (gh
+exit semantics, --watch/--fail-fast/--required/--interval with clean
+validation) and, riding along, =compass pr record= (the pr-create
+task's first slice). Raw =gh pr checks= retired from the runbook and
+four recipes.

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-pr-create
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-pr-create
-#+pr:
+#+pr: 1087
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -68,7 +68,7 @@ pr-checks branch (PR #1084).
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1087][#1087]] | [ores.compass] Add pr create: open PRs with conventions built in |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -19,7 +19,13 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Opening a PR by hand has the most conventions to remember — title
+format, body sections, the Traceability table with full UUIDs and
+published-page links, recording the PR on the task. Build them into
+=compass pr create=: validated =[component]= title, Summary/Changes
+body from flags, Traceability derived from the branch's task doc and
+its parent story, branch pushed with =-u= when needed, PR recorded via
+=pr record=, and the journal stamped.
 
 * Status
 
@@ -34,7 +40,14 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- =compass pr create --title "[c] D" [--summary ...] [--change ...]
+  [--draft] [--task ...]= opens a PR whose body carries Summary,
+  Changes, and a Traceability table with the story and task full
+  UUIDs and site links.
+- Title convention validated; refuses to run from =main=.
+- The PR is recorded on the task doc and the journal is stamped
+  without manual steps.
+- The create-PR recipe leads with the command.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -74,6 +74,9 @@ pr-checks branch (PR #1084).
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Empty gh output → IndexError; pass parsed PR number to record | compass_pr.py | Accepted | b54902d50 |
+| 2 | #+title: parsing should be case-insensitive (org spec) | compass_pr.py | Accepted | b54902d50 |
+| 3 | :ID: search should be case-insensitive | compass_pr.py | Accepted | b54902d50 |
+| 4 | Validate task/story :ID: present before Traceability | compass_pr.py | Accepted | b54902d50 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
@@ -19,7 +19,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+=compass pr merge <N>= closes out a PR with guard rails: refuses to
+merge while review threads are unresolved or CI is red, merges via
+=gh=, deletes the remote branch, and prompts the task/journal
+close-out. Replaces the merge recipe's raw =gh pr merge=.
 
 * Status
 
@@ -34,7 +37,15 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Merge is a *merge commit* — never squash, never rebase — matching
+  the repository's history (=gh pr merge --merge=).
+- Default guard rails: refuse while review threads are unresolved or
+  CI is red/pending.
+- =--force= overrides the guards (merge with red CI), stating
+  loudly what was bypassed.
+- Deletes the remote branch after merge; prompts the task/journal
+  close-out.
+- The merge recipe leads with the command.
 
 * Plan
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -2,7 +2,7 @@
 :ID: CC928252-E0C5-4C3C-A7A8-D613593E4E37
 :END:
 #+title: How do I create a PR?
-#+description: Open a pull request via the gh CLI with a structured title and HEREDOC body — and the conventions ORE Studio follows on title format.
+#+description: Open a pull request with compass pr create — title validation, structured body, and the Traceability table generated from the branch's task and story.
 #+type: recipe
 #+level: cross
 #+filetags: :github:pr:gh:recipe:
@@ -19,51 +19,24 @@ correctly-formatted title and a structured body?
 
 * Answer
 
-1. /Push the branch/ first if it isn't on the remote yet:
+1. /Create the PR/ with =compass pr create=. It validates the title
+   convention, assembles the body (Summary, Changes, and the
+   =## Traceability= table derived from the branch's task and story
+   docs), pushes the branch with =-u= if needed, opens the PR, records
+   it on the task (=#+pr:= and the =* PRs= table), and stamps the
+   session journal:
 
    #+begin_src sh :results verbatim
-   git push -u origin "$(git branch --show-current)"
+   ./compass.sh pr create --title "[component] One-line description" \
+     --summary "What changes, why." \
+     --change "First change" --change "Second change"
    #+end_src
 
-2. /Create the PR/ with =gh pr create=. Include a =## Traceability=
-   table at the end of the body with a row per artefact, each carrying
-   a markdown link to the published HTML page and the full UUID. Use a
-   HEREDOC for the body so newlines are preserved:
+   Use =--draft= for a draft PR and =--task <uuid-or-slug>= when the
+   branch carries more than one task.
 
-   #+begin_src sh :results verbatim
-   gh pr create --title "[component] One-line description" \
-     --body "$(cat <<'EOF'
-   ## Summary
-
-   Brief paragraph.
-
-   ## Changes
-
-   - First change
-   - Second change
-
-   ## Traceability
-
-   | Artefact | Link | ID |
-   |----------|------|----|
-   | Story | [Story title here](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/story.html) | STORY-FULL-UUID |
-   | Task | [Task title here](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/task_TASK_SLUG.html) | TASK-FULL-UUID |
-EOF
-   )"
-   #+end_src
-
-3. /Confirm the PR URL/ that =gh= prints; verify the title format
-   matches =[COMPONENT] Description=.
-
-4. /Record the PR in the task./ One command — it finds the task by
-   matching =#+branch:= against the current branch, sets =#+pr:=, and
-   adds the =* PRs= table row (the canonical record =compass where
-   --prs= reads):
-
-   #+begin_src sh :results verbatim
-   ./compass.sh pr record            # current branch's PR
-   ./compass.sh pr record 123        # explicit PR number
-   #+end_src
+2. /Confirm the PR URL/ it prints, then commit and push the task-doc
+   record it staged (the command prints the exact git invocation).
 
 * Conventions
 
@@ -91,7 +64,8 @@ EOF
 
 * Script
 
-Bare =gh= CLI; no wrapper. The CLI must be authenticated (=gh auth
+=compass pr create= (=projects/ores.compass/src/compass_pr.py=)
+wrapping =gh pr create=. The =gh= CLI must be authenticated (=gh auth
 login=) once per checkout.
 
 * Tested by

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -129,14 +129,14 @@ _SITE_BASE = "https://orestudio.github.io/OreStudio/"
 
 def _org_title(text, kind):
     """#+title: value with the 'Task: ' / 'Story: ' prefix stripped."""
-    m = re.search(r"^#\+title:\s*(.+)$", text, re.M)
+    m = re.search(r"^#\+title:\s*(.+)$", text, re.M | re.I)
     if not m:
         return ""
-    return re.sub(rf"^{kind}:\s*", "", m.group(1).strip())
+    return re.sub(rf"(?i)^{kind}:\s*", "", m.group(1).strip())
 
 
 def _org_id(text):
-    m = re.search(r":ID:\s+([0-9A-Fa-f-]{36})", text)
+    m = re.search(r"(?i):ID:\s+([0-9A-Fa-f-]{36})", text)
     return m.group(1) if m else ""
 
 
@@ -171,6 +171,10 @@ def _cmd_create(args, project_root):
     task_id = _org_id(task_text)
     task_title = _org_title(task_text, "Task")
     task_rel = task_path.relative_to(project_root)
+    if not task_id:
+        print(f"❌ No :ID: property found in task doc {task_rel}.",
+              file=sys.stderr)
+        return 1
     story_path = task_path.parent / "story.org"
     try:
         story_text = story_path.read_text(encoding="utf-8")
@@ -180,6 +184,10 @@ def _cmd_create(args, project_root):
     story_id = _org_id(story_text)
     story_title = _org_title(story_text, "Story")
     story_rel = story_path.relative_to(project_root)
+    if not story_id:
+        print(f"❌ No :ID: property found in story doc {story_rel}.",
+              file=sys.stderr)
+        return 1
 
     summary = args.summary or "(Fill in: what changes, why.)"
     changes = "\n".join(f"- {c}" for c in (args.change or ["(Fill in.)"]))
@@ -211,21 +219,31 @@ def _cmd_create(args, project_root):
         print(p.stderr.strip() or "❌ gh pr create failed.",
               file=sys.stderr)
         return p.returncode
-    url = p.stdout.strip().splitlines()[-1]
+    lines = p.stdout.strip().splitlines()
+    if not lines:
+        print("❌ gh pr create succeeded but returned no output.",
+              file=sys.stderr)
+        return 1
+    url = lines[-1]
     print(f"✅ PR created: {url}")
+    try:
+        number = int(url.rstrip("/").rsplit("/", 1)[-1])
+    except ValueError:
+        print(f"❌ Could not parse PR number from URL '{url}'.",
+              file=sys.stderr)
+        return 1
 
     # Record on the task doc and stamp the journal.
     import types
-    rc = _cmd_record(types.SimpleNamespace(pr=0, task=args.task),
+    rc = _cmd_record(types.SimpleNamespace(pr=number, task=args.task),
                      project_root)
     if rc != 0:
         return rc
-    number = url.rstrip("/").rsplit("/", 1)[-1]
     compass = Path(project_root) / "projects" / "ores.compass" / "compass.sh"
     subprocess.run([str(compass), "journal", "update",
                     "--story", story_id, "--task", task_id,
                     "--branch", branch, "--state", "STARTED",
-                    "--pr", number], cwd=str(project_root))
+                    "--pr", str(number)], cwd=str(project_root))
     print("ℹ️  Task doc updated — commit and push the record:")
     print(f"    git add {task_rel} && git commit && git push")
     return 0

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -193,16 +193,14 @@ def _cmd_create(args, project_root):
         f"| Task | [{task_title}]({_site_url(task_rel)}) | {task_id} |\n\n"
         "🤖 Generated with [Claude Code](https://claude.com/claude-code)")
 
-    # Push with -u when the branch has no upstream yet.
-    up = subprocess.run(["git", "rev-parse", "--abbrev-ref", "@{u}"],
-                        capture_output=True, text=True,
-                        cwd=str(project_root))
-    if up.returncode != 0:
-        print(f"🔼 Pushing {branch} with upstream…")
-        p = subprocess.run(["git", "push", "-u", "origin", branch],
-                           cwd=str(project_root))
-        if p.returncode != 0:
-            return p.returncode
+    # Ensure the branch exists on the remote under its own name — a
+    # branch created off origin/main tracks origin/main until first
+    # push, so @{u} is not a reliable signal. push -u is idempotent.
+    print(f"🔼 Pushing {branch}…")
+    p = subprocess.run(["git", "push", "-u", "origin", branch],
+                       cwd=str(project_root))
+    if p.returncode != 0:
+        return p.returncode
 
     cmd = ["gh", "pr", "create", "--title", args.title, "--body", body]
     if args.draft:

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -10,6 +10,11 @@ Subcommands:
                 to the * PRs table. The task is found by matching
                 #+branch: against the current branch (override with
                 --task); idempotent when the PR is already recorded.
+  create        Open a PR with the conventions built in: validated
+                [component] title, Summary/Changes body, Traceability
+                table derived from the branch's task and story docs,
+                branch pushed with -u if needed, PR recorded on the
+                task and stamped in the journal.
 
 The review-round verbs (list, reply, resolve, pending) live in the
 Review pillar: compass review --help.
@@ -119,6 +124,115 @@ def _cmd_record(args, project_root):
     return 0
 
 
+_SITE_BASE = "https://orestudio.github.io/OreStudio/"
+
+
+def _org_title(text, kind):
+    """#+title: value with the 'Task: ' / 'Story: ' prefix stripped."""
+    m = re.search(r"^#\+title:\s*(.+)$", text, re.M)
+    if not m:
+        return ""
+    return re.sub(rf"^{kind}:\s*", "", m.group(1).strip())
+
+
+def _org_id(text):
+    m = re.search(r":ID:\s+([0-9A-Fa-f-]{36})", text)
+    return m.group(1) if m else ""
+
+
+def _site_url(rel_path):
+    return _SITE_BASE + str(rel_path).removesuffix(".org") + ".html"
+
+
+def _cmd_create(args, project_root):
+    branch = _current_branch(project_root)
+    if not branch or branch == "main":
+        print("❌ Refusing to open a PR from main or a detached HEAD.",
+              file=sys.stderr)
+        return 1
+
+    # Title convention: [component] Description, ideally <= 72 chars.
+    if not re.match(r"^\[[^\]]+\] \S", args.title):
+        print("❌ Title must follow the convention: "
+              "'[component] Description' (multi-component: [a,b,c]).",
+              file=sys.stderr)
+        return 1
+    if len(args.title) > 72:
+        print(f"⚠️  Title is {len(args.title)} chars; convention prefers "
+              "<= 72.", file=sys.stderr)
+
+    # Traceability: the branch's task doc and its parent story.
+    task_path, task_text = _find_task_doc(project_root, branch, args.task)
+    if task_path is None:
+        print(f"❌ No task doc found for branch '{branch}' "
+              "(set #+branch: on the task, or pass --task).",
+              file=sys.stderr)
+        return 1
+    task_id = _org_id(task_text)
+    task_title = _org_title(task_text, "Task")
+    task_rel = task_path.relative_to(project_root)
+    story_path = task_path.parent / "story.org"
+    try:
+        story_text = story_path.read_text(encoding="utf-8")
+    except OSError:
+        print(f"❌ No story.org next to {task_rel}.", file=sys.stderr)
+        return 1
+    story_id = _org_id(story_text)
+    story_title = _org_title(story_text, "Story")
+    story_rel = story_path.relative_to(project_root)
+
+    summary = args.summary or "(Fill in: what changes, why.)"
+    changes = "\n".join(f"- {c}" for c in (args.change or ["(Fill in.)"]))
+    body = (
+        f"## Summary\n\n{summary}\n\n"
+        f"## Changes\n\n{changes}\n\n"
+        "## Traceability\n\n"
+        "| Artefact | Link | ID |\n"
+        "|----------|------|----|\n"
+        f"| Story | [{story_title}]({_site_url(story_rel)}) | {story_id} |\n"
+        f"| Task | [{task_title}]({_site_url(task_rel)}) | {task_id} |\n\n"
+        "🤖 Generated with [Claude Code](https://claude.com/claude-code)")
+
+    # Push with -u when the branch has no upstream yet.
+    up = subprocess.run(["git", "rev-parse", "--abbrev-ref", "@{u}"],
+                        capture_output=True, text=True,
+                        cwd=str(project_root))
+    if up.returncode != 0:
+        print(f"🔼 Pushing {branch} with upstream…")
+        p = subprocess.run(["git", "push", "-u", "origin", branch],
+                           cwd=str(project_root))
+        if p.returncode != 0:
+            return p.returncode
+
+    cmd = ["gh", "pr", "create", "--title", args.title, "--body", body]
+    if args.draft:
+        cmd.append("--draft")
+    p = subprocess.run(cmd, capture_output=True, text=True,
+                       cwd=str(project_root))
+    if p.returncode != 0:
+        print(p.stderr.strip() or "❌ gh pr create failed.",
+              file=sys.stderr)
+        return p.returncode
+    url = p.stdout.strip().splitlines()[-1]
+    print(f"✅ PR created: {url}")
+
+    # Record on the task doc and stamp the journal.
+    import types
+    rc = _cmd_record(types.SimpleNamespace(pr=0, task=args.task),
+                     project_root)
+    if rc != 0:
+        return rc
+    number = url.rstrip("/").rsplit("/", 1)[-1]
+    compass = Path(project_root) / "projects" / "ores.compass" / "compass.sh"
+    subprocess.run([str(compass), "journal", "update",
+                    "--story", story_id, "--task", task_id,
+                    "--branch", branch, "--state", "STARTED",
+                    "--pr", number], cwd=str(project_root))
+    print("ℹ️  Task doc updated — commit and push the record:")
+    print(f"    git add {task_rel} && git commit && git push")
+    return 0
+
+
 def run(argv, project_root):
     """Entry point: compass pr <subcommand>."""
     ap = argparse.ArgumentParser(
@@ -149,6 +263,20 @@ def run(argv, project_root):
                     help="Task UUID or slug (default: match #+branch: "
                          "against the current branch)")
 
+    cr = sub.add_parser("create",
+                        help="Open a PR with the conventions built in")
+    cr.add_argument("--title", required=True,
+                    help="PR title: '[component] Description'")
+    cr.add_argument("--summary", default="",
+                    help="Summary paragraph for the body")
+    cr.add_argument("--change", action="append", default=[],
+                    help="A Changes bullet (repeatable)")
+    cr.add_argument("--task", default="",
+                    help="Task UUID or slug (default: match #+branch: "
+                         "against the current branch)")
+    cr.add_argument("--draft", action="store_true",
+                    help="Open as a draft PR")
+
     args = ap.parse_args(argv)
     if args.subcmd == "checks" and args.interval is not None:
         if args.interval < 0:
@@ -159,4 +287,6 @@ def run(argv, project_root):
         return _cmd_checks(args, project_root)
     if args.subcmd == "record":
         return _cmd_record(args, project_root)
+    if args.subcmd == "create":
+        return _cmd_create(args, project_root)
     return 1


### PR DESCRIPTION
## Summary

Fifth slice of the PR-management story: compass pr create opens a PR with the repo conventions enforced by tooling instead of prose — validated title, structured body, and the Traceability table derived from the branch's task and story docs. This PR was opened by the command itself.

## Changes

- New create verb in compass_pr.py: title validation ([component] Description, 72-char advisory), Summary/Changes body from flags, Traceability table with full UUIDs and published-page links, --draft and --task overrides
- Pushes the branch with -u (idempotent; @{u} is unreliable before first push — found dogfooding)
- After creation: records the PR on the task doc (pr record) and stamps the session journal automatically
- Create-PR recipe rewritten around the command; the HEREDOC gh incantation is gone
- Close out the pr-checks task (shipped in #1084)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [Add compass pr create with conventions built in](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.html) | B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)