### PR TITLE
[ores.compass] Compass quality-of-life improvements

### DIFF
--- a/doc/agile/product_backlog/inbox/add_a_compass_command_to_move_a_task_between_stori.org
+++ b/doc/agile/product_backlog/inbox/add_a_compass_command_to_move_a_task_between_stori.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 7E113DC6-2C6C-401B-B52E-76E2C912C835
+:END:
+#+title: Add a compass command to move a task between stories. Today …
+#+description: Add a compass command to move a task between stories. Today there is no 'task move': relocating a task means reverting the old story's wiring, re-running compass add with --id into the new parent, deleting the old file, and hand-editing tables. A 'compass task move <slug> --story <target>' should rehome the file, rewire both Tasks tables, and update the task's parent links.
+#+type: capture
+#+level: cross
+#+filetags: :capture:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/pr_merge_close_out_should_tolerate_already_closed.org
+++ b/doc/agile/product_backlog/inbox/pr_merge_close_out_should_tolerate_already_closed.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 03A8CA42-A764-46B3-9D0D-3C2E4BC272AC
+:END:
+#+title: pr merge close-out should tolerate already-closed tasks. Whe…
+#+description: pr merge close-out should tolerate already-closed tasks. When every task on the branch is already DONE and the paperwork committed, the close-out's git commit finds nothing to commit, fails, and aborts the merge (post-#1102 hardening). Detect the nothing-to-commit case and proceed to merge instead of aborting; also consider which task the close-out picks when several tasks share the branch.
+#+type: capture
+#+level: cross
+#+filetags: :capture:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/story_new_support_content_flags_and_first_task_co.org
+++ b/doc/agile/product_backlog/inbox/story_new_support_content_flags_and_first_task_co.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 7B16D632-08E7-4089-A6A6-168CA7153F65
+:END:
+#+title: story new: support content flags and first-task control. com…
+#+description: story new: support content flags and first-task control. compass story new cannot pass --goal/--acceptance through to the story or its first task, and the first task's slug is hard-coded to implement_<story-slug> with no --task-slug or --no-task option. Scaffolding a story whose first task is a real, named task currently forces a scaffold-then-replace dance (delete the task file, re-add with compass add, preserve the UUID).
+#+type: capture
+#+level: cross
+#+filetags: :capture:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
@@ -23,7 +23,7 @@ that standardises session start around compass.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -43,7 +43,7 @@ that standardises session start around compass.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:0442BF8D-760D-4454-88BF-4509FA6BB192][Detect merged PRs in compass bearings]] | BACKLOG | | | bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state. |
+| [[id:0442BF8D-760D-4454-88BF-4509FA6BB192][Detect merged PRs in compass bearings]] | DONE | 2026-06-06 | 2026-06-06 | bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state. |
 | [[id:82763717-CFA8-42F4-B775-BE48AB64E78A][Instantiate recipe body from arguments in compass add]] | BACKLOG | | | compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly. |
 | [[id:C200F3C6-8737-47AD-80D7-A2445760E60D][Add an init-session skill]] | BACKLOG | | | Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action. |
 

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
@@ -44,7 +44,7 @@ that standardises session start around compass.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:0442BF8D-760D-4454-88BF-4509FA6BB192][Detect merged PRs in compass bearings]] | DONE | 2026-06-06 | 2026-06-06 | bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state. |
-| [[id:82763717-CFA8-42F4-B775-BE48AB64E78A][Instantiate recipe body from arguments in compass add]] | BACKLOG | | | compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly. |
+| [[id:82763717-CFA8-42F4-B775-BE48AB64E78A][Instantiate recipe body from arguments in compass add]] | DONE | 2026-06-06 | 2026-06-06 | compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly. |
 | [[id:C200F3C6-8737-47AD-80D7-A2445760E60D][Add an init-session skill]] | BACKLOG | | | Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
@@ -45,7 +45,7 @@ that standardises session start around compass.
 |------+-------+-------+-----+-------------|
 | [[id:0442BF8D-760D-4454-88BF-4509FA6BB192][Detect merged PRs in compass bearings]] | DONE | 2026-06-06 | 2026-06-06 | bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state. |
 | [[id:82763717-CFA8-42F4-B775-BE48AB64E78A][Instantiate recipe body from arguments in compass add]] | DONE | 2026-06-06 | 2026-06-06 | compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly. |
