### PR TITLE
[ores.shell] Add the provision tenant command

### DIFF
--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.org
@@ -67,7 +67,7 @@ chapter follow in the [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning sc
 | [[id:BC79836F-9E46-43F3-B0CB-D4247F0A95A9][Add lei and synthetic shell commands]] | STARTED | 2026-06-06 | | lei countries/entities and synthetic generate — the data-source plumbing. |
 | [[id:9F96763F-5BA7-4F7E-970E-FE404A14D5C1][Add parties, account-parties and reports shell commands]] | STARTED | 2026-06-06 | | parties list, account-parties add, tenants complete-provisioning, reports templates — the refdata/iam/reporting plumbing. |
 | [[id:5D782E09-99EE-4C6C-837D-61F28559798B][Add the provision system command]] | STARTED | 2026-06-06 | | Porcelain spanning the SystemProvisionerWizard: bootstrap admin + first tenant with single-tenant defaults. |
-| [[id:678F9B7C-98AD-4386-ACC9-D5501907C7ED][Add the provision tenant command]] | BACKLOG | | | Porcelain spanning the TenantProvisioningWizard: bundle publish, GLEIF/synthetic data, association, finalize. |
+| [[id:678F9B7C-98AD-4386-ACC9-D5501907C7ED][Add the provision tenant command]] | STARTED | 2026-06-06 | | Porcelain spanning the TenantProvisioningWizard: bundle publish, GLEIF/synthetic data, association, finalize. |
 | [[id:2995B78B-6130-4FE7-ACE2-54D98EAE86B6][Add the provision party command]] | BACKLOG | | | Porcelain spanning the PartyProvisioningWizard: counterparties, org bundle, reports, activation. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
@@ -66,7 +66,7 @@ Add 'provision tenant': logged in as the tenant admin of a bootstrap-mode tenant
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Review round 1: no comments | — | — | Bot had no feedback. CI linux-gcc-debug-ninja failure (byte-iterator string construction from PR #1131, on main) fixed in this branch: as_string_view in parties/account-parties/reports. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
@@ -8,7 +8,7 @@
 #+filetags: :shell:provisioning:dq:synthetic:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-provisioners-from-shell
-#+pr:
+#+pr: 1138
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -60,7 +60,7 @@ Add 'provision tenant': logged in as the tenant admin of a bootstrap-mode tenant
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1138][#1138]] | [ores.shell] Add the provision tenant command |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
+++ b/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell:provisioning:dq:synthetic:implement_provisioners_from_shell:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-provisioners-from-shell
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ Add 'provision tenant': logged in as the tenant admin of a bootstrap-mode tenant
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Implemented; build and unit tests green; PR pending. |
+| Waiting on   | Review.                                |
+| Next         | Merge; then the provision party porcelain task. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -40,9 +40,19 @@ Add 'provision tenant': logged in as the tenant admin of a bootstrap-mode tenant
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+1. Extend =nats_client::login_info= with =account_id= (set at login
+   and auto-login) — phase 3 needs the logged-in account's id, which
+   the session previously discarded.
+2. Refactor =synthetic_commands= to expose =generate_flag_specs()=,
+   =build_generate_request()= and =generate()= so the porcelain
+   embeds generation without duplicating the 15 knobs.
+3. =provision tenant= in =provision_commands=: validate flags up
+   front (source, root-lei applicability, timeout, knobs); resolve
+   the bundle (=--bundle= or first available, the wizard's default);
+   publish + =wait_for_instance=; synthetic generation when selected;
+   associate the admin with Operational parties (non-fatal, feedback
+   reset so scripts do not abort); clear =system.bootstrap_mode=
+   (warn-only) and complete provisioning (fatal).
 
 * Notes
 
@@ -59,3 +69,18 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+* Result
+
+Implemented per plan. Notes:
+
+- The association and bootstrap-flag phases are non-fatal exactly as
+  in the wizard, with an explicit =command_feedback::reset()= so
+  their warnings cannot abort a load script; finalize remains fatal.
+- =--dataset-size= from the wizard's GLEIF page is deliberately
+  absent: the coverage mapping shows the tenant wizard collects it
+  but never transmits it in the publish params — there is nothing to
+  cover.
+- Verified by build + unit tests (23/71 green), menu registration and
+  flag-validation paths in the binary. Live verification lands with
+  the e2e script.

--- a/projects/ores.nats/include/ores.nats/service/nats_client.hpp
+++ b/projects/ores.nats/include/ores.nats/service/nats_client.hpp
@@ -92,6 +92,7 @@ public:
     struct login_info {
         std::string jwt;
         std::string username;
+        std::string account_id;
         std::string tenant_id;
         std::string tenant_name;
     };

--- a/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
@@ -75,6 +75,23 @@ public:
     static void process_system(std::ostream& out,
                                ores::nats::service::nats_client& session,
                                const std::vector<std::string>& args);
+
+    /**
+     * @brief The tenant provisioner flow: provision tenant
+     * [--bundle <code>] [--source gleif|synthetic] [--root-lei <lei>]
+     * [--timeout <s>] [synthetic generation knobs].
+     *
+     * Run logged in as the tenant admin of a bootstrap-mode tenant.
+     * Publishes the selected bundle (default: first available) and
+     * waits on its workflow; generates the synthetic organisation
+     * when --source synthetic; associates the admin with all
+     * Operational parties (non-fatal, as the wizard); clears the
+     * bootstrap flag and completes provisioning. Requires logout and
+     * re-login afterwards, exactly as the wizard instructs.
+     */
+    static void process_tenant(std::ostream& out,
+                               ores::nats::service::nats_client& session,
+                               const std::vector<std::string>& args);
 };
 
 }

--- a/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
@@ -22,6 +22,9 @@
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/service/nats_client.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -73,6 +76,29 @@ public:
     static void process_generate(std::ostream& out,
                                  ores::nats::service::nats_client& session,
                                  const std::vector<std::string>& args);
+
+    /**
+     * @brief The generation knob flag specs, for commands that embed
+     * synthetic generation (provision tenant).
+     */
+    static std::vector<flag_spec> generate_flag_specs();
+
+    /**
+     * @brief Build a generation request from parsed flags, reporting
+     * the offending flag on validation failure.
+     */
+    static std::optional<ores::synthetic::messaging::generate_organisation_request>
+    build_generate_request(std::ostream& out, const parsed_args& parsed);
+
+    /**
+     * @brief Execute a generation request, printing the entity counts
+     * and the actual seed used. Marks command failure on error.
+     *
+     * @return true on success.
+     */
+    static bool generate(std::ostream& out,
+                         ores::nats::service::nats_client& session,
+                         const ores::synthetic::messaging::generate_organisation_request& req);
 };
 
 }

