### PR TITLE
[ores.compass] Add pr merge with guard rails; scaffold pr sync

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -72,6 +72,7 @@ with traceability, merge) as follow-on tasks.
 | [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | DONE | 2026-06-05 | 2026-06-05 | compass pr checks with gh exit semantics; raw gh pr checks retired from docs. PR #1084. |
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | DONE | 2026-06-05 | 2026-06-05 | pr record (#1084) + pr create (#1087): validated title, traceability from task/story docs, auto-record, journal stamp. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | STARTED | 2026-06-05 | | Merge commit only; refuse on unresolved threads or red CI; --force escape; delete branch; close-out prompt. |
+| [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | BACKLOG | | | fetch + rebase + report; --push (force-with-lease); conflicts: stop with guidance, or --abort-on-conflict for unattended use. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -33,7 +33,7 @@ with traceability, merge) as follow-on tasks.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | pr checks + record shipped (PR #1084). Implementing pr create. |
+| Now           | pr create shipped (PR #1087). Implementing pr merge — the last verb. |
 | Waiting on    | Nothing.                               |
 | Next          | Conversation-comments gap, then the pr pillar verbs: checks, create, merge. |
 | Last touched  | 2026-06-05                               |
@@ -70,8 +70,8 @@ with traceability, merge) as follow-on tasks.
 | [[id:745668F6-3F30-4C0C-B6F4-45077873AABD][Implement compass review commands (list, reply, resolve)]] | DONE | 2026-06-05 | 2026-06-05 | The four review-round verbs (list, reply, resolve, pending) wrapping gh; --owner/--repo from git remote. PR #1078. |
 | [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | DONE | 2026-06-05 | 2026-06-05 | Conversation section in review list; gh pr view --comments retired. PR #1081. |
 | [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | DONE | 2026-06-05 | 2026-06-05 | compass pr checks with gh exit semantics; raw gh pr checks retired from docs. PR #1084. |
-| [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | STARTED | 2026-06-05 | | Title format, Summary/Changes skeleton, Traceability from journal story/task UUIDs, auto-record in PRs table. pr record (first slice) shipped with #1084. |
-| [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | BACKLOG | | | Refuse on unresolved threads or red CI; merge, delete branch, prompt close-out. |
+| [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | DONE | 2026-06-05 | 2026-06-05 | pr record (#1084) + pr create (#1087): validated title, traceability from task/story docs, auto-record, journal stamp. |
+| [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | STARTED | 2026-06-05 | | Merge commit only; refuse on unresolved threads or red CI; --force escape; delete branch; close-out prompt. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_create.org
@@ -31,11 +31,11 @@ its parent story, branch pushed with =-u= when needed, PR recorded via
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | pr record (auto-record slice) shipped with #1084; create itself next. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -80,3 +80,10 @@ pr-checks branch (PR #1084).
 | 4 | Validate task/story :ID: present before Traceability | compass_pr.py | Accepted | b54902d50 |
 
 * Result
+
+Shipped across PRs [[https://github.com/OreStudio/OreStudio/pull/1084][#1084]] (=pr record=) and [[https://github.com/OreStudio/OreStudio/pull/1087][#1087]] (=pr create=,
+merged 2026-06-05): one command validates the title, builds the body
+with the Traceability table derived from the branch's task and story
+docs, pushes, opens the PR, records it on the task, and stamps the
+journal. PR #1087 was opened by the command itself; dogfooding caught
+the unreliable pre-push @{u} check.

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-pr-merge
-#+pr:
+#+pr: 1088
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -59,7 +59,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1088][#1088]] | [ores.compass] Add pr merge with guard rails; scaffold pr sync |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-pr-merge
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -28,7 +28,7 @@ close-out. Replaces the merge recipe's raw =gh pr merge=.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
@@ -65,6 +65,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | pr=0 treated as falsy; validate positive integer | compass_pr.py | Accepted | 9def8887f; record fixed too |
+| 2 | pr positional should default to None not 0 | compass_pr.py | Accepted | 9def8887f |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F
+:END:
+#+title: Task: Add compass pr sync: fetch main and rebase, conflict-aware
+#+description: compass pr sync runs git fetch origin main + git rebase origin/main, reporting ahead/behind; --push force-pushes with lease after success. On conflicts: stop where git stops, list conflicted files and the ways out (continue/abort), exit non-zero; --abort-on-conflict rolls back automatically for unattended use. Replaces the review-round runbook's raw step 1.
+#+type: task
+#+level: s1
+#+filetags: :compass_pr_management:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -2,12 +2,12 @@
 :ID: 95D560C6-3551-4810-9D11-55F9F82B483C
 :END:
 #+title: How do I merge a PR?
-#+description: Merge an approved, green PR via the gh CLI and clean up the feature branch.
+#+description: Merge an approved PR with compass pr merge — guard rails on threads and CI, merge commit only, branch cleanup.
 #+type: recipe
 #+level: cross
 #+filetags: :github:pr:merge:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-05
 
 This is the last step in the [[id:545D6B43-17FC-0234-FF2B-AB6565695616][PR Manager]] lifecycle. Only run it
 after the user has explicitly confirmed CI is green and all review
@@ -19,25 +19,20 @@ How do I merge a green, approved PR and delete its feature branch?
 
 * Answer
 
-1. /Verify CI is green/. Never merge a yellow or red PR.
+1. /Merge/ — the guard rails are built in: the command refuses while
+   review threads are unresolved or CI is not green, always creates a
+   merge commit (never squash/rebase), and deletes the branch:
 
    #+begin_src sh :results verbatim
-   ./compass.sh pr checks
+   ./compass.sh pr merge             # current branch's PR
+   ./compass.sh pr merge 123         # explicit PR number
+   ./compass.sh pr merge --force     # override the guards, stating what was bypassed
    #+end_src
 
-2. /Verify all review threads are resolved/ — see the resolve loop
-   in [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]].
+2. /Close out/: follow the printed prompt — mark the task DONE with a
+   Result, update the story's =* Tasks= row, stamp the journal.
 
-3. /Merge the PR/ and delete the branch in one go:
-
-   #+begin_src sh :results verbatim
-   gh pr merge --delete-branch
-   #+end_src
-
-   =--delete-branch= removes both the remote and (if checked out)
-   the local branch.
-
-4. /Sync local main/:
+3. /Sync local main/:
 
    #+begin_src sh :results verbatim
    git checkout main
@@ -54,7 +49,8 @@ How do I merge a green, approved PR and delete its feature branch?
 
 * Script
 
-Bare =gh= CLI; no wrapper.
+=compass pr merge= (=projects/ores.compass/src/compass_pr.py=)
+wrapping =gh pr merge --merge --delete-branch=.
 
 * Tested by
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -3200,8 +3200,8 @@ def main():
                                "'review pending [--since 24h]'; 'review --help'")
     subparsers.add_parser("pr",
                           help="PR: pull-request lifecycle verbs via gh — "
-                               "'pr checks [<pr>] [--watch]', 'pr record [<pr>]'; "
-                               "'pr --help'")
+                               "'pr checks [--watch]', 'pr create', 'pr merge [--force]', "
+                               "'pr record'; 'pr --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -300,15 +300,17 @@ def _cmd_merge(args, project_root):
         print("   Use --force to merge anyway.", file=sys.stderr)
         return 1
     if blocked:
-        print("⚠️  --force: merging despite:")
+        print("⚠️  --force: merging despite:", flush=True)
         for b in blocked:
-            print(f"   - {b}")
+            print(f"   - {b}", flush=True)
 
     # Always a merge commit — never squash, never rebase — matching
-    # the repository's history.
-    p = subprocess.run(
-        ["gh", "pr", "merge", str(number), "--merge", "--delete-branch"],
-        cwd=str(project_root))
+    # the repository's history. --force needs gh's --admin to bypass
+    # the base branch protection (required checks still pending).
+    cmd = ["gh", "pr", "merge", str(number), "--merge", "--delete-branch"]
+    if args.force and blocked:
+        cmd.append("--admin")
+    p = subprocess.run(cmd, cwd=str(project_root))
     if p.returncode != 0:
         return p.returncode
     print(f"✅ PR #{number} merged (merge commit); branch deleted.")

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -90,6 +90,9 @@ def _find_task_doc(project_root, branch, task_ref):
 
 
 def _cmd_record(args, project_root):
+    if args.pr is not None and args.pr <= 0:
+        print("❌ PR number must be a positive integer.", file=sys.stderr)
+        return 1
     # Resolve the PR: explicit number or the current branch's PR.
     sel = [str(args.pr)] if args.pr else []
     p = subprocess.run(
@@ -255,6 +258,9 @@ def _cmd_create(args, project_root):
 
 
 def _cmd_merge(args, project_root):
+    if args.pr is not None and args.pr <= 0:
+        print("❌ PR number must be a positive integer.", file=sys.stderr)
+        return 1
     # Resolve the PR number (explicit or the current branch's).
     sel = [str(args.pr)] if args.pr else []
     p = subprocess.run(
@@ -337,7 +343,7 @@ def run(argv, project_root):
     rp = sub.add_parser("record",
                         help="Record a PR on its task doc (#+pr: and the "
                              "* PRs table)")
-    rp.add_argument("pr", nargs="?", type=int, default=0,
+    rp.add_argument("pr", nargs="?", type=int,
                     help="PR number (default: the current branch's PR)")
     rp.add_argument("--task", default="",
                     help="Task UUID or slug (default: match #+branch: "
@@ -359,7 +365,7 @@ def run(argv, project_root):
 
     mp = sub.add_parser("merge",
                         help="Merge a PR (merge commit) with guard rails")
-    mp.add_argument("pr", nargs="?", type=int, default=0,
+    mp.add_argument("pr", nargs="?", type=int,
                     help="PR number (default: the current branch's PR)")
     mp.add_argument("--force", action="store_true",
                     help="Merge even with unresolved threads or red CI "

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -268,7 +268,7 @@ def _cmd_merge(args, project_root):
     if state != "OPEN":
         print(f"❌ PR #{number} is {state}, not open.", file=sys.stderr)
         return 1
-    print(f"🔀 Merging PR #{number}: {title}")
+    print(f"🔀 Merging PR #{number}: {title}", flush=True)
 
     # Guard rails: unresolved review threads and CI state.
     import compass_review

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -15,6 +15,11 @@ Subcommands:
                 table derived from the branch's task and story docs,
                 branch pushed with -u if needed, PR recorded on the
                 task and stamped in the journal.
+  merge [pr]    Merge a PR with guard rails: refuses while review
+                threads are unresolved or CI is not green (--force to
+                override, stating what was bypassed), always a merge
+                commit (never squash/rebase), deletes the branch, and
+                prompts the task/journal close-out.
 
 The review-round verbs (list, reply, resolve, pending) live in the
 Review pillar: compass review --help.
@@ -249,6 +254,65 @@ def _cmd_create(args, project_root):
     return 0
 
 
+def _cmd_merge(args, project_root):
+    # Resolve the PR number (explicit or the current branch's).
+    sel = [str(args.pr)] if args.pr else []
+    p = subprocess.run(
+        ["gh", "pr", "view", *sel, "--json", "number,title,state"],
+        capture_output=True, text=True, cwd=str(project_root))
+    if p.returncode != 0:
+        print(p.stderr.strip() or "❌ gh pr view failed.", file=sys.stderr)
+        return p.returncode
+    pr = json.loads(p.stdout)
+    number, title, state = pr["number"], pr["title"], pr["state"]
+    if state != "OPEN":
+        print(f"❌ PR #{number} is {state}, not open.", file=sys.stderr)
+        return 1
+    print(f"🔀 Merging PR #{number}: {title}")
+
+    # Guard rails: unresolved review threads and CI state.
+    import compass_review
+    owner, repo = compass_review._default_owner_repo(project_root)
+    blocked = []
+    rc, threads = compass_review._fetch_unresolved_threads(
+        owner, repo, number)
+    if rc != 0:
+        return rc
+    if threads:
+        blocked.append(f"{len(threads)} unresolved review thread(s) — "
+                       f"compass review list {number}")
+    ci = subprocess.run(["gh", "pr", "checks", str(number)],
+                        capture_output=True, text=True,
+                        cwd=str(project_root))
+    if ci.returncode != 0:
+        blocked.append(f"CI is not green — compass pr checks {number}")
+
+    if blocked and not args.force:
+        print("❌ Refusing to merge:", file=sys.stderr)
+        for b in blocked:
+            print(f"   - {b}", file=sys.stderr)
+        print("   Use --force to merge anyway.", file=sys.stderr)
+        return 1
+    if blocked:
+        print("⚠️  --force: merging despite:")
+        for b in blocked:
+            print(f"   - {b}")
+
+    # Always a merge commit — never squash, never rebase — matching
+    # the repository's history.
+    p = subprocess.run(
+        ["gh", "pr", "merge", str(number), "--merge", "--delete-branch"],
+        cwd=str(project_root))
+    if p.returncode != 0:
+        return p.returncode
+    print(f"✅ PR #{number} merged (merge commit); branch deleted.")
+    print("ℹ️  Close out the task: mark it DONE with a Result, update the")
+    print("   story's * Tasks row, and stamp the journal:")
+    print(f"   compass journal update --story <id> --task <id> "
+          f"--branch <branch> --state DONE --pr {number}")
+    return 0
+
+
 def run(argv, project_root):
     """Entry point: compass pr <subcommand>."""
     ap = argparse.ArgumentParser(
@@ -293,6 +357,14 @@ def run(argv, project_root):
     cr.add_argument("--draft", action="store_true",
                     help="Open as a draft PR")
 
+    mp = sub.add_parser("merge",
+                        help="Merge a PR (merge commit) with guard rails")
+    mp.add_argument("pr", nargs="?", type=int, default=0,
+                    help="PR number (default: the current branch's PR)")
+    mp.add_argument("--force", action="store_true",
+                    help="Merge even with unresolved threads or red CI "
+                         "(states what was bypassed)")
+
     args = ap.parse_args(argv)
     if args.subcmd == "checks" and args.interval is not None:
         if args.interval < 0:
@@ -305,4 +377,6 @@ def run(argv, project_root):
         return _cmd_record(args, project_root)
     if args.subcmd == "create":
         return _cmd_create(args, project_root)
+    if args.subcmd == "merge":
+        return _cmd_merge(args, project_root)
     return 1


### PR DESCRIPTION
## Summary

Final verb of the PR-management story: compass pr merge closes out a PR with the repo's conventions enforced — and the sixth task (pr sync) is scaffolded with its conflict-handling design pinned.

## Changes

- pr merge [<pr>]: refuses while review threads are unresolved or CI is not green; --force overrides, stating what was bypassed
- Always a merge commit (gh pr merge --merge --delete-branch) — never squash or rebase, matching repo history
- Prints the task/journal close-out prompt after merging
- Merge recipe rewritten around the command
- Close out pr-create task (#1084/#1087); scaffold pr sync task with conflict-aware design (stop-with-guidance default, --abort-on-conflict for unattended use)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [Add compass pr merge with guard rails](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.html) | 4F12BD41-06E1-4EE8-AEC4-98A5B55915B6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)