-| [[id:C200F3C6-8737-47AD-80D7-A2445760E60D][Add an init-session skill]] | BACKLOG | | | Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action. |
+| [[id:C200F3C6-8737-47AD-80D7-A2445760E60D][Add an init-session skill]] | DONE | 2026-06-06 | 2026-06-06 | Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0
+:END:
+#+title: Story: Compass quality-of-life improvements
+#+description: Grab-bag of small compass improvements that don't warrant their own story: bearings PR-state detection, recipe body arguments in compass add, and an init-session skill.
+#+type: story
+#+level: s2
+#+filetags: :compass:tooling:llm:sprint_19:v0:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Deliver a set of small, independent compass improvements that don't
+warrant individual stories: accurate PR state in the orientation
+output, recipes born with content from =compass add=, and a skill
+that standardises session start around compass.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-06                               |
+
+* Acceptance
+
+- =bearings= / =fleet= / =where= surface the PR state (open/merged/closed),
+  with merged visually distinct from open.
+- =compass add recipe= accepts body arguments rendered through the
+  mustache template; no post-generation editing needed.
+- An init-session skill exists prescribing compass-first operation,
+  recipe search for command info, and a bearings-based session start.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:0442BF8D-760D-4454-88BF-4509FA6BB192][Detect merged PRs in compass bearings]] | BACKLOG | | | bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state. |
+| [[id:82763717-CFA8-42F4-B775-BE48AB64E78A][Instantiate recipe body from arguments in compass add]] | BACKLOG | | | compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly. |
+| [[id:C200F3C6-8737-47AD-80D7-A2445760E60D][Add an init-session skill]] | BACKLOG | | | Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass:pr:bearings:compass_quality_of_life:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-quality-of-life
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ compass bearings (and fleet/where) currently report the PR associated with the c
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -58,3 +58,11 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Added =pr_state()= (gh-backed, cached, fails soft to =None=) and a
+state chip on the journal PR line: =[open]= green, =[merged]= magenta
+with a "sync main or start the next task" hint, =[closed]= red. The
+annotation is enabled only for single-entry views (=journal where=,
+which =bearings= reuses) so =journal log= stays gh-free. Verified
+against PR #1100 and #1102 (both merged); when gh is unavailable the
+PR line renders exactly as before.

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:pr:bearings:compass_quality_of_life:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-quality-of-life
-#+pr:
+#+pr: 1106
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -49,7 +49,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1106][#1106]] | [ores.compass] Compass quality-of-life improvements |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 0442BF8D-760D-4454-88BF-4509FA6BB192
+:END:
+#+title: Task: Detect merged PRs in compass bearings
+#+description: bearings shows the branch's PR as if still open even after it has been merged; detect and surface the merged state.
+#+type: task
+#+level: s1
+#+filetags: :compass:pr:bearings:compass_quality_of_life:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+compass bearings (and fleet/where) currently report the PR associated with the current branch without checking whether it has already been merged, so a merged PR looks identical to an open one. Query the PR state (e.g. via gh) and surface merged/closed status in the orientation output so a session starts with an accurate picture of the work item.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-06                               |
+
+* Acceptance
+
+- bearings shows the PR state (open/merged/closed) next to the PR number
+- a merged PR is visually distinct from an open one in bearings output
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.org
@@ -55,7 +55,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Round 1 (2026-06-06): no review comments — only a gemini-code-assist daily-quota notice | — | n/a | Branch rebased on main and force-pushed; nothing to address |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_init_session_skill.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_init_session_skill.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: C200F3C6-8737-47AD-80D7-A2445760E60D
+:END:
+#+title: Task: Add an init-session skill
+#+description: Add a Claude Code skill that standardises session start: prefer compass for all operations, search recipes for command info, run compass bearings, then summarise and suggest the next action.
+#+type: task
+#+level: s1
+#+filetags: :compass:skill:llm:compass_quality_of_life:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Session starts are ad hoc: the LLM sometimes reaches for --help or Unix tools instead of compass and recipes. Add an 'init session' skill with these steps: 1. try to use compass for all operations, and if there are limitations make them clear to the user; 2. to find information about any compass command, search recipes first (compass search "<term>" or compass list --type recipe); 3. find your bearings by running ./compass.sh bearings; then provide the user a summary of the bearings and suggest the next action.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-06                               |
+
+* Acceptance
+
+- skill instructs to prefer compass for all operations and to surface limitations to the user
+- skill instructs to search recipes for compass command info, with the correct search syntax
+- skill runs compass bearings and ends with a summary plus a suggested next action
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_init_session_skill.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_init_session_skill.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass:skill:llm:compass_quality_of_life:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-quality-of-life
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Session starts are ad hoc: the LLM sometimes reaches for --help or Unix tools in
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -59,3 +59,11 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Scaffolded =doc/llm/skills/init-session/SKILL.org= via =compass add
+skill= (renamed to kebab-case to match the deployed skill folders)
+with the four-step ritual: compass-first operation with limitations
+surfaced as captures, recipe search before guessing command syntax
+(=compass search= / =list --type recipe=), =compass bearings=, then a
+summary plus suggested next action. Deployed with =compass build
+skills= and verified the bundle output.

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_recipe_body_args.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_recipe_body_args.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 82763717-CFA8-42F4-B775-BE48AB64E78A
+:END:
+#+title: Task: Instantiate recipe body from arguments in compass add
+#+description: compass add recipe scaffolds placeholder boilerplate that must be edited afterwards; accept body content as arguments and render it through the mustache template directly.
+#+type: task
+#+level: s1
+#+filetags: :compass:codegen:recipe:compass_quality_of_life:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Tasks and stories can already be born with content via --goal and --acceptance, but recipes still come out as boilerplate that has to be edited after generation. Extend compass add (and the underlying codegen template) so the recipe body sections (question, answer, etc.) can be supplied as arguments and instantiated via the mustache template, removing the modify-after-scaffold step.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-06                               |
+
+* Acceptance
+
+- compass add recipe accepts body arguments (e.g. question, answer) rendered into the template
+- a recipe created with body arguments needs no post-generation editing
+- the add-doc recipe documents the new flags
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_recipe_body_args.org
+++ b/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_recipe_body_args.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass:codegen:recipe:compass_quality_of_life:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-quality-of-life
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Tasks and stories can already be born with content via --goal and --acceptance, 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -59,3 +59,11 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Added =--intro=, =--question=, =--answer=, =--script=, =--tested-by=
+and repeatable =--see-also= to =doc_generate= and templated the recipe
+body sections in =doc_recipe.org.mustache=; values render verbatim
+(org markup, multi-line) and absent flags fall back to the original
+placeholders — verified the no-args output is byte-identical to the
+old scaffold. Documented the flags in the codegen "New recipe"
+section.

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -96,6 +96,7 @@ Developer toolkit consolidation: fold operational scripts into compass, extend O
 | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Compass bearings command]] | DONE | 2026-06-02 | 2026-06-05 | Single-command LLM orientation (compass bearings): where, last session, memory pointer, and command cheat-sheet. |
 | [[id:746A337A-E96D-42E5-BC47-8EB1FCDD6A30][Add compass test run]] | BACKLOG | | | Run all / composite-component / single-component tests or Catch2 name/tag filters; --build delegates to cmake; .env loaded for direct binary runs. |
 | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Add PR management support to compass]] | DONE | 2026-06-05 | 2026-06-05 | Review pillar (list/reply/resolve/pending) + PR pillar (sync/checks/create/record/merge); runbook and recipes compass end-to-end. Promotes the sprint-18 capture. |
