### PR TITLE
[docs] proj: link cleanup; restore task plans

### DIFF
--- a/doc/agile/product_backlog/next/async_workflow_progress_for_large_party_hierarchies.org
+++ b/doc/agile/product_backlog/next/async_workflow_progress_for_large_party_hierarchies.org
@@ -14,7 +14,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 For tenants with more than ~20 parties the synchronous =provision-parties=
 endpoint will time out. Add an async path: return =workflow_id= immediately
 and poll =workflow.v1.status= from a progress page. See Phase 4 in
-[[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+[[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/dq_refdata_service_boundary_cleanup.org
+++ b/doc/agile/product_backlog/next/dq_refdata_service_boundary_cleanup.org
@@ -13,7 +13,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 
 DQ bundle publication currently writes directly to =ores_refdata_*= tables.
 This must be routed via =refdata.v1.*= NATS endpoints. See "Open Questions"
-in [[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+in [[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/extend_ores_workflow_barrier_event_workflow.org
+++ b/doc/agile/product_backlog/next/extend_ores_workflow_barrier_event_workflow.org
@@ -13,7 +13,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 
 Second financial workflow: apply a knock-in/out barrier event to a trade and
 cascade to Greeks recomputation and reporting. See Phase 5 in
-[[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+[[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/extend_ores_workflow_trade_expiry_workflow.org
+++ b/doc/agile/product_backlog/next/extend_ores_workflow_trade_expiry_workflow.org
@@ -12,7 +12,7 @@
 This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
 
 First financial workflow in =ores.workflow=: expire a trade and cascade to
-positions, P&L reporting and scheduler cleanup. See Phase 5 in [[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+positions, P&L reporting and scheduler cleanup. See Phase 5 in [[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/financial_workflows_trade_expiry_and_barrier_event.org
+++ b/doc/agile/product_backlog/next/financial_workflows_trade_expiry_and_barrier_event.org
@@ -12,7 +12,7 @@
 This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
 
 Extend =ores.workflow= with the first two financial workflow types, deferred
-from the [[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][three-level provisioning plan]] (Phase 5).
+from the [[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][three-level provisioning plan]] (Phase 5).
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/iam_refdata_service_boundary_cleanup.org
+++ b/doc/agile/product_backlog/next/iam_refdata_service_boundary_cleanup.org
@@ -15,7 +15,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 are pre-existing violations noted in the plan and must be fixed to ensure
 correct RLS enforcement and clean service ownership. See "Known pre-existing
 violations" in
-[[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+[[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/multi_select_lei_picker_for_partyprovisionpage.org
+++ b/doc/agile/product_backlog/next/multi_select_lei_picker_for_partyprovisionpage.org
@@ -15,7 +15,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 so the tenant admin can pick the full GLEIF hierarchy (root + subsidiaries)
 in one pass, creating one =provision_party_input= entry per selected LEI.
 See Phase 4 in
-[[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+[[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/party_wizard_ux_improvements.org
+++ b/doc/agile/product_backlog/next/party_wizard_ux_improvements.org
@@ -12,7 +12,7 @@
 This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
 
 Follow-on UX polish for the three-level provisioning wizard, deferred from
-the [[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][three-level provisioning plan]] (Phase 4).
+the [[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][three-level provisioning plan]] (Phase 4).
 
 ***** Tasks
 

--- a/doc/agile/product_backlog/next/provisioned_accounts_force_password_reset_on_first_login.org
+++ b/doc/agile/product_backlog/next/provisioned_accounts_force_password_reset_on_first_login.org
@@ -14,7 +14,7 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *next
 When =workflow.v1.parties.provision= creates an account it should set
 =password_reset_required = true= so the party admin is forced to change the
 initial password on first login. See Phase 4 in
-[[file:../../plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
+[[proj:doc/plans/2026-03-30-three-level-provisioning-and-workflow-service.md][plan]].
 
 ***** Tasks
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
@@ -69,16 +69,23 @@ which lives on as the rollout task below.
 | [[id:76178191-E20D-4479-BC01-79B877247D03][Tangle all mustache templates from facet-documenting org files]] | DONE | 2026-06-06 | 2026-06-06 | Every mustache template should be tangled from an org-mode file that documents its facet (literate style, as with the gnuplot charts). Each facet group gets a 'namespace' org file documenting the group, and a top-level file describes all the groups — a three-level literate hierarchy: template <- facet doc <- group doc <- groups overview. |
 | [[id:DDE8CF4A-3883-40D1-9BC0-19706162B70A][Add facet and facet-group doc types to compass and codegen]] | DONE | 2026-06-06 | 2026-06-06 | The literate template hierarchy introduces two new document types — the facet doc (one per template family, tangling to its .mustache files) and the facet grouping doc (namespace page per group). Teach ores.codegen generate_doc and compass add to scaffold both, so facet docs are never hand-rolled from the generic knowledge type. |
 | [[id:C771C122-3A96-48FB-BCF0-AE7D38CD526E][Replace file: links with proj: links across the documentation]] | BACKLOG | | | Audit every org document for file: links pointing at repo files (sources, JSON, scripts, images) and convert them to proj: links, which export to GitHub blob URLs on the published site. file: links to non-org files 404 because the site build only publishes org->html; found via the profiles.json links in the template-library docs. |
-| [[id:C4473D28-E366-468C-AAED-36CE8C374EDB][Refine the cpp facet grouping]] | STARTED | 2026-06-06 | | The cpp group's 58 templates landed in five facets, but the split is coarse: cpp_domain_type holds 22 templates and cpp_service mixes two distinct families (component-service scaffolding vs the per-entity service pair). Analyse the set against the profiles and the MASD facet definitions and re-cut into finer, more cohesive facets. |
+| [[id:C4473D28-E366-468C-AAED-36CE8C374EDB][Refine the cpp facet grouping]] | DONE | 2026-06-06 | 2026-06-06 | The cpp group's 58 templates landed in five facets, but the split is coarse: cpp_domain_type holds 22 templates and cpp_service mixes two distinct families (component-service scaffolding vs the per-entity service pair). Analyse the set against the profiles and the MASD facet definitions and re-cut into finer, more cohesive facets. |
 
 * Decisions
 
-- /Granularity:/ one org file per *facet* — a template family by
-  filename prefix — with each template a
+- /Granularity:/ one org file per *facet*, with each template a
   =#+begin_src mustache :tangle <name>.mustache= block preceded by
   prose (role, model inputs, output artefact, profiles). Groups
   (=cmake=, =cpp=, =sql=, =doc=, =assets=) get =<slug>_group.org=
   namespace docs; =overview.org= tops the hierarchy.
+- /Facet cut:/ facets are cohesive MASD facets — entity-lifecycle
+  layer × profile membership — not filename-prefix buckets, and stay
+  at roughly a dozen templates or fewer without rationale. The cpp
+  re-cut (PR #1136) set the pattern: cpp_domain, cpp_table,
+  cpp_repository, cpp_qt, cpp_messaging, cpp_service_app,
+  cpp_component, cpp_model_types. IDs stay stable when a facet merely
+  renames; moved blocks get their GENERATED FILE header repointed
+  (render-neutral, header-only artefact diffs).
 - /Location:/ org sources co-located with their artefacts in
   =projects/ores.codegen/library/templates/=.
 - /Tangle tooling:/ =ores-build-codegen-templates.el= behind the

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
@@ -43,9 +43,9 @@ which lives on as the rollout task below.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Rolling out the literate migration across the remaining facets. |
+| Now           | Replacing file: links with proj: across the docs (last task). |
 | Waiting on    | Nothing.                               |
-| Next          | Migrate cpp, sql, doc and assets groups; wire CI drift check. |
+| Next          | Close the story once the link cleanup merges. |
 | Last touched  | 2026-06-06                               |
 
 * Acceptance
@@ -68,7 +68,7 @@ which lives on as the rollout task below.
 | [[id:675045C6-61AE-405D-817F-8501064C64D2][Design the literate template layout and tangle workflow]] | DONE | 2026-06-06 | 2026-06-06 | Decide file layout, grouping, tangle tooling and drift check; prove with a pilot batch. |
 | [[id:76178191-E20D-4479-BC01-79B877247D03][Tangle all mustache templates from facet-documenting org files]] | DONE | 2026-06-06 | 2026-06-06 | Every mustache template should be tangled from an org-mode file that documents its facet (literate style, as with the gnuplot charts). Each facet group gets a 'namespace' org file documenting the group, and a top-level file describes all the groups — a three-level literate hierarchy: template <- facet doc <- group doc <- groups overview. |
 | [[id:DDE8CF4A-3883-40D1-9BC0-19706162B70A][Add facet and facet-group doc types to compass and codegen]] | DONE | 2026-06-06 | 2026-06-06 | The literate template hierarchy introduces two new document types — the facet doc (one per template family, tangling to its .mustache files) and the facet grouping doc (namespace page per group). Teach ores.codegen generate_doc and compass add to scaffold both, so facet docs are never hand-rolled from the generic knowledge type. |
-| [[id:C771C122-3A96-48FB-BCF0-AE7D38CD526E][Replace file: links with proj: links across the documentation]] | BACKLOG | | | Audit every org document for file: links pointing at repo files (sources, JSON, scripts, images) and convert them to proj: links, which export to GitHub blob URLs on the published site. file: links to non-org files 404 because the site build only publishes org->html; found via the profiles.json links in the template-library docs. |
+| [[id:C771C122-3A96-48FB-BCF0-AE7D38CD526E][Replace file: links with proj: links across the documentation]] | STARTED | 2026-06-06 | | Audit every org document for file: links pointing at repo files (sources, JSON, scripts, images) and convert them to proj: links, which export to GitHub blob URLs on the published site. file: links to non-org files 404 because the site build only publishes org->html; found via the profiles.json links in the template-library docs. |
 | [[id:C4473D28-E366-468C-AAED-36CE8C374EDB][Refine the cpp facet grouping]] | DONE | 2026-06-06 | 2026-06-06 | The cpp group's 58 templates landed in five facets, but the split is coarse: cpp_domain_type holds 22 templates and cpp_service mixes two distinct families (component-service scaffolding vs the per-entity service pair). Analyse the set against the profiles and the MASD facet definitions and re-cut into finer, more cohesive facets. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_add_facet_doc_types_to_tooling.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_add_facet_doc_types_to_tooling.org
@@ -38,9 +38,9 @@ compass add facet and compass add facet_group scaffold the two new literate-temp
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_design_literate_template_layout.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_design_literate_template_layout.org
@@ -55,8 +55,40 @@ in the parent story's =* Decisions= section.
 
 * Plan
 
-(Cleared at close; decisions distilled into the parent story's
-=* Decisions=.)
+Survey results: 140 templates in =projects/ores.codegen/library/templates/=,
+prefix families cpp (58), sql (26), doc (18), cmake (8), qt (2),
+plantuml (1), shell (1). Consumed by =generator.py= via *pystache*;
+=profiles.json= maps 23 profiles → template/output pairs. Standalone
+={{! }}= comment lines are stripped by the mustache spec (pystache
+complies; several templates already use them), so a generated-file
+header is output-neutral.
+
+Proposed decisions:
+
+1. /Granularity:/ one org file per *facet* (template family by
+   filename prefix, e.g. =cmake=, =cpp_domain_type=, =cpp_qt=,
+   =sql_schema=, =doc=), each template a named
+   =#+begin_src mustache :tangle <name>.mustache= block with prose
+   documenting role, model inputs, output artefact. Group docs
+   (=cpp=, =sql=, =doc=, =cmake=) and a top-level overview complete
+   the capture's three-level hierarchy in the rollout task.
+2. /Location:/ org sources co-located in
+   =projects/ores.codegen/library/templates/=, tangling to sibling
+   =.mustache= files.
+3. /Tangle tooling:/ =ores-build-codegen-templates.el= (modelled on
+   =ores-build-clang-format.el=) tangles every =.org= under
+   =library/templates/=; CMake target =tangle_codegen_templates=.
+4. /Header:/ first line of each tangled file is
+   ={{! GENERATED FILE — tangled from <facet>.org; edit the org source. }}=
+   — output-neutral under pystache.
+5. /Drift check:/ run the tangle then =git diff --exit-code --
+   projects/ores.codegen/library/templates= (CI job / compass hook in
+   the rollout task).
+
+Pilot batch: the =cmake= facet (8 templates). Verify (a) tangled
+files match originals byte-for-byte apart from the header line, and
+(b) full codegen regeneration is byte-identical (header stripped in
+render).
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_refine_cpp_facet_grouping.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_refine_cpp_facet_grouping.org
@@ -25,11 +25,11 @@ Each cpp facet doc is a cohesive MASD facet rather than a filename-prefix bucket
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org-mode documents]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -38,28 +38,8 @@ Each cpp facet doc is a cohesive MASD facet rather than a filename-prefix bucket
 
 * Plan
 
-Analysis: map the 58 cpp templates to facets by profile membership
-and entity-lifecycle layer, not filename prefix. Proposed cut
-(5 facets → 8):
-
-| Facet | N | Members | Rationale |
-|-------+---+---------+-----------|
-| cpp_domain (new) | 6 | class ×2 (temporal/non), json_io ×2, generator ×2 | The value type and its serialisation/test data; =domain= / =non-temporal-domain= / =generator= profiles. |
-| cpp_table (new) | 4 | table ×2, table_io ×2 | libfort presentation adapter; distinct concern within the =domain= profile. |
-| cpp_repository (rename of cpp_domain_type, keeps ID) | 12 | entity ×4, mapper ×4, repository ×4 | The persistence triplet; =repository= / =non-temporal-repository= profiles. Exactly the dozen guideline. |
-| cpp_qt (unchanged) | 10 | five hpp/cpp pairs | Already cohesive; =qt= profile. |
-| cpp_service_app (rename of cpp_service, keeps ID) | 12 | app ×3, host ×2, config ×5, main, stub_test | The =component-service= scaffold, now without the unrelated entity-service pair. |
-| cpp_messaging (new) | 6 | protocol ×2, nats_changed_event, nats_handler, service ×2 | The entity's NATS surface end-to-end: message types → handler → service; =protocol= / =nats-eventing= / =nats-handler= / =service= profiles. |
-| cpp_component (gains export) | 6 | header, stub ×3, test_main, export | export.hpp ships with every component profile — it belongs with the skeleton. |
-| cpp_model_types (rename of cpp_support, keeps ID) | 2 | enum, field_group | Standalone model formats; =enum= / =field-group= profiles. |
-
-Implementation: scaffold the three new facets with =compass add
-facet=; move sections wholesale between docs (script — heading to
-next top-level heading); rename the three persisting docs (file +
-title, IDs stable); update each moved block's GENERATED FILE header
-to its new source doc; re-tangle (artefact headers change, render
-output does not); regenerate inventories; update the cpp group doc
-summary; zero-diff drift check against the new commit.
+(Cleared at close; the facet cut and rationale are distilled into the
+parent story's =* Decisions=.)
 
 * Notes
 
@@ -76,3 +56,16 @@ summary; zero-diff drift check against the new commit.
 | 1 | 8-bit enum hex print needs unary + promotion (re-flag of PR #1132 finding after section move) | cpp_model_types.org | Declined | Out of scope: migration keeps template content byte-identical. Already captured as fix_enum_hex_print_8bit. |
 
 * Result
+
+Delivered in PR [[https://github.com/OreStudio/OreStudio/pull/1136][#1136]] (merged). The cpp group's five prefix buckets
+became eight cohesive facets cut by entity-lifecycle layer and
+profile membership — cpp_domain (6), cpp_table (4), cpp_repository
+(12, ex cpp_domain_type), cpp_qt (10), cpp_messaging (6, including
+the entity-service pair extracted from cpp_service),
+cpp_service_app (12, ex cpp_service), cpp_component (6, gaining
+export.hpp) and cpp_model_types (2, ex cpp_support). The full
+template→facet mapping with rationale is preserved in the analysis
+table distilled to the story's =* Decisions=. IDs stayed stable
+across the three renames; sections moved with prose intact; the 43
+re-headered artefacts were verified header-only diffs; the drift CI
+gate passed on the change.

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_refine_cpp_facet_grouping.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_refine_cpp_facet_grouping.org
@@ -38,8 +38,28 @@ Each cpp facet doc is a cohesive MASD facet rather than a filename-prefix bucket
 
 * Plan
 
-(Cleared at close; the facet cut and rationale are distilled into the
-parent story's =* Decisions=.)
+Analysis: map the 58 cpp templates to facets by profile membership
+and entity-lifecycle layer, not filename prefix. Proposed cut
+(5 facets → 8):
+
+| Facet | N | Members | Rationale |
+|-------+---+---------+-----------|
+| cpp_domain (new) | 6 | class ×2 (temporal/non), json_io ×2, generator ×2 | The value type and its serialisation/test data; =domain= / =non-temporal-domain= / =generator= profiles. |
+| cpp_table (new) | 4 | table ×2, table_io ×2 | libfort presentation adapter; distinct concern within the =domain= profile. |
+| cpp_repository (rename of cpp_domain_type, keeps ID) | 12 | entity ×4, mapper ×4, repository ×4 | The persistence triplet; =repository= / =non-temporal-repository= profiles. Exactly the dozen guideline. |
+| cpp_qt (unchanged) | 10 | five hpp/cpp pairs | Already cohesive; =qt= profile. |
+| cpp_service_app (rename of cpp_service, keeps ID) | 12 | app ×3, host ×2, config ×5, main, stub_test | The =component-service= scaffold, now without the unrelated entity-service pair. |
+| cpp_messaging (new) | 6 | protocol ×2, nats_changed_event, nats_handler, service ×2 | The entity's NATS surface end-to-end: message types → handler → service; =protocol= / =nats-eventing= / =nats-handler= / =service= profiles. |
+| cpp_component (gains export) | 6 | header, stub ×3, test_main, export | export.hpp ships with every component profile — it belongs with the skeleton. |
+| cpp_model_types (rename of cpp_support, keeps ID) | 2 | enum, field_group | Standalone model formats; =enum= / =field-group= profiles. |
+
+Implementation: scaffold the three new facets with =compass add
+facet=; move sections wholesale between docs (script — heading to
+next top-level heading); rename the three persisting docs (file +
+title, IDs stable); update each moved block's GENERATED FILE header
+to its new source doc; re-tangle (artefact headers change, render
+output does not); regenerate inventories; update the cpp group doc
+summary; zero-diff drift check against the new commit.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -68,6 +68,6 @@ exists.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Round 1: no line comments (review summary only) | — | — | CI green (build, check, drift); nothing to address. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -8,7 +8,7 @@
 #+filetags: :documentation:site:links:codegen_literate_templates:sprint_20:v0:
 #+owner: marco
 #+branch: feature/codegen-literate-templates
-#+pr:
+#+pr: 1139
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -62,7 +62,7 @@ exists.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1139][#1139]] | [docs] proj: link cleanup; restore task plans |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -27,9 +27,9 @@ No org document links a repo file via file: when the target is not published as 
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org-mode documents]] |
-| Now          | Not yet started.                       |
+| Now          | Audit done, links converted; awaiting PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR review, then close the story.       |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -38,9 +38,23 @@ No org document links a repo file via file: when the target is not published as 
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Audit of all 257 =file:= links in org docs (excluding venv/build):
+
+| Target kind | Count | Verdict |
+|-------------+-------+---------|
+| =.png= images | 175 | Keep — published by the =site:images= attachment component; inline rendering needs =file:=. |
+| =.org= documents | 55 | Keep — ox-publish rewrites them to =.html=. |
+| =.svg= images | 10 | Keep — published (=site:images=). |
+| =.md= plans | 9 | *Convert* — Markdown is not published; all nine point at the three-level provisioning plan. |
+| =.pdf= | 2 | Keep — published (=site:pdf=). |
+| Placeholder/prose (=file:...=, =[[file:]]= in text) | 6 | Not links; leave. |
+
+So the original "convert images too" intent inverts: images /must/
+stay =file:= to render inline, and the site publishes them. Only the
+nine Markdown links convert to =proj:=. Document the id/file/proj
+rule in the org-roam knowledge doc (the page that owns the
+static-site link machinery), since no dedicated link-conventions doc
+exists.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :documentation:site:links:codegen_literate_templates:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/codegen-literate-templates
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,7 +25,7 @@ No org document links a repo file via file: when the target is not published as 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org-mode documents]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
@@ -38,9 +38,9 @@ No org document links a repo file via file: when the target is not published as 
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_tangle_mustache_templates_from_org.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_tangle_mustache_templates_from_org.org
@@ -48,8 +48,25 @@ hierarchy: template ← facet doc ← group doc ← groups overview.
 
 * Plan
 
-(Cleared at close; the rollout approach is recorded in the parent
-story's =* Decisions= and the library overview.)
+Migrate the remaining 132 templates group by group, one commit per
+facet, using =compass add facet= scaffolds. Facet split:
+
+- /cpp/ (58): =cpp_domain_type= (22), =cpp_service= (12), =cpp_qt=
+  (10), =cpp_component= (5), =cpp_nats= (2), rest into =cpp_support=
+  (enum, export, header, …).
+- /sql/ (26): =sql_schema= (9), =sql_service= (4), =sql_populate=
+  (dataset/populate/tag/currency/… reference-data inserts).
+- /doc/ (18): single =doc= facet (the compass add scaffolds,
+  including doc_facet/doc_facet_group themselves — self-hosting).
+- /assets/ (4): single =assets= facet (qt .ui ×2, plantuml_er,
+  shell_service_vars).
+
+Per facet: scaffold with =compass add facet --facet-group <g>=, move
+each template into a =:tangle= block with the GENERATED FILE header
+and prose (role, model inputs, output, profiles from profiles.json),
+tangle, verify byte-identical modulo header, regenerate inventories.
+Finish by wiring the two drift checks into CI (tangle zero-diff +
+inventory --check).
 
 * Notes
 

--- a/doc/knowledge/documentation/org_roam.org
+++ b/doc/knowledge/documentation/org_roam.org
@@ -124,6 +124,24 @@ in [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] for the full output path),
 include the ORE Studio stylesheet and nav bar, and writes the generated
 =graphdata.json= alongside it.
 
+*** Link types: id, file, proj
+
+Which link type to use depends on whether the target is published by
+the site build:
+
+- =[[id:UUID]]= :: the default for any org document in the graph —
+  resolves locally, in the graph, and on the published site.
+- =[[file:path]]= :: only for targets the site build publishes as-is:
+  org documents (exported to =.html=) and attachments matching the
+  publish components — images (=png=, =jpe?g=, =gif=, =svg=), =css=
+  and =pdf=. Inline images must use =file:= to render as =<img>=.
+- =[[proj:path/from/repo/root]]= :: everything else — source files,
+  JSON, scripts, Markdown, directories. The site build does not copy
+  these, so a =file:= link 404s on the published site; =proj:= links
+  export to GitHub blob URLs instead (=ores-build-site.el= defines
+  the type). Locally they do not resolve — that is the accepted
+  trade-off.
+
 * See also
 
 - [[https://www.orgroam.com/manual.html][org-roam manual]] — full reference for org-roam commands, configuration, and concepts.

--- a/doc/llm/memory/prefer_compass_lifecycle_commands.org
+++ b/doc/llm/memory/prefer_compass_lifecycle_commands.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID: C4A0648F-0A9A-467E-9375-ED22B3BBEE23
+:END:
+#+title: Prefer compass commands for lifecycle operations
+#+description: Use compass pr sync/checks/create/merge, task start/done, review list/reply/resolve — not raw git/gh — for agile lifecycle steps.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+For any lifecycle operation that compass covers — branch sync (pr sync), CI state (pr checks), PR creation/merge (pr create/merge), task state flips (task start/done), review rounds (review list/reply/resolve) — invoke the compass command rather than raw git/gh equivalents, even when the raw command feels quicker.
+
+*Why:* Compass commands carry side-effects the raw commands skip: journal stamps, story-table wiring, PR records on tasks, state/date flips. Hand-running git fetch/rebase or gh pr view silently drops those, causing state drift the sprint audit then flags. Marco corrected this during the literate-templates story (2026-06-06).
+
+*How to apply:* Before reaching for git/gh in an agile workflow step, check compass --help for the matching subcommand; if compass lacks it, file a capture for the gap instead of working around it.

--- a/doc/llm/memory/task_plans_are_historical_records.org
+++ b/doc/llm/memory/task_plans_are_historical_records.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID: D86BD831-B22A-42B7-B0FA-80778ACC7C52
+:END:
+#+title: Task plans are historical records — never clear at close
+#+description: At task close, distil decisions into the story's * Decisions but keep the * Plan body intact; it records what we actually did.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+
+When closing a task, write the * Result and distil key decisions into the parent story's * Decisions, but never clear or truncate the task's * Plan section — the plan stays as the historical record of what we did.
+
+*Why:* Marco corrected the earlier convention (the doc_task scaffold used to say plans are 'cleared when the task closes') during the literate-templates story on 2026-06-06: cleared plans destroy the audit trail of how a task was actually executed. The scaffold text was updated in the same change.
+
+*How to apply:* During any task close-out (compass task done, the work-task runbook, or sprint close), leave * Plan untouched apart from normal edits made while working. If a plan was drafted but superseded, annotate it rather than delete it.

--- a/projects/ores.codegen/library/templates/doc.org
+++ b/projects/ores.codegen/library/templates/doc.org
@@ -1089,9 +1089,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 ,* Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
 
 ,* Notes
 

--- a/projects/ores.codegen/library/templates/doc_task.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_task.org.mustache
@@ -44,9 +44,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
 
 * Notes
 


### PR DESCRIPTION
## Summary

Closes the last task of the literate-templates story. Repo-wide audit of all 257 file: links found only one broken class: nine Markdown links from backlog captures (the site publishes images, org→html, css and pdf — those stay file:, and inline images require it). Converted the nine to proj: and documented the id/file/proj link rule in the org-roam knowledge doc. Also restores the three task Plans cleared at earlier close-outs — per the new convention, plans are the historical record and are never cleared (scaffold updated at its literate source) — and adds two feedback memories (compass-first lifecycle commands; plans never cleared).

## Changes

- Convert nine .md file: links in product_backlog/next captures to proj:
- Document the id/file/proj link rule in doc/knowledge/documentation/org_roam.org; full audit table on the task
- Restore cleared Plans on the design, rollout and facet-grouping tasks; update doc_task scaffold guidance (via doc.org, tangled)
- Close the facet-grouping task with Result; distil the facet-cohesion rule into the story Decisions
- Memories: prefer compass lifecycle commands; task plans are historical records

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Convert codegen mustache templates to literate org-mode documents](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.html) | 1B686436-FBF6-47EB-87D5-5E13A509F7D1 |
| Task | [Replace file: links with proj: links across the documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.html) | C771C122-3A96-48FB-BCF0-AE7D38CD526E |

🤖 Generated with [Claude Code](https://claude.com/claude-code)