--- a/projects/ores.shell/src/app/application.cpp
+++ b/projects/ores.shell/src/app/application.cpp
@@ -99,6 +99,7 @@ bool auto_login(ores::nats::service::nats_client& session,
         ores::nats::service::nats_client::login_info info;
         info.jwt = result->token;
         info.username = result->username;
+        info.account_id = result->account_id;
         info.tenant_id = result->tenant_id;
         info.tenant_name = result->tenant_name;
         session.set_auth(std::move(info));

--- a/projects/ores.shell/src/app/commands/account_parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/account_parties_commands.cpp
@@ -22,6 +22,7 @@
 #include "ores.iam.api/domain/account_party_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/messaging/account_party_protocol.hpp"
 #include "ores.refdata.api/messaging/party_protocol.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
@@ -45,8 +46,8 @@ std::optional<Response> do_auth_request(std::ostream& out,
                                         const std::string& body) {
     try {
         auto reply = session.authenticated_request(subject, body);
-        std::string data_str(reply.data.begin(), reply.data.end());
-        auto result = rfl::json::read<Response>(data_str);
+        auto result = rfl::json::read<Response>(
+                ores::nats::as_string_view(reply.data));
         if (!result) {
             fail(out) << "Failed to parse response: " << result.error().what()
                       << std::endl;

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -355,6 +355,7 @@ void accounts_commands::process_login(std::ostream& out,
     nats_client::login_info info;
     info.jwt = result->token;
     info.username = result->username;
+    info.account_id = result->account_id;
     info.tenant_id = result->tenant_id;
     info.tenant_name = result->tenant_name;
     session.set_auth(std::move(info));

--- a/projects/ores.shell/src/app/commands/parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/parties_commands.cpp
@@ -20,6 +20,7 @@
 #include "ores.shell/app/commands/parties_commands.hpp"
 #include "ores.refdata.api/domain/party_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/party_protocol.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
@@ -98,8 +99,8 @@ void parties_commands::process_list(std::ostream& out,
     try {
         auto reply = session.authenticated_request(std::string(req.nats_subject),
                                                    rfl::json::write(req));
-        std::string data_str(reply.data.begin(), reply.data.end());
-        auto result = rfl::json::read<refdata::messaging::get_parties_response>(data_str);
+        auto result = rfl::json::read<refdata::messaging::get_parties_response>(
+                ores::nats::as_string_view(reply.data));
         if (!result) {
             fail(out) << "Failed to parse response: " << result.error().what()
                       << std::endl;

--- a/projects/ores.shell/src/app/commands/provision_commands.cpp
+++ b/projects/ores.shell/src/app/commands/provision_commands.cpp
@@ -23,6 +23,19 @@
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/accounts_commands.hpp"
+#include "ores.shell/app/commands/synthetic_commands.hpp"
+#include "ores.shell/app/commands/workflow_commands.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
+#include "ores.dq.api/messaging/dataset_bundle_protocol.hpp"
+#include "ores.dq.api/messaging/publish_bundle_protocol.hpp"
+#include "ores.iam.api/domain/account_party.hpp"
+#include "ores.iam.api/messaging/account_party_protocol.hpp"
+#include "ores.iam.api/messaging/tenant_protocol.hpp"
+#include "ores.refdata.api/messaging/party_protocol.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include "ores.variability.api/messaging/system_settings_protocol.hpp"
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <cli/cli.h>
 #include <functional>
@@ -36,6 +49,10 @@ using namespace logging;
 using ores::nats::service::nats_client;
 
 namespace {
+
+// The wizards' generous timeouts for publish dispatch and waits.
+constexpr std::chrono::minutes publish_timeout(5);
+constexpr std::chrono::seconds default_wait_timeout(300);
 
 // The wizard's "slow" timeout for the provision-tenant request.
 constexpr std::chrono::seconds provision_timeout(120);
@@ -106,6 +123,17 @@ void provision_commands::register_commands(cli::Menu& root_menu, nats_client& se
         {"username password email --tenant-admin-password <pw> [--tenant-code <c>] "
          "[--tenant-name <n>] [--tenant-type <t>] [--tenant-hostname <h>] "
          "[--tenant-description <d>] [--tenant-admin <user>] [--tenant-admin-email <email>]"});
+
+    provision_menu->Insert(
+        "tenant",
+        [&session](std::ostream& out, std::vector<std::string> args) {
+            process_tenant(std::ref(out), std::ref(session), args);
+        },
+        "Provision the logged-in bootstrap-mode tenant: publish a bundle, "
+        "optionally generate synthetic data, associate the admin with the "
+        "parties and finalize",
+        {"[--bundle <code>] [--source gleif|synthetic] [--root-lei <lei>] "
+         "[--timeout <seconds>] [synthetic generation knobs — see synthetic generate]"});
 
     root_menu.Insert(std::move(provision_menu));
 }
@@ -237,6 +265,207 @@ void provision_commands::process_system(std::ostream& out,
         << tenant_req.hostname << " <password>  — the tenant is in bootstrap mode; "
         << "run provision tenant." << std::endl;
     BOOST_LOG_SEV(lg(), info) << "System provisioned; tenant " << tenant->tenant_id;
+}
+
+void provision_commands::process_tenant(std::ostream& out,
+                                        nats_client& session,
+                                        const std::vector<std::string>& args) {
+    auto specs = synthetic_commands::generate_flag_specs();
+    specs.push_back({.name = "bundle", .requires_value = true, .default_value = ""});
+    specs.push_back({.name = "source", .requires_value = true, .default_value = "gleif"});
+    specs.push_back({.name = "root-lei", .requires_value = true, .default_value = ""});
+    specs.push_back({.name = "timeout", .requires_value = true,
+                     .default_value = std::to_string(default_wait_timeout.count())});
+
+    auto parsed = parse_args(args, specs);
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (!parsed->positionals.empty()) {
+        fail(out) << "provision tenant takes no positional arguments; see help."
+                  << std::endl;
+        return;
+    }
+
+    const auto& source = parsed->flag("source");
+    if (source != "gleif" && source != "synthetic") {
+        fail(out) << "--source must be gleif or synthetic: " << source << std::endl;
+        return;
+    }
+    if (source != "gleif" && !parsed->flag("root-lei").empty()) {
+        fail(out) << "--root-lei only applies to --source gleif." << std::endl;
+        return;
+    }
+    auto wait_timeout = parse_positive_seconds(parsed->flag("timeout"));
+    if (!wait_timeout) {
+        fail(out) << "Timeout must be a positive number of seconds: "
+                  << parsed->flag("timeout") << std::endl;
+        return;
+    }
+    // Build (and validate) the generation request up front even though
+    // it only runs in synthetic mode: fail fast on bad knobs.
+    auto generate_req = synthetic_commands::build_generate_request(out, *parsed);
+    if (!generate_req)
+        return;
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in. Log in as the tenant admin of the "
+                     "bootstrap-mode tenant first." << std::endl;
+        return;
+    }
+    const auto username = session.auth().username;
+
+    // Resolve the bundle: explicit --bundle, else the first available,
+    // which is the wizard's default selection.
+    auto bundle_code = parsed->flag("bundle");
+    if (bundle_code.empty()) {
+        dq::messaging::get_dataset_bundles_request bundles_req;
+        auto bundles = do_request(out, session, bundles_req,
+                                  std::chrono::seconds(30), true);
+        if (!bundles)
+            return;
+        if (bundles->bundles.empty()) {
+            fail(out) << "No dataset bundles are available to publish." << std::endl;
+            return;
+        }
+        bundle_code = bundles->bundles.front().code;
+        out << "Using bundle '" << bundle_code << "' (first available)." << std::endl;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Provisioning tenant: bundle " << bundle_code
+                              << ", source " << source;
+
+    // Phase 1: publish the bundle and wait on its workflow.
+    out << "[1/4] Publishing bundle '" << bundle_code << "'..." << std::endl;
+    dq::messaging::publish_bundle_request publish_req;
+    publish_req.bundle_code = bundle_code;
+    publish_req.mode = dq::domain::publication_mode::upsert;
+    publish_req.published_by = username;
+    publish_req.atomic = true;
+    if (!parsed->flag("root-lei").empty()) {
+        dq::messaging::publish_bundle_params params;
+        params.lei_parties =
+            dq::messaging::lei_parties_params{.root_lei = parsed->flag("root-lei")};
+        publish_req.params_json = dq::messaging::build_params_json(params);
+    }
+    auto published = do_request(out, session, publish_req, publish_timeout, true);
+    if (!published)
+        return;
+    if (!published->success) {
+        fail(out) << "Failed to publish bundle: " << published->error_message
+                  << std::endl;
+        return;
+    }
+    out << "  Dispatched " << published->datasets_dispatched
+        << " dataset(s); workflow instance: " << published->instance_id << std::endl;
+    if (!workflow_commands::wait_for_instance(out, session, published->instance_id,
+                                              *wait_timeout))
+        return;
+
+    // Phase 2: synthetic generation, when selected.
+    if (source == "synthetic") {
+        out << "[2/4] Generating synthetic organisation..." << std::endl;
+        if (!synthetic_commands::generate(out, session, *generate_req))
+            return;
+    } else {
+        out << "[2/4] GLEIF source: no generation step." << std::endl;
+    }
+
+    // Phase 3: associate the admin with every Operational party.
+    // Non-fatal, exactly as the wizard treats it.
+    out << "[3/4] Associating '" << username << "' with the operational parties..."
+        << std::endl;
+    int linked = 0;
+    if (session.auth().account_id.empty()) {
+        out << "⚠ No account id in the session; skipping party association. "
+               "Re-login and use account-parties add to associate manually."
+            << std::endl;
+    } else {
+        refdata::messaging::get_parties_request parties_req;
+        parties_req.limit = 1000;
+        auto parties = do_request(out, session, parties_req,
+                                  std::chrono::seconds(30), true);
+        if (parties) {
+            iam::messaging::save_account_party_request assoc_req;
+            try {
+                const auto account_uuid = boost::lexical_cast<boost::uuids::uuid>(
+                    session.auth().account_id);
+                for (const auto& party : parties->parties) {
+                    if (party.party_category != "Operational")
+                        continue;
+                    iam::domain::account_party association;
+                    association.tenant_id = party.tenant_id.to_string();
+                    association.account_id = account_uuid;
+                    association.party_id = party.id;
+                    association.modified_by = username;
+                    association.performed_by = username;
+                    association.change_reason_code = std::string(
+                        dq::domain::change_reason_constants::codes::new_record);
+                    association.change_commentary =
+                        "Tenant provisioning: tenant admin associated with party";
+                    assoc_req.account_parties.push_back(std::move(association));
+                }
+            } catch (const boost::bad_lexical_cast&) {
+                out << "⚠ Session account id is not a UUID; skipping association."
+                    << std::endl;
+            }
+            if (!assoc_req.account_parties.empty()) {
+                auto assoc = do_request(out, session, assoc_req,
+                                        std::chrono::seconds(30), true);
+                if (assoc && assoc->success)
+                    linked = static_cast<int>(assoc_req.account_parties.size());
+                else
+                    out << "⚠ Party association failed; continuing (associate "
+                           "manually with account-parties add)." << std::endl;
+            }
+        } else {
+            out << "⚠ Could not list parties; continuing without association."
+                << std::endl;
+        }
+        // The association phase is non-fatal: clear any failure mark
+        // its requests may have left so the script does not abort.
+        command_feedback::reset();
+    }
+    out << "  " << linked << " part" << (linked == 1 ? "y" : "ies") << " associated."
+        << std::endl;
+
+    // Phase 4: clear the bootstrap flag (warn-only, as the wizard)
+    // and complete provisioning (fatal).
+    out << "[4/4] Finalizing tenant provisioning..." << std::endl;
+    variability::messaging::save_setting_request setting_req =
+        variability::messaging::save_setting_request::from(
+            variability::domain::system_setting{
+                .name = "system.bootstrap_mode",
+                .value = "false",
+                .data_type = "boolean",
+                .description = "Bootstrap mode disabled after tenant setup",
+                .modified_by = username,
+                .change_reason_code = std::string(
+                    dq::domain::change_reason_constants::codes::new_record),
+                .change_commentary = "Tenant provisioning completed via shell",
+                .recorded_at = std::chrono::system_clock::now()});
+    auto setting = do_request(out, session, setting_req, std::chrono::seconds(30), true);
+    if (!setting || !setting->success) {
+        out << "⚠ Could not clear system.bootstrap_mode; continuing." << std::endl;
+        command_feedback::reset();
+    }
+
+    iam::messaging::complete_tenant_provisioning_command complete_req;
+    auto completed = do_request(out, session, complete_req,
+                                std::chrono::seconds(30), true);
+    if (!completed)
+        return;
+    if (!completed->success) {
+        fail(out) << "Failed to complete tenant provisioning: " << completed->message
+                  << std::endl;
+        return;
+    }
+
+    out << "✓ Tenant provisioned: bundle '" << bundle_code << "', " << linked
+        << " part" << (linked == 1 ? "y" : "ies") << " associated." << std::endl;
+    out << "Next: logout, then log back in — the party setup is per party; run "
+           "provision party <party>." << std::endl;
+    BOOST_LOG_SEV(lg(), info) << "Tenant provisioned; bundle " << bundle_code;
 }
 
 }

--- a/projects/ores.shell/src/app/commands/reports_commands.cpp
+++ b/projects/ores.shell/src/app/commands/reports_commands.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/commands/reports_commands.hpp"
 #include "ores.dq.api/messaging/report_definition_template_protocol.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include <cli/cli.h>
@@ -74,10 +75,9 @@ void reports_commands::process_templates(std::ostream& out,
     try {
         auto reply = session.authenticated_request(std::string(req.nats_subject),
                                                    rfl::json::write(req));
-        std::string data_str(reply.data.begin(), reply.data.end());
         auto result =
             rfl::json::read<dq::messaging::list_dq_report_definition_templates_response>(
-                data_str);
+                ores::nats::as_string_view(reply.data));
         if (!result) {
             fail(out) << "Failed to parse response: " << result.error().what()
                       << std::endl;

--- a/projects/ores.shell/src/app/commands/synthetic_commands.cpp
+++ b/projects/ores.shell/src/app/commands/synthetic_commands.cpp
@@ -62,13 +62,11 @@ void synthetic_commands::register_commands(cli::Menu& root_menu, nats_client& se
     root_menu.Insert(std::move(synthetic_menu));
 }
 
-void synthetic_commands::process_generate(std::ostream& out,
-                                          nats_client& session,
-                                          const std::vector<std::string>& args) {
+std::vector<flag_spec> synthetic_commands::generate_flag_specs() {
     // Defaults mirror generate_organisation_request, which mirrors the
     // tenant provisioning wizard's synthetic page.
     synthetic::messaging::generate_organisation_request defaults;
-    auto parsed = parse_args(args, {
+    return {
         {.name = "country", .requires_value = true, .default_value = defaults.country},
         {.name = "party-count", .requires_value = true,
          .default_value = std::to_string(defaults.party_count)},
@@ -95,24 +93,14 @@ void synthetic_commands::process_generate(std::ostream& out,
         {.name = "no-addresses"},
         {.name = "no-identifiers"},
         {.name = "seed", .requires_value = true, .default_value = ""}
-    });
-    if (!parsed) {
-        fail(out) << parsed.error() << std::endl;
-        return;
-    }
-    if (!parsed->positionals.empty()) {
-        fail(out) << "synthetic generate takes no positional arguments; see help."
-                  << std::endl;
-        return;
-    }
+    };
+}
 
-    if (!session.is_logged_in()) {
-        fail(out) << "Not logged in." << std::endl;
-        return;
-    }
-
+std::optional<synthetic::messaging::generate_organisation_request>
+synthetic_commands::build_generate_request(std::ostream& out,
+                                           const parsed_args& parsed) {
     synthetic::messaging::generate_organisation_request req;
-    req.country = parsed->flag("country");
+    req.country = parsed.flag("country");
 
     // Numeric knobs: validate each as an unsigned integer.
     const std::vector<std::pair<std::string, std::uint32_t*>> knobs = {
@@ -128,28 +116,33 @@ void synthetic_commands::process_generate(std::ostream& out,
         {"contacts-per-party", &req.contacts_per_party},
         {"contacts-per-counterparty", &req.contacts_per_counterparty}};
     for (const auto& [name, target] : knobs) {
-        auto v = parse_uint32(parsed->flag(name));
+        auto v = parse_uint32(parsed.flag(name));
         if (!v) {
             fail(out) << "Flag --" << name << " must be an unsigned integer: "
-                      << parsed->flag(name) << std::endl;
-            return;
+                      << parsed.flag(name) << std::endl;
+            return std::nullopt;
         }
         *target = *v;
     }
 
-    req.generate_addresses = !parsed->flag_set("no-addresses");
-    req.generate_identifiers = !parsed->flag_set("no-identifiers");
+    req.generate_addresses = !parsed.flag_set("no-addresses");
+    req.generate_identifiers = !parsed.flag_set("no-identifiers");
 
-    if (!parsed->flag("seed").empty()) {
-        auto seed = parse_uint64(parsed->flag("seed"));
+    if (!parsed.flag("seed").empty()) {
+        auto seed = parse_uint64(parsed.flag("seed"));
         if (!seed) {
             fail(out) << "Flag --seed must be an unsigned integer: "
-                      << parsed->flag("seed") << std::endl;
-            return;
+                      << parsed.flag("seed") << std::endl;
+            return std::nullopt;
         }
         req.seed = *seed;
     }
+    return req;
+}
 
+bool synthetic_commands::generate(
+    std::ostream& out, nats_client& session,
+    const synthetic::messaging::generate_organisation_request& req) {
     BOOST_LOG_SEV(lg(), info) << "Generating synthetic organisation: "
                               << rfl::json::write(req);
     out << "Generating synthetic organisation (country " << req.country << ", "
@@ -165,11 +158,11 @@ void synthetic_commands::process_generate(std::ostream& out,
         if (!result) {
             fail(out) << "Failed to parse response: " << result.error().what()
                       << std::endl;
-            return;
+            return false;
         }
         if (!result->success) {
             fail(out) << "Generation failed: " << result->error_message << std::endl;
-            return;
+            return false;
         }
 
         out << "✓ Synthetic organisation generated (seed " << result->seed << "):"
@@ -184,9 +177,36 @@ void synthetic_commands::process_generate(std::ostream& out,
         out << "  identifiers:         " << result->identifiers_count << std::endl;
         out << "Reproduce with: synthetic generate --seed " << result->seed << std::endl;
         BOOST_LOG_SEV(lg(), info) << "Synthetic generation complete; seed " << result->seed;
+        return true;
     } catch (const std::exception& e) {
         fail(out) << "Request failed: " << e.what() << std::endl;
+        return false;
     }
+}
+
+void synthetic_commands::process_generate(std::ostream& out,
+                                          nats_client& session,
+                                          const std::vector<std::string>& args) {
+    auto parsed = parse_args(args, generate_flag_specs());
+    if (!parsed) {
+        fail(out) << parsed.error() << std::endl;
+        return;
+    }
+    if (!parsed->positionals.empty()) {
+        fail(out) << "synthetic generate takes no positional arguments; see help."
+                  << std::endl;
+        return;
+    }
+
+    if (!session.is_logged_in()) {
+        fail(out) << "Not logged in." << std::endl;
+        return;
+    }
+
+    auto req = build_generate_request(out, *parsed);
+    if (!req)
+        return;
+    generate(out, session, *req);
 }
 
 }


### PR DESCRIPTION
## Summary

Sixth task of the provisioning-commands story. 'provision tenant' spans the TenantProvisioningWizard's four execute phases: bundle publish (default: first available, the wizard's default selection) with workflow wait; synthetic generation when --source synthetic (all 15 knobs reused from synthetic generate); admin-to-Operational-parties association (non-fatal exactly as the wizard, with the failure flag reset so scripts don't abort); bootstrap-flag clear (warn-only) plus complete-provisioning (fatal). login_info now carries account_id for the association phase, and synthetic_commands exposes its specs/builder/executor for reuse. --dataset-size is deliberately omitted: the coverage mapping shows the wizard collects but never transmits it.

## Changes

- provision tenant: 4 phases with wizard semantics and per-phase progress.
- login_info gains account_id (login + auto-login).
- synthetic_commands refactored to expose generate_flag_specs/build_generate_request/generate.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Implement ores-shell provisioning commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/story.html) | 31B8013E-10FF-4FCC-9D1D-D5BAF8D16437 |
| Task | [Add the provision tenant command](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/implement_provisioners_from_shell/task_provision_tenant_command.html) | 678F9B7C-98AD-4386-ACC9-D5501907C7ED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)