+| [[id:A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0][Compass quality-of-life improvements]] | BACKLOG | | | Grab-bag of small improvements: bearings PR-state detection, recipe body arguments in compass add, init-session skill. |
 
 *** Epic: Codegen
 

--- a/doc/llm/skills/init-session/SKILL.org
+++ b/doc/llm/skills/init-session/SKILL.org
@@ -1,0 +1,83 @@
+:PROPERTIES:
+:ID: 936389EC-7E0A-4925-9023-D4FA33C0FBF4
+:END:
+#+title: Init Session
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :compass:llm:orientation:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+#+begin_export markdown
+---
+name: init-session
+description: Initialise a session — compass-first operation, recipe search for command info, bearings, then a summary and suggested next action.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+At the start of a session, or whenever the user asks to "init the
+session", "find your bearings", or orient yourself in the repository.
+
+* How to use this skill
+
+1. /Use compass for all your operations./ Reach for =compass=
+   (search, list, show, where, story, task, sprint, capture,
+   journal, pr, review, ...) before falling back to Unix tools or
+   raw =gh=/=git= invocations. If compass cannot do something you
+   need, make the limitation clear to the user — gaps in compass
+   are captures, not workarounds.
+
+2. /To find information about any compass command, search the
+   recipes/ — never guess flags from =--help= alone:
+
+   #+begin_src sh :results verbatim
+   ./compass.sh search "<term>"
+   ./compass.sh list --type recipe --tag compass
+   #+end_src
+
+3. /Find your bearings/:
+
+   #+begin_src sh :results verbatim
+   ./compass.sh bearings
+   #+end_src
+
+4. /Report back/: provide the user a summary of the bearings —
+   where we are (branch, story, task, PR and its state), whether
+   the environment is up, and anything unusual (stale branch,
+   merged PR, drifted worktree) — and suggest the next action.
+
+* Recipes
+
+- [[id:FE388774-0714-4D93-AEB0-D6221314D4F9][How do I orient a new session?]]
+- [[id:BDA8F7FB-5CEC-42D8-BC78-766BBC8D4285][How do I search docs with compass?]]
+- [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]]
+
+* Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the compass tool's component model.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/recipes/codegen/how_do_i_create_a_new_doc.org
+++ b/doc/recipes/codegen/how_do_i_create_a_new_doc.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :codegen:templates:agile:recipe:
 #+created: 2026-05-18
