### PR TITLE
[llm] Add devops-setup-environment; close the skill cleanup story

### DIFF
--- a/build/scripts/generate_skills_catalogue.py
+++ b/build/scripts/generate_skills_catalogue.py
@@ -43,9 +43,7 @@ DOMAINS = {
 }
 
 # Planned-but-not-yet-created skills, shown as prose under each section.
-PENDING = {
-    "devops": "=devops-setup-environment=",
-}
+PENDING = {}
 
 MAX_DESC = 110
 

--- a/doc/agile/versions/v0/sprint_20/skills_cleanup/story.org
+++ b/doc/agile/versions/v0/sprint_20/skills_cleanup/story.org
@@ -28,11 +28,11 @@ the skill cleanup is done.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Defining the skill naming convention.  |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Inventory compass commands and map them to skills. |
+| Next          | Nothing.                               |
 | Last touched  | 2026-06-06                               |
 
 * Acceptance
@@ -61,7 +61,7 @@ the skill cleanup is done.
 | [[id:6B8FD32F-6183-4C17-A53A-BBB0DD7A7021][Inventory compass commands and map them to skills]] | DONE | 2026-06-06 | 2026-06-06 | Catalogue every compass command and subcommand across all pillars (orient, search, scaffold, capture, journal, provision, test, build, operate, shell, review, pr) and map each workflow onto a skill named per the convention. Identify gaps: workflows with no skill, skills with no compass backing. |
 | [[id:7ED9E952-5AFF-4061-A327-BA3F8A42D6DC][Audit existing skills: rename or delete per convention]] | DONE | 2026-06-06 | 2026-06-06 | Review all ~40 existing skills in .claude/skills against the naming convention and the compass command map. Rename skills to action-oriented names (e.g. sprint-planner becomes agile-plan-sprint), delete or merge skills that overlap with the new compass workflow skills, and update all cross-references. |
 | [[id:123A4E3F-F2D8-4B40-8C4F-94E0C5586408][Create compass workflow skills]] | DONE | 2026-06-06 | 2026-06-06 | Create the new skills that wrap compass workflows so compass is used instead of raw unix tools: new story, new task, find recipe, find knowledge, find document, close task, close story, close task and story, merge PR, address PR review, sync branch, find bearings, journal, and fleet. Names follow the convention from the first task. |
-| [[id:D281AC53-C205-458D-B9FF-2B65E79A0BDC][Add a setup-environment skill]] | BACKLOG | | | New skill that sets up a working environment end-to-end: compass index with org-roam sync, build skills, build settings, env init, database recreate, and optionally run the ores shell provisioning script. Named per the convention from the first task. |
+| [[id:D281AC53-C205-458D-B9FF-2B65E79A0BDC][Add a setup-environment skill]] | DONE | 2026-06-06 | 2026-06-06 | New skill that sets up a working environment end-to-end: compass index with org-roam sync, build skills, build settings, env init, database recreate, and optionally run the ores shell provisioning script. Named per the convention from the first task. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
+++ b/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
@@ -54,7 +54,8 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Description exceeds the catalogue's 110-char limit, truncates | devops-setup-environment/SKILL.org | Accepted | Fixed in 03d1b265b; 109 chars. |
+| 1 | license: LICENSE.txt vs :tangle LICENCE.txt mismatch | devops-setup-environment/SKILL.org | Accepted (broadened) | Template defect in all 63 skills; fixed doc_skill.org.mustache and every skill in 03d1b265b. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
+++ b/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
@@ -8,7 +8,7 @@
 #+filetags: :skills:compass:environment:provisioning:skills_cleanup:sprint_20:v0:
 #+owner: marco
 #+branch: feature/setup-environment-skill
