### PR TITLE
[diff] Create the ores.diff component

### DIFF
--- a/doc/agile/product_backlog/inbox/ores-diff-structured-topology.org
+++ b/doc/agile/product_backlog/inbox/ores-diff-structured-topology.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 7F55F750-4AB5-4F51-A944-B743C83CB54D
+:END:
+#+title: ores.diff: structured topology for nested entities
+#+description: Extend the flat diff model with an optional path (ordered segments) on field_value/diff_entry and list-identity-aware mapping guidance, so instruments and other nested entities can diff with real topology (grouping, collapse, leg-aware changes) instead of stringly path names. Design deliberately when the first nested consumer lands.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Extend the deliberately flat =ores.diff= model for nested entities:
+an optional =path= (ordered segments, e.g. =["Legs", "1",
+"Schedule"]=) on =field_value= / =diff_entry= alongside the display
+name, plus mapper guidance for list identity (match legs by a stable
+key, not by index, so reordering or inserting a leg does not show as
+a wall of changed fields). Flat consumers — the history dialogs'
+Field/Old/New tables — are unaffected; richer UIs gain grouping,
+collapse and "all changes under leg 2" addressing without string
+parsing.
+
+* Why
+
+The v1 model is one flat ordered list of (name, rendered value) pairs
+per version; nested entities flatten in the mapper with topology
+encoded in path-style display names. That is exactly right for every
+current consumer (currency pilot, the 64 history dialogs, the shell
+unified diff), but instruments and trades will eventually need real
+topology. Designing the extension deliberately when the first nested
+consumer lands beats retrofitting it in a rush — and the extension
+point (optional path next to the display name) is already documented
+in the component overview so the flat model does not paint us into a
+corner.
+
+* References
+
+- =projects/ores.diff/modeling/component_overview.org= — the flatness
+  decision and extension path.
+- =projects/ores.diff/include/ores.diff/engine/compare.hpp= — "the
+  engine never interprets names".
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
@@ -98,9 +98,9 @@ in-flight model migration); codegen the mappers (deferred).
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Design complete; tasks raised.         |
+| Now           | Phase B1: creating the ores.diff component. |
 | Waiting on    | Nothing.                               |
-| Next          | Phase A: grow the base and migrate the six hand-rolled dialogs. |
+| Next          | Phase B2: pilot server-side diffs on currency. |
 | Last touched  | 2026-06-05                               |
 
 * Acceptance
@@ -120,8 +120,8 @@ in-flight model migration); codegen the mappers (deferred).
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:40781D42-C34B-47F3-8612-7FA9C2202E5B][Design the history diff architecture and testing strategy]] | DONE | 2026-06-05 | 2026-06-05 | Design distributed into this story's Architecture and the tasks' Plans. |
-| [[id:E9348344-C7A1-4B4A-969D-BDB56C96DE9A][Grow HistoryDialogBase and migrate the six hand-rolled dialogs]] | BACKLOG | | | Phase A: DiffResult, helpers, calculateDiff flow, load/stale plumbing in the base; migrate the 6 diff dialogs. |
-| [[id:83B7239F-5C29-4C52-900E-C9623C608DFD][Create the ores.diff component]] | BACKLOG | | | Phase B1: diff model + engine, scaffolded via component-creator; exhaustive unit tests. |
+| [[id:E9348344-C7A1-4B4A-969D-BDB56C96DE9A][Grow HistoryDialogBase and migrate the six hand-rolled dialogs]] | DONE | 2026-06-05 | 2026-06-05 | Scope grew to all 64 version-history dialogs; event-log dialogs renamed to Audit. PR 1080. |
+| [[id:83B7239F-5C29-4C52-900E-C9623C608DFD][Create the ores.diff component]] | STARTED | 2026-06-05 | | Phase B1: diff model + engine, scaffolded via component-creator; exhaustive unit tests. |
 | [[id:D575DCF0-2341-4630-9C47-F428F82C2FCE][Pilot server-side history diffs end to end on currency]] | BACKLOG | | | Phase B2: currency mapper, extended response, handler compose, dialog renders server rows. |
 | [[id:7B2998F0-3B7B-4A11-8A44-7464BF3F4CBB][Adopt the base in the history-dialog template and roll out]] | BACKLOG | | | Phase C: template target form + per-domain rollout. Gated on codegen org-model migration. |
 | [[id:D759765E-85A3-47B6-91C5-23FF938B0B34][Codegen field mappers from entity models]] | BACKLOG | | | Phase D, deferred: generate mappers once the hand-written shape is proven. |

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
@@ -66,6 +66,11 @@ frontend.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | export.hpp pulls boost/config into public headers | export.hpp | Accepted | Standard preprocessor checks instead; 669ca3aac. Visibility flags out of scope (project-wide policy). |
+| 2 | Missing unordered_set include | compare.cpp | Accepted | 8ddea0fa8 |
+| 3 | unordered_map<sv,bool> as a set is an anti-pattern | compare.cpp | Accepted | unordered_set; 8ddea0fa8 |
+| 4 | Same for seen_in_previous | compare.cpp | Accepted | 8ddea0fa8 |
+| 5 | Test runner registers database listener it does not need | tests/main.cpp | Partially accepted | Database listener dropped; logging listener kept for compass test logging integration; 2530254a7 |
+| 6 | Trim unused test target dependencies | tests/CMakeLists.txt | Partially accepted | faker and utility dropped; testing/logging kept for the listener; 2530254a7 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
@@ -8,7 +8,7 @@
 #+filetags: :diff:component:architecture:consolidate_history_dialogs:sprint_19:v0:
 #+owner: marco
 #+branch: feature/create-ores-diff
