### PR TITLE
[ores.compass] pr merge closes the task; task start fetches main

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -31,7 +31,7 @@ with traceability, merge) as follow-on tasks.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
 | Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
@@ -74,6 +74,7 @@ with traceability, merge) as follow-on tasks.
 | [[id:4F12BD41-06E1-4EE8-AEC4-98A5B55915B6][Add compass pr merge with guard rails]] | DONE | 2026-06-05 | 2026-06-05 | Merge commit only; guards on threads/CI proven live; --force via gh --admin; worktree-safe branch cleanup. PR #1088. |
 | [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | DONE | 2026-06-05 | 2026-06-05 | fetch + rebase + report; --push; conflict stop-with-guidance / --abort-on-conflict. PR #1092. |
 | [[id:7C440877-9523-4BB9-A5F6-2CA6B7376650][pr merge: stamp the journal automatically]] | DONE | 2026-06-05 | 2026-06-05 | Map merged head branch to task doc, derive UUIDs, journal update --state DONE; prompt keeps only judgement work. |
+| [[id:8D929399-4065-41DE-8097-BA76516CC5F8][pr merge closes the task unless --keep-open]] | STARTED | 2026-06-05 | | A merged PR means the task shipped: pr merge runs the task-done close-out (task + story row DONE, journal) on the branch's task, with --keep-open for multi-task branches and partial work. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_task.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_task.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 8D929399-4065-41DE-8097-BA76516CC5F8
+:END:
+#+title: Task: pr merge closes the task unless --keep-open
+#+description: A merged PR means the task shipped: pr merge runs the task-done close-out (task + story row DONE, journal) on the branch's task, with --keep-open for multi-task branches and partial work.
+#+type: task
+#+level: s1
+#+filetags: :compass_pr_management:sprint_19:v0:
+#+owner: marco
+#+branch: feature/pr-merge-closes-task
+#+pr: 1098
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Merging is the natural task-completion event, but close-out was still a separate command. After a successful merge, run task done on the branch's task (task and story row to DONE with dates, journal stamped); --keep-open suppresses it for multi-task branches, partial slices, and closure PRs. Only the Result prose remains.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- pr merge closes the matched task via task done (DONE rows, dates, journal) by default
+- --keep-open leaves the task untouched apart from the merge journal stamp
+- No or ambiguous task match falls back to the close-out hint
+- Merge recipe documents the default and the flag
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1098][#1098]] | [ores.compass] pr merge closes the task; task start fetches main |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_task.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_task.org
@@ -57,6 +57,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | task_path conditionally bound, read in elif branch | compass_pr.py | Accepted | init to None; 840a7b4dc |
 
 * Result

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -21,17 +21,20 @@ How do I merge a green, approved PR and delete its feature branch?
 
 1. /Merge/ — the guard rails are built in: the command refuses while
    review threads are unresolved or CI is not green, always creates a
-   merge commit (never squash/rebase), and deletes the remote branch
-   (worktree-safe; the local branch is left alone):
+   merge commit (never squash/rebase), deletes the remote branch
+   (worktree-safe), and closes the branch's task out (task and story
+   row to DONE, journal stamped):
 
    #+begin_src sh :results verbatim
-   ./compass.sh pr merge             # current branch's PR
-   ./compass.sh pr merge 123         # explicit PR number
-   ./compass.sh pr merge --force     # override the guards, stating what was bypassed
+   ./compass.sh pr merge               # current branch's PR
+   ./compass.sh pr merge 123           # explicit PR number
+   ./compass.sh pr merge --force       # override the guards, stating what was bypassed
+   ./compass.sh pr merge --keep-open   # leave the task open (multi-task branch, partial slice)
    #+end_src
 
