### PR TITLE
[ores.shell] Add the provision system command

### DIFF
--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
@@ -66,7 +66,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 | [[id:F77DC2CF-C082-4DA5-80F7-454BAA781100][Add bundles and workflow shell commands]] | STARTED | 2026-06-06 | | bundles list, bundles publish [--wait], workflow wait — the dataset-publication plumbing. |
 | [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | STARTED | 2026-06-06 | | lei countries/entities and synthetic generate — the data-source plumbing. |
 | [[id:9F96763F-5BA7-4F7E-970E-FE404A14D5C1][Add parties, account-parties and reports shell commands]] | STARTED | 2026-06-06 | | parties list, account-parties add, tenants complete-provisioning, reports templates — the refdata/iam/reporting plumbing. |
-| [[id:5D782E09-99EE-4C6C-837D-61F28559798B][Add the provision system command]] | BACKLOG | | | Porcelain spanning the SystemProvisionerWizard: bootstrap admin + first tenant with single-tenant defaults. |
+| [[id:5D782E09-99EE-4C6C-837D-61F28559798B][Add the provision system command]] | STARTED | 2026-06-06 | | Porcelain spanning the SystemProvisionerWizard: bootstrap admin + first tenant with single-tenant defaults. |
 | [[id:678F9B7C-98AD-4386-ACC9-D5501907C7ED][Add the provision tenant command]] | BACKLOG | | | Porcelain spanning the TenantProvisioningWizard: bundle publish, GLEIF/synthetic data, association, finalize. |
 | [[id:2995B78B-6130-4FE7-ACE2-54D98EAE86B6][Add the provision party command]] | BACKLOG | | | Porcelain spanning the PartyProvisioningWizard: counterparties, org bundle, reports, activation. |
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell:provisioning:iam:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-provisioners-from-shell
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Add 'provision system <username> <password> <email> --tenant-admin-password <pw>
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Implemented; build and unit tests green; PR pending. |
+| Waiting on   | Review.                                |
+| Next         | Merge; then the provision tenant porcelain task. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -40,9 +40,20 @@ Add 'provision system <username> <password> <email> --tenant-admin-password <pw>
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+1. New =provision_commands= group (will host all three porcelain
+   commands); =provision system= as a freeform command.
+2. Validate everything up front per the wizard's page rules
+   (username/code regexes, email format, password length), then:
+   bootstrap-status check (phase 0), create-admin (phase 1),
+   auto-login via the existing =accounts_commands::process_login=
+   (phase 2), provision-tenant with the wizard's 120s timeout
+   (phase 3).
+3. Defaults reproduce single-tenant mode; =--tenant-*= flags
+   override. Tenant admin email derives from the tenant code
+   (=admin@<code>.com=) like the wizard's pre-fill.
+4. Per-phase progress lines; failures mark command_feedback; session
+   left logged in as the system admin with the next login line
+   printed.
 
 * Notes
 
@@ -59,3 +70,20 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+* Result
+
+Implemented per plan. Notes:
+
+- /No =--multi-tenant= flag./ The wizard's setup-mode page only
+  controls GUI field locking — the provision request is identical in
+  both modes. In the shell, supplying =--tenant-*= flags /is/
+  multi-tenant mode; the flag would have carried no information.
+  (Deviation from the brainstorm strawman, per the no-1-1 decision.)
+- Refuses to run when already logged in or when the system is not in
+  bootstrap mode (phase 0 status check), with clear errors.
+- All validation happens before any backend call; the three phases
+  print progress and the closing line gives the exact next login.
+- Verified by build + unit tests (23/71 green), menu registration and
+  the usage/validation paths in the binary. Live verification against
+  a fresh database lands with the e2e script.

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
@@ -8,7 +8,7 @@
 #+filetags: :shell:provisioning:iam:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-provisioners-from-shell
-#+pr:
+#+pr: 1135
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -61,7 +61,7 @@ Add 'provision system <username> <password> <email> --tenant-admin-password <pw>
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1135][#1135]] | [ores.shell] Add the provision system command |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.org
@@ -67,7 +67,7 @@ Add 'provision system <username> <password> <email> --tenant-admin-password <pw>
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Validate tenant code before derived email | provision_commands.cpp:168 | Accepted | Tenant code/name/hostname checks moved ahead of the account validations. |
 
 * Result
 

--- a/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
@@ -1,0 +1,82 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_COMMANDS_PROVISION_COMMANDS_HPP
+#define ORES_SHELL_APP_COMMANDS_PROVISION_COMMANDS_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <string>
+#include <vector>
+
+namespace cli {
+
+class Menu;
+
+}
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Porcelain provisioning commands.
+ *
+ * Each command spans one of the GUI provisioning wizards end-to-end,
+ * with the wizard's defaults, per-phase progress and failures that
+ * abort a loaded script. The wizard pages define capability coverage,
+ * not the surface: a single command with flags replaces each wizard.
+ */
+class provision_commands {
+private:
+    inline static std::string_view logger_name = "ores.shell.app.commands.provision_commands";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Register provisioning commands.
+     *
+     * Creates the provision submenu.
+     */
+    static void register_commands(cli::Menu& root_menu,
+                                  ores::nats::service::nats_client& session);
+
+    /**
+     * @brief The system provisioner flow: provision system <username>
+     * <password> <email> --tenant-admin-password <pw> [--tenant-code
+     * <c>] [--tenant-name <n>] [--tenant-type <t>] [--tenant-hostname
+     * <h>] [--tenant-description <d>] [--tenant-admin <user>]
+     * [--tenant-admin-email <email>].
+     *
+     * Requires bootstrap mode and no login. Creates the initial admin,
+     * logs in as it, and provisions the first tenant with its admin
+     * account. Defaults reproduce the wizard's single-tenant mode;
+     * the session is left logged in as the system admin.
+     */
+    static void process_system(std::ostream& out,
+                               ores::nats::service::nats_client& session,
+                               const std::vector<std::string>& args);
+};
+
+}
+
+#endif

