### PR TITLE
[compass] Export SSH_AUTH_SOCK from agent dir in compass.sh

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
@@ -30,7 +30,7 @@ captures, story search by exact folder name, and a task move command.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -51,7 +51,7 @@ captures, story search by exact folder name, and a task move command.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:63B1D3C7-EE7C-45E2-8E43-97FABAD5BCF4][Load SSH_AUTH_SOCK from .env in compass.sh]] | BACKLOG | | | compass.sh does not export SSH_AUTH_SOCK, so git push/fetch from sandboxed sessions need manual agent setup; source it from .env alongside the other ORES_ vars. Re-filed from the closed CLI UX redesign story (task CCFF58E1). |
+| [[id:63B1D3C7-EE7C-45E2-8E43-97FABAD5BCF4][Load SSH_AUTH_SOCK from .env in compass.sh]] | STARTED | 2026-06-06 | | compass.sh does not export SSH_AUTH_SOCK, so git push/fetch from sandboxed sessions need manual agent setup; source it from .env alongside the other ORES_ vars. Re-filed from the closed CLI UX redesign story (task CCFF58E1). |
 | [[id:A2F91FCF-BB36-4D5C-A38B-4D0BACDAD417][Dashboard cannot start services via compass: whole command treated as one path]] | BACKLOG | | | Starting services from the Emacs dashboard fails with: /bin/bash: /home/marco/Development/OreStudio/OreStudio.local1/projects/ores.compass/compass.sh services start: No such file or directory [exited abnormally with code 127]. The error shows the entire command string ('compass.sh services start') being treated as a single executable path — likely a quoting/argv bug in ores-dashboard.el / ores-db.el's compass invocation (string passed where an argv list or shell -c form is needed). Fix the elisp runner and check the other compass calls from the dashboard for the same pattern. |
 | [[id:32172CAF-FE28-4C7B-87CD-4992A894D8A8][Review Claude Code settings: auto-authorise compass commands]] | BACKLOG | | | Register the key compass commands in Claude Code settings (CLAUDE.md or settings.json) so they are available as shell shortcuts without needing to type the full path each time. |
 | [[id:827652D1-566A-4044-A0F9-B69ABF709288][Make compass search results actionable]] | BACKLOG | | | Observed: Claude bypasses compass search because the result format does not look directly useful — a title, tags, a path, and an ellipsised snippet, with no obvious next action. Refactor the output to be focused and actionable: one tight block per hit with a ready-to-run yellow hint (compass show <UUID>, matching the house hint UX used by audit/fleet), the doc type, and ideally a direct answer extract for question-shaped queries (recipes' Question/Answer sections). Fewer, better-ranked results beat ten loose ones; consider --limit defaulting low and a -v for the current verbose form. |

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_quality_of_life:sprint_20:v0:
 #+owner: marco
 #+branch: feature/compass-load-ssh-auth-sock
-#+pr: 1113
+#+pr: 1118
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -60,6 +60,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1118][#1118]] | [compass] Export SSH_AUTH_SOCK from agent dir in compass.sh |
 | [[https://github.com/OreStudio/OreStudio/pull/1113][#1113]] | [agile] Add compass quality of life story to sprint 20 |
 
 * Review

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_quality_of_life:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-load-ssh-auth-sock
 #+pr: 1113
 #+blocked_on:
 #+blocked_since:
@@ -31,7 +31,7 @@ more as gh/git operations move into compass (pr/review pillars).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.org
@@ -67,7 +67,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Harden ORES_SSH_AGENT_DIR parsing: CRLF, quotes, whitespace, tilde, dir check | projects/ores.compass/compass.sh | Accepted | Fixed in a77b2d6dd; normalised like compass.py's .env parser, interior spaces preserved. |
 
 * Result
 

--- a/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
+++ b/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
@@ -2,13 +2,13 @@
 :ID: F7E4C41F-AF34-43E5-ADC3-1D837126B3DE
 :END:
 #+title: Set SSH_AUTH_SOCK for git operations
-#+description: The sandboxed shell does not inherit the user SSH agent. Source build/scripts/set_ssh_agent.sh before git push/fetch/pull.
+#+description: The sandboxed shell does not inherit the user SSH agent. compass-invoked git works out of the box; source build/scripts/set_ssh_agent.sh only before raw git push/fetch/pull.
 #+type: memory
 #+memory_subtype: feedback
 #+level: cross
 #+filetags: :memory:feedback:
 #+created: 2026-05-26
-#+updated: 2026-05-30
+#+updated: 2026-06-06
 
 The sandboxed shell environment does not inherit the user's SSH agent
 socket. Any =git push=, =git fetch=, or =git pull= will fail with
@@ -20,7 +20,12 @@ unlocked, but the sandbox starts with an empty =SSH_AUTH_SOCK=. The
 git remote uses SSH (=git@github.com:=), and without the agent the
 connection fails on authentication.
 
-*How to apply:* Source the project script before any push/fetch/pull:
+*How to apply:* Anything run through =compass= (=pr create=, =pr
+sync=, =capture promote=, =task start=, ...) needs no setup:
+=compass.sh= exports =SSH_AUTH_SOCK= automatically from the sole
+socket in =ORES_SSH_AGENT_DIR= (from =.env=; default
+=~/.ssh/agent=) when the calling environment does not provide a live
+one. For /raw/ git commands, source the project script first:
 
 #+begin_src sh
 source build/scripts/set_ssh_agent.sh

--- a/projects/ores.compass/compass.sh
+++ b/projects/ores.compass/compass.sh
@@ -70,13 +70,23 @@ cd "$REPO_ROOT"
 # doc/llm/memory/set_ssh_auth_sock_for_git_operations.org.
 if [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
     AGENT_DIR=$(grep -s '^ORES_SSH_AGENT_DIR=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2-)
+    # Normalise the raw value the way compass.py parses .env: strip CR
+    # (CRLF .env on Windows), surrounding quotes, and whitespace; expand a
+    # leading ~/.
+    AGENT_DIR=$(printf '%s' "$AGENT_DIR" | tr -d '\r"'\' \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     AGENT_DIR="${AGENT_DIR:-$HOME/.ssh/agent}"
-    for sock in "$AGENT_DIR"/*; do
-        if [ -S "$sock" ]; then
-            export SSH_AUTH_SOCK="$sock"
-            break
-        fi
-    done
+    case "$AGENT_DIR" in
+        "~/"*) AGENT_DIR="$HOME/${AGENT_DIR#\~/}" ;;
+    esac
+    if [ -d "$AGENT_DIR" ]; then
+        for sock in "$AGENT_DIR"/*; do
+            if [ -S "$sock" ]; then
+                export SSH_AUTH_SOCK="$sock"
+                break
+            fi
+        done
+    fi
 fi
 
 # --- Execute the Python CLI ---

--- a/projects/ores.compass/compass.sh
+++ b/projects/ores.compass/compass.sh
@@ -61,6 +61,24 @@ source "$VENV_BIN/activate"
 REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR")
 cd "$REPO_ROOT"
 
+# --- SSH agent (sandboxed sessions) ---
+# Sandboxed shells do not inherit the user's SSH agent socket, so any git
+# push/fetch spawned by compass (pr create, capture promote, task start)
+# would fail publickey auth. When SSH_AUTH_SOCK is unset or dead, adopt the
+# sole socket in the agent directory: ORES_SSH_AGENT_DIR from .env when set,
+# else ~/.ssh/agent. See
+# doc/llm/memory/set_ssh_auth_sock_for_git_operations.org.
+if [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
+    AGENT_DIR=$(grep -s '^ORES_SSH_AGENT_DIR=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2-)
+    AGENT_DIR="${AGENT_DIR:-$HOME/.ssh/agent}"
+    for sock in "$AGENT_DIR"/*; do
+        if [ -S "$sock" ]; then
+            export SSH_AUTH_SOCK="$sock"
+            break
+        fi
+    done
+fi
+
 # --- Execute the Python CLI ---
 # Pass every argument straight through to compass.py, including --help/-h,
 # so the help shown is compass.py's own (complete, always-current) command

--- a/projects/ores.compass/src/env_init.py
+++ b/projects/ores.compass/src/env_init.py
@@ -402,6 +402,12 @@ def run(argv, project_root: Path) -> int:
 
     db_host = existing.get("ORES_DB_HOST") or "localhost"
 
+    # SSH agent directory (optional): compass.sh exports SSH_AUTH_SOCK from
+    # the sole socket in this directory when the calling environment does not
+    # provide a live one (e.g. sandboxed LLM sessions).
+    ssh_agent_dir = (existing.get("ORES_SSH_AGENT_DIR")
+                     or str(Path.home() / ".ssh" / "agent"))
+
     print("Resolving passwords...")
     ddl_pw = _get_or_gen(existing, "ORES_DB_DDL_PASSWORD")
     cli_pw = _get_or_gen(existing, "ORES_DB_CLI_PASSWORD")
@@ -451,6 +457,13 @@ ORES_CHECKOUT_LABEL={label}
         out.append(f"ORES_PRESET={preset}\n")
     out.append(f"""\
 ORES_DATABASE_NAME={db_name}
+
+# ---------------------------------------------------------------------------
+# SSH agent directory (optional) — compass.sh exports SSH_AUTH_SOCK from the
+# sole socket in this directory when the calling environment does not provide
+# a live one (e.g. sandboxed LLM sessions).
+# ---------------------------------------------------------------------------
+ORES_SSH_AGENT_DIR={ssh_agent_dir}
 
 # ---------------------------------------------------------------------------
 # NATS (per-environment: port derived from label suffix)


### PR DESCRIPTION
## Summary

Sandboxed sessions do not inherit the user's SSH agent socket, so git push/fetch spawned by compass (pr create, capture promote, task start) failed publickey auth until set_ssh_agent.sh was sourced by hand. compass.sh now adopts the sole live socket in the agent directory when SSH_AUTH_SOCK is unset or dead, configured via ORES_SSH_AGENT_DIR in .env (default ~/.ssh/agent). This PR was itself pushed with SSH_AUTH_SOCK stripped from the environment, through the new wrapper logic.

## Changes

- compass.sh: export SSH_AUTH_SOCK from the sole live socket in ORES_SSH_AGENT_DIR (.env) or ~/.ssh/agent when unset/dead
- env init: write ORES_SSH_AGENT_DIR (optional, override-preserving; no env-format version bump — absent values fall back to the default)
- Memory doc updated: compass-invoked git needs no setup; set_ssh_agent.sh remains for raw git

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality of life](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.html) | EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38 |
| Task | [Load SSH_AUTH_SOCK from .env in compass.sh](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_compass_load_ssh_auth_sock.html) | 63B1D3C7-EE7C-45E2-8E43-97FABAD5BCF4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)