### PR TITLE
[compass] pr merge never touches task state; fix close-out bugs

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.org
@@ -29,7 +29,7 @@ by the sibling story [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented 
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -53,7 +53,7 @@ by the sibling story [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented 
 |------+-------+-------+-----+-------------|
 | [[id:C0EAC29C-7283-4A9C-999E-8F9FDB80FE5A][Distinguish creating stories and tasks from picking them up]] | BACKLOG | | | Make the create vs pick-up distinction first-class in compass: creating a story/task scaffolds docs only; picking one up creates the branch, marks STARTED, and stamps the journal. |
 | [[id:7F5F3182-68EB-48D7-B2F3-1E6C3A6C2570][Design a clean PR close-out workflow]] | BACKLOG | | | Brainstorm and document a clean work-lifecycle so bookkeeping never needs its own PR. Candidate rules: every story gets a scaffold task, so scaffolding PRs close the scaffold task instead of wrongly closing the first real task; bookkeeping (task DONE, story and sprint sync, Result) always ends the review round and rides the PR before merge; pr merge never closes a task whose deliverable the PR does not contain (--keep-open semantics by default for non-deliverable PRs). Motivated by PR 1111, where the scaffold PR auto-closed the unstarted naming-convention task and the fix needed a follow-up PR. |
-| [[id:DF4B8745-1B15-4213-B3B2-DB5C87AB35EB][Fix pr merge close-out bugs]] | BACKLOG | | | Two bugs seen merging PR 1111: (1) the close-out commit guard string-matches 'nothing to commit', but with unrelated unstaged changes (e.g. vcpkg submodule pointer) git says 'no changes added to commit', so compass aborts before calling gh pr merge; (2) the close-out push races GitHub's merge API, which rejects with 'Base branch was modified' — needs a retry. Make the close-out commit detection robust (use git status --porcelain or check staged paths, not message text) and retry the merge on the transient GraphQL error. |
+| [[id:DF4B8745-1B15-4213-B3B2-DB5C87AB35EB][Fix pr merge close-out bugs]] | DONE | 2026-06-06 | 2026-06-06 | Two bugs seen merging PR 1111: (1) the close-out commit guard string-matches 'nothing to commit', but with unrelated unstaged changes (e.g. vcpkg submodule pointer) git says 'no changes added to commit', so compass aborts before calling gh pr merge; (2) the close-out push races GitHub's merge API, which rejects with 'Base branch was modified' — needs a retry. Make the close-out commit detection robust (use git status --porcelain or check staged paths, not message text) and retry the merge on the transient GraphQL error. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
@@ -65,7 +65,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Task-state regex \S+ could capture a trailing table pipe | compass_pr.py | Accepted | Fixed in ff22781f1; [A-Z]+ matches the todo vocabulary. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:pr:bug:compass_create_vs_pickup:sprint_20:v0:
 #+owner: marco
 #+branch: feature/fix-pr-merge-closeout
-#+pr:
+#+pr: 1127
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -59,7 +59,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1127][#1127]] | [compass] pr merge never touches task state; fix close-out bugs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass:pr:bug:compass_create_vs_pickup:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-pr-merge-closeout
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -19,22 +19,33 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Make =compass pr merge= robust and aligned with the validated
+close-out design: merge never touches task state (bookkeeping ends
+the review round via =compass task done= and rides the PR), the
+close-out string-match crash is gone, and the transient GitHub
+base-branch-modified race is retried instead of failing the merge.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
 
--
+- =pr merge= performs no task close-out: a STARTED task draws a
+  warning before the merge and a reminder after; nothing is committed
+  by merge itself. =--keep-open= is gone.
+- No git porcelain message parsing remains in compass_pr.py: the PR
+  record path checks the staged diff instead.
+- "Base branch was modified" from GitHub's merge API is retried up to
+  three times before failing.
+- The merge recipe and pr-merge skill describe the new semantics.
 
 * Plan
 
@@ -57,3 +68,12 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Implemented in compass_pr.py: the pre-merge close-out block and the
+post-merge fallback are gone — merge only merges, warning when the
+branch's task is not DONE and reminding afterwards; --keep-open is
+removed. The gh merge call retries the transient base-branch-modified
+GraphQL race (3 attempts). The PR-record path checks the staged diff
+instead of parsing git's locale- and state-dependent commit message —
+the exact crash from PR 1111. Merge recipe and pr-merge skill updated
+to match.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -92,7 +92,7 @@ gates the sprint: no other story starts until it is done.*
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented skill cleanup]] | DONE | 2026-06-06 | 2026-06-06 | Naming convention; compass command inventory and skill map; rename/delete existing skills; add compass workflow skills. |
-| [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] | BACKLOG | | | Create vs pick-up split; scaffold tasks; bookkeeping rides the PR (no PR-to-close-a-PR); robust pr merge close-out. |
+| [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] | STARTED | 2026-06-06 | | Create vs pick-up split; scaffold tasks; bookkeeping rides the PR (no PR-to-close-a-PR); robust pr merge close-out. |
 
 *** Epic: Codegen
 

