### PR TITLE
[ores.shell] Add flag parsing and stop-on-error load semantics

### DIFF
--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
@@ -36,7 +36,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -62,7 +62,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:1AD5B684-404D-447F-B8A6-77AABDF829AF][Add flag parsing and stop-on-error load semantics]] | BACKLOG | | | Shell infrastructure for the provisioning surface: optional --flag parsing and load that aborts on first failure. |
+| [[id:1AD5B684-404D-447F-B8A6-77AABDF829AF][Add flag parsing and stop-on-error load semantics]] | STARTED | 2026-06-06 | | Shell infrastructure for the provisioning surface: optional --flag parsing and load that aborts on first failure. |
 | [[id:F77DC2CF-C082-4DA5-80F7-454BAA781100][Add bundles and workflow shell commands]] | BACKLOG | | | bundles list, bundles publish [--wait], workflow wait — the dataset-publication plumbing. |
 | [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | BACKLOG | | | lei countries/entities and synthetic generate — the data-source plumbing. |
 | [[id:9F96763F-5BA7-4F7E-970E-FE404A14D5C1][Add parties, account-parties and reports shell commands]] | BACKLOG | | | parties list, account-parties add, tenants complete-provisioning, reports templates — the refdata/iam/reporting plumbing. |

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
@@ -8,7 +8,7 @@
 #+filetags: :shell:infrastructure:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-provisioners-from-shell
-#+pr:
+#+pr: 1121
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -68,7 +68,7 @@ Add the two pieces of shell infrastructure the provisioning design rests on: a s
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1121][#1121]] | [ores.shell] Add flag parsing and stop-on-error load semantics |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
@@ -74,7 +74,8 @@ Add the two pieces of shell infrastructure the provisioning design rests on: a s
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Whitespace+CR-only lines fed as commands | script_runner.cpp:50 | Accepted | \r added to the leading-whitespace search; regression test added. Empty-string guard not taken: unreachable once the sets match (per no-defensive-code convention). |
+| 2 | Port parsing: partial consumption and range unchecked | connection_commands.cpp:100 | Accepted | Full-consumption + [0, 65535] range check; pre-existing code but connect opens every provisioning script. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell:infrastructure:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-provisioners-from-shell
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Add the two pieces of shell infrastructure the provisioning design rests on: a s
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Implemented with unit tests and smoke-tested; PR pending. |
+| Waiting on   | Review.                                |
+| Next         | Merge; then the bundles/workflow plumbing task. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -40,9 +40,27 @@ Add the two pieces of shell infrastructure the provisioning design rests on: a s
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+1. =app/command_feedback= — thread-local last-command-failed flag
+   (=reset/mark_failure/failed=) plus a =fail(out)= stream helper that
+   marks failure and prints the =✗ = prefix.
+2. =app/command_args= — =parse_args(tokens, specs)= →
+   =std::expected<parsed_args, std::string>=: positionals plus
+   declared =--flags= (switches and =--flag value= / =--flag=value=),
+   unknown flag or missing value is an error.
+3. =app/script_runner= — the load loop extracted as a pure function
+   over an =istream= and a feed callback, returning
+   executed/aborted/line/command, so semantics are unit-testable.
+4. Rework =load= to take variadic args: =load <file>
+   [--continue-on-error]=; stop-on-error default via
+   command_feedback; abort report with line and command; failures
+   propagate to nested loads.
+5. Wire =Cli::WrongCommandHandler= and =StdExceptionHandler= in
+   =repl::setup_menus= to mark failure — typos in scripts abort too.
+6. Mechanically route every =out << "✗ "= failure site through
+   =fail(out)= across all command groups.
+7. New =projects/ores.shell/tests= (Catch2, peer pattern):
+   command_args, command_feedback and script_runner tests; wire
+   =add_subdirectory= and run.
 
 * Notes
 
@@ -59,3 +77,31 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Implemented exactly per plan:
+
+- =app/command_feedback= — thread-local failure flag plus =fail(out)=
+  helper that marks failure and prints the =✗ = prefix. All ~90
+  existing failure sites across the nine command groups now route
+  through it (mechanical =out << "✗ "= → =fail(out) << "=).
+- =app/command_args= — =parse_args= over
+  =std::expected<parsed_args, std::string>=: switches and value flags
+  (=--flag value= / =--flag=value=), defaults, unknown-flag and
+  missing-value errors. 11 unit tests.
+- =app/script_runner= — load loop extracted as =run_script(istream,
+  feed, out, continue_on_error)= returning
+  executed/aborted/line/command. 6 unit tests including nested
+  propagation.
+- =load <file> [--continue-on-error]= reworked as a freeform command
+  over the parser and runner; stop-on-error default; abort report
+  with line and command; the abort itself marks failure so nested
+  loads abort too.
+- =Cli::WrongCommandHandler= / =StdExceptionHandler= wired in
+  =repl::setup_menus= — typos and uncaught exceptions count as
+  failures in scripts.
+- New =projects/ores.shell/tests= (first tests for the component):
+  17 cases / 44 assertions, all green.
+
+Smoke-tested against the real binary: a script with an unknown
+command aborts at the right line without printing "Script complete";
+=--continue-on-error= runs to completion.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -75,7 +75,7 @@ script library. Design first, implementation as a follow-up story.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:A19D5B00-BEF3-4718-922D-16F58EEBAAB4][Provisioners from the shell — analysis and design]] | STARTED | 2026-06-06 | | Map the three provisioner wizards to the shell command surface; brainstorm the idiomatic ores-shell interface; decide implementation approach and scope follow-up stories. |
-| [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] | BACKLOG | | | Flag parsing + stop-on-error load; plumbing (bundles, workflow, lei, synthetic, parties, account-parties, reports); provision system/tenant/party porcelain. Scoped by the design story. |
+| [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] | STARTED | 2026-06-06 | | Flag parsing + stop-on-error load; plumbing (bundles, workflow, lei, synthetic, parties, account-parties, reports); provision system/tenant/party porcelain. Scoped by the design story. |
 | [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning script library]] | BACKLOG | | | Org-mode script library in ores.shell/scripts/ with emacs tangle CMake target; end-to-end provision_all script; manual chapter. Depends on the commands story. |
 
 ** Tooling

--- a/projects/ores.shell/CMakeLists.txt
+++ b/projects/ores.shell/CMakeLists.txt
@@ -16,4 +16,5 @@
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)