-#+pr:
+#+pr: 1091
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -60,7 +60,7 @@ frontend.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1091][#1091]] | [diff] Create the ores.diff component |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :diff:component:architecture:consolidate_history_dialogs:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/create-ores-diff
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -27,7 +27,7 @@ frontend.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs onto HistoryDialogBase]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_grow-history-dialog-base.org
@@ -8,7 +8,7 @@
 #+filetags: :qt:refactor:history:consolidate_history_dialogs:sprint_19:v0:
 #+owner: marco
 #+branch: feature/grow-history-dialog-base
-#+pr:
+#+pr: 1080
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -30,11 +30,11 @@ broke GCC/AppleClang).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs onto HistoryDialogBase]] |
-| Now          | All 64 version-history dialogs migrated; full build green; raising the PR. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Raise the PR and run the review runbook. |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -105,3 +105,15 @@ broke GCC/AppleClang).
 | 7 | Task doc must include * Review section | task_grow-history-dialog-base.org | Declined | Section already present with the standard table; comment anchored on the adjacent empty PRs table |
 
 * Result
+
+Merged in [[https://github.com/OreStudio/OreStudio/pull/1080][PR 1080]]. HistoryDialogBase owns the full shared pipeline
+(toolbar, version list via ordered-cells VersionRow, changes-tab diff
+flow with placeholders, optional-aware diff helpers, async request
+plumbing, watcher cleanup). All 64 version-history dialogs migrated —
+the six hand-rolled diff dialogs plus the 58 generated-pattern ones —
+for a net reduction of ~10,600 lines. Revert semantics unified to
+revert-to-selected with confirmation; the three event-log screens
+renamed to Audit (Session, Publication, JobDefinition) with the
+History-vs-Audit distinction recorded in the UX language doc. One
+review round: six tr()/destructor-pattern fixes accepted, one
+declined with evidence.

--- a/doc/llm/memory/comments_describe_present_state.org
+++ b/doc/llm/memory/comments_describe_present_state.org
@@ -1,0 +1,30 @@
+:PROPERTIES:
+:ID: DF4A351E-4D7C-4C9D-AB43-D90E69702EC5
+:END:
+#+title: Comments describe how things are, never how they used to be
+#+description: Code comments must describe the present state of the code only. Never write comments that contrast with a previous implementation, justify a review change, or explain what something replaced - that history belongs in commit messages and PR bodies.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+Code comments describe the present state of the code only — what it
+does and why it is shaped that way. Never write comments that
+contrast with a previous implementation ("rather than X", "no longer
+uses Y", "previously Z"), justify a review change, or explain what
+something replaced.
+
+*Why:* Marco interrupted a review round on PR 1091 twice to delete
+exactly such comments (an export-macro comment explaining what it
+replaced, a CMake comment noting dependencies that were removed).
+The history of how code came to be belongs in commit messages and PR
+bodies, which are permanently attached to the change; in the source
+it rots into noise the moment the old state is forgotten.
+
+*How to apply:* Whenever writing or editing comments in any source
+file (C++, CMake, SQL, scripts) — especially when applying review
+feedback or refactoring, where the temptation to narrate the change
+is strongest. Before committing, re-read added comments and strip any
+clause whose subject is the old code rather than the current code.

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.platform)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.logging)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.diff)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.database)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.testing)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.telemetry/core)

--- a/projects/ores.diff/CMakeLists.txt
+++ b/projects/ores.diff/CMakeLists.txt
@@ -1,0 +1,21 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)

--- a/projects/ores.diff/include/ores.diff/domain/diff_entry.hpp
+++ b/projects/ores.diff/include/ores.diff/domain/diff_entry.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_DOMAIN_DIFF_ENTRY_HPP
+#define ORES_DIFF_DOMAIN_DIFF_ENTRY_HPP
+
+#include <string>
+
+namespace ores::diff::domain {
+
+/**
+ * @brief One changed field: its name and both rendered values.
+ *
+ * A field added in the current version has an empty old_value; a
+ * field removed from the current version has an empty new_value.
+ */
+struct diff_entry final {
+    /**
+     * @brief Display name of the field, e.g. "ISO Code".
+     */
+    std::string field_name;
+
+    /**
+     * @brief The previous version's rendered value; empty when the
+     * field was added.
+     */
+    std::string old_value;
+
+    /**
+     * @brief The current version's rendered value; empty when the
+     * field was removed.
+     */
+    std::string new_value;
+
+    friend bool operator==(const diff_entry&, const diff_entry&) = default;
+};
+
+}
+
+#endif