--- a/doc/llm/skills/pr-merge/SKILL.org
+++ b/doc/llm/skills/pr-merge/SKILL.org
@@ -24,11 +24,10 @@ Merging an approved PR. Guard rails refuse while review threads are unresolved o
 
 * How to use this skill
 
-1. /Ensure the bookkeeping rode the PR/: the task was closed with =agile-close-task= on this branch. If the PR does not deliver its task, keep the task open:
-
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh pr merge --keep-open
-   #+end_src
+1. /Ensure the bookkeeping rode the PR/: the task was closed with
+   =agile-close-task= on this branch. If the PR does not deliver its
+   task, just merge — merge never touches task state; a STARTED task
+   only draws a warning.
 
 
 2. /Merge/ (merge commit, never squash):

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -19,27 +19,26 @@ How do I merge a green, approved PR and delete its feature branch?
 
 * Answer
 
-0. /Write the task's =* Result=/ first — the close-out commit rides
-   the PR, so the prose must be in the working tree before merging.
+0. /Close the bookkeeping first/ if this PR delivers its task: run
+   =compass task done <slug>=, write the =* Result=, and commit on
+   the PR branch — the close-out rides the PR. Merge never touches
+   task state; a task that is still STARTED only draws a warning
+   (tasks may legitimately span several PRs).
 
 1. /Merge/ — the guard rails are built in: the command refuses while
-   review threads are unresolved or CI is not green; then it closes
-   the task out (task and story row to DONE, journal stamped), commits
-   and pushes the close-out on the PR branch, merges (always a merge
-   commit — never squash/rebase), and deletes the remote branch
-   (worktree-safe). Nothing is left in the working tree:
+   review threads are unresolved or CI is not green, merges (always
+   a merge commit — never squash/rebase), retries GitHub's transient
+   base-branch-modified race, and deletes the remote branch
+   (worktree-safe):
 
    #+begin_src sh :results verbatim
    ./compass.sh pr merge               # current branch's PR
    ./compass.sh pr merge 123           # explicit PR number
    ./compass.sh pr merge --force       # override the guards, stating what was bypassed
-   ./compass.sh pr merge --keep-open   # leave the task open (multi-task branch, partial slice)
    #+end_src
 
-2. With =--keep-open=, no close-out happens — run =compass task done
-   <slug>= when the task really finishes. When merging a PR whose
-   branch is not checked out here, the close-out falls back to the
-   working tree and needs a follow-up commit.
+2. If the task was left open on purpose, close it on the PR that
+   really finishes it — never with a bookkeeping-only PR.
 
 3. /Sync local main/:
 

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -21,7 +21,10 @@ Subcommands:
                 past GitHub branch protection, e.g. a required check
                 that never reported on a doc-only PR), always a merge
                 commit (never squash/rebase), deletes the branch, and
-                prompts the task/journal close-out.
+                retries GitHub's transient base-branch-modified race.
+                Merge never touches task state: close the task first
+                with 'compass task done' so the bookkeeping rides the
+                PR; a STARTED task only draws a warning.
   sync          Fetch origin/main and rebase the current branch onto
                 it. On conflicts: stop where git stops, list the
                 conflicted files and the ways out (--abort-on-conflict
@@ -37,6 +40,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -259,21 +263,26 @@ def _cmd_create(args, project_root):
            f"Story-ID: {story_id}\n"
            f"Task-ID: {task_id}")
     # add first: a just-scaffolded task doc is untracked, and a commit
-    # pathspec alone does not pick those up.
+    # pathspec alone does not pick those up. Check the staged diff
+    # rather than parsing git's commit message, which varies with the
+    # state of the rest of the tree ("nothing to commit" vs "no
+    # changes added to commit").
     subprocess.run(["git", "add", "--", str(task_rel)],
                    cwd=str(project_root))