--- a/projects/ores.shell/include/ores.shell/app/command_args.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_args.hpp
@@ -1,0 +1,76 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMAND_ARGS_HPP
+#define ORES_SHELL_APP_COMMAND_ARGS_HPP
+
+#include <expected>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace ores::shell::app {
+
+/**
+ * @brief Declares one optional --flag accepted by a command.
+ *
+ * A switch (requires_value == false) is either present ("true") or
+ * absent (defaults to "false"). A value flag accepts "--name value"
+ * or "--name=value" and falls back to default_value when absent.
+ */
+struct flag_spec {
+    /// Flag name without the leading dashes, e.g. "continue-on-error".
+    std::string name;
+    /// True when the flag carries a value; false for a boolean switch.
+    bool requires_value = false;
+    /// Value used when the flag is not supplied. Switches use "false".
+    std::string default_value;
+};
+
+/**
+ * @brief Result of parsing a command's argument tokens.
+ */
+struct parsed_args {
+    /// Arguments that are not flags, in order of appearance.
+    std::vector<std::string> positionals;
+    /// Flag name to effective value; switches hold "true"/"false".
+    std::map<std::string, std::string> flags;
+
+    /** @brief True when a boolean switch was supplied. */
+    bool flag_set(const std::string& name) const;
+
+    /** @brief Effective value of a flag (supplied or default). */
+    const std::string& flag(const std::string& name) const;
+};
+
+/**
+ * @brief Parse raw argument tokens into positionals and declared flags.
+ *
+ * Flags may appear anywhere among the positionals. An undeclared flag,
+ * or a value flag with no value, yields an error message suitable for
+ * direct display to the user. The cli library hands commands plain
+ * strings; this is the single place that turns them into options.
+ */
+std::expected<parsed_args, std::string>
+parse_args(const std::vector<std::string>& tokens,
+           const std::vector<flag_spec>& specs);
+
+}
+
+#endif

--- a/projects/ores.shell/include/ores.shell/app/command_feedback.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_feedback.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMAND_FEEDBACK_HPP
+#define ORES_SHELL_APP_COMMAND_FEEDBACK_HPP
+
+#include <iosfwd>
+
+namespace ores::shell::app {
+
+/**
+ * @brief Uniform failure signal for shell commands.
+ *
+ * The cli library's command handlers return void, so a command has no
+ * machine-readable way to report failure to callers such as the load
+ * command's script runner. Commands mark failure here (normally via
+ * fail()); the script runner resets the flag before feeding each line
+ * and inspects it afterwards to implement stop-on-error semantics.
+ *
+ * The flag is thread-local: each shell session processes commands on
+ * one thread, and nested script executions share the same flag so an
+ * inner abort propagates to the outer script.
+ */
+class command_feedback final {
+public:
+    command_feedback() = delete;
+
+    /** @brief Clear the failure flag ahead of executing a command. */
+    static void reset();
+
+    /** @brief Record that the current command failed. */
+    static void mark_failure();
+
+    /** @brief True if a failure was recorded since the last reset. */
+    static bool failed();
+};
+
+/**
+ * @brief Report a command failure: marks the failure flag and emits
+ * the conventional "✗ " prefix, returning the stream for the message.
+ *
+ * Usage: fail(out) << "Request failed: " << e.what() << std::endl;
+ */
+std::ostream& fail(std::ostream& out);
+
+}
+
+#endif

--- a/projects/ores.shell/include/ores.shell/app/script_runner.hpp
+++ b/projects/ores.shell/include/ores.shell/app/script_runner.hpp
@@ -1,0 +1,61 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_SCRIPT_RUNNER_HPP
+#define ORES_SHELL_APP_SCRIPT_RUNNER_HPP
+
+#include <functional>
+#include <iosfwd>
+#include <string>
+
+namespace ores::shell::app {
+
+/**
+ * @brief Outcome of executing a .ores script.
+ */
+struct script_result {
+    /// Number of commands fed to the session.
+    int executed = 0;
+    /// True when the script stopped at a failed command.
+    bool aborted = false;
+    /// 1-based line number of the failed command (when aborted).
+    int aborted_line = 0;
+    /// The command that failed (when aborted).
+    std::string aborted_command;
+};
+
+/**
+ * @brief Execute a .ores script: one command per line, '#' comments
+ * and blank lines skipped, surrounding whitespace trimmed.
+ *
+ * Each command is echoed to out with a "> " prefix and handed to
+ * feed. Failure is observed through command_feedback: the flag is
+ * reset before each command and inspected afterwards. By default the
+ * first failed command aborts the run; continue_on_error restores
+ * the keep-going behaviour. The runner is separated from the load
+ * command so these semantics are unit-testable without a cli session.
+ */
+script_result run_script(std::istream& in,
+                         const std::function<void(const std::string&)>& feed,
+                         std::ostream& out,
+                         bool continue_on_error);
+
+}
+
+#endif

--- a/projects/ores.shell/src/app/command_args.cpp
+++ b/projects/ores.shell/src/app/command_args.cpp
@@ -1,0 +1,87 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/command_args.hpp"
+#include <algorithm>
+
+namespace ores::shell::app {
+
+bool parsed_args::flag_set(const std::string& name) const {
+    auto i = flags.find(name);
+    return i != flags.end() && i->second == "true";
+}
+
+const std::string& parsed_args::flag(const std::string& name) const {
+    return flags.at(name);
+}
+
+std::expected<parsed_args, std::string>
+parse_args(const std::vector<std::string>& tokens,
+           const std::vector<flag_spec>& specs) {
+    parsed_args r;
+    for (const auto& spec : specs)
+        r.flags[spec.name] = spec.requires_value ? spec.default_value
+                                                 : std::string("false");
+
+    auto find_spec = [&](const std::string& name) {
+        return std::find_if(specs.begin(), specs.end(),
+                            [&](const auto& s) { return s.name == name; });
+    };
+
+    for (std::size_t i = 0; i < tokens.size(); ++i) {
+        const auto& token = tokens[i];
+        if (!token.starts_with("--")) {
+            r.positionals.push_back(token);
+            continue;
+        }
+
+        auto body = token.substr(2);
+        std::string inline_value;
+        bool has_inline_value = false;
+        if (auto eq = body.find('='); eq != std::string::npos) {
+            inline_value = body.substr(eq + 1);
+            body = body.substr(0, eq);
+            has_inline_value = true;
+        }
+
+        auto spec = find_spec(body);
+        if (spec == specs.end())
+            return std::unexpected("Unknown flag: --" + body);
+
+        if (!spec->requires_value) {
+            if (has_inline_value)
+                return std::unexpected("Flag --" + body +
+                                       " does not take a value");
+            r.flags[body] = "true";
+            continue;
+        }
+
+        if (has_inline_value) {
+            r.flags[body] = inline_value;
+            continue;
+        }
+
+        if (i + 1 >= tokens.size() || tokens[i + 1].starts_with("--"))
+            return std::unexpected("Flag --" + body + " requires a value");
+        r.flags[body] = tokens[++i];
+    }
+    return r;
+}
+
+}