-#+pr:
+#+pr: 1124
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -48,7 +48,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1124][#1124]] | [llm] Add devops-setup-environment; close the skill cleanup story |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
+++ b/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :skills:compass:environment:provisioning:skills_cleanup:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/setup-environment-skill
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented skill cleanup]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -57,3 +57,10 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+devops-setup-environment created: composes the per-piece devops
+skills in dependency order — doc-sync-index, deploy skills, deploy
+settings, env init, db recreate, optional shell provisioning via
+projects/ores.shell/scripts/bootstrap.ores, and a bearings
+verification at the end. Catalogue regenerated with no pending
+skills remaining; bundle deployed.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -91,7 +91,7 @@ gates the sprint: no other story starts until it is done.*
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented skill cleanup]] | STARTED | 2026-06-06 | | Naming convention; compass command inventory and skill map; rename/delete existing skills; add compass workflow skills. |
+| [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented skill cleanup]] | DONE | 2026-06-06 | 2026-06-06 | Naming convention; compass command inventory and skill map; rename/delete existing skills; add compass workflow skills. |
 | [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] | BACKLOG | | | Create vs pick-up split; scaffold tasks; bookkeeping rides the PR (no PR-to-close-a-PR); robust pr merge close-out. |
 
 *** Epic: Codegen

