### PR TITLE
[ores.shell] Add bundles and workflow shell commands

### DIFF
--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
@@ -63,7 +63,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:1AD5B684-404D-447F-B8A6-77AABDF829AF][Add flag parsing and stop-on-error load semantics]] | STARTED | 2026-06-06 | | Shell infrastructure for the provisioning surface: optional --flag parsing and load that aborts on first failure. |
-| [[id:F77DC2CF-C082-4DA5-80F7-454BAA781100][Add bundles and workflow shell commands]] | BACKLOG | | | bundles list, bundles publish [--wait], workflow wait — the dataset-publication plumbing. |
+| [[id:F77DC2CF-C082-4DA5-80F7-454BAA781100][Add bundles and workflow shell commands]] | STARTED | 2026-06-06 | | bundles list, bundles publish [--wait], workflow wait — the dataset-publication plumbing. |
 | [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | BACKLOG | | | lei countries/entities and synthetic generate — the data-source plumbing. |
 | [[id:9F96763F-5BA7-4F7E-970E-FE404A14D5C1][Add parties, account-parties and reports shell commands]] | BACKLOG | | | parties list, account-parties add, tenants complete-provisioning, reports templates — the refdata/iam/reporting plumbing. |
 | [[id:5D782E09-99EE-4C6C-837D-61F28559798B][Add the provision system command]] | BACKLOG | | | Porcelain spanning the SystemProvisionerWizard: bootstrap admin + first tenant with single-tenant defaults. |

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
@@ -8,7 +8,7 @@
 #+filetags: :shell:dq:workflow:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-provisioners-from-shell
-#+pr:
+#+pr: 1126
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -61,7 +61,7 @@ Add the dataset-publication plumbing: 'bundles list' (dq.v1.dataset-bundles.list
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1126][#1126]] | [ores.shell] Add bundles and workflow shell commands |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
@@ -67,7 +67,11 @@ Add the dataset-publication plumbing: 'bundles list' (dq.v1.dataset-bundles.list
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Tolerate transient poll failures in wait | workflow_commands.cpp:165 | Accepted | 5 consecutive failures tolerated; transient warnings avoid fail() so a recovered wait does not abort load; success=false stays a hard failure. |
+| 2 | Validate timeout positive (bundles) | bundles_commands.cpp:186 | Accepted | Shared parse_positive_seconds in command_args (full consumption + > 0); validated before dispatching the publish. |
+| 3 | Validate timeout positive (workflow) | workflow_commands.cpp:123 | Accepted | Same helper. |
+| 4 | reinterpret_cast on possibly-empty reply | bundles_commands.cpp:56 | Accepted | Iterator-range string construction. |
+| 5 | reinterpret_cast on possibly-empty reply | workflow_commands.cpp:48 | Accepted | Iterator-range string construction; same legacy pattern in older command files left for a separate cleanup. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell:dq:workflow:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-provisioners-from-shell
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Add the dataset-publication plumbing: 'bundles list' (dq.v1.dataset-bundles.list
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Implemented; build and unit tests green; PR pending. |
+| Waiting on   | Review.                                |
+| Next         | Merge; then the lei/synthetic plumbing task. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -40,9 +40,20 @@ Add the dataset-publication plumbing: 'bundles list' (dq.v1.dataset-bundles.list
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+1. =workflow_commands= group: =workflow steps <id>= (one-shot dump)
+   and =workflow wait <id> [--timeout <s>]= — poll
+   =workflow.v1.instances.steps= every 3s printing status
+   transitions; terminal detection as the GUI's WorkflowStepsWidget
+   (any =failed= step → failure; all =completed*= → success);
+   =wait_for_instance= exposed for reuse.
+2. =bundles_commands= group: =bundles list= over
+   =dq.v1.dataset-bundles.list= (table via dataset_bundle_table_io);
+   =bundles publish <code> [--wait] [--root-lei] [--party-id]
+   [--dataset] [--timeout]= over =dq.v1.bundles.publish= (upsert,
+   atomic, published_by = logged-in user, wizard's 5m dispatch
+   timeout), delegating to =wait_for_instance= on =--wait=.
+3. Register both in =repl::setup_menus=; link
+   =ores.workflow.api.lib=.
 
 * Notes
 
@@ -59,3 +70,19 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Implemented per plan. Notes:
+
+- Typed publication parameters instead of the generic =--param k=v=
+  sketched at scoping time: =--root-lei=, =--party-id= and
+  =--dataset= map 1-1 onto =publish_bundle_params= (the only params
+  the wizards ever send). =--dataset= currently accepts a single
+  value — the party wizard opts into exactly one counterparty
+  dataset; revisit if a flow ever needs more.
+- =bundles publish= without =--wait= prints the instance id and the
+  exact =workflow wait= command to follow progress; with =--wait= it
+  blocks, streaming step transitions, and fails the command (for
+  =load='s stop-on-error) on workflow failure or timeout.
+- Verified by build + unit tests (18 cases green) and menu
+  registration in the binary; live verification against a running
+  backend lands with the porcelain tasks and the e2e script.

--- a/projects/ores.shell/include/ores.shell/app/command_args.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_args.hpp
@@ -20,8 +20,10 @@
 #ifndef ORES_SHELL_APP_COMMAND_ARGS_HPP
 #define ORES_SHELL_APP_COMMAND_ARGS_HPP
 
+#include <chrono>
 #include <expected>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -70,6 +72,13 @@ struct parsed_args {
 std::expected<parsed_args, std::string>
 parse_args(const std::vector<std::string>& tokens,
            const std::vector<flag_spec>& specs);
+
+/**
+ * @brief Parse a duration flag value as a positive whole number of
+ * seconds. Rejects partial numbers ("30x"), zero and negatives.
+ */
+std::optional<std::chrono::seconds>
+parse_positive_seconds(const std::string& value);
 
 }
 

--- a/projects/ores.shell/include/ores.shell/app/commands/bundles_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/bundles_commands.hpp
@@ -1,0 +1,86 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMANDS_BUNDLES_COMMANDS_HPP
+#define ORES_SHELL_APP_COMMANDS_BUNDLES_COMMANDS_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <string>
+#include <vector>
+
+namespace cli {
+
+class Menu;
+
+}
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Commands for dataset bundles.
+ *
+ * Lists the bundles available for publication and publishes one,
+ * mirroring what the provisioning wizards do behind their bundle
+ * pages. Publication dispatches a workflow; --wait blocks on it via
+ * workflow_commands::wait_for_instance.
+ */
+class bundles_commands {
+private:
+    inline static std::string_view logger_name = "ores.shell.app.commands.bundles_commands";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Register bundle-related commands.
+     *
+     * Creates the bundles submenu with list and publish operations.
+     */
+    static void register_commands(cli::Menu& root_menu,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief List the dataset bundles available on the server.
+     */
+    static void process_list(std::ostream& out,
+                             ores::nats::service::nats_client& session);
+
+    /**
+     * @brief Publish a bundle: bundles publish <code> [--wait]
+     * [--root-lei <lei>] [--party-id <id>] [--dataset <code>]
+     * [--timeout <seconds>].
+     *
+     * Publishes atomically in upsert mode as the logged-in user, as
+     * the wizards do. --root-lei, --party-id and --dataset populate
+     * the publication parameters; --wait blocks until the dispatched
+     * workflow reaches a terminal state.
+     */
+    static void process_publish(std::ostream& out,
+                                ores::nats::service::nats_client& session,
+                                const std::vector<std::string>& args);
+};
+
+}
+
+#endif

--- a/projects/ores.shell/include/ores.shell/app/commands/workflow_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/workflow_commands.hpp
@@ -1,0 +1,89 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMANDS_WORKFLOW_COMMANDS_HPP
+#define ORES_SHELL_APP_COMMANDS_WORKFLOW_COMMANDS_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <chrono>
+#include <string>
+
+namespace cli {
+
+class Menu;
+
+}
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Commands for observing workflow instances.
+ *
+ * Bundle publication and other long-running operations dispatch a
+ * workflow and return an instance id; these commands poll the
+ * workflow engine until the instance reaches a terminal state, as
+ * the GUI's WorkflowStepsWidget does.
+ */
+class workflow_commands {
+private:
+    inline static std::string_view logger_name = "ores.shell.app.commands.workflow_commands";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Register workflow-related commands.
+     *
+     * Creates the workflow submenu with steps and wait operations.
+     */
+    static void register_commands(cli::Menu& root_menu,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief Display the current steps of a workflow instance.
+     */
+    static void process_steps(std::ostream& out,
+                              ores::nats::service::nats_client& session,
+                              const std::string& instance_id);
+
+    /**
+     * @brief Block until a workflow instance reaches a terminal state.
+     *
+     * Polls workflow.v1.instances.steps every three seconds, printing
+     * each step's status transitions. A step in status "failed" is a
+     * terminal failure; all steps "completed" (with or without
+     * warnings) is terminal success. Marks command failure on
+     * workflow failure or timeout.
+     *
+     * @return true when the instance completed successfully.
+     */
+    static bool wait_for_instance(std::ostream& out,
+                                  ores::nats::service::nats_client& session,
+                                  const std::string& instance_id,
+                                  std::chrono::seconds timeout);
+};
+
+}
+
+#endif

--- a/projects/ores.shell/src/CMakeLists.txt
+++ b/projects/ores.shell/src/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(${lib_target_name}
         ores.dq.api.lib
         ores.variability.api.lib
         ores.refdata.api.lib
+        ores.workflow.api.lib
         ores.nats.lib
         cli::cli)
 

--- a/projects/ores.shell/src/app/command_args.cpp
+++ b/projects/ores.shell/src/app/command_args.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/command_args.hpp"
 #include <algorithm>
+#include <stdexcept>
 
 namespace ores::shell::app {
 
@@ -82,6 +83,19 @@ parse_args(const std::vector<std::string>& tokens,
         r.flags[body] = tokens[++i];
     }
     return r;
+}
+
+std::optional<std::chrono::seconds>
+parse_positive_seconds(const std::string& value) {
+    try {
+        std::size_t pos = 0;
+        const long v = std::stol(value, &pos);
+        if (pos != value.size() || v <= 0)
+            return std::nullopt;
+        return std::chrono::seconds(v);
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
 }
 
 }

--- a/projects/ores.shell/src/app/commands/bundles_commands.cpp
+++ b/projects/ores.shell/src/app/commands/bundles_commands.cpp
@@ -1,0 +1,190 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/commands/bundles_commands.hpp"
+#include "ores.dq.api/domain/dataset_bundle_table_io.hpp" // IWYU pragma: keep.
+#include "ores.dq.api/messaging/dataset_bundle_protocol.hpp"
+#include "ores.dq.api/messaging/publish_bundle_protocol.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/commands/workflow_commands.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <cli/cli.h>
+#include <chrono>
+#include <functional>
+#include <ostream>
+#include <rfl/json.hpp>
+
+namespace ores::shell::app::commands {
+
+using namespace logging;
+using ores::nats::service::nats_client;
+
+namespace {
+
+// Publication dispatch can take a while on large bundles; mirror the
+// wizards' generous request timeout.
+constexpr std::chrono::minutes publish_timeout(5);
+constexpr std::chrono::seconds default_wait_timeout(300);
+
+template <typename Response>
+std::optional<Response> do_auth_request(std::ostream& out,
+                                        nats_client& session,
+                                        const std::string& subject,
+                                        const std::string& body,
+                                        std::chrono::milliseconds timeout =
+                                            std::chrono::seconds(30)) {
+    try {
+        auto reply = session.authenticated_request(subject, body, timeout);
+        auto data_str =
+            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
+        auto result = rfl::json::read<Response>(data_str);
+        if (!result) {
+            fail(out) << "Failed to parse response" << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+}
+
+void bundles_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
+    auto bundles_menu = std::make_unique<cli::Menu>("bundles");
+
+    bundles_menu->Insert(
+        "list",
+        [&session](std::ostream& out) {
+            process_list(std::ref(out), std::ref(session));
+        },
+        "List the dataset bundles available for publication");
+
+    bundles_menu->Insert(
+        "publish",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            process_publish(std::ref(out), std::ref(session), args);
+        },
+        "Publish a dataset bundle (dispatches a workflow; --wait blocks on it)",
+        {"code [--wait] [--root-lei <lei>] [--party-id <id>] [--dataset <code>] "
+         "[--timeout <seconds>]"});
+
+    root_menu.Insert(std::move(bundles_menu));
+}
+
+void bundles_commands::process_list(std::ostream& out, nats_client& session) {
+    BOOST_LOG_SEV(lg(), debug) << "Initiating get dataset bundles request.";
+
+    dq::messaging::get_dataset_bundles_request req;
+    auto result = do_auth_request<dq::messaging::get_dataset_bundles_response>(
+        out, session, std::string(req.nats_subject), rfl::json::write(req));
+    if (!result)
+        return;
+
+    BOOST_LOG_SEV(lg(), info) << "Successfully retrieved " << result->bundles.size()
+                              << " bundles.";
+    out << result->bundles << std::endl;
+}
+
+void bundles_commands::process_publish(std::ostream& out,
+                                       nats_client& session,
+                                       const std::vector<std::string>& args) {
+    auto parsed = parse_args(args, {
+        {.name = "wait"},
+        {.name = "root-lei", .requires_value = true, .default_value = ""},
+        {.name = "party-id", .requires_value = true, .default_value = ""},
+        {.name = "dataset", .requires_value = true, .default_value = ""},
+        {.name = "timeout", .requires_value = true,
+         .default_value = std::to_string(default_wait_timeout.count())}
+    });
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (parsed->positionals.size() != 1) {
+        fail(out) << "Usage: bundles publish <code> [--wait] [--root-lei <lei>] "
+                     "[--party-id <id>] [--dataset <code>] [--timeout <seconds>]"
+                  << std::endl;
+        return;
+    }
+
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in." << std::endl;
+        return;
+    }
+
+    const auto& code = parsed->positionals.front();
+
+    dq::messaging::publish_bundle_params params;
+    if (!parsed->flag("dataset").empty())
+        params.opted_in_datasets.push_back(parsed->flag("dataset"));
+    if (!parsed->flag("root-lei").empty())
+        params.lei_parties = dq::messaging::lei_parties_params{
+            .root_lei = parsed->flag("root-lei")};
+    if (!parsed->flag("party-id").empty())
+        params.party_id = parsed->flag("party-id");
+
+    dq::messaging::publish_bundle_request req;
+    req.bundle_code = code;
+    req.mode = dq::domain::publication_mode::upsert;
+    req.published_by = session.auth().username;
+    req.atomic = true;
+    const bool has_params = !params.opted_in_datasets.empty() ||
+        params.lei_parties.has_value() || params.party_id.has_value();
+    if (has_params)
+        req.params_json = dq::messaging::build_params_json(params);
+
+    BOOST_LOG_SEV(lg(), info) << "Publishing bundle: " << code
+                              << " (params: " << req.params_json << ")";
+    out << "Publishing bundle '" << code << "'..." << std::endl;
+
+    auto result = do_auth_request<dq::messaging::publish_bundle_response>(
+        out, session, std::string(req.nats_subject), rfl::json::write(req),
+        publish_timeout);
+    if (!result)
+        return;
+
+    if (!result->success) {
+        fail(out) << "Failed to publish bundle: " << result->error_message << std::endl;
+        return;
+    }
+
+    out << "✓ Dispatched " << result->datasets_dispatched << " dataset(s); workflow instance: "
+        << result->instance_id << std::endl;
+    BOOST_LOG_SEV(lg(), info) << "Bundle " << code << " dispatched; instance "
+                              << result->instance_id;
+
+    if (!parsed->flag_set("wait")) {
+        out << "Follow progress with: workflow wait " << result->instance_id << std::endl;
+        return;
+    }
+
+    std::chrono::seconds timeout(0);
+    try {
+        timeout = std::chrono::seconds(std::stol(parsed->flag("timeout")));
+    } catch (const std::exception&) {
+        fail(out) << "Invalid timeout: " << parsed->flag("timeout") << std::endl;
+        return;
+    }
+    workflow_commands::wait_for_instance(out, session, result->instance_id, timeout);
+}
+
+}

--- a/projects/ores.shell/src/app/commands/bundles_commands.cpp
+++ b/projects/ores.shell/src/app/commands/bundles_commands.cpp
@@ -52,8 +52,7 @@ std::optional<Response> do_auth_request(std::ostream& out,
                                             std::chrono::seconds(30)) {
     try {
         auto reply = session.authenticated_request(subject, body, timeout);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
+        std::string data_str(reply.data.begin(), reply.data.end());
         auto result = rfl::json::read<Response>(data_str);
         if (!result) {
             fail(out) << "Failed to parse response" << std::endl;
@@ -131,6 +130,17 @@ void bundles_commands::process_publish(std::ostream& out,
         return;
     }
 
+    // Validate the wait timeout before dispatching anything.
+    std::optional<std::chrono::seconds> wait_timeout;
+    if (parsed->flag_set("wait")) {
+        wait_timeout = parse_positive_seconds(parsed->flag("timeout"));
+        if (!wait_timeout) {
+            fail(out) << "Timeout must be a positive number of seconds: "
+                      << parsed->flag("timeout") << std::endl;
+            return;
+        }
+    }
+
     const auto& code = parsed->positionals.front();
 
     dq::messaging::publish_bundle_params params;
@@ -172,19 +182,11 @@ void bundles_commands::process_publish(std::ostream& out,
     BOOST_LOG_SEV(lg(), info) << "Bundle " << code << " dispatched; instance "
                               << result->instance_id;
 
-    if (!parsed->flag_set("wait")) {
+    if (!wait_timeout) {
         out << "Follow progress with: workflow wait " << result->instance_id << std::endl;
         return;
     }
-
-    std::chrono::seconds timeout(0);
-    try {
-        timeout = std::chrono::seconds(std::stol(parsed->flag("timeout")));
-    } catch (const std::exception&) {
-        fail(out) << "Invalid timeout: " << parsed->flag("timeout") << std::endl;
-        return;
-    }
-    workflow_commands::wait_for_instance(out, session, result->instance_id, timeout);
+    workflow_commands::wait_for_instance(out, session, result->instance_id, *wait_timeout);
 }
 
 }

--- a/projects/ores.shell/src/app/commands/workflow_commands.cpp
+++ b/projects/ores.shell/src/app/commands/workflow_commands.cpp
@@ -22,6 +22,7 @@
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.workflow.api/messaging/workflow_query_protocol.hpp"
 #include <cli/cli.h>
+#include <expected>
 #include <map>
 #include <ostream>
 #include <rfl/json.hpp>
@@ -36,43 +37,36 @@ namespace {
 
 constexpr std::chrono::seconds poll_interval(3);
 constexpr std::chrono::seconds default_timeout(300);
+constexpr int max_consecutive_poll_failures = 5;
 
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-std::optional<workflow::messaging::get_workflow_steps_response>
-fetch_steps(std::ostream& out, nats_client& session, const std::string& instance_id) {
+/**
+ * @brief Fetch the steps of an instance without reporting failure.
+ *
+ * Transport and parse errors are returned as the error string so the
+ * caller decides whether they are fatal (one-shot commands) or
+ * transient (the polling loop, which tolerates a few in a row). A
+ * server response with success == false is a definitive answer, also
+ * left to the caller.
+ */
+std::expected<workflow::messaging::get_workflow_steps_response, std::string>
+fetch_steps(nats_client& session, const std::string& instance_id) {
     workflow::messaging::get_workflow_steps_request req;
     req.workflow_instance_id = instance_id;
 
-    auto result = do_auth_request<workflow::messaging::get_workflow_steps_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
-    if (!result)
-        return std::nullopt;
-    if (!result->success) {
-        fail(out) << "Failed to fetch workflow steps: " << result->message << std::endl;
-        return std::nullopt;
+    try {
+        auto reply = session.authenticated_request(std::string(req.nats_subject),
+                                                   rfl::json::write(req));
+        std::string data_str(reply.data.begin(), reply.data.end());
+        auto result =
+            rfl::json::read<workflow::messaging::get_workflow_steps_response>(data_str);
+        if (!result)
+            return std::unexpected("Failed to parse response");
+        return *result;
+    } catch (const std::exception& e) {
+        return std::unexpected(e.what());
     }
-    return result;
 }
+
 
 void print_step(std::ostream& out,
                 const workflow::messaging::workflow_step_summary& step,
@@ -114,16 +108,15 @@ void workflow_commands::register_commands(cli::Menu& root_menu, nats_client& ses
                 return;
             }
 
-            std::chrono::seconds timeout(0);
-            try {
-                timeout = std::chrono::seconds(std::stol(parsed->flag("timeout")));
-            } catch (const std::exception&) {
-                fail(out) << "Invalid timeout: " << parsed->flag("timeout") << std::endl;
+            auto timeout = parse_positive_seconds(parsed->flag("timeout"));
+            if (!timeout) {
+                fail(out) << "Timeout must be a positive number of seconds: "
+                          << parsed->flag("timeout") << std::endl;
                 return;
             }
 
             wait_for_instance(std::ref(out), std::ref(session),
-                              parsed->positionals.front(), timeout);
+                              parsed->positionals.front(), *timeout);
         },
         "Wait for a workflow instance to reach a terminal state",
         {"instance_id [--timeout <seconds>]"});
@@ -136,9 +129,15 @@ void workflow_commands::process_steps(std::ostream& out,
                                       const std::string& instance_id) {
     BOOST_LOG_SEV(lg(), debug) << "Fetching steps for workflow instance: " << instance_id;
 
-    auto result = fetch_steps(out, session, instance_id);
-    if (!result)
+    auto result = fetch_steps(session, instance_id);
+    if (!result) {
+        fail(out) << "Request failed: " << result.error() << std::endl;
         return;
+    }
+    if (!result->success) {
+        fail(out) << "Failed to fetch workflow steps: " << result->message << std::endl;
+        return;
+    }
 
     if (result->steps.empty()) {
         out << "No steps recorded for instance " << instance_id << "." << std::endl;
@@ -158,42 +157,66 @@ bool workflow_commands::wait_for_instance(std::ostream& out,
 
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     std::map<int, std::string> last_status;
+    int consecutive_failures = 0;
 
     while (true) {
-        auto result = fetch_steps(out, session, instance_id);
-        if (!result)
-            return false;
-
-        // Print transitions since the previous poll.
-        for (const auto& step : result->steps) {
-            auto& last = last_status[step.step_index];
-            if (last != step.status) {
-                last = step.status;
-                print_step(out, step, result->steps.size());
-            }
-        }
-
-        // Terminal-state detection, as the GUI's WorkflowStepsWidget:
-        // any failed step is a terminal failure; all steps completed
-        // (with or without warnings) is terminal success.
-        const auto total = result->steps.size();
-        std::size_t completed = 0;
-        for (const auto& step : result->steps) {
-            if (step.status == "failed") {
-                fail(out) << "Workflow failed at step " << (step.step_index + 1) << " of "
-                          << total << ": " << step.error << std::endl;
-                BOOST_LOG_SEV(lg(), error) << "Workflow instance " << instance_id
-                                           << " failed at step " << step.step_index << ": "
-                                           << step.error;
+        auto result = fetch_steps(session, instance_id);
+        if (!result) {
+            // Transient transport/parse errors are tolerated for a few
+            // polls — long waits routinely survive network blips. The
+            // warning deliberately avoids fail(): were the wait to
+            // recover and succeed, an earlier mark would still abort a
+            // load script.
+            ++consecutive_failures;
+            out << "⚠ Poll failed (" << consecutive_failures << "/"
+                << max_consecutive_poll_failures << "): " << result.error() << std::endl;
+            BOOST_LOG_SEV(lg(), warn) << "Poll " << consecutive_failures << " failed for "
+                                      << instance_id << ": " << result.error();
+            if (consecutive_failures >= max_consecutive_poll_failures) {
+                fail(out) << "Aborting wait after " << max_consecutive_poll_failures
+                          << " consecutive poll failures." << std::endl;
                 return false;
             }
-            if (step.status == "completed" || step.status == "completed_with_warnings")
-                ++completed;
-        }
-        if (total > 0 && completed == total) {
-            out << "✓ All " << total << " step(s) completed." << std::endl;
-            BOOST_LOG_SEV(lg(), info) << "Workflow instance " << instance_id << " completed.";
-            return true;
+        } else if (!result->success) {
+            // A definitive server answer (e.g. unknown instance or
+            // tenant mismatch) — retrying cannot help.
+            fail(out) << "Failed to fetch workflow steps: " << result->message << std::endl;
+            return false;
+        } else {
+            consecutive_failures = 0;
+
+            // Print transitions since the previous poll.
+            for (const auto& step : result->steps) {
+                auto& last = last_status[step.step_index];
+                if (last != step.status) {
+                    last = step.status;
+                    print_step(out, step, result->steps.size());
+                }
+            }
+
+            // Terminal-state detection, as the GUI's WorkflowStepsWidget:
+            // any failed step is a terminal failure; all steps completed
+            // (with or without warnings) is terminal success.
+            const auto total = result->steps.size();
+            std::size_t completed = 0;
+            for (const auto& step : result->steps) {
+                if (step.status == "failed") {
+                    fail(out) << "Workflow failed at step " << (step.step_index + 1)
+                              << " of " << total << ": " << step.error << std::endl;
+                    BOOST_LOG_SEV(lg(), error) << "Workflow instance " << instance_id
+                                               << " failed at step " << step.step_index
+                                               << ": " << step.error;
+                    return false;
+                }
+                if (step.status == "completed" || step.status == "completed_with_warnings")
+                    ++completed;
+            }
+            if (total > 0 && completed == total) {
+                out << "✓ All " << total << " step(s) completed." << std::endl;
+                BOOST_LOG_SEV(lg(), info) << "Workflow instance " << instance_id
+                                          << " completed.";
+                return true;
+            }
         }
 
         if (std::chrono::steady_clock::now() + poll_interval > deadline) {

--- a/projects/ores.shell/src/app/commands/workflow_commands.cpp
+++ b/projects/ores.shell/src/app/commands/workflow_commands.cpp
@@ -1,0 +1,211 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/commands/workflow_commands.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.workflow.api/messaging/workflow_query_protocol.hpp"
+#include <cli/cli.h>
+#include <map>
+#include <ostream>
+#include <rfl/json.hpp>
+#include <thread>
+
+namespace ores::shell::app::commands {
+
+using namespace logging;
+using ores::nats::service::nats_client;
+
+namespace {
+
+constexpr std::chrono::seconds poll_interval(3);
+constexpr std::chrono::seconds default_timeout(300);
+
+template <typename Response>
+std::optional<Response> do_auth_request(std::ostream& out,
+                                        nats_client& session,
+                                        const std::string& subject,
+                                        const std::string& body) {
+    try {
+        auto reply = session.authenticated_request(subject, body);
+        auto data_str =
+            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
+        auto result = rfl::json::read<Response>(data_str);
+        if (!result) {
+            fail(out) << "Failed to parse response" << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+std::optional<workflow::messaging::get_workflow_steps_response>
+fetch_steps(std::ostream& out, nats_client& session, const std::string& instance_id) {
+    workflow::messaging::get_workflow_steps_request req;
+    req.workflow_instance_id = instance_id;
+
+    auto result = do_auth_request<workflow::messaging::get_workflow_steps_response>(
+        out, session, std::string(req.nats_subject), rfl::json::write(req));
+    if (!result)
+        return std::nullopt;
+    if (!result->success) {
+        fail(out) << "Failed to fetch workflow steps: " << result->message << std::endl;
+        return std::nullopt;
+    }
+    return result;
+}
+
+void print_step(std::ostream& out,
+                const workflow::messaging::workflow_step_summary& step,
+                std::size_t total) {
+    out << "  [" << (step.step_index + 1) << "/" << total << "] " << step.name << ": "
+        << step.status;
+    if (!step.error.empty())
+        out << " — " << step.error;
+    out << std::endl;
+}
+
+}
+
+void workflow_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
+    auto workflow_menu = std::make_unique<cli::Menu>("workflow");
+
+    workflow_menu->Insert(
+        "steps",
+        [&session](std::ostream& out, std::string instance_id) {
+            process_steps(std::ref(out), std::ref(session), instance_id);
+        },
+        "Show the steps of a workflow instance",
+        {"instance_id"});
+
+    workflow_menu->Insert(
+        "wait",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            auto parsed = parse_args(args, {
+                {.name = "timeout", .requires_value = true,
+                 .default_value = std::to_string(default_timeout.count())}
+            });
+            if (!parsed) {
+                fail(out) << parsed.error() << std::endl;
+                return;
+            }
+            if (parsed->positionals.size() != 1) {
+                fail(out) << "Usage: workflow wait <instance_id> [--timeout <seconds>]"
+                          << std::endl;
+                return;
+            }
+
+            std::chrono::seconds timeout(0);
+            try {
+                timeout = std::chrono::seconds(std::stol(parsed->flag("timeout")));
+            } catch (const std::exception&) {
+                fail(out) << "Invalid timeout: " << parsed->flag("timeout") << std::endl;
+                return;
+            }
+
+            wait_for_instance(std::ref(out), std::ref(session),
+                              parsed->positionals.front(), timeout);
+        },
+        "Wait for a workflow instance to reach a terminal state",
+        {"instance_id [--timeout <seconds>]"});
+
+    root_menu.Insert(std::move(workflow_menu));
+}
+
+void workflow_commands::process_steps(std::ostream& out,
+                                      nats_client& session,
+                                      const std::string& instance_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Fetching steps for workflow instance: " << instance_id;
+
+    auto result = fetch_steps(out, session, instance_id);
+    if (!result)
+        return;
+
+    if (result->steps.empty()) {
+        out << "No steps recorded for instance " << instance_id << "." << std::endl;
+        return;
+    }
+
+    for (const auto& step : result->steps)
+        print_step(out, step, result->steps.size());
+}
+
+bool workflow_commands::wait_for_instance(std::ostream& out,
+                                          nats_client& session,
+                                          const std::string& instance_id,
+                                          std::chrono::seconds timeout) {
+    BOOST_LOG_SEV(lg(), info) << "Waiting for workflow instance: " << instance_id
+                              << " (timeout: " << timeout.count() << "s)";
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::map<int, std::string> last_status;
+
+    while (true) {
+        auto result = fetch_steps(out, session, instance_id);
+        if (!result)
+            return false;
+
+        // Print transitions since the previous poll.
+        for (const auto& step : result->steps) {
+            auto& last = last_status[step.step_index];
+            if (last != step.status) {
+                last = step.status;
+                print_step(out, step, result->steps.size());
+            }
+        }
+
+        // Terminal-state detection, as the GUI's WorkflowStepsWidget:
+        // any failed step is a terminal failure; all steps completed
+        // (with or without warnings) is terminal success.
+        const auto total = result->steps.size();
+        std::size_t completed = 0;
+        for (const auto& step : result->steps) {
+            if (step.status == "failed") {
+                fail(out) << "Workflow failed at step " << (step.step_index + 1) << " of "
+                          << total << ": " << step.error << std::endl;
+                BOOST_LOG_SEV(lg(), error) << "Workflow instance " << instance_id
+                                           << " failed at step " << step.step_index << ": "
+                                           << step.error;
+                return false;
+            }
+            if (step.status == "completed" || step.status == "completed_with_warnings")
+                ++completed;
+        }
+        if (total > 0 && completed == total) {
+            out << "✓ All " << total << " step(s) completed." << std::endl;
+            BOOST_LOG_SEV(lg(), info) << "Workflow instance " << instance_id << " completed.";
+            return true;
+        }
+
+        if (std::chrono::steady_clock::now() + poll_interval > deadline) {
+            fail(out) << "Timed out after " << timeout.count()
+                      << "s waiting for workflow instance " << instance_id
+                      << ". Check progress with: workflow steps " << instance_id << std::endl;
+            BOOST_LOG_SEV(lg(), error) << "Timed out waiting for workflow instance "
+                                       << instance_id;
+            return false;
+        }
+        std::this_thread::sleep_for(poll_interval);
+    }
+}
+
+}

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -21,6 +21,7 @@
 #include "ores.iam.api/messaging/login_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/accounts_commands.hpp"
+#include "ores.shell/app/commands/bundles_commands.hpp"
 #include "ores.shell/app/commands/change_reason_categories_commands.hpp"
 #include "ores.shell/app/commands/change_reasons_commands.hpp"
 #include "ores.shell/app/commands/connection_commands.hpp"
@@ -32,6 +33,7 @@
 #include "ores.shell/app/commands/subscription_commands.hpp"
 #include "ores.shell/app/commands/tenants_commands.hpp"
 #include "ores.shell/app/commands/variability_commands.hpp"
+#include "ores.shell/app/commands/workflow_commands.hpp"
 #include "ores.utility/rfl/reflectors.hpp"       // IWYU pragma: keep.
 #include "ores.utility/streaming/std_vector.hpp" // IWYU pragma: keep.
 #include "ores.utility/version/version.hpp"
@@ -81,6 +83,8 @@ std::unique_ptr<cli::Cli> repl::setup_menus() {
     tenants_commands::register_commands(*root, session_, pagination_);
     navigation_commands::register_commands(*root, pagination_);
     script_commands::register_commands(*root, active_session_);
+    bundles_commands::register_commands(*root, session_);
+    workflow_commands::register_commands(*root, session_);
 
     auto cli_instance = std::make_unique<cli::Cli>(std::move(root));
     cli_instance->ExitAction([](auto& out) { out << "Bye!" << std::endl; });

--- a/projects/ores.shell/tests/app_command_args_tests.cpp
+++ b/projects/ores.shell/tests/app_command_args_tests.cpp
@@ -30,6 +30,7 @@ const std::string tags("[app]");
 
 using ores::shell::app::flag_spec;
 using ores::shell::app::parse_args;
+using ores::shell::app::parse_positive_seconds;
 using namespace ores::logging;
 
 TEST_CASE("parse_args_positionals_only", tags) {
@@ -135,4 +136,22 @@ TEST_CASE("parse_args_switch_with_inline_value_is_error", tags) {
                         {{.name = "continue-on-error"}});
     REQUIRE_FALSE(r.has_value());
     CHECK(r.error().find("continue-on-error") != std::string::npos);
+}
+
+TEST_CASE("parse_positive_seconds_accepts_positive_integers", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_positive_seconds("300");
+    REQUIRE(r.has_value());
+    CHECK(r->count() == 300);
+}
+
+TEST_CASE("parse_positive_seconds_rejects_bad_input", tags) {
+    auto lg(make_logger(test_suite));
+
+    CHECK_FALSE(parse_positive_seconds("0").has_value());
+    CHECK_FALSE(parse_positive_seconds("-5").has_value());
+    CHECK_FALSE(parse_positive_seconds("30x").has_value());
+    CHECK_FALSE(parse_positive_seconds("abc").has_value());
+    CHECK_FALSE(parse_positive_seconds("").has_value());
 }


### PR DESCRIPTION
## Summary

Second task of the provisioning-commands story: the dataset-publication plumbing. 'bundles list' shows the publishable bundles; 'bundles publish <code>' dispatches a publication workflow (upsert, atomic, as the logged-in user) with the wizards' parameters available as typed flags (--root-lei, --party-id, --dataset), and '--wait' blocks until the workflow reaches a terminal state, streaming step transitions. 'workflow steps/wait' expose the polling loop standalone for diagnosis and resume. Terminal-state detection mirrors the GUI's WorkflowStepsWidget; failures mark command_feedback so load's stop-on-error aborts scripts.

## Changes

- New workflow command group: steps and wait (3s poll, --timeout, transition streaming, reusable wait_for_instance).
- New bundles command group: list and publish [--wait] with typed publication params.
- Register both groups; link ores.workflow.api.lib.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Implement ores-shell provisioning commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.html) | 31B8013E-10FF-4FCC-9D1D-D5BAF8D16437 |
| Task | [Add bundles and workflow shell commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_bundles_and_workflow_commands.html) | F77DC2CF-C082-4DA5-80F7-454BAA781100 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)