--- a/projects/ores.shell/src/app/command_feedback.cpp
+++ b/projects/ores.shell/src/app/command_feedback.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/command_feedback.hpp"
+#include <ostream>
+
+namespace {
+
+thread_local bool last_command_failed = false;
+
+}
+
+namespace ores::shell::app {
+
+void command_feedback::reset() {
+    last_command_failed = false;
+}
+
+void command_feedback::mark_failure() {
+    last_command_failed = true;
+}
+
+bool command_feedback::failed() {
+    return last_command_failed;
+}
+
+std::ostream& fail(std::ostream& out) {
+    command_feedback::mark_failure();
+    return out << "✗ ";
+}
+
+}

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/accounts_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/account_table_io.hpp"         // IWYU pragma: keep.
 #include "ores.iam.api/domain/account_version_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/domain/login_info_table_io.hpp"      // IWYU pragma: keep.
@@ -85,12 +86,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -106,12 +107,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -301,7 +302,7 @@ void accounts_commands::process_list_accounts(std::ostream& out,
     BOOST_LOG_SEV(lg(), debug) << "Initiating list account request.";
 
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to list accounts." << std::endl;
+        fail(out) << "You must be logged in to list accounts." << std::endl;
         return;
     }
 
@@ -347,7 +348,7 @@ void accounts_commands::process_login(std::ostream& out,
         return;
 
     if (!result->success) {
-        out << "✗ Login failed: " << result->message << std::endl;
+        fail(out) << "Login failed: " << result->message << std::endl;
         return;
     }
 
@@ -371,7 +372,7 @@ void accounts_commands::process_lock_account(std::ostream& out,
         boost::lexical_cast<boost::uuids::uuid>(account_id);
     } catch (const boost::bad_lexical_cast&) {
         BOOST_LOG_SEV(lg(), error) << "Invalid account ID format: " << account_id;
-        out << "✗ Invalid account ID format. Expected UUID." << std::endl;
+        fail(out) << "Invalid account ID format. Expected UUID." << std::endl;
         return;
     }
 
@@ -386,7 +387,7 @@ void accounts_commands::process_lock_account(std::ostream& out,
         return;
 
     if (result->results.empty()) {
-        out << "✗ No results returned from server" << std::endl;
+        fail(out) << "No results returned from server" << std::endl;
         return;
     }
 
@@ -397,7 +398,7 @@ void accounts_commands::process_lock_account(std::ostream& out,
             << "  Account ID: " << account_id << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to lock account: " << account_result.message;
-        out << "✗ Failed to lock account: " << account_result.message << std::endl;
+        fail(out) << "Failed to lock account: " << account_result.message << std::endl;
     }
 }
 
@@ -409,7 +410,7 @@ void accounts_commands::process_unlock_account(std::ostream& out,
         boost::lexical_cast<boost::uuids::uuid>(account_id);
     } catch (const boost::bad_lexical_cast&) {
         BOOST_LOG_SEV(lg(), error) << "Invalid account ID format: " << account_id;
-        out << "✗ Invalid account ID format. Expected UUID." << std::endl;
+        fail(out) << "Invalid account ID format. Expected UUID." << std::endl;
         return;
     }
 
@@ -424,7 +425,7 @@ void accounts_commands::process_unlock_account(std::ostream& out,
         return;
 
     if (result->results.empty()) {
-        out << "✗ No results returned from server" << std::endl;
+        fail(out) << "No results returned from server" << std::endl;
         return;
     }
 
@@ -435,7 +436,7 @@ void accounts_commands::process_unlock_account(std::ostream& out,
             << "  Account ID: " << account_id << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to unlock account: " << account_result.message;
-        out << "✗ Failed to unlock account: " << account_result.message << std::endl;
+        fail(out) << "Failed to unlock account: " << account_result.message << std::endl;
     }
 }
 
@@ -460,7 +461,7 @@ void accounts_commands::process_create_account(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Account creation failed: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 
@@ -486,7 +487,7 @@ void accounts_commands::process_list_login_info(std::ostream& out, nats_client& 
 
 void accounts_commands::process_logout(std::ostream& out, nats_client& session) {
     if (!session.is_logged_in()) {
-        out << "✗ Not logged in." << std::endl;
+        fail(out) << "Not logged in." << std::endl;
         return;
     }
 
@@ -499,10 +500,10 @@ void accounts_commands::process_logout(std::ostream& out, nats_client& session) 
         if (result && result->success) {
             out << "✓ Logged out successfully." << std::endl;
         } else {
-            out << "✗ Logout failed." << std::endl;
+            fail(out) << "Logout failed." << std::endl;
         }
     } catch (const std::exception& e) {
-        out << "✗ Logout failed: " << e.what() << std::endl;
+        fail(out) << "Logout failed: " << e.what() << std::endl;
     }
     session.clear_auth();
 }
@@ -537,7 +538,7 @@ void accounts_commands::process_bootstrap(std::ostream& out,
         out << "  You can now login with the credentials provided." << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Bootstrap failed: " << result->error_message;
-        out << "✗ Bootstrap failed: " << result->error_message << std::endl;
+        fail(out) << "Bootstrap failed: " << result->error_message << std::endl;
     }
 }
 
@@ -554,7 +555,7 @@ void accounts_commands::process_list_sessions(std::ostream& out,
             req.account_id = account_id;
         } catch (const boost::bad_lexical_cast&) {
             BOOST_LOG_SEV(lg(), error) << "Invalid account ID format: " << account_id;
-            out << "✗ Invalid account ID format. Expected UUID." << std::endl;
+            fail(out) << "Invalid account ID format. Expected UUID." << std::endl;
             return;
         }
     }
@@ -718,7 +719,7 @@ void accounts_commands::process_get_account_history(std::ostream& out,
     BOOST_LOG_SEV(lg(), debug) << "Initiating get account history for: " << username;
 
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get account history." << std::endl;
+        fail(out) << "You must be logged in to get account history." << std::endl;
         return;
     }
 