--- a/doc/llm/skills/agile-add-capture/SKILL.org
+++ b/doc/llm/skills/agile-add-capture/SKILL.org
@@ -76,7 +76,7 @@ decomposition of unstructured text, use
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-add-release-notes/SKILL.org
+++ b/doc/llm/skills/agile-add-release-notes/SKILL.org
@@ -126,7 +126,7 @@ Markdown in Emacs (=C-c C-e m m=) for the GitHub release.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-add-story/SKILL.org
+++ b/doc/llm/skills/agile-add-story/SKILL.org
@@ -51,7 +51,7 @@ Creating a story without picking it up — backlog refinement, sprint planning, 
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-add-task/SKILL.org
+++ b/doc/llm/skills/agile-add-task/SKILL.org
@@ -49,7 +49,7 @@ Adding a task to an existing story without picking it up — docs only, no branc
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-brainstorm-idea/SKILL.org
+++ b/doc/llm/skills/agile-brainstorm-idea/SKILL.org
@@ -115,7 +115,7 @@ output. Always scaffold via the codegen — never hand-write.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-close-task/SKILL.org
+++ b/doc/llm/skills/agile-close-task/SKILL.org
@@ -50,7 +50,7 @@ Ending a task at the end of its review round — /before/ the merge, so the book
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-find-bearings/SKILL.org
+++ b/doc/llm/skills/agile-find-bearings/SKILL.org
@@ -65,7 +65,7 @@ session", "find your bearings", or orient yourself in the repository.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-open-sprint/SKILL.org
+++ b/doc/llm/skills/agile-open-sprint/SKILL.org
@@ -77,7 +77,7 @@ do at the same time, before, or after.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-plan-sprint/SKILL.org
+++ b/doc/llm/skills/agile-plan-sprint/SKILL.org
@@ -127,7 +127,7 @@ sprint-selection goal, use [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][backlog-re
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-refine-backlog/SKILL.org
+++ b/doc/llm/skills/agile-refine-backlog/SKILL.org
@@ -97,7 +97,7 @@ come up.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-show-backlog/SKILL.org
+++ b/doc/llm/skills/agile-show-backlog/SKILL.org
@@ -42,7 +42,7 @@ Browsing the product backlog buckets: inbox (unrefined), next, deferred, discard
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-show-fleet/SKILL.org
+++ b/doc/llm/skills/agile-show-fleet/SKILL.org
@@ -44,7 +44,7 @@ Seeing what every git worktree is doing: branch, story, task, and open PR per ch
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-show-journal/SKILL.org
+++ b/doc/llm/skills/agile-show-journal/SKILL.org
@@ -49,7 +49,7 @@ Reviewing where we have been: the per-worktree session journal of story and task
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-show-sprint/SKILL.org
+++ b/doc/llm/skills/agile-show-sprint/SKILL.org
@@ -48,7 +48,7 @@ Reviewing the current sprint: stories grouped by state, and drift between story 
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-show-status/SKILL.org
+++ b/doc/llm/skills/agile-show-status/SKILL.org
@@ -44,7 +44,7 @@ Orientation: where are we — current version, sprint, and in-flight stories and
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-start-hotfix/SKILL.org
+++ b/doc/llm/skills/agile-start-hotfix/SKILL.org
@@ -47,7 +47,7 @@ A production error needs an out-of-band fix: scaffold story and task on a hotfix
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-start-story/SKILL.org
+++ b/doc/llm/skills/agile-start-story/SKILL.org
@@ -53,7 +53,7 @@ Picking up a brand-new unit of work: story, first task, and feature branch in on
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/agile-start-task/SKILL.org
+++ b/doc/llm/skills/agile-start-task/SKILL.org
@@ -54,7 +54,7 @@ Picking up an existing task: switch to (or create) its branch, mark it STARTED, 
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -131,7 +131,7 @@ Environment, database, services, shell, client, site.
 | [[id:A8102388-6D8B-40D8-B6B1-1DB29E9DD6D2][devops-run-client]] | Devops Run Client | Launch the Qt client detached, with optional colour and instance name for parallel runs. |
 | [[id:40DE3AD0-7A32-45FF-9DFA-5F9492187F2A][devops-run-shell]] | Devops Run Shell | Launch ores.shell with NATS and login defaults from .env, interactively or scripted with -f. |
 | [[id:29075D79-6152-4C3A-B9E0-4E97010D8E0B][devops-run-sql]] | Devops Run SQL | Run SQL in the environment via compass with credentials and connection from .env. |
-| [[id:C35F1575-4894-46B9-9356-E68F275CFD3B][devops-setup-environment]] | Devops Setup Environment | Set up a working environment end-to-end: sync the doc indexes, deploy skills and settings, initialise the e... |
+| [[id:C35F1575-4894-46B9-9356-E68F275CFD3B][devops-setup-environment]] | Devops Setup Environment | Set up a working environment end-to-end: sync indexes, deploy skills and settings, init env, recreate the DB. |
 | [[id:DBAE601D-183D-4B61-85ED-2823E2AF0EEC][devops-show-services]] | Devops Show Services | Show service fleet status: running, stopped, missing. |
 | [[id:96EBB175-83BD-4DD3-B35C-769C86CB3075][devops-start-services]] | Devops Start Services | Start the service fleet and verify everything came up. |
 | [[id:74D7BEDE-5FEC-45AE-9977-CC9A6C5D47A0][devops-stop-services]] | Devops Stop Services | Stop the service fleet cleanly. |

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -131,12 +131,10 @@ Environment, database, services, shell, client, site.
 | [[id:A8102388-6D8B-40D8-B6B1-1DB29E9DD6D2][devops-run-client]] | Devops Run Client | Launch the Qt client detached, with optional colour and instance name for parallel runs. |
 | [[id:40DE3AD0-7A32-45FF-9DFA-5F9492187F2A][devops-run-shell]] | Devops Run Shell | Launch ores.shell with NATS and login defaults from .env, interactively or scripted with -f. |
 | [[id:29075D79-6152-4C3A-B9E0-4E97010D8E0B][devops-run-sql]] | Devops Run SQL | Run SQL in the environment via compass with credentials and connection from .env. |
+| [[id:C35F1575-4894-46B9-9356-E68F275CFD3B][devops-setup-environment]] | Devops Setup Environment | Set up a working environment end-to-end: sync the doc indexes, deploy skills and settings, initialise the e... |
 | [[id:DBAE601D-183D-4B61-85ED-2823E2AF0EEC][devops-show-services]] | Devops Show Services | Show service fleet status: running, stopped, missing. |
 | [[id:96EBB175-83BD-4DD3-B35C-769C86CB3075][devops-start-services]] | Devops Start Services | Start the service fleet and verify everything came up. |
 | [[id:74D7BEDE-5FEC-45AE-9977-CC9A6C5D47A0][devops-stop-services]] | Devops Stop Services | Stop the service fleet cleanly. |
-
-Being created by the /Action-oriented skill cleanup/ story:
-=devops-setup-environment=.
 
 * Skills (=skill-=)
 

--- a/doc/llm/skills/code-add-domain-type/SKILL.org
+++ b/doc/llm/skills/code-add-domain-type/SKILL.org
@@ -88,7 +88,7 @@ reproduce it here.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-add-tests/SKILL.org
+++ b/doc/llm/skills/code-add-tests/SKILL.org
@@ -86,7 +86,7 @@ if you have not seen the contract.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-investigate-test-failure/SKILL.org
+++ b/doc/llm/skills/code-investigate-test-failure/SKILL.org
@@ -69,7 +69,7 @@ cannot make on its own.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-review-component/SKILL.org
+++ b/doc/llm/skills/code-review-component/SKILL.org
@@ -95,7 +95,7 @@ component "production-ready". For PR-delta reviews, use the sibling
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-review-pr/SKILL.org
+++ b/doc/llm/skills/code-review-pr/SKILL.org
@@ -76,7 +76,7 @@ the latter, use [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-run-build/SKILL.org
+++ b/doc/llm/skills/code-run-build/SKILL.org
@@ -56,7 +56,7 @@ CMake — or generate PlantUML diagrams as part of a build.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/code-start-branch/SKILL.org
+++ b/doc/llm/skills/code-start-branch/SKILL.org
@@ -43,7 +43,7 @@ Out-of-band work with no task attached: experiments, throwaway spikes, one-off f
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-cli-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-cli-entity/SKILL.org
@@ -69,7 +69,7 @@ Until the gap is resolved, this layer is incomplete.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-component/SKILL.org
+++ b/doc/llm/skills/codegen-add-component/SKILL.org
@@ -116,7 +116,7 @@ group + 3 subs).
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-entity/SKILL.org
@@ -89,7 +89,7 @@ and phase boundaries). Use =feature-branch-manager= between phases and
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-http-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-http-entity/SKILL.org
@@ -72,7 +72,7 @@ Until the gap is resolved, this layer is incomplete.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-qt-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-qt-entity/SKILL.org
@@ -86,7 +86,7 @@ authoritative implementation — do not reproduce it here.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-shell-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-shell-entity/SKILL.org
@@ -69,7 +69,7 @@ Until the gap is resolved, this layer is incomplete.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-sql-schema/SKILL.org
+++ b/doc/llm/skills/codegen-add-sql-schema/SKILL.org
@@ -73,7 +73,7 @@ authoritative implementation — do not reproduce it here.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/codegen-add-wt-entity/SKILL.org
+++ b/doc/llm/skills/codegen-add-wt-entity/SKILL.org
@@ -68,7 +68,7 @@ Until the gap is resolved, this layer is incomplete.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-deploy-manual/SKILL.org
+++ b/doc/llm/skills/devops-deploy-manual/SKILL.org
@@ -39,7 +39,7 @@ Building the user manual PDF after manual content changes.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-deploy-settings/SKILL.org
+++ b/doc/llm/skills/devops-deploy-settings/SKILL.org
@@ -39,7 +39,7 @@ Claude Code settings.json is older than its org source (compass bearings warns):
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-deploy-site/SKILL.org
+++ b/doc/llm/skills/devops-deploy-site/SKILL.org
@@ -40,7 +40,7 @@ Building and publishing the documentation website from the org-roam graph — al
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-deploy-skills/SKILL.org
+++ b/doc/llm/skills/devops-deploy-skills/SKILL.org
@@ -45,7 +45,7 @@ Skill sources changed and the deployed bundle is stale (compass bearings warns):
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-recreate-db/SKILL.org
+++ b/doc/llm/skills/devops-recreate-db/SKILL.org
@@ -49,7 +49,7 @@ The schema drifted (bearings warns), migrations need a clean slate, or the datab
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-run-client/SKILL.org
+++ b/doc/llm/skills/devops-run-client/SKILL.org
@@ -39,7 +39,7 @@ Launching the Qt client, detached so the terminal stays free; colour and instanc
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-run-shell/SKILL.org
+++ b/doc/llm/skills/devops-run-shell/SKILL.org
@@ -46,7 +46,7 @@ Launching ores.shell with NATS and login defaults from .env — interactive, or 
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-run-sql/SKILL.org
+++ b/doc/llm/skills/devops-run-sql/SKILL.org
@@ -40,7 +40,7 @@ Running SQL in the environment — queries or scripts, with credentials and conn
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-setup-environment/SKILL.org
+++ b/doc/llm/skills/devops-setup-environment/SKILL.org
@@ -13,7 +13,7 @@
 #+begin_export markdown
 ---
 name: devops-setup-environment
