### PR TITLE
[ores.shell] Add lei and synthetic shell commands

### DIFF
--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
@@ -64,7 +64,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 |------+-------+-------+-----+-------------|
 | [[id:1AD5B684-404D-447F-B8A6-77AABDF829AF][Add flag parsing and stop-on-error load semantics]] | STARTED | 2026-06-06 | | Shell infrastructure for the provisioning surface: optional --flag parsing and load that aborts on first failure. |
 | [[id:F77DC2CF-C082-4DA5-80F7-454BAA781100][Add bundles and workflow shell commands]] | STARTED | 2026-06-06 | | bundles list, bundles publish [--wait], workflow wait — the dataset-publication plumbing. |
-| [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | BACKLOG | | | lei countries/entities and synthetic generate — the data-source plumbing. |
+| [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | STARTED | 2026-06-06 | | lei countries/entities and synthetic generate — the data-source plumbing. |
 | [[id:9F96763F-5BA7-4F7E-970E-FE404A14D5C1][Add parties, account-parties and reports shell commands]] | BACKLOG | | | parties list, account-parties add, tenants complete-provisioning, reports templates — the refdata/iam/reporting plumbing. |
 | [[id:5D782E09-99EE-4C6C-837D-61F28559798B][Add the provision system command]] | BACKLOG | | | Porcelain spanning the SystemProvisionerWizard: bootstrap admin + first tenant with single-tenant defaults. |
 | [[id:678F9B7C-98AD-4386-ACC9-D5501907C7ED][Add the provision tenant command]] | BACKLOG | | | Porcelain spanning the TenantProvisioningWizard: bundle publish, GLEIF/synthetic data, association, finalize. |

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
@@ -8,7 +8,7 @@
 #+filetags: :shell:dq:synthetic:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-provisioners-from-shell
-#+pr:
+#+pr: 1128
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -61,7 +61,7 @@ Add the data-source plumbing: 'lei countries' and 'lei entities <country> [--fil
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1128][#1128]] | [ores.shell] Add lei and synthetic shell commands |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell:dq:synthetic:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-provisioners-from-shell
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Add the data-source plumbing: 'lei countries' and 'lei entities <country> [--fil
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Implemented; build and unit tests green; PR pending. |
+| Waiting on   | Review.                                |
+| Next         | Merge; then the parties/reports plumbing task. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -40,9 +40,20 @@ Add the data-source plumbing: 'lei countries' and 'lei entities <country> [--fil
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+1. =lei_commands= group: =lei countries= (distinct countries from
+   =dq.v1.lei-entities.summary= with empty filter, as the GUI picker
+   does) and =lei entities <country> [--filter <text>]=
+   (case-insensitive substring on the legal name, client-side like
+   the picker's proxy filter).
+2. =synthetic_commands= group: =synthetic generate= with all 15 knobs
+   as flags defaulted from =generate_organisation_request= (itself
+   the wizard's defaults); =--no-addresses= / =--no-identifiers=
+   switches for the two default-true booleans; optional =--seed=;
+   wizard's 10m request timeout; print response counts and the
+   actual seed with a reproduce hint.
+3. =parse_uint32= / =parse_uint64= pure helpers in =command_args=
+   (full consumption, range-checked) with unit tests.
+4. Register both groups; link =ores.synthetic.api.lib=.
 
 * Notes
 
@@ -59,3 +70,19 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Implemented per plan. Notes:
+
+- =lei countries= derives the distinct list client-side from the
+  summary response, exactly as the GUI's LeiEntityPicker populates
+  its country combo; =lei entities= prints LEI, country, category and
+  legal name with a shown/total count so =--filter= narrowing is
+  visible.
+- =synthetic generate= rejects any malformed knob before sending;
+  the success report lists all eight entity counts and ends with
+  "Reproduce with: synthetic generate --seed <seed>" so random runs
+  are capturable.
+- Verified by build + unit tests (23 cases / 67 assertions green,
+  including the new uint parsers) and menu registration in the
+  binary. Live verification lands with the porcelain tasks and the
+  e2e script.

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.org
@@ -67,7 +67,10 @@ Add the data-source plumbing: 'lei countries' and 'lei entities <country> [--fil
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | " -1" bypasses unsigned validation via stoull whitespace skip | command_args.cpp:107 | Accepted | Stricter than suggested: first character must be a digit (rejects whitespace, +, -). |
+| 2 | Add whitespace-negative test | app_command_args_tests.cpp:186 | Accepted | " -1", " 1" and "+1" cases added for both widths. |
+| 3 | Login check in lei countries | lei_commands.cpp:96 | Accepted | Guard added. |
+| 4 | Login check in lei entities | lei_commands.cpp:127 | Accepted | Guard added after arg parsing. |
 
 * Result
 

--- a/projects/ores.shell/include/ores.shell/app/command_args.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_args.hpp
@@ -21,6 +21,7 @@
 #define ORES_SHELL_APP_COMMAND_ARGS_HPP
 
 #include <chrono>
+#include <cstdint>
 #include <expected>
 #include <map>
 #include <optional>
@@ -79,6 +80,18 @@ parse_args(const std::vector<std::string>& tokens,
  */
 std::optional<std::chrono::seconds>
 parse_positive_seconds(const std::string& value);
+
+/**
+ * @brief Parse a flag value as an unsigned 32-bit integer.
+ * Rejects partial numbers, negatives and out-of-range values.
+ */
+std::optional<std::uint32_t> parse_uint32(const std::string& value);
+
+/**
+ * @brief Parse a flag value as an unsigned 64-bit integer.
+ * Rejects partial numbers, negatives and out-of-range values.
+ */
+std::optional<std::uint64_t> parse_uint64(const std::string& value);
 
 }
 

--- a/projects/ores.shell/include/ores.shell/app/commands/lei_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/lei_commands.hpp
@@ -1,0 +1,80 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMANDS_LEI_COMMANDS_HPP
+#define ORES_SHELL_APP_COMMANDS_LEI_COMMANDS_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <string>
+#include <vector>
+
+namespace cli {
+
+class Menu;
+
+}
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Commands for browsing GLEIF LEI entities.
+ *
+ * The command-line replacement for the GUI's root-LEI entity picker:
+ * find the countries with entities, then search a country's entities
+ * to obtain the LEI passed to bundle publication via --root-lei.
+ */
+class lei_commands {
+private:
+    inline static std::string_view logger_name = "ores.shell.app.commands.lei_commands";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Register LEI-related commands.
+     *
+     * Creates the lei submenu with countries and entities operations.
+     */
+    static void register_commands(cli::Menu& root_menu,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief List the countries that have LEI entities.
+     */
+    static void process_countries(std::ostream& out,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief List a country's LEI entities: lei entities <country>
+     * [--filter <text>], where --filter is a case-insensitive
+     * substring match on the entity legal name.
+     */
+    static void process_entities(std::ostream& out,
+                                 ores::nats::service::nats_client& session,
+                                 const std::vector<std::string>& args);
+};
+
+}
+
+#endif

--- a/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
@@ -1,0 +1,80 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMANDS_SYNTHETIC_COMMANDS_HPP
+#define ORES_SHELL_APP_COMMANDS_SYNTHETIC_COMMANDS_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <string>
+#include <vector>
+
+namespace cli {
+
+class Menu;
+
+}
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Commands for synthetic data generation.
+ *
+ * Wraps the synthetic organisation generator the tenant provisioning
+ * wizard uses for its synthetic data source. Every generation knob is
+ * an optional flag carrying the wizard's default; the response prints
+ * the actual seed used so a random run can be reproduced.
+ */
+class synthetic_commands {
+private:
+    inline static std::string_view logger_name = "ores.shell.app.commands.synthetic_commands";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Register synthetic-data commands.
+     *
+     * Creates the synthetic submenu with the generate operation.
+     */
+    static void register_commands(cli::Menu& root_menu,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief Generate a synthetic organisation:
+     * synthetic generate [--country GB|US] [--party-count N]
+     * [--party-max-depth N] [--counterparty-count N]
+     * [--counterparty-max-depth N] [--portfolio-leaf-count N]
+     * [--portfolio-max-depth N] [--books-per-portfolio N]
+     * [--business-unit-count N] [--business-unit-max-depth N]
+     * [--contacts-per-party N] [--contacts-per-counterparty N]
+     * [--no-addresses] [--no-identifiers] [--seed N].
+     */
+    static void process_generate(std::ostream& out,
+                                 ores::nats::service::nats_client& session,
+                                 const std::vector<std::string>& args);
+};
+
+}
+
+#endif

--- a/projects/ores.shell/src/CMakeLists.txt
+++ b/projects/ores.shell/src/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(${lib_target_name}
         ores.dq.api.lib
         ores.variability.api.lib
         ores.refdata.api.lib
+        ores.synthetic.api.lib
         ores.workflow.api.lib
         ores.nats.lib
         cli::cli)

--- a/projects/ores.shell/src/app/command_args.cpp
+++ b/projects/ores.shell/src/app/command_args.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/command_args.hpp"
 #include <algorithm>
+#include <cctype>
 #include <limits>
 #include <stdexcept>
 
@@ -103,7 +104,9 @@ namespace {
 
 std::optional<unsigned long long> parse_unsigned(const std::string& value,
                                                  unsigned long long max) {
-    if (value.empty() || value[0] == '-')
+    // Require a leading digit: stoull would otherwise skip whitespace
+    // and wrap negatives (" -1") into huge unsigned values.
+    if (value.empty() || !std::isdigit(static_cast<unsigned char>(value[0])))
         return std::nullopt;
     try {
         std::size_t pos = 0;

--- a/projects/ores.shell/src/app/command_args.cpp
+++ b/projects/ores.shell/src/app/command_args.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/command_args.hpp"
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 
 namespace ores::shell::app {
@@ -96,6 +97,39 @@ parse_positive_seconds(const std::string& value) {
     } catch (const std::exception&) {
         return std::nullopt;
     }
+}
+
+namespace {
+
+std::optional<unsigned long long> parse_unsigned(const std::string& value,
+                                                 unsigned long long max) {
+    if (value.empty() || value[0] == '-')
+        return std::nullopt;
+    try {
+        std::size_t pos = 0;
+        const unsigned long long v = std::stoull(value, &pos);
+        if (pos != value.size() || v > max)
+            return std::nullopt;
+        return v;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+}
+
+std::optional<std::uint32_t> parse_uint32(const std::string& value) {
+    auto v = parse_unsigned(value, std::numeric_limits<std::uint32_t>::max());
+    if (!v)
+        return std::nullopt;
+    return static_cast<std::uint32_t>(*v);
+}
+
+std::optional<std::uint64_t> parse_uint64(const std::string& value) {
+    auto v = parse_unsigned(value, std::numeric_limits<std::uint64_t>::max());
+    if (!v)
+        return std::nullopt;
+    return static_cast<std::uint64_t>(*v);
 }
 
 }

--- a/projects/ores.shell/src/app/commands/lei_commands.cpp
+++ b/projects/ores.shell/src/app/commands/lei_commands.cpp
@@ -1,0 +1,151 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/commands/lei_commands.hpp"
+#include "ores.dq.api/messaging/lei_entity_summary_protocol.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include <algorithm>
+#include <cli/cli.h>
+#include <functional>
+#include <iomanip>
+#include <ostream>
+#include <rfl/json.hpp>
+#include <set>
+
+namespace ores::shell::app::commands {
+
+using namespace logging;
+using ores::nats::service::nats_client;
+
+namespace {
+
+std::optional<dq::messaging::get_lei_entities_summary_response>
+fetch_entities(std::ostream& out, nats_client& session, const std::string& country_filter) {
+    dq::messaging::get_lei_entities_summary_request req;
+    req.country_filter = country_filter;
+
+    try {
+        auto reply = session.authenticated_request(std::string(req.nats_subject),
+                                                   rfl::json::write(req));
+        std::string data_str(reply.data.begin(), reply.data.end());
+        auto result =
+            rfl::json::read<dq::messaging::get_lei_entities_summary_response>(data_str);
+        if (!result) {
+            fail(out) << "Failed to parse response" << std::endl;
+            return std::nullopt;
+        }
+        if (!result->success) {
+            fail(out) << "Failed to fetch LEI entities: " << result->error_message
+                      << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+std::string to_lower_copy(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
+}
+
+void lei_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
+    auto lei_menu = std::make_unique<cli::Menu>("lei");
+
+    lei_menu->Insert(
+        "countries",
+        [&session](std::ostream& out) {
+            process_countries(std::ref(out), std::ref(session));
+        },
+        "List the countries that have LEI entities");
+
+    lei_menu->Insert(
+        "entities",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            process_entities(std::ref(out), std::ref(session), args);
+        },
+        "List a country's LEI entities, optionally filtered by legal name",
+        {"country [--filter <text>]"});
+
+    root_menu.Insert(std::move(lei_menu));
+}
+
+void lei_commands::process_countries(std::ostream& out, nats_client& session) {
+    BOOST_LOG_SEV(lg(), debug) << "Fetching LEI entity countries.";
+
+    auto result = fetch_entities(out, session, "");
+    if (!result)
+        return;
+
+    std::set<std::string> countries;
+    for (const auto& entity : result->entities)
+        countries.insert(entity.country);
+
+    BOOST_LOG_SEV(lg(), info) << "Found " << countries.size() << " countries.";
+    for (const auto& country : countries)
+        out << country << std::endl;
+    out << countries.size() << " countr" << (countries.size() == 1 ? "y" : "ies")
+        << " with LEI entities." << std::endl;
+}
+
+void lei_commands::process_entities(std::ostream& out,
+                                    nats_client& session,
+                                    const std::vector<std::string>& args) {
+    auto parsed = parse_args(args, {
+        {.name = "filter", .requires_value = true, .default_value = ""}
+    });
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (parsed->positionals.size() != 1) {
+        fail(out) << "Usage: lei entities <country> [--filter <text>]" << std::endl;
+        return;
+    }
+    const auto& country = parsed->positionals.front();
+    const auto filter = to_lower_copy(parsed->flag("filter"));
+
+    BOOST_LOG_SEV(lg(), debug) << "Fetching LEI entities for country: " << country
+                               << " (filter: '" << filter << "')";
+
+    auto result = fetch_entities(out, session, country);
+    if (!result)
+        return;
+
+    std::size_t shown = 0;
+    for (const auto& entity : result->entities) {
+        if (!filter.empty() &&
+            to_lower_copy(entity.entity_legal_name).find(filter) == std::string::npos)
+            continue;
+        out << std::left << std::setw(22) << entity.lei << std::setw(8) << entity.country
+            << std::setw(18) << entity.entity_category << entity.entity_legal_name
+            << std::endl;
+        ++shown;
+    }
+    out << shown << " of " << result->entities.size() << " entit"
+        << (result->entities.size() == 1 ? "y" : "ies") << " shown." << std::endl;
+}
+
+}

--- a/projects/ores.shell/src/app/commands/lei_commands.cpp
+++ b/projects/ores.shell/src/app/commands/lei_commands.cpp
@@ -93,6 +93,11 @@ void lei_commands::register_commands(cli::Menu& root_menu, nats_client& session)
 }
 
 void lei_commands::process_countries(std::ostream& out, nats_client& session) {
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in." << std::endl;
+        return;
+    }
+
     BOOST_LOG_SEV(lg(), debug) << "Fetching LEI entity countries.";
 
     auto result = fetch_entities(out, session, "");
@@ -124,6 +129,11 @@ void lei_commands::process_entities(std::ostream& out,
         fail(out) << "Usage: lei entities <country> [--filter <text>]" << std::endl;
         return;
     }
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in." << std::endl;
+        return;
+    }
+
     const auto& country = parsed->positionals.front();
     const auto filter = to_lower_copy(parsed->flag("filter"));
 

--- a/projects/ores.shell/src/app/commands/synthetic_commands.cpp
+++ b/projects/ores.shell/src/app/commands/synthetic_commands.cpp
@@ -1,0 +1,190 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/commands/synthetic_commands.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
+#include <chrono>
+#include <cli/cli.h>
+#include <functional>
+#include <ostream>
+#include <rfl/json.hpp>
+
+namespace ores::shell::app::commands {
+
+using namespace logging;
+using ores::nats::service::nats_client;
+
+namespace {
+
+// Generation walks the whole organisation tree server-side; mirror the
+// wizard's generous timeout.
+constexpr std::chrono::minutes generate_timeout(10);
+
+}
+
+void synthetic_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
+    auto synthetic_menu = std::make_unique<cli::Menu>("synthetic");
+
+    synthetic_menu->Insert(
+        "generate",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            process_generate(std::ref(out), std::ref(session), args);
+        },
+        "Generate a synthetic organisation (parties, counterparties, portfolios, "
+        "books, business units)",
+        {"[--country GB|US] [--party-count N] [--party-max-depth N] "
+         "[--counterparty-count N] [--counterparty-max-depth N] "
+         "[--portfolio-leaf-count N] [--portfolio-max-depth N] "
+         "[--books-per-portfolio N] [--business-unit-count N] "
+         "[--business-unit-max-depth N] [--contacts-per-party N] "
+         "[--contacts-per-counterparty N] [--no-addresses] [--no-identifiers] "
+         "[--seed N]"});
+
+    root_menu.Insert(std::move(synthetic_menu));
+}
+
+void synthetic_commands::process_generate(std::ostream& out,
+                                          nats_client& session,
+                                          const std::vector<std::string>& args) {
+    // Defaults mirror generate_organisation_request, which mirrors the
+    // tenant provisioning wizard's synthetic page.
+    synthetic::messaging::generate_organisation_request defaults;
+    auto parsed = parse_args(args, {
+        {.name = "country", .requires_value = true, .default_value = defaults.country},
+        {.name = "party-count", .requires_value = true,
+         .default_value = std::to_string(defaults.party_count)},
+        {.name = "party-max-depth", .requires_value = true,
+         .default_value = std::to_string(defaults.party_max_depth)},
+        {.name = "counterparty-count", .requires_value = true,
+         .default_value = std::to_string(defaults.counterparty_count)},
+        {.name = "counterparty-max-depth", .requires_value = true,
+         .default_value = std::to_string(defaults.counterparty_max_depth)},
+        {.name = "portfolio-leaf-count", .requires_value = true,
+         .default_value = std::to_string(defaults.portfolio_leaf_count)},
+        {.name = "portfolio-max-depth", .requires_value = true,
+         .default_value = std::to_string(defaults.portfolio_max_depth)},
+        {.name = "books-per-portfolio", .requires_value = true,
+         .default_value = std::to_string(defaults.books_per_leaf_portfolio)},
+        {.name = "business-unit-count", .requires_value = true,
+         .default_value = std::to_string(defaults.business_unit_count)},
+        {.name = "business-unit-max-depth", .requires_value = true,
+         .default_value = std::to_string(defaults.business_unit_max_depth)},
+        {.name = "contacts-per-party", .requires_value = true,
+         .default_value = std::to_string(defaults.contacts_per_party)},
+        {.name = "contacts-per-counterparty", .requires_value = true,
+         .default_value = std::to_string(defaults.contacts_per_counterparty)},
+        {.name = "no-addresses"},
+        {.name = "no-identifiers"},
+        {.name = "seed", .requires_value = true, .default_value = ""}
+    });
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (!parsed->positionals.empty()) {
+        fail(out) << "synthetic generate takes no positional arguments; see help."
+                  << std::endl;
+        return;
+    }
+
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in." << std::endl;
+        return;
+    }
+
+    synthetic::messaging::generate_organisation_request req;
+    req.country = parsed->flag("country");
+
+    // Numeric knobs: validate each as an unsigned integer.
+    const std::vector<std::pair<std::string, std::uint32_t*>> knobs = {
+        {"party-count", &req.party_count},
+        {"party-max-depth", &req.party_max_depth},
+        {"counterparty-count", &req.counterparty_count},
+        {"counterparty-max-depth", &req.counterparty_max_depth},
+        {"portfolio-leaf-count", &req.portfolio_leaf_count},
+        {"portfolio-max-depth", &req.portfolio_max_depth},
+        {"books-per-portfolio", &req.books_per_leaf_portfolio},
+        {"business-unit-count", &req.business_unit_count},
+        {"business-unit-max-depth", &req.business_unit_max_depth},
+        {"contacts-per-party", &req.contacts_per_party},
+        {"contacts-per-counterparty", &req.contacts_per_counterparty}};
+    for (const auto& [name, target] : knobs) {
+        auto v = parse_uint32(parsed->flag(name));
+        if (!v) {
+            fail(out) << "Flag --" << name << " must be an unsigned integer: "
+                      << parsed->flag(name) << std::endl;
+            return;
+        }
+        *target = *v;
+    }
+
+    req.generate_addresses = !parsed->flag_set("no-addresses");
+    req.generate_identifiers = !parsed->flag_set("no-identifiers");
+
+    if (!parsed->flag("seed").empty()) {
+        auto seed = parse_uint64(parsed->flag("seed"));
+        if (!seed) {
+            fail(out) << "Flag --seed must be an unsigned integer: "
+                      << parsed->flag("seed") << std::endl;
+            return;
+        }
+        req.seed = *seed;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Generating synthetic organisation: "
+                              << rfl::json::write(req);
+    out << "Generating synthetic organisation (country " << req.country << ", "
+        << req.party_count << " parties)..." << std::endl;
+
+    try {
+        auto reply = session.authenticated_request(std::string(req.nats_subject),
+                                                   rfl::json::write(req),
+                                                   generate_timeout);
+        std::string data_str(reply.data.begin(), reply.data.end());
+        auto result =
+            rfl::json::read<synthetic::messaging::generate_organisation_response>(data_str);
+        if (!result) {
+            fail(out) << "Failed to parse response" << std::endl;
+            return;
+        }
+        if (!result->success) {
+            fail(out) << "Generation failed: " << result->error_message << std::endl;
+            return;
+        }
+
+        out << "✓ Synthetic organisation generated (seed " << result->seed << "):"
+            << std::endl;
+        out << "  parties:             " << result->parties_count << std::endl;
+        out << "  counterparties:      " << result->counterparties_count << std::endl;
+        out << "  business unit types: " << result->business_unit_types_count << std::endl;
+        out << "  business units:      " << result->business_units_count << std::endl;
+        out << "  portfolios:          " << result->portfolios_count << std::endl;
+        out << "  books:               " << result->books_count << std::endl;
+        out << "  contacts:            " << result->contacts_count << std::endl;
+        out << "  identifiers:         " << result->identifiers_count << std::endl;
+        out << "Reproduce with: synthetic generate --seed " << result->seed << std::endl;
+        BOOST_LOG_SEV(lg(), info) << "Synthetic generation complete; seed " << result->seed;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+    }
+}
+
+}

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -27,10 +27,12 @@
 #include "ores.shell/app/commands/connection_commands.hpp"
 #include "ores.shell/app/commands/countries_commands.hpp"
 #include "ores.shell/app/commands/currencies_commands.hpp"
+#include "ores.shell/app/commands/lei_commands.hpp"
 #include "ores.shell/app/commands/navigation_commands.hpp"
 #include "ores.shell/app/commands/rbac_commands.hpp"
 #include "ores.shell/app/commands/script_commands.hpp"
 #include "ores.shell/app/commands/subscription_commands.hpp"
+#include "ores.shell/app/commands/synthetic_commands.hpp"
 #include "ores.shell/app/commands/tenants_commands.hpp"
 #include "ores.shell/app/commands/variability_commands.hpp"
 #include "ores.shell/app/commands/workflow_commands.hpp"
@@ -85,6 +87,8 @@ std::unique_ptr<cli::Cli> repl::setup_menus() {
     script_commands::register_commands(*root, active_session_);
     bundles_commands::register_commands(*root, session_);
     workflow_commands::register_commands(*root, session_);
+    lei_commands::register_commands(*root, session_);
+    synthetic_commands::register_commands(*root, session_);
 
     auto cli_instance = std::make_unique<cli::Cli>(std::move(root));
     cli_instance->ExitAction([](auto& out) { out << "Bye!" << std::endl; });

--- a/projects/ores.shell/tests/app_command_args_tests.cpp
+++ b/projects/ores.shell/tests/app_command_args_tests.cpp
@@ -172,6 +172,9 @@ TEST_CASE("parse_uint32_rejects_bad_input", tags) {
     auto lg(make_logger(test_suite));
 
     CHECK_FALSE(parse_uint32("-1").has_value());
+    CHECK_FALSE(parse_uint32(" -1").has_value());
+    CHECK_FALSE(parse_uint32(" 1").has_value());
+    CHECK_FALSE(parse_uint32("+1").has_value());
     CHECK_FALSE(parse_uint32("4294967296").has_value());
     CHECK_FALSE(parse_uint32("12x").has_value());
     CHECK_FALSE(parse_uint32("").has_value());
@@ -184,6 +187,7 @@ TEST_CASE("parse_uint64_accepts_large_values_and_rejects_bad_input", tags) {
     REQUIRE(r.has_value());
     CHECK(*r == 18446744073709551615ull);
     CHECK_FALSE(parse_uint64("-1").has_value());
+    CHECK_FALSE(parse_uint64(" -1").has_value());
     CHECK_FALSE(parse_uint64("seed").has_value());
     CHECK_FALSE(parse_uint64("").has_value());
 }

--- a/projects/ores.shell/tests/app_command_args_tests.cpp
+++ b/projects/ores.shell/tests/app_command_args_tests.cpp
@@ -31,6 +31,8 @@ const std::string tags("[app]");
 using ores::shell::app::flag_spec;
 using ores::shell::app::parse_args;
 using ores::shell::app::parse_positive_seconds;
+using ores::shell::app::parse_uint32;
+using ores::shell::app::parse_uint64;
 using namespace ores::logging;
 
 TEST_CASE("parse_args_positionals_only", tags) {
@@ -154,4 +156,34 @@ TEST_CASE("parse_positive_seconds_rejects_bad_input", tags) {
     CHECK_FALSE(parse_positive_seconds("30x").has_value());
     CHECK_FALSE(parse_positive_seconds("abc").has_value());
     CHECK_FALSE(parse_positive_seconds("").has_value());
+}
+
+TEST_CASE("parse_uint32_accepts_unsigned_integers", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_uint32("42");
+    REQUIRE(r.has_value());
+    CHECK(*r == 42u);
+    CHECK(parse_uint32("0").has_value());
+    CHECK(parse_uint32("4294967295").has_value());
+}
+
+TEST_CASE("parse_uint32_rejects_bad_input", tags) {
+    auto lg(make_logger(test_suite));
+
+    CHECK_FALSE(parse_uint32("-1").has_value());
+    CHECK_FALSE(parse_uint32("4294967296").has_value());
+    CHECK_FALSE(parse_uint32("12x").has_value());
+    CHECK_FALSE(parse_uint32("").has_value());
+}
+
+TEST_CASE("parse_uint64_accepts_large_values_and_rejects_bad_input", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto r = parse_uint64("18446744073709551615");
+    REQUIRE(r.has_value());
+    CHECK(*r == 18446744073709551615ull);
+    CHECK_FALSE(parse_uint64("-1").has_value());
+    CHECK_FALSE(parse_uint64("seed").has_value());
+    CHECK_FALSE(parse_uint64("").has_value());
 }


### PR DESCRIPTION
## Summary

Third task of the provisioning-commands story: the data-source plumbing. 'lei countries' and 'lei entities <country> [--filter <text>]' replace the GUI's root-LEI entity picker for finding the --root-lei value; 'synthetic generate' wraps synthetic.v1.organisation.generate with all 15 generation knobs as flags carrying the tenant wizard's defaults, --no-addresses/--no-identifiers switches and optional --seed, printing the entity counts and the actual seed used so random runs are reproducible. New parse_uint32/parse_uint64 helpers validate every numeric knob before anything is sent.

## Changes

- New lei command group: countries and entities with client-side legal-name filter.
- New synthetic command group: generate with 15 defaulted knobs, 10m timeout, seed reporting.
- parse_uint32/parse_uint64 in command_args with unit tests; link ores.synthetic.api.lib.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Implement ores-shell provisioning commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.html) | 31B8013E-10FF-4FCC-9D1D-D5BAF8D16437 |
| Task | [Add lei and synthetic shell commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_lei_and_synthetic_commands.html) | BC79836F-9E46-43F3-B0CB-D4247F0A95A9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)