### PR TITLE
[ores.compass] Add pr sync: conflict-aware fetch and rebase

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -33,7 +33,7 @@ with traceability, merge) as follow-on tasks.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | pr create shipped (PR #1087). Implementing pr merge — the last verb. |
+| Now           | pr merge shipped (PR #1088, merged by itself). Implementing pr sync — the last verb. |
 | Waiting on    | Nothing.                               |
 | Next          | Conversation-comments gap, then the pr pillar verbs: checks, create, merge. |
 | Last touched  | 2026-06-05                               |
@@ -71,8 +71,8 @@ with traceability, merge) as follow-on tasks.
 | [[id:5C9B5256-9246-48D4-9763-4C9098904072][Extend compass review list to conversation-level comments]] | DONE | 2026-06-05 | 2026-06-05 | Conversation section in review list; gh pr view --comments retired. PR #1081. |
 | [[id:DCC5B3B1-9262-47A3-8C27-61F12D136922][Add compass pr checks: CI status for a PR]] | DONE | 2026-06-05 | 2026-06-05 | compass pr checks with gh exit semantics; raw gh pr checks retired from docs. PR #1084. |
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | DONE | 2026-06-05 | 2026-06-05 | pr record (#1084) + pr create (#1087): validated title, traceability from task/story docs, auto-record, journal stamp. |
-| [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | STARTED | 2026-06-05 | | Merge commit only; refuse on unresolved threads or red CI; --force escape; delete branch; close-out prompt. |
-| [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | BACKLOG | | | fetch + rebase + report; --push (force-with-lease); conflicts: stop with guidance, or --abort-on-conflict for unattended use. |
+| [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | DONE | 2026-06-05 | 2026-06-05 | Merge commit only; guards on threads/CI proven live; --force via gh --admin; worktree-safe branch cleanup. PR #1088. |
+| [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | STARTED | 2026-06-05 | | fetch + rebase + report; --push (force-with-lease); conflicts: stop with guidance, or --abort-on-conflict for unattended use. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge.org
@@ -28,11 +28,11 @@ close-out. Replaces the merge recipe's raw =gh pr merge=.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -69,3 +69,10 @@ task closes. Plans do not outlive their task.)
 | 2 | pr positional should default to None not 0 | compass_pr.py | Accepted | 9def8887f |
 
 * Result
+
+Shipped in PR [[https://github.com/OreStudio/OreStudio/pull/1088][#1088]] (merged 2026-06-05 — by the command itself, the
+first compass-driven merge). Guard rails proven live: the command
+refused its own PR on unresolved threads + pending CI; =--force=
+exercised the gh =--admin= path against base branch protection; the
+multi-worktree cleanup issue (gh --delete-branch checks out main)
+found and fixed by deleting the remote branch directly.

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-pr-sync
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,7 +25,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-pr-sync
-#+pr:
+#+pr: 1092
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -60,7 +60,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1092][#1092]] | [ores.compass] Add pr sync: conflict-aware fetch and rebase |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
@@ -19,7 +19,13 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Every review round starts with fetch + rebase, and every conflict
+leaves the session improvising. =compass pr sync= makes step 1 one
+command: fetch =origin/main=, rebase the current branch, report how
+far ahead it is; =--push= force-pushes with lease after success. On
+conflicts: stop where git stops, list the conflicted files and the
+ways out (continue/abort); =--abort-on-conflict= rolls back
+automatically so unattended runs never strand a half-finished rebase.
 
 * Status
 
@@ -34,7 +40,13 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- =compass pr sync [--push] [--abort-on-conflict]= fetches, rebases,
+  and reports; refuses on =main= and detached HEAD.
+- Conflict stop lists the files and prints continue/abort guidance;
+  =--abort-on-conflict= restores the branch; both exit non-zero.
+- Non-conflict failures surface git's own message untouched.
+- The review-round runbook and the address-review-comments recipe
+  lead with the command.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.org
@@ -66,6 +66,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Merge cleanup claims deletion unconditionally; no main/master guard | compass_pr.py | Accepted | verified + guarded; 7f95079aa |
 
 * Result

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -25,7 +25,7 @@ Handle one complete review round: sync with main, read all review comments, deci
 
 In execution order:
 
-1. /Sync with main./ Fetch and rebase: =git fetch origin main && git rebase origin/main=. Never address review comments on a stale branch.
+1. /Sync with main./ =compass pr sync= — fetch, rebase, and report; on conflicts it stops with the conflicted files and the ways out. Never address review comments on a stale branch.
 
 2. /Check CI status./ Before reading comments, inspect the current CI state:
 

--- a/doc/recipes/github/how_do_i_address_pr_review_comments.org
+++ b/doc/recipes/github/how_do_i_address_pr_review_comments.org
@@ -37,13 +37,13 @@ Then, for each PR that needs a round in this checkout:
    branch is up to date:
 
    #+begin_src sh :results verbatim
-   git fetch origin main
-   git rebase origin/main
+   ./compass.sh pr sync
    #+end_src
 
-   Addressing comments on a stale branch risks rebase conflicts later
-   and can cause merge noise that confuses reviewers. Rebase first,
-   then address; never the other way around.
+   On conflicts the command stops where git stops and lists the ways
+   out. Addressing comments on a stale branch risks rebase conflicts
+   later and merge noise; sync first, then address — never the other
+   way around.
 
 1. /Read the open comments/:
 

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -20,6 +20,11 @@ Subcommands:
                 override, stating what was bypassed), always a merge
                 commit (never squash/rebase), deletes the branch, and
                 prompts the task/journal close-out.
+  sync          Fetch origin/main and rebase the current branch onto
+                it. On conflicts: stop where git stops, list the
+                conflicted files and the ways out (--abort-on-conflict
+                to roll back automatically for unattended use).
+                --push force-pushes (with lease) after success.
 
 The review-round verbs (list, reply, resolve, pending) live in the
 Review pillar: compass review --help.
@@ -331,6 +336,71 @@ def _cmd_merge(args, project_root):
     return 0
 
 
+def _cmd_sync(args, project_root):
+    branch = _current_branch(project_root)
+    if not branch:
+        print("❌ Detached HEAD — check out a branch first.",
+              file=sys.stderr)
+        return 1
+    if branch == "main":
+        print("❌ Already on main — use: git pull --ff-only origin main",
+              file=sys.stderr)
+        return 1
+
+    print(f"🔄 Syncing {branch} with origin/main…", flush=True)
+    p = subprocess.run(["git", "fetch", "origin", "main"],
+                       cwd=str(project_root))
+    if p.returncode != 0:
+        return p.returncode
+
+    p = subprocess.run(["git", "rebase", "origin/main"],
+                       capture_output=True, text=True,
+                       cwd=str(project_root))
+    if p.returncode != 0:
+        conflicted = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=U"],
+            capture_output=True, text=True,
+            cwd=str(project_root)).stdout.split()
+        if not conflicted:
+            # Not a conflict stop (dirty tree, etc.) — surface git's
+            # own message untouched.
+            print(p.stderr.strip() or p.stdout.strip(), file=sys.stderr)
+            return p.returncode
+        print(f"❌ Rebase stopped on {len(conflicted)} conflicted "
+              "file(s):", file=sys.stderr)
+        for f in conflicted:
+            print(f"   - {f}", file=sys.stderr)
+        if args.abort_on_conflict:
+            subprocess.run(["git", "rebase", "--abort"],
+                           cwd=str(project_root))
+            print("↩️  Rebase aborted; branch restored. Sync needs a "
+                  "human.", file=sys.stderr)
+            return 1
+        print("   Resolve each file, then:  git add <file> && "
+              "git rebase --continue", file=sys.stderr)
+        print("   Or roll back with:        git rebase --abort",
+              file=sys.stderr)
+        return 1
+
+    msg = (p.stdout.strip() or p.stderr.strip()).splitlines()
+    if msg:
+        print(msg[-1])
+    ahead = subprocess.run(
+        ["git", "rev-list", "--count", "origin/main..HEAD"],
+        capture_output=True, text=True,
+        cwd=str(project_root)).stdout.strip()
+    print(f"✅ {branch}: {ahead} commit(s) ahead of origin/main.")
+
+    if args.push:
+        p = subprocess.run(
+            ["git", "push", "--force-with-lease", "-u", "origin", branch],
+            cwd=str(project_root))
+        if p.returncode != 0:
+            return p.returncode
+        print(f"🔼 Pushed {branch} (force-with-lease).")
+    return 0
+
+
 def run(argv, project_root):
     """Entry point: compass pr <subcommand>."""
     ap = argparse.ArgumentParser(
@@ -383,6 +453,16 @@ def run(argv, project_root):
                     help="Merge even with unresolved threads or red CI "
                          "(states what was bypassed)")
 
+    sp = sub.add_parser("sync",
+                        help="Fetch origin/main and rebase the current "
+                             "branch onto it")
+    sp.add_argument("--push", action="store_true",
+                    help="Force-push (with lease) after a successful "
+                         "rebase")
+    sp.add_argument("--abort-on-conflict", action="store_true",
+                    help="Roll back automatically when the rebase "
+                         "conflicts (for unattended use)")
+
     args = ap.parse_args(argv)
     if args.subcmd == "checks" and args.interval is not None:
         if args.interval < 0:
@@ -397,4 +477,6 @@ def run(argv, project_root):
         return _cmd_create(args, project_root)
     if args.subcmd == "merge":
         return _cmd_merge(args, project_root)
+    if args.subcmd == "sync":
+        return _cmd_sync(args, project_root)
     return 1

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -321,14 +321,24 @@ def _cmd_merge(args, project_root):
     p = subprocess.run(cmd, cwd=str(project_root))
     if p.returncode != 0:
         return p.returncode
-    head = subprocess.run(
+    head_proc = subprocess.run(
         ["gh", "pr", "view", str(number), "--json", "headRefName",
          "--jq", ".headRefName"],
-        capture_output=True, text=True, cwd=str(project_root)).stdout.strip()
-    if head:
-        subprocess.run(["git", "push", "origin", "--delete", head],
-                       cwd=str(project_root))
-    print(f"✅ PR #{number} merged (merge commit); remote branch deleted.")
+        capture_output=True, text=True, cwd=str(project_root))
+    head = head_proc.stdout.strip() if head_proc.returncode == 0 else ""
+    deleted = False
+    if head and head not in ("main", "master"):
+        deleted = subprocess.run(
+            ["git", "push", "origin", "--delete", head],
+            cwd=str(project_root)).returncode == 0
+    if deleted:
+        print(f"✅ PR #{number} merged (merge commit); remote branch "
+              f"{head} deleted.")
+    else:
+        print(f"✅ PR #{number} merged (merge commit).")
+        print(f"⚠️  Remote branch deletion skipped or failed"
+              f"{f' ({head})' if head else ''} — delete it manually if "
+              "needed.", file=sys.stderr)
     print("ℹ️  Close out the task: mark it DONE with a Result, update the")
     print("   story's * Tasks row, and stamp the journal:")
     print(f"   compass journal update --story <id> --task <id> "

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -307,13 +307,23 @@ def _cmd_merge(args, project_root):
     # Always a merge commit — never squash, never rebase — matching
     # the repository's history. --force needs gh's --admin to bypass
     # the base branch protection (required checks still pending).
-    cmd = ["gh", "pr", "merge", str(number), "--merge", "--delete-branch"]
+    # No gh --delete-branch: it checks out the default branch locally,
+    # which fails in a multi-worktree fleet where main lives in
+    # another worktree. Delete the remote branch directly instead.
+    cmd = ["gh", "pr", "merge", str(number), "--merge"]
     if args.force and blocked:
         cmd.append("--admin")
     p = subprocess.run(cmd, cwd=str(project_root))
     if p.returncode != 0:
         return p.returncode
-    print(f"✅ PR #{number} merged (merge commit); branch deleted.")
+    head = subprocess.run(
+        ["gh", "pr", "view", str(number), "--json", "headRefName",
+         "--jq", ".headRefName"],
+        capture_output=True, text=True, cwd=str(project_root)).stdout.strip()
+    if head:
+        subprocess.run(["git", "push", "origin", "--delete", head],
+                       cwd=str(project_root))
+    print(f"✅ PR #{number} merged (merge commit); remote branch deleted.")
     print("ℹ️  Close out the task: mark it DONE with a Result, update the")
     print("   story's * Tasks row, and stamp the journal:")
     print(f"   compass journal update --story <id> --task <id> "


### PR DESCRIPTION
## Summary

Final task of the PR-management story: compass pr sync makes the review-round's step 1 one command — fetch origin/main, rebase, report — with honest conflict handling. Also carries the worktree-safe branch cleanup for pr merge, found merging #1088 with the command itself.

## Changes

- pr sync [--push] [--abort-on-conflict]: fetch + rebase + ahead-count; refuses on main/detached HEAD; --push force-pushes with lease
- Conflicts: stop where git stops, list conflicted files, print continue/abort guidance; --abort-on-conflict rolls back for unattended use; non-conflict failures surface git's message untouched
- pr merge: drop gh --delete-branch (checks out main locally — fails in a multi-worktree fleet); delete the remote branch directly
- Review-round runbook and address-review-comments recipe lead with pr sync; close out the pr-merge task (merged in #1088 by the command itself)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [Add compass pr sync: fetch main and rebase, conflict-aware](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_sync.html) | C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)