-    p = subprocess.run(
-        ["git", "commit", "-m", msg, "--", str(task_rel)],
-        capture_output=True, text=True, cwd=str(project_root))
-    if p.returncode == 0:
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", str(task_rel)],
+        cwd=str(project_root)).returncode != 0
+    if staged:
+        p = subprocess.run(
+            ["git", "commit", "-m", msg, "--", str(task_rel)],
+            capture_output=True, text=True, cwd=str(project_root))
+        if p.returncode != 0:
+            print(p.stderr.strip() or p.stdout.strip(), file=sys.stderr)
+            return p.returncode
         p = subprocess.run(["git", "push"], cwd=str(project_root))
         if p.returncode != 0:
             return p.returncode
         print(f"✅ PR record committed and pushed ({task_rel}).")
-    elif "nothing to commit" not in (p.stdout + p.stderr):
-        # Nothing-to-commit (idempotent record) is fine; anything else
-        # should be surfaced.
-        print(p.stderr.strip() or p.stdout.strip(), file=sys.stderr)
     compass = Path(project_root) / "projects" / "ores.compass" / "compass.sh"
     subprocess.run([str(compass), "journal", "update",
                     "--story", story_id, "--task", task_id,
@@ -338,63 +347,51 @@ def _cmd_merge(args, project_root):
         capture_output=True, text=True, cwd=str(project_root))
     head = head_proc.stdout.strip() if head_proc.returncode == 0 else ""
 
-    # A merged PR means the task shipped: close it out BEFORE merging
-    # so the DONE docs ride the PR itself and nothing strands in the
-    # working tree. Only possible when we are on the PR's branch.
+    # Merge never touches task state. Bookkeeping (task done, Result,
+    # story/sprint sync) ends the review round and rides the PR via
+    # 'compass task done' — see the work-lifecycle story. A task that
+    # is still STARTED here gets a warning, not a close-out: tasks may
+    # legitimately span several PRs, and a scaffolding PR must never
+    # close the task whose deliverable it does not contain.
     task_id = ""
-    task_path = None
+    task_state = ""
     if head:
         task_path, task_text = _find_task_doc(project_root, head, "")
         if task_path is not None:
             task_id = _org_id(task_text)
-    compass = (Path(project_root) / "projects" / "ores.compass"
-               / "compass.sh")
-    closed_out = False
-    on_head = _current_branch(project_root) == head
-    if task_id and not args.keep_open and on_head:
-        res = subprocess.run([str(compass), "task", "done", task_id,
-                              "--pr", str(number)], cwd=str(project_root))
-        if res.returncode != 0:
-            return res.returncode
-        story_rel = (task_path.parent / "story.org").relative_to(
-            project_root)
-        task_rel = task_path.relative_to(project_root)
-        story_id = _org_id(
-            (task_path.parent / "story.org").read_text(encoding="utf-8"))
-        msg = (f"[agile] Close task on merge of PR #{number}\n\n"
-               f"Story-ID: {story_id}\n"
-               f"Task-ID: {task_id}")
-        subprocess.run(["git", "add", "--", str(task_rel), str(story_rel)],
-                       cwd=str(project_root))
-        c = subprocess.run(["git", "commit", "-m", msg, "--",
-                            str(task_rel), str(story_rel)],
-                           capture_output=True, text=True,
-                           cwd=str(project_root))
-        if c.returncode == 0:
-            p = subprocess.run(["git", "push"], cwd=str(project_root))
-            if p.returncode != 0:
-                return p.returncode
-            print(f"✅ Close-out committed and pushed on {head}.")
-            closed_out = True
-        elif "nothing to commit" not in (c.stdout + c.stderr):
-            print(c.stderr.strip() or c.stdout.strip(), file=sys.stderr)
-            return c.returncode
+            m = re.search(r"^\| State\s*\|\s*(\S+)", task_text, re.M)
+            task_state = m.group(1) if m else ""
+    if task_id and task_state and task_state != "DONE":
+        print(f"⚠️  Task on this branch is {task_state}, not DONE — if "
+              f"this PR delivers it, close it first: compass task done "
+              f"{task_id}", file=sys.stderr)
 
     # Always a merge commit — never squash, never rebase — matching
     # the repository's history. gh's --admin bypasses the base branch
     # protection whenever --force was given (a human taking
     # responsibility should not then be refused by a policy
     # technicality, e.g. a required check that never reported on a
-    # doc-only PR), or when the close-out push just made CI pending
-    # again (the delta is the tool-authored docs commit). No gh
-    # --delete-branch: it checks out the default branch locally, which
-    # fails in a multi-worktree fleet where main lives in another
-    # worktree. Delete the remote branch directly instead.
+    # doc-only PR). No gh --delete-branch: it checks out the default
+    # branch locally, which fails in a multi-worktree fleet where main
+    # lives in another worktree. Delete the remote branch directly
+    # instead. GitHub's merge API intermittently rejects with "Base
+    # branch was modified" right after a push (a GraphQL race) — retry
+    # a few times before giving up.
     cmd = ["gh", "pr", "merge", str(number), "--merge"]
-    if args.force or closed_out:
+    if args.force:
         cmd.append("--admin")
-    p = subprocess.run(cmd, cwd=str(project_root))
-    if p.returncode != 0:
+    for attempt in range(3):
+        p = subprocess.run(cmd, capture_output=True, text=True,
+                           cwd=str(project_root))
+        if p.returncode == 0:
+            break
+        err = (p.stdout + p.stderr)
+        if "Base branch was modified" in err and attempt < 2:
+            print("ℹ️  GitHub reports the base branch was modified "
+                  "(transient race) — retrying…", flush=True)
+            time.sleep(3)
+            continue
+        print(err.strip(), file=sys.stderr)
         return p.returncode
     deleted = False
     if head and head not in ("main", "master"):
@@ -410,30 +407,12 @@ def _cmd_merge(args, project_root):
               f"{f' ({head})' if head else ''} — delete it manually if "
               "needed.", file=sys.stderr)
 
