### PR TITLE
[ores.compass] pr merge: close out on the branch before merging

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/story.org
@@ -75,6 +75,7 @@ with traceability, merge) as follow-on tasks.
 | [[id:C2EA546D-3CE8-4E2F-88F9-28E0238CDD4F][Add compass pr sync: fetch main and rebase, conflict-aware]] | DONE | 2026-06-05 | 2026-06-05 | fetch + rebase + report; --push; conflict stop-with-guidance / --abort-on-conflict. PR #1092. |
 | [[id:7C440877-9523-4BB9-A5F6-2CA6B7376650][pr merge: stamp the journal automatically]] | DONE | 2026-06-05 | 2026-06-05 | Map merged head branch to task doc, derive UUIDs, journal update --state DONE; prompt keeps only judgement work. |
 | [[id:8D929399-4065-41DE-8097-BA76516CC5F8][pr merge closes the task unless --keep-open]] | STARTED | 2026-06-05 | | A merged PR means the task shipped: pr merge runs the task-done close-out (task + story row DONE, journal) on the branch's task, with --keep-open for multi-task branches and partial work. |
+| [[id:6B20541F-F744-42A0-B6F9-9AA9F4AC35B9][pr merge: close out on the branch before merging]] | STARTED | 2026-06-05 | | Run task done, commit close-out on the PR branch, push, then merge — DONE rides the PR. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_before.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_before.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 6B20541F-F744-42A0-B6F9-9AA9F4AC35B9
+:END:
+#+title: Task: pr merge: close out on the branch before merging
+#+description: Run task done, commit the close-out docs on the PR branch, and push before merging, so DONE state rides the PR and nothing strands in the working tree.
+#+type: task
+#+level: s1
+#+filetags: :compass_pr_management:sprint_19:v0:
+#+owner: marco
+#+branch: feature/pr-merge-close-before
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Closing the task after merging leaves the DONE edits with no branch to land on, forcing a follow-up closure PR every time. Reorder: after the guards pass, run task done, commit the close-out (including any pre-written Result prose) on the PR branch, push, then merge with gh --admin to cover the tool-authored docs commit that makes CI pending again.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- Default merge: guards, task done, close-out commit pushed, merge, branch deleted — working tree clean afterwards
+- Close-out only rides when the current branch is the PR head; otherwise fall back to post-merge close-out with a hint
+- --keep-open skips close-out entirely
+- Merge recipe: write the Result before merging
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_before.org
+++ b/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_before.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_pr_management:sprint_19:v0:
 #+owner: marco
 #+branch: feature/pr-merge-close-before
-#+pr:
+#+pr: 1099
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -51,7 +51,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1099][#1099]] | [ores.compass] pr merge: close out on the branch before merging |
 
 * Review
 

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -19,11 +19,15 @@ How do I merge a green, approved PR and delete its feature branch?
 
 * Answer
 
+0. /Write the task's =* Result=/ first — the close-out commit rides
+   the PR, so the prose must be in the working tree before merging.
+
 1. /Merge/ — the guard rails are built in: the command refuses while
-   review threads are unresolved or CI is not green, always creates a
-   merge commit (never squash/rebase), deletes the remote branch
-   (worktree-safe), and closes the branch's task out (task and story
-   row to DONE, journal stamped):
+   review threads are unresolved or CI is not green; then it closes
+   the task out (task and story row to DONE, journal stamped), commits
+   and pushes the close-out on the PR branch, merges (always a merge
+   commit — never squash/rebase), and deletes the remote branch
+   (worktree-safe). Nothing is left in the working tree:
 
    #+begin_src sh :results verbatim
    ./compass.sh pr merge               # current branch's PR
@@ -32,9 +36,10 @@ How do I merge a green, approved PR and delete its feature branch?
    ./compass.sh pr merge --keep-open   # leave the task open (multi-task branch, partial slice)
    #+end_src
 
-2. /Close out/: write the task's =* Result= prose and commit. With
-   =--keep-open=, run =compass task done <slug>= when the task really
-   finishes.
+2. With =--keep-open=, no close-out happens — run =compass task done
+   <slug>= when the task really finishes. When merging a PR whose
+   branch is not checked out here, the close-out falls back to the
+   working tree and needs a follow-up commit.
 
 3. /Sync local main/:
 

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -327,23 +327,64 @@ def _cmd_merge(args, project_root):
         for b in blocked:
             print(f"   - {b}", flush=True)
 
-    # Always a merge commit — never squash, never rebase — matching
-    # the repository's history. --force needs gh's --admin to bypass
-    # the base branch protection (required checks still pending).
-    # No gh --delete-branch: it checks out the default branch locally,
-    # which fails in a multi-worktree fleet where main lives in
-    # another worktree. Delete the remote branch directly instead.
-    cmd = ["gh", "pr", "merge", str(number), "--merge"]
-    if args.force and blocked:
-        cmd.append("--admin")
-    p = subprocess.run(cmd, cwd=str(project_root))
-    if p.returncode != 0:
-        return p.returncode
     head_proc = subprocess.run(
         ["gh", "pr", "view", str(number), "--json", "headRefName",
          "--jq", ".headRefName"],
         capture_output=True, text=True, cwd=str(project_root))
     head = head_proc.stdout.strip() if head_proc.returncode == 0 else ""
