### PR TITLE
[agile] Encode the close-out workflow in runbooks; close the story

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.org
@@ -29,11 +29,11 @@ by the sibling story [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented 
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing.                               |
 | Last touched  | 2026-06-06                               |
 
 * Acceptance
@@ -52,10 +52,24 @@ by the sibling story [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:C0EAC29C-7283-4A9C-999E-8F9FDB80FE5A][Distinguish creating stories and tasks from picking them up]] | DONE | 2026-06-06 | 2026-06-06 | Make the create vs pick-up distinction first-class in compass: creating a story/task scaffolds docs only; picking one up creates the branch, marks STARTED, and stamps the journal. |
-| [[id:7F5F3182-68EB-48D7-B2F3-1E6C3A6C2570][Design a clean PR close-out workflow]] | BACKLOG | | | Brainstorm and document a clean work-lifecycle so bookkeeping never needs its own PR. Candidate rules: every story gets a scaffold task, so scaffolding PRs close the scaffold task instead of wrongly closing the first real task; bookkeeping (task DONE, story and sprint sync, Result) always ends the review round and rides the PR before merge; pr merge never closes a task whose deliverable the PR does not contain (--keep-open semantics by default for non-deliverable PRs). Motivated by PR 1111, where the scaffold PR auto-closed the unstarted naming-convention task and the fix needed a follow-up PR. |
+| [[id:7F5F3182-68EB-48D7-B2F3-1E6C3A6C2570][Design a clean PR close-out workflow]] | DONE | 2026-06-06 | 2026-06-06 | Brainstorm and document a clean work-lifecycle so bookkeeping never needs its own PR. Candidate rules: every story gets a scaffold task, so scaffolding PRs close the scaffold task instead of wrongly closing the first real task; bookkeeping (task DONE, story and sprint sync, Result) always ends the review round and rides the PR before merge; pr merge never closes a task whose deliverable the PR does not contain (--keep-open semantics by default for non-deliverable PRs). Motivated by PR 1111, where the scaffold PR auto-closed the unstarted naming-convention task and the fix needed a follow-up PR. |
 | [[id:DF4B8745-1B15-4213-B3B2-DB5C87AB35EB][Fix pr merge close-out bugs]] | DONE | 2026-06-06 | 2026-06-06 | Two bugs seen merging PR 1111: (1) the close-out commit guard string-matches 'nothing to commit', but with unrelated unstaged changes (e.g. vcpkg submodule pointer) git says 'no changes added to commit', so compass aborts before calling gh pr merge; (2) the close-out push races GitHub's merge API, which rejects with 'Base branch was modified' — needs a retry. Make the close-out commit detection robust (use git status --porcelain or check staged paths, not message text) and retry the merge on the transient GraphQL error. |
 
 * Decisions
+
+- Create vs pick-up: =compass add story/task= scaffolds docs only;
+  =compass task start= picks up (branch + STARTED + journal) and
+  derives =feature/<slug-kebab>= for branchless tasks.
+- Every new story gets an automatic scaffold task that owns the
+  branch and is clocked on by =story new=; the first real task is
+  born BACKLOG and unbranched. Scaffold PRs close scaffold tasks.
+- Bookkeeping ends the review round and rides the PR: =task done= +
+  Result + story/sprint sync are committed on the PR branch before
+  merging. =pr merge= never touches task state — a STARTED task only
+  draws a warning — and =--keep-open= is gone.
+- Rejected: opt-in scaffold-task flag (relies on remembering),
+  taskless scaffold PRs (breaks traceability), close-on-merge with
+  confirmation (prompts do not compose into skills).
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:pr:workflow:agile:compass_create_vs_pickup:sprint_20:v0:
 #+owner: marco
 #+branch: feature/design-clean-pr-closeout-workflow
-#+pr:
+#+pr: 1134
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -66,7 +66,7 @@ decisions validated explicitly.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1134][#1134]] | [agile] Encode the close-out workflow in runbooks; close the story |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
@@ -72,7 +72,8 @@ decisions validated explicitly.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Sync step listed after merge despite before-merge prose | work_task_to_merged_pr | Accepted | Fixed in a126ec11e; order is close-out, sync, merge. |
+| 1 | Postconditions stale vs the new merge step | start_new_story | Accepted | Fixed in a126ec11e. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass:pr:workflow:agile:compass_create_vs_pickup:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/design-clean-pr-closeout-workflow
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -75,3 +75,12 @@ decisions validated explicitly.
 |   |                 |      |          |       |
 
 * Result
+
+Design brainstormed and validated 2026-06-06 (see * Plan), then
+implemented across the story's other two tasks (PRs 1127, 1130). This
+task's closing deliverable: the three runbooks now describe the
+implemented workflow — start_new_story (scaffold task owns the
+branch; close it before merging the scaffold PR), work_task_to_merged_pr
+(close-out precedes merge and rides the PR; merge never touches task
+state; duplicate step numbering fixed), and handle_pr_review_round
+(final round ends with task done before pr merge).

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -92,7 +92,7 @@ gates the sprint: no other story starts until it is done.*
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:58A77C0F-0AF0-428F-854C-049B731844CA][Action-oriented skill cleanup]] | DONE | 2026-06-06 | 2026-06-06 | Naming convention; compass command inventory and skill map; rename/delete existing skills; add compass workflow skills. |
-| [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] | STARTED | 2026-06-06 | | Create vs pick-up split; scaffold tasks; bookkeeping rides the PR (no PR-to-close-a-PR); robust pr merge close-out. |
+| [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] | DONE | 2026-06-06 | 2026-06-06 | Create vs pick-up split; scaffold tasks; bookkeeping rides the PR (no PR-to-close-a-PR); robust pr merge close-out. |
 
 *** Epic: Codegen
 

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -53,6 +53,11 @@ In execution order:
 
 10. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
 
