### PR TITLE
Story: clear component documentation debt

### DIFF
--- a/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/story.org
+++ b/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/story.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: CF1F3E3F-F6D7-479A-808A-E09E22B43344
+:END:
+#+title: Story: Clear component documentation debt
+#+description: Bring every component's group-level modeling documentation up to standard: missing overviews, unfilled skeleton sections, and missing PlantUML diagrams flagged by validate_docs.sh; reconcile the validator with the create-component runbook's 'group overview is optional' wording.
+#+type: story
+#+level: s2
+#+filetags: :documentation:component:codegen:sprint_19:v0:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+=validate_docs.sh= reports seventeen violations, all pre-existing
+documentation debt at the component *group* level of split
+components: the per-part overviews (e.g. =ores.dq/api/modeling/=) are
+fine, but the group-level =projects/ores.X/modeling/= doc is missing,
+skeletal, or lacks a diagram. Clear the debt so the validator runs
+clean, and reconcile the contradiction between the validator (which
+demands group-level docs) and the create-component runbook (which
+calls the group-level overview "optional").
+
+The violations as of 2026-06-05:
+
+| Violation | Meaning | Components |
+|-----------+---------+------------|
+| =MISSING_OVERVIEW= | no group-level =modeling/component_overview.org= | analytics, dq, iam, refdata, scheduler, workspace |
+| =MISSING_SECTION= | group overview exists but skeleton sections unfilled (Inputs, Outputs, Entry points, Dependencies, See also) | compute, controller, reporting, trading, workflow |
+| =MISSING_PUML= | no group-level diagram in =modeling/= | compute, controller, reporting, seeder, trading, workflow |
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Pick up the violations task.           |
+| Last touched  | 2026-06-05                               |
+
+* Acceptance
+
+- =validate_docs.sh= reports zero violations.
+- Every new group-level overview has real content per the
+  [[id:B9D3D469-9E59-465F-8C18-34546B680D13][Component Documentation Guide]] — summary, inputs, outputs, entry
+  points, dependencies and see-also links — not placeholder text.
+- Group-level PlantUML diagrams exist for the flagged components and
+  render via the diagram pipeline.
+- The create-component runbook and the validator agree on whether the
+  group-level overview is required; whichever way the decision goes,
+  the loser is amended.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:90523C36-6A3E-400C-8E8C-99B4E175E199][Fix the seventeen validate_docs violations]] | BACKLOG | | | Write the six missing group overviews, fill the five skeletal ones, add the six missing pumls; reconcile validator vs runbook. |
+
+* Decisions
+
+* Out of scope
+
+- Per-part overviews (api/core/service) — these are already in place
+  and validating.

--- a/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/task_implement_clear_component_doc_debt.org
+++ b/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/task_implement_clear_component_doc_debt.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 90523C36-6A3E-400C-8E8C-99B4E175E199
+:END:
+#+title: Task: Fix the seventeen validate_docs violations
+#+description: Initial task for: Clear component documentation debt
+#+type: task
+#+level: s1
+#+filetags: :clear_component_doc_debt:sprint_19:v0:
+#+owner: marco
+#+branch: feature/clear-component-doc-debt
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:CF1F3E3F-F6D7-479A-808A-E09E22B43344][Clear component documentation debt]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Clear all seventeen =validate_docs.sh= violations listed in the
+parent story's table: write the six missing group-level component
+overviews, fill the five skeletal ones, add the six missing
+group-level PlantUML diagrams, and reconcile the validator with the
+create-component runbook's "group overview is optional" wording.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:CF1F3E3F-F6D7-479A-808A-E09E22B43344][Clear component documentation debt]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- =validate_docs.sh= exits with zero violations.
+- New and filled overviews carry real content per the Component
+  Documentation Guide; no placeholder text remains.
+- Validator and runbook agree on the group-level overview rule.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -79,6 +79,7 @@ while dogfooding the product.
 | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Account type badge in Qt]] | DONE | 2026-06-04 | 2026-06-04 | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. PR [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]]. |
 | [[id:72E7A7D0-A268-410F-B137-942DC5F16934][Badge colour semantics]] | DONE | 2026-06-04 | 2026-06-04 | Gray = inactive only; recolour service/unlocked/done; orange missing-definition fallback; detail dialog badges; UX language doc. PR [[https://github.com/OreStudio/OreStudio/pull/1044][#1044]]. |
 | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs]] | STARTED | 2026-06-05 | | Server-side diffs via ores.diff + per-entity mappers; HistoryDialogBase everywhere; shell unified diff. Design done; 6 tasks raised. |
+| [[id:CF1F3E3F-F6D7-479A-808A-E09E22B43344][Clear component documentation debt]] | BACKLOG | | | Seventeen validate_docs violations: six missing group overviews, five skeletal, six missing pumls; reconcile validator vs runbook. |
 
 ** Tooling
 


### PR DESCRIPTION
## Summary

Adds a sprint 19 story capturing the seventeen pre-existing `validate_docs.sh` violations as a single piece of documentation debt, with one task raised. All violations are at the component **group** level of split components — the per-part overviews (api/core/service) are in place and validating.

The violations as of 2026-06-05:

| Violation | Meaning | Components |
|-----------|---------|------------|
| `MISSING_OVERVIEW` | no group-level `modeling/component_overview.org` | analytics, dq, iam, refdata, scheduler, workspace |
| `MISSING_SECTION` | group overview exists but skeleton sections unfilled | compute, controller, reporting, trading, workflow |
| `MISSING_PUML` | no group-level diagram in `modeling/` | compute, controller, reporting, seeder, trading, workflow |

The story also covers reconciling a contradiction: the validator demands group-level docs while the create-component runbook calls the group-level overview "optional" — whichever way the decision goes, the loser is amended.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clear component documentation debt](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/story.html) | CF1F3E3F-F6D7-479A-808A-E09E22B43344 |
| Task | [Fix the seventeen validate_docs violations](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/clear_component_doc_debt/task_implement_clear_component_doc_debt.html) | 90523C36-6A3E-400C-8E8C-99B4E175E199 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)