-description: Set up a working environment end-to-end: sync the doc indexes, deploy skills and settings, initialise the environment, recreate the database, and optionally run the shell provisioning script.
+description: Set up a working environment end-to-end: sync indexes, deploy skills and settings, init env, recreate the DB.
 license: Complete terms in LICENSE.txt
 ---
 #+end_export
@@ -88,7 +88,7 @@ Run the steps in order; each is idempotent.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-setup-environment/SKILL.org
+++ b/doc/llm/skills/devops-setup-environment/SKILL.org
@@ -1,0 +1,106 @@
+:PROPERTIES:
+:ID: C35F1575-4894-46B9-9356-E68F275CFD3B
+:END:
+#+title: Devops Setup Environment
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :skills:claude_code:compass:environment:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+#+begin_export markdown
+---
+name: devops-setup-environment
+description: Set up a working environment end-to-end: sync the doc indexes, deploy skills and settings, initialise the environment, recreate the database, and optionally run the shell provisioning script.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Setting up a working environment end-to-end: a fresh checkout, a new
+worktree, after a long-lived branch switch, or whenever bearings
+shows multiple staleness warnings at once. Runs the individual
+devops skills in dependency order; for a single stale piece, use the
+specific skill instead.
+
+* How to use this skill
+
+Run the steps in order; each is idempotent.
+
+1. /Sync the doc indexes/ (=doc-sync-index=):
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh index --org-roam-db-sync
+   #+end_src
+
+2. /Deploy the skills bundle/ (=devops-deploy-skills=):
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh build skills
+   #+end_src
+
+3. /Deploy Claude Code settings/ (=devops-deploy-settings=):
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh build settings
+   #+end_src
+
+4. /Initialise the environment/ — .env, certificates, IAM key:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh env init
+   #+end_src
+
+5. /Recreate the database/ (=devops-recreate-db=) — stop services
+   first if they hold connections:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh db recreate -y -k
+   #+end_src
+
+6. /Optionally, provision via the shell/ — run the bootstrap script
+   (super_admin, base system, tenant_admin, party):
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh shell -f projects/ores.shell/scripts/bootstrap.ores
+   #+end_src
+
+7. /Verify/ — services up, bearings clean:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh services start && ./projects/ores.compass/compass.sh bearings
+   #+end_src
+
+* Recipes
+
+- [[id:FE388774-0714-4D93-AEB0-D6221314D4F9][How do I orient a new session?]] — the verification at the end.
+- [[id:DEAC11AE-3753-49FA-994A-98594162A605][How do I index notes for compass?]] — step 1 in detail.
+- [[id:B5F231A9-5403-482C-8F2A-12D6917C58CD][How do I deploy the skills?]] — step 2 in detail.
+
+* Reference
+
+- [[id:2003934B-ED05-D114-404B-08C0E0D844BB][Skills catalogue]]§DevOps — the per-piece skills this composes.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/devops-show-services/SKILL.org
+++ b/doc/llm/skills/devops-show-services/SKILL.org
@@ -40,7 +40,7 @@ Checking whether the environment is up: which services run, which stopped or wen
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-start-services/SKILL.org
+++ b/doc/llm/skills/devops-start-services/SKILL.org
@@ -39,7 +39,7 @@ Bringing the service fleet up — NATS and the ores services.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/devops-stop-services/SKILL.org
+++ b/doc/llm/skills/devops-stop-services/SKILL.org
@@ -39,7 +39,7 @@ Stopping the service fleet cleanly — before db recreate, env changes, or shutd
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-add-class-diagram/SKILL.org
+++ b/doc/llm/skills/doc-add-class-diagram/SKILL.org
@@ -63,7 +63,7 @@ architecture diagram at =projects/modeling/ores.puml=.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-add-component-model/SKILL.org
+++ b/doc/llm/skills/doc-add-component-model/SKILL.org
@@ -78,7 +78,7 @@ overview), and again whenever the architecture changes.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-add-er-diagram/SKILL.org
+++ b/doc/llm/skills/doc-add-er-diagram/SKILL.org
@@ -64,7 +64,7 @@ catch up, or when documenting newly-added tables.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-add-knowledge/SKILL.org
+++ b/doc/llm/skills/doc-add-knowledge/SKILL.org
@@ -46,7 +46,7 @@ Capturing durable, cross-cutting rationale as a knowledge document — concepts,
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-add-recipe/SKILL.org
+++ b/doc/llm/skills/doc-add-recipe/SKILL.org
@@ -76,7 +76,7 @@ invoke.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-find/SKILL.org
+++ b/doc/llm/skills/doc-find/SKILL.org
@@ -53,7 +53,7 @@ Finding documents: full-text search or structured filters across the whole org-r
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-show/SKILL.org
+++ b/doc/llm/skills/doc-show/SKILL.org
@@ -42,7 +42,7 @@ Reading one document when you have its UUID or a prefix: metadata, blurb, incomi
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-sync-index/SKILL.org
+++ b/doc/llm/skills/doc-sync-index/SKILL.org
@@ -42,7 +42,7 @@ The search index or org-roam database is stale (compass prints staleness chips) 
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-sync-recipes/SKILL.org
+++ b/doc/llm/skills/doc-sync-recipes/SKILL.org
@@ -107,7 +107,7 @@ location changes.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/doc-update-manual/SKILL.org
+++ b/doc/llm/skills/doc-update-manual/SKILL.org
@@ -115,7 +115,7 @@ behaviour, even if the user did not explicitly ask for a manual update.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/pr-address-review/SKILL.org
+++ b/doc/llm/skills/pr-address-review/SKILL.org
@@ -76,7 +76,7 @@ Review comments arrived on a PR: handle one complete round — sync, read, decid
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/pr-merge/SKILL.org
+++ b/doc/llm/skills/pr-merge/SKILL.org
@@ -54,7 +54,7 @@ Merging an approved PR. Guard rails refuse while review threads are unresolved o
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/pr-show-checks/SKILL.org
+++ b/doc/llm/skills/pr-show-checks/SKILL.org
@@ -45,7 +45,7 @@ Inspecting CI state on a PR: which checks pass, fail, or are pending.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/pr-sync-branch/SKILL.org
+++ b/doc/llm/skills/pr-sync-branch/SKILL.org
@@ -44,7 +44,7 @@ The branch is stale relative to origin/main — rebase before doing anything els
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/skill-add/SKILL.org
+++ b/doc/llm/skills/skill-add/SKILL.org
@@ -112,7 +112,7 @@ propagate to Claude Code.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/skill-delete/SKILL.org
+++ b/doc/llm/skills/skill-delete/SKILL.org
@@ -85,7 +85,7 @@ subsumes an old one.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/skill-review/SKILL.org
+++ b/doc/llm/skills/skill-review/SKILL.org
@@ -112,7 +112,7 @@ might overlap.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/doc/llm/skills/skill-show-catalogue/SKILL.org
+++ b/doc/llm/skills/skill-show-catalogue/SKILL.org
@@ -91,7 +91,7 @@ domain-grouped view.
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or