+11. /If this was the final round and the PR delivers the task/, end
+    the bookkeeping now so it rides the PR: =compass task done
+    <slug>=, write the =* Result=, commit, push. Then merge —
+    =compass pr merge= never touches task state.
+
 * Postconditions
 
 - All CI checks on the PR are green.

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -42,20 +42,24 @@ In execution order:
      --description "What it delivers." --tags "topic"
    #+end_src
 
-   This fetches =main=, creates =feature/my-feature=, and writes =story.org= + a linked task into the current sprint. To add a task to an /existing/ story instead, use =compass task new --story <id>=.
+   This fetches =main=, creates =feature/my-feature=, and writes three
+   documents into the current sprint: =story.org=, a /scaffold task/
+   (STARTED, owning the branch — the scaffold PR closes /it/), and the
+   first real task (BACKLOG, no branch). To add a task to an
+   /existing/ story instead, use =compass task new --story <id>=.
 
 2a. /Prefer content at scaffold time./ Pass =--goal= and =--acceptance= so the docs are born complete. When editing afterwards anyway, read every generated file first and use the real =:ID:= values — never placeholder UUIDs.
 
-3. /Clock on./ Run =compass task start= with the first task's slug to switch
-   branch, mark the task STARTED, and stamp the session journal:
+3. /Already clocked on./ =story new= clocks on to the scaffold task
+   automatically (STARTED + journal). The first /real/ task is picked
+   up later, when its work begins:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh task start <first-task-slug>
    #+end_src
 
-   This is the explicit "I am now working on this" signal. The journal entry
-   records the story, task, branch, and state so =compass where= and
-   =compass fleet= show context after a restart.
+   =task start= derives =feature/<slug-kebab>= when the task has no
+   =#+branch:= (override with =--branch=).
 
 4. /Complete the prose./ Whatever was not supplied at scaffold time: =* Out of scope=, extra =* Tasks= rows beyond the scaffolded one (each =compass add task= wires its own row), and any =[[id:UUID]]= cross-references.
 
@@ -65,7 +69,17 @@ In execution order:
 
 7. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
 