-#+updated: 2026-05-20
+#+updated: 2026-06-06
 
 For the contract every generated document follows (frontmatter, sections, TODO
 vocabulary), see [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][document types]]. For background on the generator itself, see
@@ -166,6 +166,20 @@ Use the =how_do_i_<thing>= slug convention. The output is
   --description "Remove the CMake binary cache to force a clean re-configure." \
   --tags "cmake,build,recipe"
 #+end_src
+
+Scaffold with content — the body sections can be supplied as
+arguments (verbatim org markup; multi-line via =$(printf ...)= or
+shell =$'...'= quoting) so the recipe is born complete instead of
+with placeholder text:
+
+- =--intro= — lead paragraph before =* Question=;
+- =--question= — the =* Question= body;
+- =--answer= — the =* Answer= body (include the =#+begin_src= block);
+- =--script= — the =* Script= body;
+- =--tested-by= — the =* Tested by= body;
+- =--see-also= — one =* See also= bullet (repeatable).
+
+Sections not supplied fall back to the fill-in placeholders.
 
 When the recipe's =* Answer= involves a shell command, write it in
 an =#+begin_src sh :results verbatim= block so the recipe is

--- a/doc/recipes/compass/how_do_i_add_a_doc_with_compass.org
+++ b/doc/recipes/compass/how_do_i_add_a_doc_with_compass.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :compass:codegen:agile:recipe:bearings:
 #+created: 2026-05-24
-#+updated: 2026-05-24
+#+updated: 2026-06-06
 
 The /Scaffold/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]]. =add= is a thin front-end
 over [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]]'s generator (called as a library) — for the full set