--- a/projects/ores.codegen/library/templates/doc_skill.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_skill.org.mustache
@@ -40,7 +40,7 @@ skill.)
 
 ** Licence
 
-#+BEGIN_SRC fundamental :tangle LICENCE.txt
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or


### PR DESCRIPTION
## Summary

Final wave of the Action-oriented skill cleanup story. Adds devops-setup-environment, composing the per-piece devops skills in dependency order (index sync, skills/settings deploys, env init, db recreate, optional bootstrap.ores provisioning, bearings verification). The catalogue has no pending skills left; all five story tasks are DONE, so the story and its sprint row close with this PR. Of the Epic: Skills gate, only the sibling lifecycle story (create vs pick-up, PR close-out workflow, pr merge fixes) remains.

## Changes

- Add devops-setup-environment skill composing the devops set end-to-end
- Regenerate catalogue; clear the pending lists entirely
- Close the add_setup_environment_skill task, the story, and its sprint row

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Action-oriented skill cleanup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/skills_cleanup/story.html) | 58A77C0F-0AF0-428F-854C-049B731844CA |
| Task | [Add a setup-environment skill](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/skills_cleanup/task_add_setup_environment_skill.html) | D281AC53-C205-458D-B9FF-2B65E79A0BDC |

🤖 Generated with [Claude Code](https://claude.com/claude-code)