-8. /Open a PR./ =compass pr create --title "[COMPONENT] Description" ...= per [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — it pushes the branch, builds the body (Summary / Changes / Traceability), records the PR on the task, and stamps the journal.
+8. /Open the scaffold PR./ =compass pr create --title "[agile] ..." ...= per [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — it pushes the branch, builds the body (Summary / Changes / Traceability), records the PR on the scaffold task, and stamps the journal.
+
+9. /Close the scaffold task before merging./ The bookkeeping rides the
+   PR — never a follow-up PR:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh task done scaffold_<slug>
+   #+end_src
+
+   Commit, push, and merge with =compass pr merge= — merge never
+   touches task state.
 
 * Postconditions
 
@@ -73,7 +87,9 @@ In execution order:
 - Story is =STARTED= in the current sprint.
 - Story is wired into the sprint's =* Stories= table.
 - PR is open with the story UUID and page link in the body.
-- PR number is recorded in the task =* PRs= table.
+- PR number is recorded in the scaffold task's =* PRs= table.
+- The scaffold task is DONE on the branch before the PR merges; the
+  first real task remains BACKLOG until its work begins.
 
 * See also
 

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -83,13 +83,14 @@ In execution order:
 
 * Postconditions
 
-- Feature branch exists on =origin=.
-- Story is =STARTED= in the current sprint.
-- Story is wired into the sprint's =* Stories= table.
-- PR is open with the story UUID and page link in the body.
-- PR number is recorded in the scaffold task's =* PRs= table.
-- The scaffold task is DONE on the branch before the PR merges; the
-  first real task remains BACKLOG until its work begins.
+- Story is =STARTED= in the current sprint and wired into the
+  sprint's =* Stories= table.
+- The scaffold PR is merged into =main= and its remote branch
+  deleted; the PR number is recorded in the scaffold task's =* PRs=
+  table.
+- The scaffold task is DONE with its close-out commit inside the
+  merged PR; the first real task remains BACKLOG until its work
+  begins.
 
 * See also
 

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -81,18 +81,18 @@ In execution order:
    =* Decisions=, commit, and push. A task spanning several PRs stays
    open — close it on the PR that completes it.
 
-9. /Merge./ =compass pr merge= — the guards refuse while threads are
-   unresolved or CI is not green; merge never touches task state (a
-   STARTED task only draws a warning), retries GitHub's transient
-   base-branch-modified race, and deletes the remote branch. See
-   [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
-
-10. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit — before the merge, so the sync rides the PR too:
+9. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit — still before the merge, so the sync rides the PR too:
 
    a. In the *story.org* =* Status= table: state → =DONE=, set =Now= to =Nothing.=, fill =End= date.
    b. In the *sprint.org* =* Stories= table: update the story row to =DONE= and fill the =End= column.
 
    Both files must stay in sync. A story marked =DONE= in =story.org= but =STARTED= or =BACKLOG= in =sprint.org= is a silent inconsistency that the sprint health review will not catch automatically.
+
+10. /Merge./ =compass pr merge= — the guards refuse while threads are
+    unresolved or CI is not green; merge never touches task state (a
+    STARTED task only draws a warning), retries GitHub's transient
+    base-branch-modified race, and deletes the remote branch. See
+    [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
 
 * Postconditions
 

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -33,13 +33,13 @@ In execution order:
    ./projects/ores.compass/compass.sh task start <task-slug>
    #+end_src
 
-   If the task was scaffolded manually (e.g. via =compass add task= rather
-   than =compass task new=) its =#+branch:= field may be empty. Supply
-   =--branch= to write the branch name into the doc and create the branch in
-   one step — no manual edit required:
+   A task with no =#+branch:= (scaffolded via =compass add task= or
+   born as a story's first real task) gets =feature/<slug-kebab>=
+   derived automatically, created off fresh =origin/main=; =--branch=
+   overrides:
 
    #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh task start <task-slug> --branch feature/<slug>
+   ./projects/ores.compass/compass.sh task start <task-slug> --branch <override>
    #+end_src
 
    This covers all three cases: new task on an existing story, resuming a
@@ -68,13 +68,26 @@ In execution order:
 
    Repeat step 7 for each review round until the PR is approved.
 
-8. /Merge./ When the PR is approved, =compass pr merge= — the guards refuse while threads are unresolved or CI is not green; the journal is stamped automatically. See [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
+8. /Close out — before the merge./ When the final review round is
+   done and the PR delivers this task, end the bookkeeping on the PR
+   branch so it rides the PR — never a follow-up PR:
 
-9. /Close out./ =compass task done <slug>= — task and story row flip to DONE with end date. Write the task's =* Result= by hand and commit.
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh task done <slug>
+   #+end_src
 
-   After merge, update the task: state → =DONE=, fill =* Result=, distill any =* Plan= into the parent story's =* Decisions=.
+   Task and story row flip to DONE with end date. Write the task's
+   =* Result= by hand, distill any =* Plan= into the parent story's
+   =* Decisions=, commit, and push. A task spanning several PRs stays
+   open — close it on the PR that completes it.
 
-9. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit:
+9. /Merge./ =compass pr merge= — the guards refuse while threads are
+   unresolved or CI is not green; merge never touches task state (a
+   STARTED task only draws a warning), retries GitHub's transient
+   base-branch-modified race, and deletes the remote branch. See
+   [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
+
+10. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit — before the merge, so the sync rides the PR too:
 
    a. In the *story.org* =* Status= table: state → =DONE=, set =Now= to =Nothing.=, fill =End= date.
    b. In the *sprint.org* =* Stories= table: update the story row to =DONE= and fill the =End= column.
@@ -83,7 +96,8 @@ In execution order:
 
 * Postconditions
 
-- Task is =DONE= with =* Result= filled.
+- Task is =DONE= with =* Result= filled, and the close-out commit is
+  /inside/ the merged PR.
 - PR is merged into =main=.
 - Review rounds are recorded in the task's =* Review= table.
 - Parent story reflects any decisions from the task's =* Plan=.


### PR DESCRIPTION
## Summary

Final task of the Clean up the compass work lifecycle story. The validated design is implemented (PRs 1127 and 1130); this PR encodes it in the three runbooks: start_new_story gains the scaffold-task steps, work_task_to_merged_pr moves close-out before merge (and fixes its duplicate step numbering), and handle_pr_review_round ends the final round with task done before pr merge. Design decisions are distilled into the story's Decisions; the task, story, and sprint row close with this PR. With it, Epic: Skills is complete and the sprint gate lifts.

## Changes

- Update start_new_story, work_task_to_merged_pr, handle_pr_review_round runbooks
- Distill design decisions into the story; close task, story, sprint row

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clean up the compass work lifecycle](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/story.html) | C1813B64-1647-4B49-B856-A8345850001C |
| Task | [Design a clean PR close-out workflow](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_create_vs_pickup/task_design_clean_pr_closeout_workflow.html) | 7F5F3182-68EB-48D7-B2F3-1E6C3A6C2570 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)