@@ -732,7 +733,7 @@ void accounts_commands::process_get_account_history(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get account history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 
@@ -752,7 +753,7 @@ void accounts_commands::process_account_info(std::ostream& out,
     BOOST_LOG_SEV(lg(), debug) << "Getting comprehensive account info for: " << username;
 
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to view account info." << std::endl;
+        fail(out) << "You must be logged in to view account info." << std::endl;
         return;
     }
 
@@ -766,12 +767,12 @@ void accounts_commands::process_account_info(std::ostream& out,
         return;
 
     if (!history_result->success) {
-        out << "✗ " << history_result->message << std::endl;
+        fail(out) << "" << history_result->message << std::endl;
         return;
     }
 
     if (history_result->history.versions.empty()) {
-        out << "✗ Account not found: " << username << std::endl;
+        fail(out) << "Account not found: " << username << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/change_reason_categories_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.dq.api/domain/change_reason_category_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
@@ -44,12 +45,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -65,12 +66,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -143,7 +144,7 @@ void change_reason_categories_commands::process_add_category(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to add a category." << std::endl;
+        fail(out) << "You must be logged in to add a category." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -167,7 +168,7 @@ void change_reason_categories_commands::process_add_category(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to add category: " << msg;
-        out << "✗ Failed to add category: " << msg << std::endl;
+        fail(out) << "Failed to add category: " << msg << std::endl;
     }
 }
 
@@ -178,7 +179,7 @@ void change_reason_categories_commands::process_delete_category(std::ostream& ou
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a category." << std::endl;
+        fail(out) << "You must be logged in to delete a category." << std::endl;
         return;
     }
 
@@ -195,7 +196,7 @@ void change_reason_categories_commands::process_delete_category(std::ostream& ou
         out << "✓ Category " << code << " deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete category: " << result->message;
-        out << "✗ Failed to delete category: " << result->message << std::endl;
+        fail(out) << "Failed to delete category: " << result->message << std::endl;
     }
 }
 
@@ -206,7 +207,7 @@ void change_reason_categories_commands::process_get_category_history(std::ostrea
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get category history." << std::endl;
+        fail(out) << "You must be logged in to get category history." << std::endl;
         return;
     }
 
@@ -220,7 +221,7 @@ void change_reason_categories_commands::process_get_category_history(std::ostrea
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get category history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/change_reasons_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.dq.api/domain/change_reason_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
@@ -44,12 +45,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -65,12 +66,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -148,7 +149,7 @@ void change_reasons_commands::process_add_change_reason(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to add a change reason." << std::endl;
+        fail(out) << "You must be logged in to add a change reason." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -177,7 +178,7 @@ void change_reasons_commands::process_add_change_reason(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to add change reason: " << msg;
-        out << "✗ Failed to add change reason: " << msg << std::endl;
+        fail(out) << "Failed to add change reason: " << msg << std::endl;
     }
 }
 
@@ -188,7 +189,7 @@ void change_reasons_commands::process_delete_change_reason(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a change reason." << std::endl;
+        fail(out) << "You must be logged in to delete a change reason." << std::endl;
         return;
     }
 
@@ -205,7 +206,7 @@ void change_reasons_commands::process_delete_change_reason(std::ostream& out,
         out << "✓ Change reason " << code << " deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete change reason: " << result->message;
-        out << "✗ Failed to delete change reason: " << result->message << std::endl;
+        fail(out) << "Failed to delete change reason: " << result->message << std::endl;
     }
 }
 
@@ -216,7 +217,7 @@ void change_reasons_commands::process_get_change_reason_history(std::ostream& ou
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get change reason history." << std::endl;
+        fail(out) << "You must be logged in to get change reason history." << std::endl;
         return;
     }
 
@@ -230,7 +231,7 @@ void change_reasons_commands::process_get_change_reason_history(std::ostream& ou
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get change reason history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <ostream>
 #include <rfl/json.hpp>
+#include <stdexcept>
 
 namespace ores::shell::app::commands {
 
@@ -93,7 +94,11 @@ void connection_commands::process_connect(std::ostream& out,
 
     if (!port.empty()) {
         try {
-            resolved_port = static_cast<std::uint16_t>(std::stoi(port));
+            std::size_t pos = 0;
+            const int p = std::stoi(port, &pos);
+            if (pos != port.size() || p < 0 || p > 65535)
+                throw std::out_of_range("invalid port");
+            resolved_port = static_cast<std::uint16_t>(p);
         } catch (...) {
             fail(out) << "Invalid port number: " << port << std::endl;
             return;

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/connection_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/messaging/bootstrap_protocol.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/config/nats_options.hpp"
@@ -94,7 +95,7 @@ void connection_commands::process_connect(std::ostream& out,
         try {
             resolved_port = static_cast<std::uint16_t>(std::stoi(port));
         } catch (...) {
-            out << "✗ Invalid port number: " << port << std::endl;
+            fail(out) << "Invalid port number: " << port << std::endl;
             return;
         }
     }
@@ -108,13 +109,13 @@ void connection_commands::process_connect(std::ostream& out,
         out << "✓ Connected to " << nats_url << std::endl;
         check_bootstrap_status(session, out);
     } catch (const std::exception& e) {
-        out << "✗ Connection failed: " << e.what() << std::endl;
+        fail(out) << "Connection failed: " << e.what() << std::endl;
     }
 }
 
 void connection_commands::process_disconnect(std::ostream& out, nats_client& session) {
     if (!session.is_connected()) {
-        out << "✗ Not connected." << std::endl;
+        fail(out) << "Not connected." << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/countries_commands.cpp
+++ b/projects/ores.shell/src/app/commands/countries_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/countries_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.refdata.api/domain/country_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/country_protocol.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
@@ -44,12 +45,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -65,12 +66,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -179,7 +180,7 @@ void countries_commands::process_add_country(std::ostream& out,
 
     // Get modified_by from logged-in user
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to add a country." << std::endl;
+        fail(out) << "You must be logged in to add a country." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -208,7 +209,7 @@ void countries_commands::process_add_country(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to add country: " << msg;
-        out << "✗ Failed to add country: " << msg << std::endl;
+        fail(out) << "Failed to add country: " << msg << std::endl;
     }
 }
 
@@ -219,7 +220,7 @@ void countries_commands::process_delete_country(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a country." << std::endl;
+        fail(out) << "You must be logged in to delete a country." << std::endl;
         return;
     }
 
@@ -236,7 +237,7 @@ void countries_commands::process_delete_country(std::ostream& out,
         out << "✓ Country " << alpha2_code << " deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete country: " << result->message;
-        out << "✗ Failed to delete country: " << result->message << std::endl;
+        fail(out) << "Failed to delete country: " << result->message << std::endl;
     }
 }
 
@@ -247,7 +248,7 @@ void countries_commands::process_get_country_history(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get country history." << std::endl;
+        fail(out) << "You must be logged in to get country history." << std::endl;
         return;
     }
 
@@ -261,7 +262,7 @@ void countries_commands::process_get_country_history(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get country history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/currencies_commands.cpp
+++ b/projects/ores.shell/src/app/commands/currencies_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/currencies_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.refdata.api/domain/currency_table_io.hpp"         // IWYU pragma: keep.
 #include "ores.refdata.api/domain/currency_version_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/currency_history_protocol.hpp"
@@ -47,12 +48,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -68,12 +69,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -190,7 +191,7 @@ void currencies_commands::process_add_currency(std::ostream& out,
 
     // Get modified_by from logged-in user
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to add a currency." << std::endl;
+        fail(out) << "You must be logged in to add a currency." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -201,7 +202,7 @@ void currencies_commands::process_add_currency(std::ostream& out,
         try {
             fractions = std::stoi(fractions_per_unit);
         } catch (...) {
-            out << "✗ Invalid fractions_per_unit value: " << fractions_per_unit << std::endl;
+            fail(out) << "Invalid fractions_per_unit value: " << fractions_per_unit << std::endl;
             return;
         }
     }
@@ -235,7 +236,7 @@ void currencies_commands::process_add_currency(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to add currency: " << msg;
-        out << "✗ Failed to add currency: " << msg << std::endl;
+        fail(out) << "Failed to add currency: " << msg << std::endl;
     }
 }
 
@@ -246,7 +247,7 @@ void currencies_commands::process_delete_currency(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a currency." << std::endl;
+        fail(out) << "You must be logged in to delete a currency." << std::endl;
         return;
     }
 
@@ -263,7 +264,7 @@ void currencies_commands::process_delete_currency(std::ostream& out,
         out << "✓ Currency " << iso_code << " deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete currency: " << result->message;
-        out << "✗ Failed to delete currency: " << result->message << std::endl;
+        fail(out) << "Failed to delete currency: " << result->message << std::endl;
     }
 }
 
@@ -274,7 +275,7 @@ void currencies_commands::process_get_currency_history(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get currency history." << std::endl;
+        fail(out) << "You must be logged in to get currency history." << std::endl;
         return;
     }
 
@@ -288,7 +289,7 @@ void currencies_commands::process_get_currency_history(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get currency history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 
@@ -309,7 +310,7 @@ void currencies_commands::process_get_currency_history_diff(std::ostream& out,
                                << iso_code;
 
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get currency history." << std::endl;
+        fail(out) << "You must be logged in to get currency history." << std::endl;
         return;
     }
 
@@ -323,7 +324,7 @@ void currencies_commands::process_get_currency_history_diff(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get currency history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/rbac_commands.cpp
+++ b/projects/ores.shell/src/app/commands/rbac_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/rbac_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/permission_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/domain/role_table_io.hpp"       // IWYU pragma: keep.
 #include "ores.iam.api/messaging/authorization_protocol.hpp"
@@ -93,12 +94,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }

--- a/projects/ores.shell/src/app/commands/script_commands.cpp
+++ b/projects/ores.shell/src/app/commands/script_commands.cpp
@@ -18,6 +18,9 @@
  *
  */
 #include "ores.shell/app/commands/script_commands.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/script_runner.hpp"
 #include "ores.logging/make_logger.hpp"
 #include <cli/cli.h>
 #include <fstream>
@@ -40,53 +43,71 @@ auto& anon_lg() {
 
 void script_commands::register_commands(cli::Menu& root, cli::CliSession*& active_session) {
     root.Insert("load",
-                [&active_session](std::ostream& out, std::string filename) {
+                [&active_session](std::ostream& out, std::vector<std::string> args) {
+                    auto parsed = parse_args(args, {
+                        {.name = "continue-on-error"}
+                    });
+                    if (!parsed) {
+                        fail(out) << parsed.error() << std::endl;
+                        return;
+                    }
+                    if (parsed->positionals.size() != 1) {
+                        fail(out) << "Usage: load <filename> [--continue-on-error]"
+                                  << std::endl;
+                        return;
+                    }
+                    const auto& filename = parsed->positionals.front();
+                    const bool continue_on_error =
+                        parsed->flag_set("continue-on-error");
+
                     if (!active_session) {
-                        out << "Error: no active session." << std::endl;
+                        fail(out) << "Error: no active session." << std::endl;
                         return;
                     }
 
                     std::ifstream file(filename);
                     if (!file.is_open()) {
-                        out << "Error: cannot open file: " << filename << std::endl;
-                        BOOST_LOG_SEV(anon_lg(), error) << "Cannot open script file: " << filename;
+                        fail(out) << "Error: cannot open file: " << filename
+                                  << std::endl;
+                        BOOST_LOG_SEV(anon_lg(), error)
+                            << "Cannot open script file: " << filename;
                         return;
                     }
 
                     out << "Loading script: " << filename << std::endl;
                     BOOST_LOG_SEV(anon_lg(), info) << "Loading script: " << filename;
 
-                    int line_num = 0;
-                    int executed = 0;
-                    std::string line;
-                    while (std::getline(file, line)) {
-                        ++line_num;
+                    auto result = run_script(
+                        file,
+                        [&active_session](const std::string& command) {
+                            active_session->Feed(command);
+                        },
+                        out, continue_on_error);
 
-                        // Skip empty lines and comments
-                        if (line.empty())
-                            continue;
-                        if (line[0] == '#')
-                            continue;
-
-                        // Strip leading/trailing whitespace
-                        auto start = line.find_first_not_of(" \t");
-                        if (start == std::string::npos)
-                            continue;
-                        auto end = line.find_last_not_of(" \t\r");
-                        auto trimmed = line.substr(start, end - start + 1);
-
-                        out << "> " << trimmed << std::endl;
-                        active_session->Feed(trimmed);
-                        ++executed;
+                    if (result.aborted) {
+                        // fail() keeps the flag set so an enclosing load
+                        // (this command runs under run_script when scripts
+                        // nest) aborts too.
+                        fail(out) << "Script aborted at line "
+                                  << result.aborted_line << ": "
+                                  << result.aborted_command << std::endl;
+                        BOOST_LOG_SEV(anon_lg(), error)
+                            << "Script aborted at line " << result.aborted_line
+                            << " of " << filename << ": "
+                            << result.aborted_command;
+                        return;
                     }
 
-                    out << "Script complete: " << executed << " command"
-                        << (executed != 1 ? "s" : "") << " executed." << std::endl;
-                    BOOST_LOG_SEV(anon_lg(), info) << "Script complete: " << executed
-                                                   << " commands executed from " << filename;
+                    out << "Script complete: " << result.executed << " command"
+                        << (result.executed != 1 ? "s" : "") << " executed."
+                        << std::endl;
+                    BOOST_LOG_SEV(anon_lg(), info)
+                        << "Script complete: " << result.executed
+                        << " commands executed from " << filename;
                 },
-                "Load and execute a .ores script file",
-                {"filename"});
+                "Load and execute a .ores script file (aborts on first error; "
+                "--continue-on-error to keep going)",
+                {"filename [--continue-on-error]"});
 }
 
 }

--- a/projects/ores.shell/src/app/commands/tenants_commands.cpp
+++ b/projects/ores.shell/src/app/commands/tenants_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/tenants_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/tenant_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
 #include "ores.platform/time/datetime.hpp"
@@ -52,12 +53,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -147,7 +148,7 @@ void tenants_commands::process_add_tenant(std::ostream& out,
 
     // Get modified_by from logged-in user
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to add a tenant." << std::endl;
+        fail(out) << "You must be logged in to add a tenant." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -182,7 +183,7 @@ void tenants_commands::process_add_tenant(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to add tenant: " << msg;
-        out << "✗ Failed to add tenant: " << msg << std::endl;
+        fail(out) << "Failed to add tenant: " << msg << std::endl;
     }
 }
 
@@ -196,7 +197,7 @@ void tenants_commands::process_tenant_history(std::ostream& out,
         boost::lexical_cast<boost::uuids::uuid>(tenant_id);
     } catch (const boost::bad_lexical_cast&) {
         BOOST_LOG_SEV(lg(), error) << "Invalid tenant ID format: " << tenant_id;
-        out << "✗ Invalid tenant ID format. Expected UUID." << std::endl;
+        fail(out) << "Invalid tenant ID format. Expected UUID." << std::endl;
         return;
     }
 
@@ -210,7 +211,7 @@ void tenants_commands::process_tenant_history(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get tenant history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 
@@ -253,7 +254,7 @@ void tenants_commands::process_delete_tenant(std::ostream& out,
     BOOST_LOG_SEV(lg(), debug) << "Initiating delete tenant request for: " << tenant_id;
 
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a tenant." << std::endl;
+        fail(out) << "You must be logged in to delete a tenant." << std::endl;
         return;
     }
 
@@ -262,7 +263,7 @@ void tenants_commands::process_delete_tenant(std::ostream& out,
         boost::lexical_cast<boost::uuids::uuid>(tenant_id);
     } catch (const boost::bad_lexical_cast&) {
         BOOST_LOG_SEV(lg(), error) << "Invalid tenant ID format: " << tenant_id;
-        out << "✗ Invalid tenant ID format. Expected UUID." << std::endl;
+        fail(out) << "Invalid tenant ID format. Expected UUID." << std::endl;
         return;
     }
 
@@ -279,7 +280,7 @@ void tenants_commands::process_delete_tenant(std::ostream& out,
         out << "✓ Tenant deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete tenant: " << result->message;
-        out << "✗ Failed to delete tenant: " << result->message << std::endl;
+        fail(out) << "Failed to delete tenant: " << result->message << std::endl;
     }
 }
 

--- a/projects/ores.shell/src/app/commands/variability_commands.cpp
+++ b/projects/ores.shell/src/app/commands/variability_commands.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.shell/app/commands/variability_commands.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp"                         // IWYU pragma: keep.
 #include "ores.variability.api/domain/system_setting_table_io.hpp" // IWYU pragma: keep.
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
@@ -44,12 +45,12 @@ std::optional<Response> do_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -65,12 +66,12 @@ std::optional<Response> do_auth_request(std::ostream& out,
             std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
-            out << "✗ Failed to parse response" << std::endl;
+            fail(out) << "Failed to parse response" << std::endl;
             return std::nullopt;
         }
         return *result;
     } catch (const std::exception& e) {
-        out << "✗ Request failed: " << e.what() << std::endl;
+        fail(out) << "Request failed: " << e.what() << std::endl;
         return std::nullopt;
     }
 }
@@ -150,7 +151,7 @@ void variability_commands::process_save_setting(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to save a setting." << std::endl;
+        fail(out) << "You must be logged in to save a setting." << std::endl;
         return;
     }
     const auto& modified_by = session.auth().username;
@@ -177,7 +178,7 @@ void variability_commands::process_save_setting(std::ostream& out,
     } else {
         const auto& msg = result->message.empty() ? "Unknown error" : result->message;
         BOOST_LOG_SEV(lg(), warn) << "Failed to save setting: " << msg;
-        out << "✗ Failed to save setting: " << msg << std::endl;
+        fail(out) << "Failed to save setting: " << msg << std::endl;
     }
 }
 
@@ -188,7 +189,7 @@ void variability_commands::process_delete_setting(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to delete a setting." << std::endl;
+        fail(out) << "You must be logged in to delete a setting." << std::endl;
         return;
     }
 
@@ -205,7 +206,7 @@ void variability_commands::process_delete_setting(std::ostream& out,
         out << "✓ Setting deleted successfully!" << std::endl;
     } else {
         BOOST_LOG_SEV(lg(), warn) << "Failed to delete setting: " << result->error_message;
-        out << "✗ Failed to delete setting: " << result->error_message << std::endl;
+        fail(out) << "Failed to delete setting: " << result->error_message << std::endl;
     }
 }
 
@@ -216,7 +217,7 @@ void variability_commands::process_get_setting_history(std::ostream& out,
 
     // Check if logged in
     if (!session.is_logged_in()) {
-        out << "✗ You must be logged in to get setting history." << std::endl;
+        fail(out) << "You must be logged in to get setting history." << std::endl;
         return;
     }
 
@@ -230,7 +231,7 @@ void variability_commands::process_get_setting_history(std::ostream& out,
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get setting history: " << result->message;
-        out << "✗ " << result->message << std::endl;
+        fail(out) << "" << result->message << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/repl.hpp"
 #include "ores.iam.api/messaging/login_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/accounts_commands.hpp"
 #include "ores.shell/app/commands/change_reason_categories_commands.hpp"
 #include "ores.shell/app/commands/change_reasons_commands.hpp"
@@ -83,6 +84,18 @@ std::unique_ptr<cli::Cli> repl::setup_menus() {
 
     auto cli_instance = std::make_unique<cli::Cli>(std::move(root));
     cli_instance->ExitAction([](auto& out) { out << "Bye!" << std::endl; });
+
+    // Route cli-level errors through command_feedback so scripts abort
+    // on unknown commands and uncaught exceptions too.
+    cli_instance->WrongCommandHandler(
+        [](std::ostream& out, const std::string& cmd) {
+            fail(out) << "Wrong command: " << cmd << std::endl;
+        });
+    cli_instance->StdExceptionHandler(
+        [](std::ostream& out, const std::string& cmd, const std::exception& e) {
+            fail(out) << "Command failed: " << cmd << " (" << e.what() << ")"
+                      << std::endl;
+        });
     return cli_instance;
 }
 

--- a/projects/ores.shell/src/app/script_runner.cpp
+++ b/projects/ores.shell/src/app/script_runner.cpp
@@ -40,8 +40,10 @@ script_result run_script(std::istream& in,
         if (line[0] == '#')
             continue;
 
-        // Strip leading/trailing whitespace.
-        auto start = line.find_first_not_of(" \t");
+        // Strip leading/trailing whitespace. The search sets match, so
+        // once start hits a non-whitespace character end cannot be npos
+        // and trimmed cannot be empty.
+        auto start = line.find_first_not_of(" \t\r");
         if (start == std::string::npos)
             continue;
         auto end = line.find_last_not_of(" \t\r");

--- a/projects/ores.shell/src/app/script_runner.cpp
+++ b/projects/ores.shell/src/app/script_runner.cpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/script_runner.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include <istream>
+#include <ostream>
+
+namespace ores::shell::app {
+
+script_result run_script(std::istream& in,
+                         const std::function<void(const std::string&)>& feed,
+                         std::ostream& out,
+                         bool continue_on_error) {
+    script_result r;
+    int line_num = 0;
+    std::string line;
+    while (std::getline(in, line)) {
+        ++line_num;
+
+        // Skip empty lines and comments.
+        if (line.empty())
+            continue;
+        if (line[0] == '#')
+            continue;
+
+        // Strip leading/trailing whitespace.
+        auto start = line.find_first_not_of(" \t");
+        if (start == std::string::npos)
+            continue;
+        auto end = line.find_last_not_of(" \t\r");
+        auto trimmed = line.substr(start, end - start + 1);
+        if (trimmed[0] == '#')
+            continue;
+
+        out << "> " << trimmed << std::endl;
+        command_feedback::reset();
+        feed(trimmed);
+        ++r.executed;
+
+        if (command_feedback::failed() && !continue_on_error) {
+            r.aborted = true;
+            r.aborted_line = line_num;
+            r.aborted_command = trimmed;
+            return r;
+        }
+    }
+    return r;
+}
+
+}

--- a/projects/ores.shell/tests/CMakeLists.txt
+++ b/projects/ores.shell/tests/CMakeLists.txt
@@ -1,0 +1,59 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+set(name "ores.shell")
+set(lib_target_name ${name}.lib)
+set(tests_binary_name ${name}.tests)
+set(tests_target_name ${name}.tests)
+
+set(files "")
+file(GLOB_RECURSE files RELATIVE
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+add_executable(${tests_target_name} ${files})
+set_target_properties(${tests_target_name}
+    PROPERTIES OUTPUT_NAME ${tests_binary_name})
+
+target_link_libraries(${tests_target_name}
+    PRIVATE
+        ${lib_target_name}
+        ores.testing.lib
+        Catch2::Catch2
+        ores.openssl_cleanup
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_custom_target(test_${tests_target_name}
+    COMMENT "Testing ${tests_target_name}" VERBATIM
+    COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    DEPENDS ${tests_target_name})
+
+add_dependencies(run_all_tests test_${tests_target_name})
+
+add_test(NAME ${tests_target_name}
+    COMMAND ${tests_binary_name} ${ORES_CATCH2_ARGS} -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+set_tests_properties(${tests_target_name} PROPERTIES
+    PROCESSORS 1
+    ENVIRONMENT "${ORES_TEST_ENV}"
+    ATTACHED_FILES_ON_FAIL "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml"
+)
+
+set_property(TEST ${tests_target_name} PROPERTY USES_XML_OUTPUT ON)

--- a/projects/ores.shell/tests/app_command_args_tests.cpp
+++ b/projects/ores.shell/tests/app_command_args_tests.cpp
@@ -1,0 +1,138 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/command_args.hpp"
+#include "ores.logging/make_logger.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+const std::string_view test_suite("ores.shell.tests");
+const std::string tags("[app]");
+
+}
+
+using ores::shell::app::flag_spec;
+using ores::shell::app::parse_args;
+using namespace ores::logging;
+
+TEST_CASE("parse_args_positionals_only", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"alpha", "beta"}, {});
+    REQUIRE(r.has_value());
+    CHECK(r->positionals == std::vector<std::string>{"alpha", "beta"});
+    CHECK(r->flags.empty());
+}
+
+TEST_CASE("parse_args_switch_defaults_to_false", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"file.ores"}, {{.name = "continue-on-error"}});
+    REQUIRE(r.has_value());
+    CHECK_FALSE(r->flag_set("continue-on-error"));
+    CHECK(r->positionals == std::vector<std::string>{"file.ores"});
+}
+
+TEST_CASE("parse_args_switch_present", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"file.ores", "--continue-on-error"},
+                        {{.name = "continue-on-error"}});
+    REQUIRE(r.has_value());
+    CHECK(r->flag_set("continue-on-error"));
+}
+
+TEST_CASE("parse_args_switch_anywhere_among_positionals", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--continue-on-error", "file.ores"},
+                        {{.name = "continue-on-error"}});
+    REQUIRE(r.has_value());
+    CHECK(r->flag_set("continue-on-error"));
+    CHECK(r->positionals == std::vector<std::string>{"file.ores"});
+}
+
+TEST_CASE("parse_args_value_flag_with_separate_value", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--seed", "42"},
+                        {{.name = "seed", .requires_value = true,
+                          .default_value = ""}});
+    REQUIRE(r.has_value());
+    CHECK(r->flag("seed") == "42");
+}
+
+TEST_CASE("parse_args_value_flag_with_inline_value", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--seed=42"},
+                        {{.name = "seed", .requires_value = true,
+                          .default_value = ""}});
+    REQUIRE(r.has_value());
+    CHECK(r->flag("seed") == "42");
+}
+
+TEST_CASE("parse_args_value_flag_uses_default_when_absent", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({}, {{.name = "dataset-size", .requires_value = true,
+                              .default_value = "small"}});
+    REQUIRE(r.has_value());
+    CHECK(r->flag("dataset-size") == "small");
+}
+
+TEST_CASE("parse_args_unknown_flag_is_error", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--bogus"}, {{.name = "continue-on-error"}});
+    REQUIRE_FALSE(r.has_value());
+    BOOST_LOG_SEV(lg, info) << "Error: " << r.error();
+    CHECK(r.error().find("--bogus") != std::string::npos);
+}
+
+TEST_CASE("parse_args_value_flag_missing_value_is_error", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--seed"},
+                        {{.name = "seed", .requires_value = true,
+                          .default_value = ""}});
+    REQUIRE_FALSE(r.has_value());
+    CHECK(r.error().find("--seed") != std::string::npos);
+}
+
+TEST_CASE("parse_args_value_flag_followed_by_flag_is_error", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--seed", "--continue-on-error"},
+                        {{.name = "seed", .requires_value = true,
+                          .default_value = ""},
+                         {.name = "continue-on-error"}});
+    REQUIRE_FALSE(r.has_value());
+    CHECK(r.error().find("--seed") != std::string::npos);
+}
+
+TEST_CASE("parse_args_switch_with_inline_value_is_error", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_args({"--continue-on-error=yes"},
+                        {{.name = "continue-on-error"}});
+    REQUIRE_FALSE(r.has_value());
+    CHECK(r.error().find("continue-on-error") != std::string::npos);
+}