--- a/projects/ores.shell/src/app/commands/provision_commands.cpp
+++ b/projects/ores.shell/src/app/commands/provision_commands.cpp
@@ -1,0 +1,240 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.shell/app/commands/provision_commands.hpp"
+#include "ores.iam.api/messaging/bootstrap_protocol.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/commands/accounts_commands.hpp"
+#include <chrono>
+#include <cli/cli.h>
+#include <functional>
+#include <ostream>
+#include <regex>
+#include <rfl/json.hpp>
+
+namespace ores::shell::app::commands {
+
+using namespace logging;
+using ores::nats::service::nats_client;
+
+namespace {
+
+// The wizard's "slow" timeout for the provision-tenant request.
+constexpr std::chrono::seconds provision_timeout(120);
+
+// Validation rules lifted from the SystemProvisionerWizard pages.
+const std::regex username_regex("^[a-zA-Z][a-zA-Z0-9_]{2,49}$");
+const std::regex email_regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._-]+\\.[a-zA-Z]{2,}$");
+const std::regex tenant_code_regex("^[a-z][a-z0-9_]{0,49}$");
+constexpr std::size_t min_password_length = 8;
+
+template <typename Request>
+std::optional<typename Request::response_type>
+do_request(std::ostream& out, nats_client& session, const Request& req,
+           std::chrono::milliseconds timeout = std::chrono::seconds(30),
+           bool authenticated = false) {
+    using Response = typename Request::response_type;
+    try {
+        const auto body = rfl::json::write(req);
+        // The unauthenticated request overload has no timeout knob.
+        auto reply = authenticated
+            ? session.authenticated_request(std::string(req.nats_subject), body, timeout)
+            : session.request(std::string(req.nats_subject), body);
+        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
+        if (!result) {
+            fail(out) << "Failed to parse response: " << result.error().what()
+                      << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+bool validate_account(std::ostream& out, std::string_view what,
+                      const std::string& username, const std::string& email,
+                      const std::string& password) {
+    if (!std::regex_match(username, username_regex)) {
+        fail(out) << what << " username must be 3-50 characters, starting with a "
+                     "letter (letters, digits, underscore): " << username << std::endl;
+        return false;
+    }
+    if (!std::regex_match(email, email_regex)) {
+        fail(out) << what << " email is not a valid address: " << email << std::endl;
+        return false;
+    }
+    if (password.size() < min_password_length) {
+        fail(out) << what << " password must be at least " << min_password_length
+                  << " characters." << std::endl;
+        return false;
+    }
+    return true;
+}
+
+}
+
+void provision_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
+    auto provision_menu = std::make_unique<cli::Menu>("provision");
+
+    provision_menu->Insert(
+        "system",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            process_system(std::ref(out), std::ref(session), args);
+        },
+        "Bootstrap the system: create the initial admin, log in as it and "
+        "provision the first tenant (wizard single-tenant defaults)",
+        {"username password email --tenant-admin-password <pw> [--tenant-code <c>] "
+         "[--tenant-name <n>] [--tenant-type <t>] [--tenant-hostname <h>] "
+         "[--tenant-description <d>] [--tenant-admin <user>] [--tenant-admin-email <email>]"});
+
+    root_menu.Insert(std::move(provision_menu));
+}
+
+void provision_commands::process_system(std::ostream& out,
+                                        nats_client& session,
+                                        const std::vector<std::string>& args) {
+    auto parsed = parse_args(args, {
+        {.name = "tenant-admin-password", .requires_value = true, .default_value = ""},
+        {.name = "tenant-code", .requires_value = true, .default_value = "default"},
+        {.name = "tenant-name", .requires_value = true, .default_value = "Default Tenant"},
+        {.name = "tenant-type", .requires_value = true, .default_value = "evaluation"},
+        {.name = "tenant-hostname", .requires_value = true, .default_value = "localhost"},
+        {.name = "tenant-description", .requires_value = true,
+         .default_value = "Default tenant for single-tenant deployment"},
+        {.name = "tenant-admin", .requires_value = true, .default_value = "tenant_admin"},
+        {.name = "tenant-admin-email", .requires_value = true, .default_value = ""}
+    });
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (parsed->positionals.size() != 3) {
+        fail(out) << "Usage: provision system <username> <password> <email> "
+                     "--tenant-admin-password <pw> [--tenant-* flags]" << std::endl;
+        return;
+    }
+
+    const auto& username = parsed->positionals[0];
+    const auto& password = parsed->positionals[1];
+    const auto& email = parsed->positionals[2];
+    const auto& tenant_code = parsed->flag("tenant-code");
+    const auto& tenant_admin = parsed->flag("tenant-admin");
+    const auto& tenant_admin_password = parsed->flag("tenant-admin-password");
+    // The wizard pre-fills the tenant admin email from the tenant code.
+    const auto tenant_admin_email = parsed->flag("tenant-admin-email").empty()
+        ? "admin@" + tenant_code + ".com"
+        : parsed->flag("tenant-admin-email");
+
+    // Validate everything before touching the backend, as the wizard
+    // pages do.
+    if (tenant_admin_password.empty()) {
+        fail(out) << "--tenant-admin-password is required (no wizard default exists)."
+                  << std::endl;
+        return;
+    }
+    if (!validate_account(out, "Admin", username, email, password))
+        return;
+    if (!validate_account(out, "Tenant admin", tenant_admin, tenant_admin_email,
+                          tenant_admin_password))
+        return;
+    if (!std::regex_match(tenant_code, tenant_code_regex)) {
+        fail(out) << "Tenant code must start with a lowercase letter (lowercase, "
+                     "digits, underscore, max 50): " << tenant_code << std::endl;
+        return;
+    }
+    if (parsed->flag("tenant-name").empty() || parsed->flag("tenant-hostname").empty()) {
+        fail(out) << "Tenant name and hostname must not be empty." << std::endl;
+        return;
+    }
+    if (session.is_logged_in()) {
+        fail(out) << "Already logged in; provision system runs against a fresh, "
+                     "bootstrap-mode system. Log out first." << std::endl;
+        return;
+    }
+
+    // Phase 0: confirm the system is in bootstrap mode, as the GUI
+    // does before ever showing the wizard.
+    iam::messaging::bootstrap_status_request status_req;
+    auto status = do_request(out, session, status_req);
+    if (!status)
+        return;
+    if (!status->is_in_bootstrap_mode) {
+        fail(out) << "System is not in bootstrap mode: " << status->message << std::endl;
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Provisioning system: admin " << username << ", tenant "
+                              << tenant_code;
+
+    // Phase 1: create the initial admin account.
+    out << "[1/3] Creating initial admin account '" << username << "'..." << std::endl;
+    iam::messaging::create_initial_admin_request admin_req;
+    admin_req.principal = username;
+    admin_req.password = password;
+    admin_req.email = email;
+    auto admin = do_request(out, session, admin_req);
+    if (!admin)
+        return;
+    if (!admin->success) {
+        fail(out) << "Failed to create admin account: " << admin->error_message
+                  << std::endl;
+        return;
+    }
+    out << "  Account created (ID: " << admin->account_id << ")." << std::endl;
+
+    // Phase 2: log in as the new admin, as the wizard does, so the
+    // provision-tenant request is authenticated.
+    out << "[2/3] Logging in as '" << username << "'..." << std::endl;
+    accounts_commands::process_login(out, session, username, password);
+    if (!session.is_logged_in())
+        return;
+
+    // Phase 3: provision the first tenant and its admin account.
+    out << "[3/3] Provisioning tenant '" << tenant_code << "'..." << std::endl;
+    iam::messaging::provision_tenant_request tenant_req;
+    tenant_req.type = parsed->flag("tenant-type");
+    tenant_req.code = tenant_code;
+    tenant_req.name = parsed->flag("tenant-name");
+    tenant_req.hostname = parsed->flag("tenant-hostname");
+    tenant_req.description = parsed->flag("tenant-description");
+    tenant_req.principal = tenant_admin;
+    tenant_req.password = tenant_admin_password;
+    tenant_req.email = tenant_admin_email;
+    auto tenant = do_request(out, session, tenant_req, provision_timeout,
+                             true /*authenticated*/);
+    if (!tenant)
+        return;
+    if (!tenant->success) {
+        fail(out) << "Failed to provision tenant: " << tenant->error_message << std::endl;
+        return;
+    }
+
+    out << "✓ System provisioned. Tenant '" << tenant_req.name << "' (ID: "
+        << tenant->tenant_id << "), admin '" << tenant_admin << "'." << std::endl;
+    out << "Next: logout, then: login " << tenant_admin << "@"
+        << tenant_req.hostname << " <password>  — the tenant is in bootstrap mode; "
+        << "run provision tenant." << std::endl;
+    BOOST_LOG_SEV(lg(), info) << "System provisioned; tenant " << tenant->tenant_id;
+}
+
+}

--- a/projects/ores.shell/src/app/commands/provision_commands.cpp
+++ b/projects/ores.shell/src/app/commands/provision_commands.cpp
@@ -152,11 +152,8 @@ void provision_commands::process_system(std::ostream& out,
                   << std::endl;
         return;
     }
-    if (!validate_account(out, "Admin", username, email, password))
-        return;
-    if (!validate_account(out, "Tenant admin", tenant_admin, tenant_admin_email,
-                          tenant_admin_password))
-        return;
+    // Tenant code first: the tenant admin email derives from it, so a
+    // bad code must not surface as a confusing derived-email error.
     if (!std::regex_match(tenant_code, tenant_code_regex)) {
         fail(out) << "Tenant code must start with a lowercase letter (lowercase, "
                      "digits, underscore, max 50): " << tenant_code << std::endl;
@@ -166,6 +163,11 @@ void provision_commands::process_system(std::ostream& out,
         fail(out) << "Tenant name and hostname must not be empty." << std::endl;
         return;
     }
+    if (!validate_account(out, "Admin", username, email, password))
+        return;
+    if (!validate_account(out, "Tenant admin", tenant_admin, tenant_admin_email,
+                          tenant_admin_password))
+        return;
     if (session.is_logged_in()) {
         fail(out) << "Already logged in; provision system runs against a fresh, "
                      "bootstrap-mode system. Log out first." << std::endl;

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -31,6 +31,7 @@
 #include "ores.shell/app/commands/lei_commands.hpp"
 #include "ores.shell/app/commands/navigation_commands.hpp"
 #include "ores.shell/app/commands/parties_commands.hpp"
+#include "ores.shell/app/commands/provision_commands.hpp"
 #include "ores.shell/app/commands/rbac_commands.hpp"
 #include "ores.shell/app/commands/reports_commands.hpp"
 #include "ores.shell/app/commands/script_commands.hpp"
@@ -95,6 +96,7 @@ std::unique_ptr<cli::Cli> repl::setup_menus() {
     parties_commands::register_commands(*root, session_);
     account_parties_commands::register_commands(*root, session_);
     reports_commands::register_commands(*root, session_);
+    provision_commands::register_commands(*root, session_);
 
     auto cli_instance = std::make_unique<cli::Cli>(std::move(root));
     cli_instance->ExitAction([](auto& out) { out << "Bye!" << std::endl; });


### PR DESCRIPTION
## Summary

Fifth task of the provisioning-commands story and the first porcelain command. 'provision system' spans the SystemProvisionerWizard end-to-end: bootstrap-mode check, create initial admin, auto-login, provision the first tenant with its admin — with the wizard's single-tenant defaults, validation rules applied before any backend call, per-phase progress, and the exact next login printed on success. One deliberate simplification per the no-1-1 design decision: no --multi-tenant flag, since the wizard's setup mode only controls GUI field locking and the provision request is identical either way.

## Changes

- New provision command group with provision system (4 phases, wizard defaults and validation).
- Refuses to run when logged in or outside bootstrap mode.
- Tenant admin email derives from the tenant code as the wizard pre-fills it.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Implement ores-shell provisioning commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.html) | 31B8013E-10FF-4FCC-9D1D-D5BAF8D16437 |
| Task | [Add the provision system command](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_system_command.html) | 5D782E09-99EE-4C6C-837D-61F28559798B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)