### PR TITLE
[ores.compass,ores.codegen] Auto-wire agile tables; pr merge journal

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -31,9 +31,9 @@ with traceability, merge) as follow-on tasks.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Nothing.                               |
+| Now           | Follow-up: pr merge journal stamping.   |
 | Waiting on    | Nothing.                               |
 | Next          | Nothing.                               |
 | Last touched  | 2026-06-05                               |
@@ -73,6 +73,7 @@ with traceability, merge) as follow-on tasks.
 | [[id:B2E4E99C-48F3-4D12-BFC5-34AB0C7960B5][Add compass pr create with conventions built in]] | DONE | 2026-06-05 | 2026-06-05 | pr record (#1084) + pr create (#1087): validated title, traceability from task/story docs, auto-record, journal stamp. |
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | DONE | 2026-06-05 | 2026-06-05 | Merge commit only; guards on threads/CI proven live; --force via gh --admin; worktree-safe branch cleanup. PR #1088. |
 | [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | DONE | 2026-06-05 | 2026-06-05 | fetch + rebase + report; --push; conflict stop-with-guidance / --abort-on-conflict. PR #1092. |
+| [[id:7C440877-9523-4BB9-A5F6-2CA6B7376650][pr merge: stamp the journal automatically]] | STARTED | 2026-06-05 | | Map merged head branch to task doc, derive UUIDs, journal update --state DONE; prompt keeps only judgement work. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_compass_pr_merge_journal.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 7C440877-9523-4BB9-A5F6-2CA6B7376650
+:END:
+#+title: Task: pr merge: stamp the journal automatically
+#+description: pr merge printed a fill-in-the-blanks journal update prompt although it can resolve everything itself: map the merged head branch to its task doc, derive the task and story UUIDs, and run journal update --state DONE. The close-out prompt shrinks to the judgement work (Result text, story row).
+#+type: task
+#+level: s1
+#+filetags: :compass_pr_management:sprint_19:v0:
+#+owner: marco
+#+branch: feature/compass-pr-merge-journal
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=pr merge= printed a fill-in-the-blanks =journal update= prompt even
+though it can resolve everything itself: map the merged head branch
+to its task doc, derive the task and story UUIDs, and stamp the
+journal with =--state DONE=. The prompt keeps only the judgement work
+(Result text, story row).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- After a successful merge the journal carries a DONE entry for the
+  merged branch's story/task with no manual steps.
+- When no task doc matches the head branch, the manual hint remains.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -127,6 +127,7 @@ migrate; the single service registry's home (=projects/services.json=).
 | [[id:BAEB661D-2AB4-4796-B415-43B49BDCD3A6][Migrate db and nats setup into the Provision pillar]] | BACKLOG | | | compass db / compass nats verbs; delete scripts, update callers. |
 | [[id:333104A0-FFFE-4C20-9390-FA2ED732C2D5][Migrate the Operate pillar (services, client, logs)]] | BACKLOG | | | compass services {start,stop,status,clear-logs} + --delete-logs, compass client. |
 | [[id:D38238C9-702F-47AC-BE64-91D84A8EE716][Migrate the Build pillar (build, site)]] | DONE | 2026-06-05 | 2026-06-05 | compass build (preset from .env; site/manual aliases) landed; compass site serve outstanding. |
+| [[id:4905428A-B631-4E67-9C93-5BF78023C840][Auto-wire agile tables: add task, task start, task done]] | STARTED | 2026-06-05 | | add task wires the BACKLOG row; task start/done flip row + dates; codegen takes --goal/--acceptance. |
 | [[id:32DB538C-E2A6-493C-8CBA-6C73A7A10EC4][Add the Generate pillar (delegating gen verbs)]] | BACKLOG | | | compass gen verbs delegating to ores.codegen (keeps its own CLI). |
 | [[id:E65F42A6-0762-4F75-866F-25A428B3973F][Surface branch staleness vs main in compass Orient]] | STARTED | 2026-06-02 | | Compact ↑ahead/↓behind-origin/main indicator (no fetch) on where/status/fleet, escalating to a warning when too stale. |
 | [[id:81DE1DC9-FB73-46DB-A8AB-E4BE8F78C591][Port sprint_metrics.py to compass sprint charts]] | DONE | | 2026-06-05 | compass sprint charts; auto-detects current sprint; deletes standalone script; updates recipes. |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
@@ -68,6 +68,8 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | task done duplicated state regex; reuse _set_doc_state | compass.py | Accepted | abe242789 |
+| 2 | task-id row match should be case-insensitive | compass.py | Accepted | abe242789 |
+| 3 | story file read twice in all-done check | compass.py | Accepted | abe242789 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
@@ -8,7 +8,7 @@
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-pr-merge-journal
-#+pr:
+#+pr: 1095
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -62,7 +62,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1095][#1095]] | [ores.compass,ores.codegen] Auto-wire agile tables; pr merge journal |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: 4905428A-B631-4E67-9C93-5BF78023C840
+:END:
+#+title: Task: Auto-wire agile tables: add task, task start, task done
+#+description: Make table wiring a compass side-effect: add task inserts the BACKLOG row into the story's Tasks table; task start flips the row to STARTED with start date and reopens the story; new task done flips task and row to DONE with end date and stamps the journal. Only prose (Goal, Result, Now) stays manual.
+#+type: task
+#+level: s1
+#+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
+#+owner: marco
+#+branch: feature/compass-pr-merge-journal
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Every scaffold was followed by the same hand-written table edits.
+Make them compass side-effects: =add task= wires the BACKLOG row into
+the story's =* Tasks= table; =task start= flips the row to STARTED
+with a start date and (re)opens the story; new =task done= flips task
+and row to DONE with end date and stamps the journal. Codegen
+templates take =--goal= and =--acceptance= so docs are born with
+content instead of boilerplate. Only prose stays manual.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- =compass add task= inserts the BACKLOG row (placeholder row
+  replaced when present); =--goal=/=--acceptance= render into the
+  doc.
+- =compass task start= sets the story row to STARTED + start date and
+  the story state to STARTED (reopening DONE stories).
+- =compass task done= sets task and story row to DONE + end date,
+  clears Now/Next, stamps the journal, and reminds about =* Result=.
+- Story scaffolds keep the wiring hint (sprint epic choice is
+  judgement).
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/llm/memory/compass_basic_commands.org
+++ b/doc/llm/memory/compass_basic_commands.org
@@ -2,7 +2,7 @@
 :ID: 28F78E07-834D-4755-BB03-89BD7C17B01E
 :END:
 #+title: Compass basic command syntax
-#+description: Syntax reference for the most-used compass commands: search, show, list, add, where, story new, task new.
+#+description: Syntax reference for the most-used compass commands: search, show, list, add, where, story/task lifecycle, review, pr.
 #+type: memory
 #+memory_subtype: reference
 #+level: cross
@@ -33,6 +33,13 @@ Core commands:
 
 - *Task new* (add a task+branch to an existing story):
   =compass.sh task new --story <id-or-slug> --slug my_task --title "Title"=
+- Task lifecycle (tables and journal are side-effects):
+  =compass.sh add task --slug s --parent-dir <story-dir> --title T --description D --goal "..." --acceptance "..."=
+  =compass.sh task start <slug> [--branch b]=  /  =compass.sh task done <slug> [--pr N]=
+- PR lifecycle:
+  =compass.sh pr sync [--push]= / =pr checks [--watch]= / =pr create --title "[c] D" --summary S --change C= / =pr merge [--force]=
+- Review round:
+  =compass.sh review pending [--since 24h]= / =review list <pr> [--detail]= / =review reply <pr> <id> "msg"= / =review resolve <pr>=
 
 - *Add* (scaffold a new artefact — always requires =--slug=, =--title=,
   =--description=, =--tags=; types =memory= and =runbook= also require

--- a/doc/llm/memory/scaffold_tasks_with_content.org
+++ b/doc/llm/memory/scaffold_tasks_with_content.org
@@ -1,0 +1,33 @@
+:PROPERTIES:
+:ID: 6071F761-FE8E-4F06-8FE7-58377A41C294
+:END:
+#+title: Scaffold tasks with content; let compass wire the tables
+#+description: Pass --goal and --acceptance to compass add task/story so docs are born with content; never edit boilerplate afterwards. Table wiring and state flips are compass side-effects: add task wires the row, task start/done flip states and dates, pr create/merge record and journal.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:compass:agile:bearings:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+Scaffold agile docs with their content: pass =--goal "..."= and repeatable
+=--acceptance "..."= to =compass add task= / =compass add story= so the doc
+is born complete — never scaffold boilerplate and edit it afterwards. All
+table wiring and state flips are compass side-effects: =add task= inserts
+the story's =* Tasks= row; =task start= flips it to STARTED with a date and
+(re)opens the story; =task done= flips task and row to DONE, clears
+Now/Next, and stamps the journal; =pr create= / =pr merge= record the PR
+and journal automatically. Only prose (Result text, story Now, sprint epic
+choice) is edited by hand.
+
+*Why:* Sessions kept following every scaffold with ad-hoc python to write
+the same table rows and state flips, and templates were generated with
+placeholder text that was immediately replaced. The user corrected this
+twice on 2026-06-05 ("why is that python code not part of compass";
+"supply the arguments to mustache rather than generate boilerplate").
+
+*How to apply:* Whenever creating or transitioning agile artefacts: use the
+flags and the lifecycle verbs (=add task --goal --acceptance=, =task
+start=, =task done=, =pr create=, =pr merge=) and never hand-edit task/
+story/sprint tables, state rows, or dates. If a transition has no compass
+verb yet, that is a gap: file a capture rather than scripting around it.

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -44,7 +44,7 @@ In execution order:
 
    This fetches =main=, creates =feature/my-feature=, and writes =story.org= + a linked task into the current sprint. To add a task to an /existing/ story instead, use =compass task new --story <id>=.
 
-2a. /Read all generated files before writing anything./ Immediately after scaffold, read every file compass created and note the =:ID:= property of each. Do this before writing any content to =story.org= or the task file. Failure to read first causes placeholder UUIDs to be written and then silently corrected — an error-prone pattern that breaks org-roam links.
+2a. /Prefer content at scaffold time./ Pass =--goal= and =--acceptance= so the docs are born complete. When editing afterwards anyway, read every generated file first and use the real =:ID:= values — never placeholder UUIDs.
 
 3. /Clock on./ Run =compass task start= with the first task's slug to switch
    branch, mark the task STARTED, and stamp the session journal:
@@ -57,9 +57,9 @@ In execution order:
    records the story, task, branch, and state so =compass where= and
    =compass fleet= show context after a restart.
 
-4. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use the actual UUIDs from step 2a for any =[[id:UUID]]= references to compass-generated tasks. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
+4. /Complete the prose./ Whatever was not supplied at scaffold time: =* Out of scope=, extra =* Tasks= rows beyond the scaffolded one (each =compass add task= wires its own row), and any =[[id:UUID]]= cross-references.
 
-5. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
+5. /Mark the story STARTED./ =compass task start= (step 3) already set the story state and table row; fill the prose =Now= / =Next= fields by hand.
 
 6. /Wire into the sprint./ Add a row to the parent sprint's =* Stories= table. Each row: =| [[id:UUID][Title]] | STARTED | date | | Theme |=.
 

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -45,7 +45,7 @@ In execution order:
    This covers all three cases: new task on an existing story, resuming a
    BACKLOG task, and restarting an already-STARTED task after a session reset.
    Read =task_<slug>.org= after clocking on: understand the =* Goal=,
-   =* Acceptance= criteria, and =* Notes=. Set =#+owner:= and =#+pr:= once known.
+   =* Acceptance= criteria, and =* Notes=. (=pr create= sets =#+pr:= later.)
 
 2. /Sync with main./ =compass pr sync= — fetch, rebase, report; on
    conflicts it stops with the conflicted files and the ways out.
@@ -68,7 +68,9 @@ In execution order:
 
    Repeat step 7 for each review round until the PR is approved.
 
-8. /Merge./ When the PR is approved, =compass pr merge= — the guards refuse while threads are unresolved or CI is not green. See [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
+8. /Merge./ When the PR is approved, =compass pr merge= — the guards refuse while threads are unresolved or CI is not green; the journal is stamped automatically. See [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
+
+9. /Close out./ =compass task done <slug>= — task and story row flip to DONE with end date. Write the task's =* Result= by hand and commit.
 
    After merge, update the task: state → =DONE=, fill =* Result=, distill any =* Plan= into the parent story's =* Decisions=.
 

--- a/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
+++ b/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :compass:workflow:agile:recipe:bearings:
 #+created: 2026-05-25
-#+updated: 2026-06-01
+#+updated: 2026-06-05
 
 The /Scaffold/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]] — composing =git= and the
 low-level =add= primitive into a one-step "start a unit of work" ritual.
@@ -85,3 +85,20 @@ created, =#+branch= set, journal updated), then cleaned up.
 - [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — the low-level =add= primitive.
 - [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][How do I see what every worktree is doing?]] — =fleet=, the companion view.
 - [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] — =.journal.org= auto-updated on task pickup.
+
+* Content and lifecycle (2026-06-05)
+
+Scaffold with content — pass =--goal "..."= and repeatable
+=--acceptance "..."= so the doc is born complete instead of with
+placeholder text. Wiring and state flips are compass side-effects:
+
+#+begin_src sh :results verbatim
+./compass.sh add task --slug s --parent-dir <story-dir> \
+  --title "T" --description "D" --goal "..." --acceptance "..." \
+  --acceptance "..."     # wires the story's * Tasks row (BACKLOG)
+./compass.sh task start <slug> [--branch b]   # row STARTED + date; story (re)opened
+./compass.sh task done <slug> [--pr N]        # row + task DONE + date; journal stamped
+#+end_src
+
+Only prose stays manual: the task's =* Result=, the story's =Now=, and
+the sprint epic choice when wiring a new story.

--- a/projects/ores.codegen/library/templates/doc_story.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_story.org.mustache
@@ -21,7 +21,7 @@ Continued from: [[id:{{predecessor_id}}][{{predecessor_title}}]].
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+{{goal}}
 
 * Status
 
@@ -36,7 +36,12 @@ Continued from: [[id:{{predecessor_id}}][{{predecessor_title}}]].
 
 * Acceptance
 
+{{#acceptance}}
+- {{.}}
+{{/acceptance}}
+{{^has_acceptance}}
 -
+{{/has_acceptance}}
 
 * Tasks
 

--- a/projects/ores.codegen/library/templates/doc_task.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_task.org.mustache
@@ -19,7 +19,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+{{goal}}
 
 * Status
 
@@ -34,7 +34,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
+{{#acceptance}}
+- {{.}}
+{{/acceptance}}
+{{^has_acceptance}}
 -
+{{/has_acceptance}}
 
 * Plan
 

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -266,6 +266,12 @@ def parse_args(argv=None):
     parser.add_argument("--source-methodology", default="",
                         help="For --type dataset_overview: brief description of "
                              "where the data came from.")
+    parser.add_argument("--goal", default="",
+                        help="Goal prose for task/story docs; defaults to "
+                             "the fill-in placeholder.")
+    parser.add_argument("--acceptance", action="append", default=[],
+                        help="An acceptance bullet for task/story docs "
+                             "(repeatable).")
     parser.add_argument("--brief", default="",
                         help="For --type component: one-line tagline that "
                              "codegen reads from the overview's #+brief: "
@@ -416,8 +422,17 @@ def main(argv=None):
         dataset_type = ""
         source_methodology = ""
 
+    goal_default = {
+        "task": "(Describe what user-visible-or-internal change this "
+                "task produces.)",
+        "story": "(Describe the user-visible outcome this story "
+                 "delivers.)",
+    }.get(args.type, "")
     variables = {
         "id": new_id,
+        "goal": args.goal or goal_default,
+        "acceptance": args.acceptance,
+        "has_acceptance": bool(args.acceptance),
         "slug": args.slug,
         "title": args.title,
         "description": args.description,

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2224,8 +2224,7 @@ def _update_task_row_in_story(story_path, task_id, state,
     lines = text.splitlines()
     today = datetime.date.today().isoformat()
     for i, line in enumerate(lines):
-        if f"[[id:{task_id}]" not in line and \
-                f"[[id:{task_id.lower()}]" not in line:
+        if f"[[id:{task_id.lower()}]" not in line.lower():
             continue
         cells = line.split("|")
         if len(cells) < 6:
@@ -2552,11 +2551,7 @@ def _cmd_task_done(task_ident, pr=""):
     task_path = Path(PROJECT_ROOT) / cands[0].rel_path
     task_uuid = _read_org_id(task_path)
 
-    text = task_path.read_text(encoding="utf-8")
-    new_text, n = re.subn(r'(\| State\s+\|)\s*\w+', r'\1 DONE',
-                          text, count=1)
-    if n:
-        task_path.write_text(new_text, encoding="utf-8")
+    _set_doc_state(task_path, "DONE")
     _set_status_field(task_path, "Now", "Nothing.")
     _set_status_field(task_path, "Next", "Nothing.")
     print(f"📝 task state → DONE ({task_path.name})")
@@ -2568,11 +2563,10 @@ def _cmd_task_done(task_ident, pr=""):
                                      set_end=True):
             print("🔗 story * Tasks row → DONE")
         # When no row remains in another state, suggest closing the story.
-        first, last = _table_bounds(
-            story_path.read_text(encoding="utf-8").splitlines(), "* Tasks")
+        story_lines = story_path.read_text(encoding="utf-8").splitlines()
+        first, last = _table_bounds(story_lines, "* Tasks")
         if first is not None:
-            rows = story_path.read_text(
-                encoding="utf-8").splitlines()[first:last + 1]
+            rows = story_lines[first:last + 1]
             states = [r.split("|")[2].strip() for r in rows
                       if "[[id:" in r and len(r.split("|")) > 2]
             if states and all(s == "DONE" for s in states):

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2033,13 +2033,15 @@ def cmd_add(argv):
     except SystemExit as exc:
         rc = exc.code
     if rc in (None, 0):
-        hint = _add_wire_hint(doc_type, rest)
-        if hint:
-            print(hint, file=sys.stderr)
-        else:
-            print("ℹ️  Remember to wire the new artefact into its parent "
-                  "(e.g. the sprint's * Stories table) where needed.",
-                  file=sys.stderr)
+        wired = _add_wire_task(rest) if doc_type == "task" else False
+        if not wired:
+            hint = _add_wire_hint(doc_type, rest)
+            if hint:
+                print(hint, file=sys.stderr)
+            elif doc_type != "task":
+                print("ℹ️  Remember to wire the new artefact into its "
+                      "parent (e.g. the sprint's * Stories table) where "
+                      "needed.", file=sys.stderr)
         if doc_type == "skill":
             print("⚠️  Rebuild the skills bundle after filling in the skill body:",
                   file=sys.stderr)
@@ -2084,6 +2086,32 @@ def _set_frontmatter_branch(path, branch):
         Path(path).write_text(new, encoding="utf-8")
 
 _ORG_ID_RE = re.compile(r"^[ \t]*:ID:\s+(\S+)\s*$", re.MULTILINE)
+
+def _add_wire_task(rest):
+    """Wire a freshly added task into its story's * Tasks table."""
+    def _opt(name):
+        for i, a in enumerate(rest):
+            if a == name and i + 1 < len(rest):
+                return rest[i + 1]
+            if a.startswith(name + "="):
+                return a.split("=", 1)[1]
+        return None
+
+    parent_dir, slug = _opt("--parent-dir"), _opt("--slug")
+    if not parent_dir or not slug:
+        return False
+    task_path = Path(PROJECT_ROOT) / parent_dir / f"task_{slug}.org"
+    story_path = Path(PROJECT_ROOT) / parent_dir / "story.org"
+    task_id = _read_org_id(task_path)
+    if not task_id or not story_path.exists():
+        return False
+    title = _org_doc_title(task_path, "Task")
+    description = _read_frontmatter_field(task_path, "description")
+    if _wire_task_into_story(story_path, task_id, title, description):
+        print(f"🔗 Wired into {story_path.relative_to(PROJECT_ROOT)} "
+              f"(* Tasks, BACKLOG).")
+    return True
+
 
 def _add_wire_hint(doc_type, rest):
     """Concrete wiring instruction for a freshly added task or story.
@@ -2133,6 +2161,106 @@ def _read_org_id(path):
         return m.group(1) if m else None
     except (OSError, UnicodeDecodeError):
         return None
+
+
+# --- Agile-table wiring: parent tables are compass side-effects ---
+
+def _org_doc_title(path, kind):
+    """#+title: value with the 'Task: '/'Story: ' prefix stripped."""
+    title = _read_frontmatter_field(Path(path), "title")
+    return re.sub(rf"(?i)^{kind}:\s*", "", title)
+
+
+def _table_bounds(lines, heading):
+    """Return (first, last) line indexes of the table under HEADING."""
+    try:
+        h = next(i for i, l in enumerate(lines)
+                 if l.strip().startswith(heading))
+    except StopIteration:
+        return None, None
+    first = None
+    for i in range(h + 1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("|"):
+            first = i
+            break
+        if stripped.startswith("* "):  # next heading, no table
+            return None, None
+    if first is None:
+        return None, None
+    last = first
+    while last + 1 < len(lines) and lines[last + 1].strip().startswith("|"):
+        last += 1
+    return first, last
+
+
+def _wire_task_into_story(story_path, task_id, title, description):
+    """Append the task's BACKLOG row to the story's * Tasks table."""
+    text = story_path.read_text(encoding="utf-8")
+    if task_id.upper() in text.upper():
+        return False  # already wired
+    lines = text.splitlines()
+    first, last = _table_bounds(lines, "* Tasks")
+    if first is None:
+        return False
+    row = f"| [[id:{task_id}][{title}]] | BACKLOG | | | {description} |"
+    # Replace an all-empty placeholder row when present, else append.
+    cells = [c.strip() for c in lines[last].split("|")]
+    if not any(cells):
+        lines[last] = row
+    else:
+        lines.insert(last + 1, row)
+    story_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True
+
+
+def _update_task_row_in_story(story_path, task_id, state,
+                              set_start=False, set_end=False):
+    """Set the state/start/end cells of the task's row in * Tasks."""
+    try:
+        text = story_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    lines = text.splitlines()
+    today = datetime.date.today().isoformat()
+    for i, line in enumerate(lines):
+        if f"[[id:{task_id}]" not in line and \
+                f"[[id:{task_id.lower()}]" not in line:
+            continue
+        cells = line.split("|")
+        if len(cells) < 6:
+            return False
+        cells[2] = f" {state} "
+        if set_start and not cells[3].strip():
+            cells[3] = f" {today} "
+        if set_end:
+            cells[4] = f" {today} "
+        lines[i] = "|".join(cells)
+        story_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return True
+    return False
+
+
+def _set_doc_state(path, state):
+    """Set the Status table's State row in a story or task doc."""
+    text = path.read_text(encoding="utf-8")
+    new_text, n = re.subn(r"^(\|\s*State\s*\|)\s*\S+(.*\|)\s*$",
+                          rf"\1 {state}\2", text, count=1, flags=re.M)
+    if n and new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+        return True
+    return False
+
+
+def _set_status_field(path, field, value):
+    """Set a prose Status row (Now/Next) in a story or task doc."""
+    text = path.read_text(encoding="utf-8")
+    new_text, n = re.subn(rf"^(\|\s*{field}\s*\|).*\|\s*$",
+                          rf"\1 {value} |", text, count=1, flags=re.M)
+    if n and new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+        return True
+    return False
 
 def resolve_story(ident):
     """Resolve a story identifier to (story_dir, title), or (None, None).
@@ -2380,9 +2508,18 @@ def _cmd_task_start(task_ident, branch_arg=""):
         task_path.write_text(new_text, encoding="utf-8")
         print(f"📝 state: BACKLOG → STARTED")
 
+    # Mirror into the story: task row STARTED with start date, and the
+    # story itself STARTED (reopens a DONE story for follow-up work).
+    task_uuid = _read_org_id(task_path)
+    if story_path.exists() and task_uuid:
+        if _update_task_row_in_story(story_path, task_uuid, "STARTED",
+                                     set_start=True):
+            print(f"🔗 story * Tasks row → STARTED")
+        if _set_doc_state(story_path, "STARTED"):
+            print(f"🔗 story state → STARTED")
+
     # Stamp the journal.
     try:
-        task_uuid = _read_org_id(task_path)
         if story_uuid and task_uuid:
             _journal_update(argparse.Namespace(
                 story=story_uuid, task=task_uuid, branch=branch,
@@ -2390,6 +2527,68 @@ def _cmd_task_start(task_ident, branch_arg=""):
     except Exception as e:
         print(f"⚠️  journal update failed: {e}", file=sys.stderr)
 
+    return 0
+
+
+def _cmd_task_done(task_ident, pr=""):
+    """compass task done <slug-or-uuid> [--pr N] — close a task out.
+
+    Task doc: State → DONE, Now/Next → Nothing. Story: task row →
+    DONE with end date; when every row is DONE, suggest closing the
+    story. Journal stamped with DONE. The * Result prose stays with
+    the session.
+    """
+    docs = doc_index.load_all()
+    il = task_ident.lower()
+    tasks = [d for d in docs.values() if d.doctype == "task"]
+    cands = [d for d in tasks
+             if (d.id and (d.id.lower() == il
+                           or d.id.lower().startswith(il)))
+             or Path(d.rel_path).stem.lower() in (f"task_{il}", il)]
+    if len(cands) != 1:
+        print(f"❌ {'No' if not cands else 'Ambiguous'} task "
+              f"matching '{task_ident}'.", file=sys.stderr)
+        return 1
+    task_path = Path(PROJECT_ROOT) / cands[0].rel_path
+    task_uuid = _read_org_id(task_path)
+
+    text = task_path.read_text(encoding="utf-8")
+    new_text, n = re.subn(r'(\| State\s+\|)\s*\w+', r'\1 DONE',
+                          text, count=1)
+    if n:
+        task_path.write_text(new_text, encoding="utf-8")
+    _set_status_field(task_path, "Now", "Nothing.")
+    _set_status_field(task_path, "Next", "Nothing.")
+    print(f"📝 task state → DONE ({task_path.name})")
+
+    story_path = task_path.parent / "story.org"
+    story_uuid = _read_org_id(story_path) if story_path.exists() else None
+    if story_uuid and task_uuid:
+        if _update_task_row_in_story(story_path, task_uuid, "DONE",
+                                     set_end=True):
+            print("🔗 story * Tasks row → DONE")
+        # When no row remains in another state, suggest closing the story.
+        first, last = _table_bounds(
+            story_path.read_text(encoding="utf-8").splitlines(), "* Tasks")
+        if first is not None:
+            rows = story_path.read_text(
+                encoding="utf-8").splitlines()[first:last + 1]
+            states = [r.split("|")[2].strip() for r in rows
+                      if "[[id:" in r and len(r.split("|")) > 2]
+            if states and all(s == "DONE" for s in states):
+                print("ℹ️  All story tasks are DONE — consider closing "
+                      "the story (State, Now, Next) and its sprint row.")
+
+    pr_value = pr or _read_frontmatter_field(task_path, "pr") or "none"
+    branch = _read_frontmatter_field(task_path, "branch") or "(none)"
+    try:
+        if story_uuid and task_uuid:
+            _journal_update(argparse.Namespace(
+                story=story_uuid, task=task_uuid, branch=branch,
+                state="DONE", pr=str(pr_value)))
+    except Exception as e:
+        print(f"⚠️  journal update failed: {e}", file=sys.stderr)
+    print("ℹ️  Write the task's * Result before committing.")
     return 0
 
 
@@ -2443,6 +2642,13 @@ def cmd_task(argv):
                               "has no branch set yet (creates the branch off "
                               "origin/main when it does not already exist)")
 
+    done_p = sub.add_parser(
+        "done",
+        help="Close a task: DONE in task and story tables, journal stamped")
+    done_p.add_argument("task", help="Task slug or UUID/prefix")
+    done_p.add_argument("--pr", default="",
+                        help="PR number for the journal (default: #+pr:)")
+
     args = ap.parse_args(argv)
 
     if args.subcmd == "new":
@@ -2465,6 +2671,9 @@ def cmd_task(argv):
 
     if args.subcmd == "start":
         return _cmd_task_start(args.task, getattr(args, "branch", ""))
+
+    if args.subcmd == "done":
+        return _cmd_task_done(args.task, getattr(args, "pr", ""))
 
 def cmd_env(argv):
     """compass env — Provision pillar: environment setup."""

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -353,10 +353,35 @@ def _cmd_merge(args, project_root):
         print(f"⚠️  Remote branch deletion skipped or failed"
               f"{f' ({head})' if head else ''} — delete it manually if "
               "needed.", file=sys.stderr)
-    print("ℹ️  Close out the task: mark it DONE with a Result, update the")
-    print("   story's * Tasks row, and stamp the journal:")
-    print(f"   compass journal update --story <id> --task <id> "
-          f"--branch <branch> --state DONE --pr {number}")
+    # Stamp the journal automatically when the merged branch maps to a
+    # task doc; the doc edits (Result, story row) need judgement and
+    # stay with the session.
+    journalled = False
+    if head:
+        task_path, task_text = _find_task_doc(project_root, head, "")
+        if task_path is not None:
+            task_id = _org_id(task_text)
+            story_path = task_path.parent / "story.org"
+            try:
+                story_id = _org_id(
+                    story_path.read_text(encoding="utf-8"))
+            except OSError:
+                story_id = ""
+            if task_id and story_id:
+                compass = (Path(project_root) / "projects"
+                           / "ores.compass" / "compass.sh")
+                subprocess.run(
+                    [str(compass), "journal", "update",
+                     "--story", story_id, "--task", task_id,
+                     "--branch", head, "--state", "DONE",
+                     "--pr", str(number)], cwd=str(project_root))
+                journalled = True
+    print("ℹ️  Close out the task: mark it DONE with a Result and update "
+          "the story's * Tasks row.")
+    if not journalled:
+        print(f"   Also stamp the journal: compass journal update "
+              f"--story <id> --task <id> --branch <branch> "
+              f"--state DONE --pr {number}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Two scaffolding frictions removed: every compass scaffold was followed by the same hand-written table edits, and pr merge printed a fill-in-the-blanks journal prompt it could resolve itself. Table wiring, state flips, and journal stamps are now compass side-effects; codegen templates accept content as arguments. Only prose (Goal, Result, Now) stays manual.

## Changes

- add task wires the BACKLOG row into the story's Tasks table (placeholder row replaced)
- task start flips the story row to STARTED with start date and (re)opens the story
- New task done: task + story row to DONE with end date, Now/Next cleared, journal stamped, Result reminder
- Codegen task/story templates take --goal and --acceptance (repeatable) — docs born with content, not boilerplate
- pr merge stamps the journal automatically (branch -> task doc -> UUIDs); prompt keeps only judgement work
- Smoke-tested the full lifecycle: add (BACKLOG row) -> start (STARTED+date) -> done (DONE+date)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Consolidate standalone scripts into compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.html) | 6695E245-E789-40EC-8AC6-EB10276CA241 |
| Task | [Auto-wire agile tables: add task, task start, task done](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_auto_wire_agile_tables.html) | 4905428A-B631-4E67-9C93-5BF78023C840 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)