--- a/projects/ores.diff/include/ores.diff/domain/diff_result.hpp
+++ b/projects/ores.diff/include/ores.diff/domain/diff_result.hpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_DOMAIN_DIFF_RESULT_HPP
+#define ORES_DIFF_DOMAIN_DIFF_RESULT_HPP
+
+#include <vector>
+#include "ores.diff/domain/diff_entry.hpp"
+
+namespace ores::diff::domain {
+
+/**
+ * @brief The ordered field-level differences between two versions.
+ *
+ * Entry order follows the current version's field order (the mapper
+ * order), with fields removed from the current version appended last
+ * in the previous version's order. Embeddable in protocol messages
+ * via rfl serialisation.
+ */
+struct diff_result final {
+    /**
+     * @brief One entry per changed, added or removed field; empty
+     * when the versions are identical.
+     */
+    std::vector<diff_entry> entries;
+
+    friend bool operator==(const diff_result&, const diff_result&) = default;
+};
+
+}
+
+#endif

--- a/projects/ores.diff/include/ores.diff/domain/field_value.hpp
+++ b/projects/ores.diff/include/ores.diff/domain/field_value.hpp
@@ -1,0 +1,50 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_DOMAIN_FIELD_VALUE_HPP
+#define ORES_DIFF_DOMAIN_FIELD_VALUE_HPP
+
+#include <string>
+
+namespace ores::diff::domain {
+
+/**
+ * @brief One field of an entity version, rendered for display.
+ *
+ * Per-entity field mappers produce ordered lists of these; the
+ * rendering decision (how a date, amount or flag becomes a string)
+ * belongs to the mapper, not to the diff engine.
+ */
+struct field_value final {
+    /**
+     * @brief Display name of the field, e.g. "ISO Code".
+     */
+    std::string name;
+
+    /**
+     * @brief The field's value rendered as a display string.
+     */
+    std::string value;
+
+    friend bool operator==(const field_value&, const field_value&) = default;
+};
+
+}
+
+#endif

--- a/projects/ores.diff/include/ores.diff/engine/compare.hpp
+++ b/projects/ores.diff/include/ores.diff/engine/compare.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_ENGINE_COMPARE_HPP
+#define ORES_DIFF_ENGINE_COMPARE_HPP
+
+#include <vector>
+#include "ores.diff/domain/diff_result.hpp"
+#include "ores.diff/domain/field_value.hpp"
+#include "ores.diff/export.hpp"
+
+namespace ores::diff::engine {
+
+/**
+ * @brief Computes the field-level differences between two versions.
+ *
+ * Fields are keyed by name. A field present in both lists with a
+ * different value yields an entry with both sides; a field only in
+ * current (added) yields an entry with an empty old_value; a field
+ * only in previous (removed) yields an entry with an empty new_value.
+ * Unchanged fields yield nothing.
+ *
+ * Entry order follows the current list's order, with removed fields
+ * appended last in the previous list's order. When a name appears
+ * more than once in a list, the first occurrence wins.
+ *
+ * The model is flat by design: nested entities flatten in the mapper,
+ * encoding topology in path-style display names (e.g. "Legs[1] /
+ * Notional"). The engine never interprets names.
+ *
+ * @param previous The older version's fields, in mapper order.
+ * @param current The newer version's fields, in mapper order.
+ */
+ORES_DIFF_EXPORT domain::diff_result
+compute(const std::vector<domain::field_value>& previous,
+        const std::vector<domain::field_value>& current);
+
+}
+
+#endif

--- a/projects/ores.diff/include/ores.diff/export.hpp
+++ b/projects/ores.diff/include/ores.diff/export.hpp
@@ -1,0 +1,31 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_EXPORT_HPP
+#define ORES_DIFF_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_DIFF_LIBRARY
+#  define ORES_DIFF_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_DIFF_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.diff/include/ores.diff/export.hpp
+++ b/projects/ores.diff/include/ores.diff/export.hpp
@@ -20,12 +20,16 @@
 #ifndef ORES_DIFF_EXPORT_HPP
 #define ORES_DIFF_EXPORT_HPP
 