--- a/projects/ores.shell/tests/app_script_runner_tests.cpp
+++ b/projects/ores.shell/tests/app_script_runner_tests.cpp
@@ -1,0 +1,150 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/script_runner.hpp"
+#include "ores.logging/make_logger.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <sstream>
+#include <vector>
+
+namespace {
+
+const std::string_view test_suite("ores.shell.tests");
+const std::string tags("[app]");
+
+}
+
+using ores::shell::app::command_feedback;
+using ores::shell::app::fail;
+using ores::shell::app::run_script;
+using namespace ores::logging;
+
+TEST_CASE("command_feedback_reset_clears_failure", tags) {
+    auto lg(make_logger(test_suite));
+
+    command_feedback::mark_failure();
+    CHECK(ores::shell::app::command_feedback::failed());
+    command_feedback::reset();
+    CHECK_FALSE(command_feedback::failed());
+}
+
+TEST_CASE("fail_marks_failure_and_prefixes_message", tags) {
+    auto lg(make_logger(test_suite));
+
+    command_feedback::reset();
+    std::ostringstream out;
+    fail(out) << "boom" << std::endl;
+    CHECK(command_feedback::failed());
+    CHECK(out.str() == "✗ boom\n");
+    command_feedback::reset();
+}
+
+TEST_CASE("run_script_executes_commands_and_skips_noise", tags) {
+    auto lg(make_logger(test_suite));
+    command_feedback::reset();
+
+    std::istringstream in("# comment\n"
+                          "\n"
+                          "  one  \n"
+                          "\t# indented comment\n"
+                          "two\n");
+    std::vector<std::string> fed;
+    std::ostringstream out;
+    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
+                        out, false);
+
+    CHECK_FALSE(r.aborted);
+    CHECK(r.executed == 2);
+    CHECK(fed == std::vector<std::string>{"one", "two"});
+}
+
+TEST_CASE("run_script_aborts_on_first_failure_by_default", tags) {
+    auto lg(make_logger(test_suite));
+    command_feedback::reset();
+
+    std::istringstream in("good\n"
+                          "bad\n"
+                          "never\n");
+    std::vector<std::string> fed;
+    std::ostringstream out;
+    auto r = run_script(in,
+                        [&](const std::string& c) {
+                            fed.push_back(c);
+                            if (c == "bad")
+                                command_feedback::mark_failure();
+                        },
+                        out, false);
+
+    CHECK(r.aborted);
+    CHECK(r.aborted_line == 2);
+    CHECK(r.aborted_command == "bad");
+    CHECK(r.executed == 2);
+    CHECK(fed == std::vector<std::string>{"good", "bad"});
+}
+
+TEST_CASE("run_script_continue_on_error_keeps_going", tags) {
+    auto lg(make_logger(test_suite));
+    command_feedback::reset();
+
+    std::istringstream in("good\n"
+                          "bad\n"
+                          "after\n");
+    std::vector<std::string> fed;
+    std::ostringstream out;
+    auto r = run_script(in,
+                        [&](const std::string& c) {
+                            fed.push_back(c);
+                            if (c == "bad")
+                                command_feedback::mark_failure();
+                        },
+                        out, true);
+
+    CHECK_FALSE(r.aborted);
+    CHECK(r.executed == 3);
+    CHECK(fed == std::vector<std::string>{"good", "bad", "after"});
+}
+
+TEST_CASE("run_script_nested_failure_propagates", tags) {
+    auto lg(make_logger(test_suite));
+    command_feedback::reset();
+
+    // Outer script feeds a command which itself runs an inner script
+    // whose failure aborts it; the inner abort marks failure, which
+    // the outer runner observes after the feed returns.
+    std::istringstream outer_in("run-inner\n"
+                                "never\n");
+    std::ostringstream out;
+    auto inner = [&](const std::string&) {
+        std::istringstream inner_in("inner-bad\n");
+        auto r = run_script(inner_in,
+                            [](const std::string&) {
+                                command_feedback::mark_failure();
+                            },
+                            out, false);
+        CHECK(r.aborted);
+        // As load does: leave the failure flag set on abort.
+        command_feedback::mark_failure();
+    };
+
+    auto r = run_script(outer_in, inner, out, false);
+    CHECK(r.aborted);
+    CHECK(r.aborted_line == 1);
+    CHECK(r.aborted_command == "run-inner");
+}