+
+    # A merged PR means the task shipped: close it out BEFORE merging
+    # so the DONE docs ride the PR itself and nothing strands in the
+    # working tree. Only possible when we are on the PR's branch.
+    task_id = ""
+    task_path = None
+    if head:
+        task_path, task_text = _find_task_doc(project_root, head, "")
+        if task_path is not None:
+            task_id = _org_id(task_text)
+    compass = (Path(project_root) / "projects" / "ores.compass"
+               / "compass.sh")
+    closed_out = False
+    on_head = _current_branch(project_root) == head
+    if task_id and not args.keep_open and on_head:
+        subprocess.run([str(compass), "task", "done", task_id,
+                        "--pr", str(number)], cwd=str(project_root))
+        story_rel = (task_path.parent / "story.org").relative_to(
+            project_root)
+        task_rel = task_path.relative_to(project_root)
+        story_id = _org_id(
+            (task_path.parent / "story.org").read_text(encoding="utf-8"))
+        msg = (f"[agile] Close task on merge of PR #{number}\n\n"
+               f"Story-ID: {story_id}\n"
+               f"Task-ID: {task_id}")
+        subprocess.run(["git", "add", "--", str(task_rel), str(story_rel)],
+                       cwd=str(project_root))
+        c = subprocess.run(["git", "commit", "-m", msg, "--",
+                            str(task_rel), str(story_rel)],
+                           capture_output=True, text=True,
+                           cwd=str(project_root))
+        if c.returncode == 0:
+            p = subprocess.run(["git", "push"], cwd=str(project_root))
+            if p.returncode != 0:
+                return p.returncode
+            print(f"✅ Close-out committed and pushed on {head}.")
+            closed_out = True
+        elif "nothing to commit" not in (c.stdout + c.stderr):
+            print(c.stderr.strip() or c.stdout.strip(), file=sys.stderr)
+
+    # Always a merge commit — never squash, never rebase — matching
+    # the repository's history. gh's --admin bypasses the base branch
+    # protection when --force was given, or when the close-out push
+    # just made CI pending again (the delta is the tool-authored docs
+    # commit). No gh --delete-branch: it checks out the default branch
+    # locally, which fails in a multi-worktree fleet where main lives
+    # in another worktree. Delete the remote branch directly instead.
+    cmd = ["gh", "pr", "merge", str(number), "--merge"]
+    if (args.force and blocked) or closed_out:
+        cmd.append("--admin")
+    p = subprocess.run(cmd, cwd=str(project_root))
+    if p.returncode != 0:
+        return p.returncode
     deleted = False
     if head and head not in ("main", "master"):
         deleted = subprocess.run(
@@ -357,23 +398,14 @@ def _cmd_merge(args, project_root):
         print(f"⚠️  Remote branch deletion skipped or failed"
               f"{f' ({head})' if head else ''} — delete it manually if "
               "needed.", file=sys.stderr)
-    # A merged PR means the task shipped: close it out (task and story
-    # row to DONE, journal stamped) via task done, unless --keep-open
-    # (multi-task branches, partial slices, closure PRs). Only the
-    # Result prose stays with the session.
-    task_id = ""
-    task_path = None
-    if head:
-        task_path, task_text = _find_task_doc(project_root, head, "")
-        if task_path is not None:
-            task_id = _org_id(task_text)
-    compass = (Path(project_root) / "projects" / "ores.compass"
-               / "compass.sh")
-    if task_id and not args.keep_open:
+
+    if task_id and not args.keep_open and not on_head:
+        # Could not ride the PR: fall back to post-merge close-out.
         subprocess.run([str(compass), "task", "done", task_id,
                         "--pr", str(number)], cwd=str(project_root))
-    elif task_id:
-        # --keep-open: just record the merge in the journal.
+        print("⚠️  Close-out edits are in the working tree (merge ran "
+              "off-branch) — commit them on a follow-up branch.")
+    elif task_id and args.keep_open:
         story_path = task_path.parent / "story.org"
         try:
             story_id = _org_id(story_path.read_text(encoding="utf-8"))
@@ -387,7 +419,7 @@ def _cmd_merge(args, project_root):
                  "--pr", str(number)], cwd=str(project_root))
         print("ℹ️  --keep-open: task left open; close it later with "
               f"compass task done {task_id}")
-    else:
+    elif not task_id:
         print("ℹ️  No task doc matches the merged branch — close out "
               "manually: compass task done <slug-or-uuid> "
               f"--pr {number}")


### PR DESCRIPTION
## Summary

Merge-time close-out previously ran after the merge, stranding the DONE edits in the working tree and forcing a follow-up closure PR. Now the close-out is committed and pushed on the PR branch before merging, so the DONE state rides the PR itself and the tree is clean afterwards.

## Changes

- After guards pass: task done, close-out commit (with any pre-written Result), push, then merge
- Merge uses gh --admin when a close-out was pushed (the protection delta is exactly the tool-authored docs commit) or under --force
- Off-branch merges fall back to post-merge close-out with a warning; --keep-open unchanged
- Merge recipe: write the Result before merging — nothing left to do afterwards

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add PR management support to compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/story.html) | 166E8E44-1573-4DE2-825F-A6037A302AE9 |
| Task | [pr merge: close out on the branch before merging](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_pr_management/task_pr_merge_closes_before.html) | 6B20541F-F744-42A0-B6F9-9AA9F4AC35B9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)