-#include <boost/config.hpp>
-
-#ifdef ORES_DIFF_LIBRARY
-#  define ORES_DIFF_EXPORT BOOST_SYMBOL_EXPORT
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  ifdef ORES_DIFF_LIBRARY
+#    define ORES_DIFF_EXPORT __declspec(dllexport)
+#  else
+#    define ORES_DIFF_EXPORT __declspec(dllimport)
+#  endif
+#elif defined(__GNUC__)
+#  define ORES_DIFF_EXPORT __attribute__((visibility("default")))
 #else
-#  define ORES_DIFF_EXPORT BOOST_SYMBOL_IMPORT
+#  define ORES_DIFF_EXPORT
 #endif
 
 #endif

--- a/projects/ores.diff/include/ores.diff/ores.diff.hpp
+++ b/projects/ores.diff/include/ores.diff/ores.diff.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DIFF_HPP
+#define ORES_DIFF_HPP
+
+/**
+ * @brief Field-level diff model and compare engine.
+ *
+ * Field-level diff vocabulary and compare engine shared by domain services and frontends.
+ */
+namespace ores::diff {}
+
+#endif

--- a/projects/ores.diff/modeling/CMakeLists.txt
+++ b/projects/ores.diff/modeling/CMakeLists.txt
@@ -1,0 +1,26 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+set(name "ores.diff")
+
+set(diagram_target generate_${name}_diagram)
+add_custom_target(${diagram_target}
+    COMMENT "Generating PlantUML diagram for ${name}" VERBATIM
+    COMMAND java ${ORES_JAVA_ARGS} -jar ${ORES_PLANTUML_JAR} ${name}.puml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
+add_dependencies(make_all_diagrams ${diagram_target})

--- a/projects/ores.diff/modeling/component_overview.org
+++ b/projects/ores.diff/modeling/component_overview.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 45754809-C069-41D4-A7E4-23CC686FE8E4
+:END:
+#+title: ores.diff
+#+description: Field-level diff vocabulary and compare engine shared by domain services and frontends.
+#+type: component
+#+level: cross
+#+filetags: :diff:component:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+name: diff
+#+full_name: ores.diff
+#+brief: Field-level diff model and compare engine.
+
+* Diagram
+
+#+attr_html: :width 100% :alt ores.diff component diagram
+#+caption: ores.diff
+[[file:ores.diff.png][file:ores.diff.png]]
+
+* Summary
+
+=ores.diff= is a dependency-light leaf component owning the vocabulary
+of "what changed" between two versions of an entity. It defines the
+diff model — =field_value= (field name plus rendered value),
+=diff_entry= (field, old value, new value) and =diff_result= (ordered
+entries) — and a compare engine that produces a =diff_result= from two
+ordered field lists. Domain services use it to compute history diffs
+server-side; frontends (Qt, shell) render its results without any
+comparison logic of their own. The types are rfl-serialisable so
+protocol messages can embed them directly.
+
+* Inputs
+
+- Ordered =field_value= lists for the previous and current versions of
+  an entity, produced by per-entity field mappers in domain services.
+
+The model is deliberately *flat*: one ordered list of (name, rendered
+value) pairs per version. Nested entities flatten in the mapper, with
+topology encoded in path-style display names (e.g. =Legs[1] /
+Notional=). When a consumer needs real topology — grouping, collapse,
+list-identity-aware diffs — the model grows an optional path
+alongside the display name rather than becoming a tree; flat
+consumers are unaffected.
+
+* Outputs
+
+- =diff_result= values: ordered field-level diff entries, embeddable
+  in NATS protocol messages via rfl serialisation.
+
+* Entry points
+
+- =include/ores.diff/domain/field_value.hpp= — field name plus
+  rendered value.
+- =include/ores.diff/domain/diff_entry.hpp= — one changed field: name,
+  old value, new value.
+- =include/ores.diff/domain/diff_result.hpp= — ordered list of entries.
+- =include/ores.diff/engine/compare.hpp= — the compare engine:
+  =compute(previous, current)= → =diff_result=.
+
+* Dependencies
+
+- None beyond std and =rfl= — the component is deliberately a leaf so
+  every domain service and frontend can depend on it without cycles.
+
+* See also
+
+- [[id:34DDEE6A-915F-404B-8721-01376903D3E4][ores.assets.api]] — a sibling leaf contract component with the same
+  dependency discipline.

--- a/projects/ores.diff/modeling/ores.diff.puml
+++ b/projects/ores.diff/modeling/ores.diff.puml
@@ -1,0 +1,51 @@
+' -*- mode: plantuml; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+'
+' Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+'
+' This program is free software; you can redistribute it and/or modify it under
+' the terms of the GNU General Public License as published by the Free Software
+' Foundation; either version 3 of the License, or (at your option) any later
+' version.
+'
+' This program is distributed in the hope that it will be useful, but WITHOUT
+' ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+' FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License along with
+' this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+' Street, Fifth Floor, Boston, MA 02110-1301, USA.
+'
+@startuml
+
+title ores.diff Component
+
+set namespaceSeparator ::
+
+namespace ores #F2F2F2 {
+    namespace diff #F2F2F2 {
+        namespace domain #FEFECE {
+            class field_value <<struct>> {
+                +name : std::string
+                +value : std::string
+            }
+            class diff_entry <<struct>> {
+                +field_name : std::string
+                +old_value : std::string
+                +new_value : std::string
+            }
+            class diff_result <<struct>> {
+                +entries : std::vector<diff_entry>
+            }
+            diff_result o-- diff_entry
+        }
+        namespace engine #FEFECE {
+            class compare <<function>> {
+                +compute(previous: vector<field_value>, current: vector<field_value>) : diff_result
+            }
+            compare ..> ores::diff::domain::field_value : consumes
+            compare ..> ores::diff::domain::diff_result : produces
+        }
+    }
+}
+
+@enduml