--- a/projects/ores.shell/tests/app_script_runner_tests.cpp
+++ b/projects/ores.shell/tests/app_script_runner_tests.cpp
@@ -75,6 +75,27 @@ TEST_CASE("run_script_executes_commands_and_skips_noise", tags) {
     CHECK(fed == std::vector<std::string>{"one", "two"});
 }
 
+TEST_CASE("run_script_skips_whitespace_and_cr_only_lines", tags) {
+    auto lg(make_logger(test_suite));
+    command_feedback::reset();
+
+    // CRLF-style input: whitespace+CR-only lines must be skipped, and
+    // commands must arrive without the trailing CR.
+    std::istringstream in("   \r\n"
+                          "\r\n"
+                          "one\r\n"
+                          "# comment\r\n"
+                          "two\r\n");
+    std::vector<std::string> fed;
+    std::ostringstream out;
+    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
+                        out, false);
+
+    CHECK_FALSE(r.aborted);
+    CHECK(r.executed == 2);
+    CHECK(fed == std::vector<std::string>{"one", "two"});
+}
+
 TEST_CASE("run_script_aborts_on_first_failure_by_default", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();

--- a/projects/ores.shell/tests/main.cpp
+++ b/projects/ores.shell/tests/main.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.testing/database_lifecycle_listener.hpp"
+#include "ores.testing/logging_listener.hpp"
+#include "ores.testing/test_timeout_listener.hpp"
+#include <boost/scope_exit.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include <openssl/crypto.h>
+
+CATCH_REGISTER_LISTENER(ores::testing::logging_listener)
+CATCH_REGISTER_LISTENER(ores::testing::database_lifecycle_listener)
+CATCH_REGISTER_LISTENER(ores::testing::test_timeout_listener)
+
+int main(int argc, char* argv[]) {
+    BOOST_SCOPE_EXIT(void) {
+        OPENSSL_cleanup();
+    }
+    BOOST_SCOPE_EXIT_END
+
+    ores::testing::logging_listener::set_test_module_name("ores.shell.tests");
+    return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
## Summary

First task of the provisioning-commands story: the shell infrastructure the provisioning surface rests on. Commands gain a uniform failure signal (command_feedback + fail(out), routed through all ~90 existing failure sites), an optional-flag parser (command_args over std::expected), and load becomes stop-on-error by default — aborting at the first failed command with line and command, --continue-on-error restoring the old behaviour — with the loop extracted as a testable script_runner. Unknown commands and uncaught exceptions count as failures via the Cli handlers. Adds the component's first test suite (17 cases / 44 assertions, green); smoke-tested against the real binary.

## Changes

- command_feedback: thread-local failure flag + fail(out); all failure sites routed through it.
- command_args: parse_args with switches, --flag value / --flag=value, defaults, unknown-flag/missing-value errors.
- script_runner + load rework: stop-on-error default, --continue-on-error, nested propagation, abort report.
- WrongCommandHandler/StdExceptionHandler mark failure; scripts abort on typos.
- New projects/ores.shell/tests wired into the build.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Implement ores-shell provisioning commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.html) | 31B8013E-10FF-4FCC-9D1D-D5BAF8D16437 |
| Task | [Add flag parsing and stop-on-error load semantics](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_shell_flags_and_load_semantics.html) | 1AD5B684-404D-447F-B8A6-77AABDF829AF |

🤖 Generated with [Claude Code](https://claude.com/claude-code)