-    if task_id and not args.keep_open and not on_head:
-        # Could not ride the PR: fall back to post-merge close-out.
-        subprocess.run([str(compass), "task", "done", task_id,
-                        "--pr", str(number)], cwd=str(project_root))
-        print("⚠️  Close-out edits are in the working tree (merge ran "
-              "off-branch) — commit them on a follow-up branch.")
-    elif task_id and args.keep_open:
-        story_path = task_path.parent / "story.org"
-        try:
-            story_id = _org_id(story_path.read_text(encoding="utf-8"))
-        except OSError:
-            story_id = ""
-        if story_id:
-            subprocess.run(
-                [str(compass), "journal", "update",
-                 "--story", story_id, "--task", task_id,
-                 "--branch", head, "--state", "STARTED",
-                 "--pr", str(number)], cwd=str(project_root))
-        print("ℹ️  --keep-open: task left open; close it later with "
-              f"compass task done {task_id}")
+    if task_id and task_state and task_state != "DONE":
+        print(f"ℹ️  Task is still {task_state} — when its work is "
+              f"complete, close it on the next PR: compass task done "
+              f"{task_id}")
     elif not task_id:
-        print("ℹ️  No task doc matches the merged branch — close out "
-              "manually: compass task done <slug-or-uuid> "
-              f"--pr {number}")
+        print("ℹ️  No task doc matches the merged branch.")
     return 0
 
 
@@ -554,9 +533,6 @@ def run(argv, project_root):
                     help="Merge even with unresolved threads, red CI, or "
                          "blocking branch protection (admin merge; states "
                          "what was bypassed)")
-    mp.add_argument("--keep-open", action="store_true",
-                    help="Leave the task open after merging (multi-task "
-                         "branches, partial slices)")
 
     sp = sub.add_parser("sync",
                         help="Fetch origin/main and rebase the current "

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -359,7 +359,7 @@ def _cmd_merge(args, project_root):
         task_path, task_text = _find_task_doc(project_root, head, "")
         if task_path is not None:
             task_id = _org_id(task_text)
-            m = re.search(r"^\| State\s*\|\s*(\S+)", task_text, re.M)
+            m = re.search(r"^\| State\s*\|\s*([A-Z]+)", task_text, re.M)
             task_state = m.group(1) if m else ""
     if task_id and task_state and task_state != "DONE":
         print(f"⚠️  Task on this branch is {task_state}, not DONE — if "


### PR DESCRIPTION
## Summary

First task of the Clean up the compass work lifecycle story. pr merge now only merges: the pre-merge close-out and post-merge fallback are removed — bookkeeping ends the review round via compass task done and rides the PR (a STARTED task draws a warning, supporting tasks that span several PRs and scaffolding PRs that must not close real tasks). Adds a retry for GitHub's transient base-branch-modified merge race, and replaces the nothing-to-commit message parsing with a staged-diff check — the exact pair of failures that broke PR 1111's merge. Merge recipe and pr-merge skill updated; --keep-open removed.

## Changes

- Remove task close-out from pr merge; warn on STARTED task instead
- Retry the base-branch-modified GraphQL race up to 3 times
- Check the staged diff in the PR-record path instead of parsing git messages
- Update the merge recipe and pr-merge skill; drop --keep-open

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clean up the compass work lifecycle](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.html) | C1813B64-1647-4B49-B856-A8345850001C |
| Task | [Fix pr merge close-out bugs](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_fix_pr_merge_closeout_bugs.html) | DF4B8745-1B15-4213-B3B2-DB5C87AB35EB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)