### PR TITLE
[codegen] Link component overview to the template library

### DIFF
--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -8,7 +8,7 @@
 #+filetags: :documentation:site:links:codegen_literate_templates:sprint_20:v0:
 #+owner: marco
 #+branch: feature/codegen-literate-templates
-#+pr: 1139
+#+pr: 1143
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -62,6 +62,7 @@ exists.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1143][#1143]] | [codegen] Link component overview to the template library |
 | [[https://github.com/OreStudio/OreStudio/pull/1139][#1139]] | [docs] proj: link cleanup; restore task plans |
 
 * Review

--- a/projects/ores.codegen/docs/architecture.org
+++ b/projects/ores.codegen/docs/architecture.org
@@ -97,7 +97,10 @@ In =src/generator.py=:
 ** Template system
 
 - Mustache via the =pystache= library.
-- Templates live in =library/templates/=.
+- Templates live in =library/templates/=. The =.mustache= files are
+  generated artefacts, tangled from the literate facet docs in the
+  same directory — see the [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] overview for
+  the hierarchy, tangle workflow, and drift checks.
 - Output is SQL, C++, or org-mode depending on the template family.
 
 ** Data files

--- a/projects/ores.codegen/modeling/component_overview.org
+++ b/projects/ores.codegen/modeling/component_overview.org
@@ -29,7 +29,10 @@ licence headers and editor modelines.
 * Inputs
 
 - JSON model files under =models/<subject>/=.
-- Mustache templates under =library/templates/=.
+- Mustache templates under =library/templates/= — generated
+  artefacts, tangled from the literate facet docs that live alongside
+  them; the [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] overview tops the hierarchy
+  (template ← facet doc ← group doc ← groups overview).
 - Static data (licences, modelines) under =library/data/=.
 - Optional generator profiles (collections of templates) declared in
   =library/profiles.json=.
@@ -49,8 +52,10 @@ each entry point accepts a custom output directory.
 
 C++ profiles are declared in =library/profiles.json= and invoked with
 =--profile <name>=. Each profile is a named collection of Mustache
-templates. The type mappings that apply across all profiles are in
-[[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]]§"Type mappings".
+templates; every template's literate source — prose on role, model
+inputs and outputs, plus the tangle block — lives in its facet doc
+under [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][the template library]]. The type mappings that apply across all
+profiles are in [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]]§"Type mappings".
 
 | Profile | Covers | Key library |
 |---|---|---|
@@ -167,6 +172,9 @@ harness.  See [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][Model Assisted Software Development]] — the MASD methodology as applied
   to ORE Studio: logical/physical space, product/component taxonomy, the
   six principles, the backout strategy, and the full facet catalogue.
+- [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the literate template hierarchy: facet
+  groups, facet docs, tangle workflow and drift checks. The group
+  docs: [[id:B5AC7383-3535-4F40-9109-08B77587EEF5][cmake]], [[id:74AB7037-B54A-43AB-A1FA-E9E16746879D][cpp]], [[id:C68F8B0E-27B6-40C7-AD18-EDD2492BF941][sql]], [[id:1BBCEB58-83E0-40F7-BC85-FE2B98E9D2FD][doc]], [[id:4A21E18E-EBA7-4734-BF3F-16574DF0CA8E][assets]].
 - [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — directory layout, internal modules,
   template system, model-template mapping, modeline configuration,
   features.


### PR DESCRIPTION
## Summary

Stranded commit from the literate-templates story: pushed to the branch minutes after PR #1139 merged, so it never reached main. The ores.codegen component overview and architecture doc predated the literate migration and had no links to the template hierarchy; Inputs, the profile catalogue and See also now point at the library overview and the five group docs, and the architecture doc's template-system section explains the .mustache files are tangled artefacts.

## Changes

- component_overview.org: link Inputs, profile catalogue and See also to the Codegen template library and group docs
- docs/architecture.org: template-system section notes templates are tangled from literate facet docs

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Convert codegen mustache templates to literate org-mode documents](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.html) | 1B686436-FBF6-47EB-87D5-5E13A509F7D1 |
| Task | [Replace file: links with proj: links across the documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.html) | C771C122-3A96-48FB-BCF0-AE7D38CD526E |

🤖 Generated with [Claude Code](https://claude.com/claude-code)