@@ -59,9 +59,14 @@ straight to the generator (=--slug=, =--title=, =--description=,
      --slug sprint_19 --title "Sprint 19" --description "…"
    #+end_src
 
-After creating a story/task, remember to wire it into its parent's
-=* Stories= / =* Tasks= section (compass reminds you; it does not edit
-the parent).
+Compass wires the new story/task into its parent's =* Stories= /
+=* Tasks= table automatically (state =BACKLOG=) — no manual edit of
+the parent is needed.
+
+Note: =--type= is supplied by compass from the =<type>= positional —
+do not pass it yourself (the =--help= output shows the underlying
+generator's flags, including =--type=, but =add= expects the type as
+a positional argument).
 
 * Script
 

--- a/projects/ores.codegen/library/templates/doc_recipe.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_recipe.org.mustache
@@ -9,27 +9,29 @@
 #+created: {{date}}
 #+updated: {{date}}
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+{{intro}}
 
 * Question
 
-(Restate the NLP question this recipe answers.)
+{{question}}
 
 * Answer
 
-#+begin_src sh :results verbatim
-# Replace with the command(s) that answer the question.
-#+end_src
+{{answer}}
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+{{script}}
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+{{tested_by}}
 
 * See also
 
+{{#see_also}}
+- {{.}}
+{{/see_also}}
+{{^has_see_also}}
 -
+{{/has_see_also}}

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -272,6 +272,26 @@ def parse_args(argv=None):
     parser.add_argument("--acceptance", action="append", default=[],
                         help="An acceptance bullet for task/story docs "
                              "(repeatable).")
+    parser.add_argument("--intro", default="",
+                        help="For --type recipe: lead paragraph pointing at "
+                             "the component model / knowledge doc the recipe "
+                             "relies on. Defaults to the fill-in placeholder.")
+    parser.add_argument("--question", default="",
+                        help="For --type recipe: the NLP question the recipe "
+                             "answers (* Question body).")
+    parser.add_argument("--answer", default="",
+                        help="For --type recipe: the * Answer body, verbatim "
+                             "org markup (may be multi-line, e.g. a "
+                             "#+begin_src block).")
+    parser.add_argument("--script", default="",
+                        help="For --type recipe: the * Script body — pointer "
+                             "to the script or wrapper that does the work.")
+    parser.add_argument("--tested-by", default="",
+                        help="For --type recipe: the * Tested by body — how "
+                             "the recipe is exercised.")
+    parser.add_argument("--see-also", action="append", default=[],
+                        help="For --type recipe: a * See also bullet, "
+                             "verbatim org markup (repeatable).")
     parser.add_argument("--brief", default="",
                         help="For --type component: one-line tagline that "
                              "codegen reads from the overview's #+brief: "
@@ -428,11 +448,38 @@ def main(argv=None):
         "story": "(Describe the user-visible outcome this story "
                  "delivers.)",
     }.get(args.type, "")
+
+    # Recipe body sections: rendered verbatim when supplied, fill-in
+    # placeholders otherwise, so a fully-argumented recipe needs no
+    # post-generation editing.
+    recipe_intro = args.intro or (
+        "(One- or two-sentence pointer to the component model and any "
+        "knowledge\ndoc this recipe relies on.)")
+    recipe_question = args.question or (
+        "(Restate the NLP question this recipe answers.)")
+    recipe_answer = args.answer or (
+        "#+begin_src sh :results verbatim\n"
+        "# Replace with the command(s) that answer the question.\n"
+        "#+end_src")
+    recipe_script = args.script or (
+        "(Pointer to the script or wrapper that does the work, if "
+        "applicable.)")
+    recipe_tested_by = args.tested_by or (
+        "(How this recipe is exercised — CI workflow, manual smoke "
+        "test, etc.)")
+
     variables = {
         "id": new_id,
         "goal": args.goal or goal_default,
         "acceptance": args.acceptance,
         "has_acceptance": bool(args.acceptance),
+        "intro": recipe_intro,
+        "question": recipe_question,
+        "answer": recipe_answer,
+        "script": recipe_script,
+        "tested_by": recipe_tested_by,
+        "see_also": args.see_also,
+        "has_see_also": bool(args.see_also),
         "slug": args.slug,
         "title": args.title,
         "description": args.description,

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -696,12 +696,13 @@ def _age_human(seconds):
         return f"{s // 3600}h"
     return f"{s // 86400}d"
 
-_C_GREEN  = "\033[32m"
-_C_YELLOW = "\033[33m"
-_C_RED    = "\033[31m"
-_C_CYAN   = "\033[36m"
-_C_BOLD   = "\033[1m"
-_C_RESET  = "\033[0m"
+_C_GREEN   = "\033[32m"
+_C_YELLOW  = "\033[33m"
+_C_RED     = "\033[31m"
+_C_CYAN    = "\033[36m"
+_C_MAGENTA = "\033[35m"
+_C_BOLD    = "\033[1m"
+_C_RESET   = "\033[0m"
 _C_SEV    = {"ok": _C_GREEN, "warn": _C_YELLOW, "stale": _C_RED}
 
 # Freshness bands for the search/index databases, in seconds.
@@ -912,8 +913,13 @@ def _journal_entries(text):
         entries.append(entry)
     return entries
 
-def _print_entry(entry):
-    """Print one journal entry in the standard fleet-style format."""
+def _print_entry(entry, with_pr_state=False):
+    """Print one journal entry in the standard fleet-style format.
+
+    with_pr_state queries gh for the PR's live state (open/merged/closed)
+    and annotates the PR line — one gh call, so only enabled for single-entry
+    views (journal where, bearings), not journal log.
+    """
     sl = entry["story_link"]
     sm = _ORG_LINK_RE.match(sl)
     story_title = sm.group(2) if sm else sl
@@ -931,7 +937,16 @@ def _print_entry(entry):
     if task_uuid:
         print(f"            {_ycmd(f'compass show {task_uuid}')}")
     print(f"    Branch: {entry.get('branch') or '—'}")
-    print(f"    PR:     {entry.get('pr') or 'none'}")
+    pr = entry.get("pr") or "none"
+    pm = re.match(r"^#(\d+)$", pr)
+    if with_pr_state and pm:
+        state = pr_state(pm.group(1))
+        chip = _PR_STATE_CHIP.get(state)
+        if chip:
+            pr = f"{pr} {chip}"
+            if state == "MERGED":
+                pr += "  (merged — sync main or start the next task)"
+    print(f"    PR:     {pr}")
 
 def _journal_update(args):
     from datetime import datetime
@@ -963,7 +978,7 @@ def _journal_where():
     if not entries:
         print("No entries in .journal.org.")
         return 0
-    _print_entry(entries[-1])
+    _print_entry(entries[-1], with_pr_state=True)
     return 0
 
 def _journal_log():
@@ -1038,6 +1053,30 @@ def open_prs_by_branch():
     except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
         return {}
     return {pr["headRefName"]: pr for pr in prs if pr.get("headRefName")}
+
+_PR_STATE_CACHE = {}
+
+def pr_state(number):
+    """State of PR #<number> via gh: 'OPEN', 'MERGED' or 'CLOSED'. None on failure."""
+    if number in _PR_STATE_CACHE:
+        return _PR_STATE_CACHE[number]
+    state = None
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", str(number), "--json", "state"],
+            capture_output=True, text=True, cwd=str(PROJECT_ROOT), timeout=20)
+        if out.returncode == 0:
+            state = json.loads(out.stdout).get("state")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        state = None
+    _PR_STATE_CACHE[number] = state
+    return state
+
+_PR_STATE_CHIP = {
+    "OPEN":   f"{_C_GREEN}[open]{_C_RESET}",
+    "MERGED": f"{_C_MAGENTA}[merged]{_C_RESET}",
+    "CLOSED": f"{_C_RED}[closed]{_C_RESET}",
+}
 
 def task_for_branch(worktree_path, branch):
     """Find a task in this worktree's tree whose #+branch == branch.


### PR DESCRIPTION
## Summary

Three small, independent compass improvements from the compass_quality_of_life story: bearings/journal where now annotate the PR with its live state from gh (a merged PR no longer masquerades as open), compass add recipe can instantiate the full recipe body from arguments, and a new init-session skill standardises session start around compass.

## Changes

- Annotate the journal PR line with a live [open]/[merged]/[closed] chip via gh pr view (cached, soft-fail), with a next-step hint when merged
- Add --intro/--question/--answer/--script/--tested-by/--see-also to doc_generate and template the recipe body sections; defaults unchanged
- Add the init-session skill (compass-first, recipe search, bearings, summary + next action) and deploy it
- Fix stale wiring claim in the add-doc recipe and document the new recipe flags
- File captures for compass gaps: task move between stories, story new content flags

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality-of-life improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_quality_of_life/story.html) | A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0 |
| Task | [Detect merged PRs in compass bearings](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_quality_of_life/task_bearings_detect_merged_pr.html) | 0442BF8D-760D-4454-88BF-4509FA6BB192 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)