-2. /Close out/: follow the printed prompt — mark the task DONE with a
-   Result, update the story's =* Tasks= row, stamp the journal.
+2. /Close out/: write the task's =* Result= prose and commit. With
+   =--keep-open=, run =compass task done <slug>= when the task really
+   finishes.
 
 3. /Sync local main/:
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2490,13 +2490,16 @@ def _cmd_task_start(task_ident, branch_arg=""):
         result = subprocess.run(["git", "switch", branch], capture_output=True, text=True,
                                 cwd=PROJECT_ROOT)
         if result.returncode != 0:
+            # New branch: fetch first so it starts from the latest main.
+            subprocess.run(["git", "fetch", "origin", "main"],
+                           cwd=PROJECT_ROOT)
             result2 = subprocess.run(
                 ["git", "switch", "-c", branch, "origin/main"],
                 capture_output=True, text=True, cwd=PROJECT_ROOT)
             if result2.returncode != 0:
                 print(f"❌ git switch failed:\n{result2.stderr.strip()}", file=sys.stderr)
                 return 1
-            print(f"✅ created and switched to {branch} (off origin/main)")
+            print(f"✅ created and switched to {branch} (off fresh origin/main)")
         else:
             print(f"✅ switched to {branch}")
 

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -353,35 +353,39 @@ def _cmd_merge(args, project_root):
         print(f"⚠️  Remote branch deletion skipped or failed"
               f"{f' ({head})' if head else ''} — delete it manually if "
               "needed.", file=sys.stderr)
-    # Stamp the journal automatically when the merged branch maps to a
-    # task doc; the doc edits (Result, story row) need judgement and
-    # stay with the session.
-    journalled = False
+    # A merged PR means the task shipped: close it out (task and story
+    # row to DONE, journal stamped) via task done, unless --keep-open
+    # (multi-task branches, partial slices, closure PRs). Only the
+    # Result prose stays with the session.
+    task_id = ""
     if head:
         task_path, task_text = _find_task_doc(project_root, head, "")
         if task_path is not None:
             task_id = _org_id(task_text)
-            story_path = task_path.parent / "story.org"
-            try:
-                story_id = _org_id(
-                    story_path.read_text(encoding="utf-8"))
-            except OSError:
-                story_id = ""
-            if task_id and story_id:
-                compass = (Path(project_root) / "projects"
-                           / "ores.compass" / "compass.sh")
-                subprocess.run(
-                    [str(compass), "journal", "update",
-                     "--story", story_id, "--task", task_id,
-                     "--branch", head, "--state", "DONE",
-                     "--pr", str(number)], cwd=str(project_root))
-                journalled = True
-    print("ℹ️  Close out the task: mark it DONE with a Result and update "
-          "the story's * Tasks row.")
-    if not journalled:
-        print(f"   Also stamp the journal: compass journal update "
-              f"--story <id> --task <id> --branch <branch> "
-              f"--state DONE --pr {number}")
+    compass = (Path(project_root) / "projects" / "ores.compass"
+               / "compass.sh")
+    if task_id and not args.keep_open:
+        subprocess.run([str(compass), "task", "done", task_id,
+                        "--pr", str(number)], cwd=str(project_root))
+    elif task_id:
+        # --keep-open: just record the merge in the journal.
+        story_path = task_path.parent / "story.org"
+        try:
+            story_id = _org_id(story_path.read_text(encoding="utf-8"))
+        except OSError:
+            story_id = ""
+        if story_id:
+            subprocess.run(
+                [str(compass), "journal", "update",
+                 "--story", story_id, "--task", task_id,
+                 "--branch", head, "--state", "STARTED",
+                 "--pr", str(number)], cwd=str(project_root))
+        print("ℹ️  --keep-open: task left open; close it later with "
+              f"compass task done {task_id}")
+    else:
+        print("ℹ️  No task doc matches the merged branch — close out "
+              "manually: compass task done <slug-or-uuid> "
+              f"--pr {number}")
     return 0
 
 
@@ -501,6 +505,9 @@ def run(argv, project_root):
     mp.add_argument("--force", action="store_true",
                     help="Merge even with unresolved threads or red CI "
                          "(states what was bypassed)")