--- a/projects/ores.diff/src/CMakeLists.txt
+++ b/projects/ores.diff/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+set(name "ores.diff")
+set(lib_binary_name ${name})
+set(lib_target_name ${name}.lib)
+
+set(files "")
+file(GLOB_RECURSE files RELATIVE
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+set(lib_files ${files})
+add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_DIFF_LIBRARY)
+set_target_properties(${lib_target_name} PROPERTIES
+    OUTPUT_NAME ${lib_binary_name})
+set_target_properties(${lib_target_name}
+    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+target_include_directories(${lib_target_name} PUBLIC
+    ${CMAKE_SOURCE_DIR}/projects/${name}/include)
+
+# Deliberately a leaf: no dependency beyond std and rfl, so every
+# domain service and frontend can link it without cycles.
+target_link_libraries(${lib_target_name}
+    PUBLIC
+        reflectcpp::reflectcpp)
+
+install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.diff/src/engine/compare.cpp
+++ b/projects/ores.diff/src/engine/compare.cpp
@@ -21,6 +21,7 @@
 
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace ores::diff::engine {
 
@@ -38,10 +39,10 @@ compute(const std::vector<domain::field_value>& previous,
     domain::diff_result result;
 
     // Current-list order drives the output: changed and added fields.
-    std::unordered_map<std::string_view, bool> seen_in_current;
+    std::unordered_set<std::string_view> seen_in_current;
     seen_in_current.reserve(current.size());
     for (const auto& field : current) {
-        if (!seen_in_current.try_emplace(field.name, true).second)
+        if (!seen_in_current.insert(field.name).second)
             continue; // First occurrence wins.
 
         const auto it = by_name.find(field.name);
@@ -60,10 +61,10 @@ compute(const std::vector<domain::field_value>& previous,
     }
 
     // Removed fields follow, in the previous list's order.
-    std::unordered_map<std::string_view, bool> seen_in_previous;
+    std::unordered_set<std::string_view> seen_in_previous;
     seen_in_previous.reserve(previous.size());
     for (const auto& field : previous) {
-        if (!seen_in_previous.try_emplace(field.name, true).second)
+        if (!seen_in_previous.insert(field.name).second)
             continue; // First occurrence wins.
 
         if (!seen_in_current.contains(field.name)) {

--- a/projects/ores.diff/src/engine/compare.cpp
+++ b/projects/ores.diff/src/engine/compare.cpp
@@ -1,0 +1,80 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.diff/engine/compare.hpp"
+
+#include <string_view>
+#include <unordered_map>
+
+namespace ores::diff::engine {
+
+domain::diff_result
+compute(const std::vector<domain::field_value>& previous,
+        const std::vector<domain::field_value>& current) {
+    // Index the previous fields by name. First occurrence wins when a
+    // name repeats; string_view keys borrow from `previous`, which
+    // outlives the map.
+    std::unordered_map<std::string_view, const domain::field_value*> by_name;
+    by_name.reserve(previous.size());
+    for (const auto& field : previous)
+        by_name.try_emplace(field.name, &field);
+
+    domain::diff_result result;
+
+    // Current-list order drives the output: changed and added fields.
+    std::unordered_map<std::string_view, bool> seen_in_current;
+    seen_in_current.reserve(current.size());
+    for (const auto& field : current) {
+        if (!seen_in_current.try_emplace(field.name, true).second)
+            continue; // First occurrence wins.
+
+        const auto it = by_name.find(field.name);
+        if (it == by_name.end()) {
+            // Added: absent side is empty.
+            result.entries.push_back(
+                {.field_name = field.name,
+                 .old_value = {},
+                 .new_value = field.value});
+        } else if (it->second->value != field.value) {
+            result.entries.push_back(
+                {.field_name = field.name,
+                 .old_value = it->second->value,
+                 .new_value = field.value});
+        }
+    }
+
+    // Removed fields follow, in the previous list's order.
+    std::unordered_map<std::string_view, bool> seen_in_previous;
+    seen_in_previous.reserve(previous.size());
+    for (const auto& field : previous) {
+        if (!seen_in_previous.try_emplace(field.name, true).second)
+            continue; // First occurrence wins.
+
+        if (!seen_in_current.contains(field.name)) {
+            result.entries.push_back(
+                {.field_name = field.name,
+                 .old_value = field.value,
+                 .new_value = {}});
+        }
+    }
+
+    return result;
+}
+
+}

--- a/projects/ores.diff/tests/CMakeLists.txt
+++ b/projects/ores.diff/tests/CMakeLists.txt
@@ -30,14 +30,14 @@ add_executable(${tests_target_name} ${files})
 set_target_properties(${tests_target_name}
     PROPERTIES OUTPUT_NAME ${tests_binary_name})
 
+# ores.testing.lib / ores.logging.lib serve the logging listener in
+# main.cpp.
 target_link_libraries(${tests_target_name}
     PRIVATE
         ${lib_target_name}
-        ores.utility.lib
         ores.testing.lib
         ores.logging.lib
         Catch2::Catch2
-        faker-cxx::faker-cxx
         ${CMAKE_THREAD_LIBS_INIT})
 
 add_custom_target(test_${tests_target_name}

--- a/projects/ores.diff/tests/CMakeLists.txt
+++ b/projects/ores.diff/tests/CMakeLists.txt
@@ -1,0 +1,61 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+set(name "ores.diff")
+set(lib_target_name ${name}.lib)
+set(tests_binary_name ${name}.tests)
+set(tests_target_name ${name}.tests)
+
+set(files "")
+file(GLOB_RECURSE files RELATIVE
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+add_executable(${tests_target_name} ${files})
+set_target_properties(${tests_target_name}
+    PROPERTIES OUTPUT_NAME ${tests_binary_name})
+
+target_link_libraries(${tests_target_name}
+    PRIVATE
+        ${lib_target_name}
+        ores.utility.lib
+        ores.testing.lib
+        ores.logging.lib
+        Catch2::Catch2
+        faker-cxx::faker-cxx
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_custom_target(test_${tests_target_name}
+    COMMENT "Testing ${tests_target_name}" VERBATIM
+    COMMAND $<TARGET_FILE:${tests_binary_name}>
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    DEPENDS ${tests_target_name})
+
+add_dependencies(run_all_tests test_${tests_target_name})
+
+add_test(NAME ${tests_target_name}
+    COMMAND ${tests_binary_name} ${ORES_CATCH2_ARGS} -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+set_tests_properties(${tests_target_name} PROPERTIES
+    PROCESSORS 1
+    ENVIRONMENT "${ORES_TEST_ENV}"
+    ATTACHED_FILES_ON_FAIL "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml"
+)
+
+set_property(TEST ${tests_target_name} PROPERTY USES_XML_OUTPUT ON)

--- a/projects/ores.diff/tests/domain_serialisation_tests.cpp
+++ b/projects/ores.diff/tests/domain_serialisation_tests.cpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.diff/domain/diff_result.hpp"
+#include "ores.diff/domain/field_value.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <rfl/json.hpp>
+
+namespace {
+
+const std::string tags("[domain]");
+
+}
+
+using ores::diff::domain::diff_entry;
+using ores::diff::domain::diff_result;
+using ores::diff::domain::field_value;
+
+TEST_CASE("diff_result_round_trips_through_rfl_json", tags) {
+    const diff_result original{
+        .entries = {{.field_name = "Name",
+                     .old_value = "US Dollar",
+                     .new_value = "United States Dollar"},
+                    {.field_name = "Market Tier",
+                     .old_value = "",
+                     .new_value = "Major"}}};
+
+    const auto json = rfl::json::write(original);
+    const auto restored = rfl::json::read<diff_result>(json);
+
+    REQUIRE(restored);
+    CHECK(*restored == original);
+}
+
+TEST_CASE("field_value_round_trips_through_rfl_json", tags) {
+    const field_value original{.name = "ISO Code", .value = "USD"};
+
+    const auto json = rfl::json::write(original);
+    const auto restored = rfl::json::read<field_value>(json);
+
+    REQUIRE(restored);
+    CHECK(*restored == original);
+}

--- a/projects/ores.diff/tests/engine_compare_tests.cpp
+++ b/projects/ores.diff/tests/engine_compare_tests.cpp
@@ -1,0 +1,205 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.diff/engine/compare.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+const std::string tags("[engine]");
+
+}
+
+using ores::diff::domain::field_value;
+using ores::diff::domain::diff_entry;
+using ores::diff::engine::compute;
+
+TEST_CASE("compare_identical_inputs_yields_empty_result", tags) {
+    const std::vector<field_value> fields{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Name", .value = "US Dollar"}};
+
+    const auto result = compute(fields, fields);
+
+    CHECK(result.entries.empty());
+}
+
+TEST_CASE("compare_both_lists_empty_yields_empty_result", tags) {
+    const auto result = compute({}, {});
+
+    CHECK(result.entries.empty());
+}
+
+TEST_CASE("compare_changed_value_yields_entry_with_both_sides", tags) {
+    const std::vector<field_value> previous{
+        {.name = "Name", .value = "US Dollar"}};
+    const std::vector<field_value> current{
+        {.name = "Name", .value = "United States Dollar"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 1);
+    CHECK(result.entries[0] == diff_entry{.field_name = "Name",
+                                          .old_value = "US Dollar",
+                                          .new_value = "United States Dollar"});
+}
+
+TEST_CASE("compare_unchanged_fields_are_omitted", tags) {
+    const std::vector<field_value> previous{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Name", .value = "US Dollar"},
+        {.name = "Symbol", .value = "$"}};
+    const std::vector<field_value> current{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Name", .value = "United States Dollar"},
+        {.name = "Symbol", .value = "$"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 1);
+    CHECK(result.entries[0].field_name == "Name");
+}
+
+TEST_CASE("compare_added_field_has_empty_old_value", tags) {
+    const std::vector<field_value> previous{
+        {.name = "ISO Code", .value = "USD"}};
+    const std::vector<field_value> current{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Market Tier", .value = "Major"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 1);
+    CHECK(result.entries[0] == diff_entry{.field_name = "Market Tier",
+                                          .old_value = "",
+                                          .new_value = "Major"});
+}
+
+TEST_CASE("compare_removed_field_has_empty_new_value", tags) {
+    const std::vector<field_value> previous{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Legacy Flag", .value = "true"}};
+    const std::vector<field_value> current{
+        {.name = "ISO Code", .value = "USD"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 1);
+    CHECK(result.entries[0] == diff_entry{.field_name = "Legacy Flag",
+                                          .old_value = "true",
+                                          .new_value = ""});
+}
+
+TEST_CASE("compare_previous_empty_reports_all_fields_added", tags) {
+    const std::vector<field_value> current{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Name", .value = "US Dollar"}};
+
+    const auto result = compute({}, current);
+
+    REQUIRE(result.entries.size() == 2);
+    CHECK(result.entries[0] == diff_entry{.field_name = "ISO Code",
+                                          .old_value = "",
+                                          .new_value = "USD"});
+    CHECK(result.entries[1] == diff_entry{.field_name = "Name",
+                                          .old_value = "",
+                                          .new_value = "US Dollar"});
+}
+
+TEST_CASE("compare_current_empty_reports_all_fields_removed", tags) {
+    const std::vector<field_value> previous{
+        {.name = "ISO Code", .value = "USD"},
+        {.name = "Name", .value = "US Dollar"}};
+
+    const auto result = compute(previous, {});
+
+    REQUIRE(result.entries.size() == 2);
+    CHECK(result.entries[0] == diff_entry{.field_name = "ISO Code",
+                                          .old_value = "USD",
+                                          .new_value = ""});
+    CHECK(result.entries[1] == diff_entry{.field_name = "Name",
+                                          .old_value = "US Dollar",
+                                          .new_value = ""});
+}
+
+TEST_CASE("compare_preserves_current_order_for_changes", tags) {
+    // Previous deliberately lists fields in a different order; the
+    // output must follow the current (mapper) order.
+    const std::vector<field_value> previous{
+        {.name = "C", .value = "3"},
+        {.name = "A", .value = "1"},
+        {.name = "B", .value = "2"}};
+    const std::vector<field_value> current{
+        {.name = "A", .value = "one"},
+        {.name = "B", .value = "two"},
+        {.name = "C", .value = "three"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 3);
+    CHECK(result.entries[0].field_name == "A");
+    CHECK(result.entries[1].field_name == "B");
+    CHECK(result.entries[2].field_name == "C");
+}
+
+TEST_CASE("compare_removed_fields_follow_in_previous_order", tags) {
+    const std::vector<field_value> previous{
+        {.name = "Kept", .value = "old"},
+        {.name = "Removed Last", .value = "x"},
+        {.name = "Removed First", .value = "y"}};
+    const std::vector<field_value> current{
+        {.name = "Added", .value = "new"},
+        {.name = "Kept", .value = "new"}};
+
+    const auto result = compute(previous, current);
+
+    // Current order first (Added, Kept), then removed fields in the
+    // previous list's order.
+    REQUIRE(result.entries.size() == 4);
+    CHECK(result.entries[0].field_name == "Added");
+    CHECK(result.entries[1].field_name == "Kept");
+    CHECK(result.entries[2].field_name == "Removed Last");
+    CHECK(result.entries[3].field_name == "Removed First");
+}
+
+TEST_CASE("compare_empty_values_on_both_sides_are_equal", tags) {
+    const std::vector<field_value> previous{{.name = "Notes", .value = ""}};
+    const std::vector<field_value> current{{.name = "Notes", .value = ""}};
+
+    const auto result = compute(previous, current);
+
+    CHECK(result.entries.empty());
+}
+
+TEST_CASE("compare_duplicate_names_first_occurrence_wins", tags) {
+    const std::vector<field_value> previous{
+        {.name = "Name", .value = "first"},
+        {.name = "Name", .value = "second"}};
+    const std::vector<field_value> current{
+        {.name = "Name", .value = "changed"},
+        {.name = "Name", .value = "ignored"}};
+
+    const auto result = compute(previous, current);
+
+    REQUIRE(result.entries.size() == 1);
+    CHECK(result.entries[0] == diff_entry{.field_name = "Name",
+                                          .old_value = "first",
+                                          .new_value = "changed"});
+}
+

--- a/projects/ores.diff/tests/main.cpp
+++ b/projects/ores.diff/tests/main.cpp
@@ -17,21 +17,13 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include <openssl/crypto.h>
-#include <boost/scope_exit.hpp>
 #include <catch2/catch_session.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
 #include "ores.testing/logging_listener.hpp"
-#include "ores.testing/database_lifecycle_listener.hpp"
 
 CATCH_REGISTER_LISTENER(ores::testing::logging_listener)
-CATCH_REGISTER_LISTENER(ores::testing::database_lifecycle_listener)
 
 int main(int argc, char* argv[]) {
-    BOOST_SCOPE_EXIT(void) {
-        OPENSSL_cleanup();
-    } BOOST_SCOPE_EXIT_END
-
     ores::testing::logging_listener::set_test_module_name("ores.diff.tests");
     return Catch::Session().run(argc, argv);
 }

--- a/projects/ores.diff/tests/main.cpp
+++ b/projects/ores.diff/tests/main.cpp
@@ -1,0 +1,37 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include <openssl/crypto.h>
+#include <boost/scope_exit.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include "ores.testing/logging_listener.hpp"
+#include "ores.testing/database_lifecycle_listener.hpp"
+
+CATCH_REGISTER_LISTENER(ores::testing::logging_listener)
+CATCH_REGISTER_LISTENER(ores::testing::database_lifecycle_listener)
+
+int main(int argc, char* argv[]) {
+    BOOST_SCOPE_EXIT(void) {
+        OPENSSL_cleanup();
+    } BOOST_SCOPE_EXIT_END
+
+    ores::testing::logging_listener::set_test_module_name("ores.diff.tests");
+    return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
## Summary

Phase B1 of the history-dialog consolidation story: creates `ores.diff`, a dependency-light leaf component owning the vocabulary of "what changed" between two versions of an entity. Domain services will use it to compute history diffs server-side; frontends (Qt, shell) render its results without comparison logic of their own.

Scaffolded with codegen (`--profile component`) from a new component overview, then grown into the real model and engine.

## Changes

- **Domain model**: `field_value` (display name, rendered value), `diff_entry` (field, old, new), `diff_result` (ordered entries) — plain aggregates, rfl-serialisable so protocol messages can embed them; equality defaulted for tests and consumers.
- **Engine**: `compute(previous, current)` keyed by field name. Changed fields carry both sides; added fields an empty old value; removed fields an empty new value; unchanged fields yield nothing. Output follows the current list's order with removed fields appended in previous order; first occurrence wins on duplicate names.
- **Deliberately flat**: one ordered list of (name, rendered value) pairs per version. Nested entities flatten in the mapper with topology encoded in path-style display names (e.g. `Legs[1] / Notional`); the engine never interprets names. The structured-topology extension (optional path segments + list-identity mapping) is captured in the backlog for when the first nested consumer (instruments/trades) lands.
- **Dependencies: std + rfl only** — the scaffold template's default links (database, utility, sqlgen, Boost) trimmed to `reflectcpp::reflectcpp` so every domain service and frontend can link the component without cycles.
- **Tests**: fourteen cases, thirty-two assertions — identical inputs, both-empty, changed values, added/removed fields, one-side-empty lists, current-order preservation, removed-fields ordering, empty-value equality, duplicate names, and rfl JSON round-trips. All pass.
- **Docs**: component overview (single source of truth for the codegen scaffold), group PlantUML diagram; `validate_docs.sh` clean for the component; codegen scaffold verifier passes.
- Agile bookkeeping: grow-base task closed as DONE with result (PR #1080); this task clocked on; structured-topology capture filed.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Consolidate history dialogs onto HistoryDialogBase](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.html) | 037B474D-84ED-4888-9054-D58AB1FB10D2 |
| Task | [Create the ores.diff component](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/task_create-ores-diff.html) | 83B7239F-5C29-4C52-900E-C9623C608DFD |
| Capture | [ores.diff: structured topology for nested entities](https://orestudio.github.io/OreStudio/doc/agile/product_backlog/inbox/ores-diff-structured-topology.html) | 7F55F750-4AB5-4F51-A944-B743C83CB54D |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