+    mp.add_argument("--keep-open", action="store_true",
+                    help="Leave the task open after merging (multi-task "
+                         "branches, partial slices)")
 
     sp = sub.add_parser("sync",
                         help="Fetch origin/main and rebase the current "

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -256,6 +256,10 @@ def _cmd_create(args, project_root):
     msg = (f"[agile] Record PR #{number} on task\n\n"
            f"Story-ID: {story_id}\n"
            f"Task-ID: {task_id}")
+    # add first: a just-scaffolded task doc is untracked, and a commit
+    # pathspec alone does not pick those up.
+    subprocess.run(["git", "add", "--", str(task_rel)],
+                   cwd=str(project_root))
     p = subprocess.run(
         ["git", "commit", "-m", msg, "--", str(task_rel)],
         capture_output=True, text=True, cwd=str(project_root))

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -362,6 +362,7 @@ def _cmd_merge(args, project_root):
     # (multi-task branches, partial slices, closure PRs). Only the
     # Result prose stays with the session.
     task_id = ""
+    task_path = None
     if head:
         task_path, task_text = _find_task_doc(project_root, head, "")
         if task_path is not None:

--- a/projects/ores.compass/src/compass_review.py
+++ b/projects/ores.compass/src/compass_review.py
@@ -21,6 +21,7 @@ import argparse
 import datetime
 import json
 import re
+import pathlib
 import subprocess
 import sys
 
@@ -328,6 +329,28 @@ def _pr_agile_links(project_root, numbers):
     return results
 
 
+def _rebasing_branch(worktree_path):
+    """Branch a detached worktree is rebasing, or '' when not rebasing.
+
+    A mid-rebase worktree reports detached HEAD, which would make its
+    PR look unowned; git keeps the real branch in rebase-merge/
+    rebase-apply head-name.
+    """
+    try:
+        gitdir = subprocess.run(
+            ["git", "-C", worktree_path, "rev-parse",
+             "--absolute-git-dir"],
+            capture_output=True, text=True).stdout.strip()
+        for state in ("rebase-merge", "rebase-apply"):
+            head = pathlib.Path(gitdir) / state / "head-name"
+            if head.is_file():
+                return head.read_text().strip().removeprefix(
+                    "refs/heads/")
+    except OSError:
+        pass
+    return ""
+
+
 def _worktree_branches(project_root):
     """Map branch name → worktree directory name, across all worktrees."""
     try:
@@ -337,12 +360,17 @@ def _worktree_branches(project_root):
             capture_output=True, text=True)
     except OSError:
         return {}
-    branches, path = {}, None
+    branches, full_path, path = {}, None, None
     for line in p.stdout.splitlines():
         if line.startswith("worktree "):
-            path = line.split(" ", 1)[1].rstrip("/").rsplit("/", 1)[-1]
+            full_path = line.split(" ", 1)[1]
+            path = full_path.rstrip("/").rsplit("/", 1)[-1]
         elif line.startswith("branch refs/heads/") and path:
             branches[line.rsplit("refs/heads/", 1)[1]] = path
+        elif line.strip() == "detached" and full_path:
+            branch = _rebasing_branch(full_path)
+            if branch:
+                branches[branch] = path
     return branches
 
 


### PR DESCRIPTION
## Summary

Two workflow gaps from live use: merge is the task-completion event but close-out was still a separate command, and task start created new branches without fetching, so they could start stale.

## Changes

- pr merge runs task done on the branch's task by default: task + story row DONE with dates, journal stamped; only the Result prose remains
- --keep-open leaves the task open (multi-task branches, partial slices), journal-stamping only
- No or ambiguous task match falls back to a manual close-out hint
- task start fetches origin/main before creating a new branch
- Merge recipe documents the default and the flag

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [pr merge closes the task unless --keep-open](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_task.html) | 8D929399-4065-41DE-8097-BA76516CC5F8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)