### PR TITLE
[agile] Start story: Agile dashboard PoC: JavaScript UI over org-mode data

### DIFF
--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/story.org
@@ -46,7 +46,7 @@ PoC that can be served from GitHub Pages and run locally without a backend.
 
 | Task                                                                                          | State   | Start      | End | Description                                          |
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+------------------------------------------------------|
-| [[id:8AA7D1CF-9364-4906-9DF0-D78CB888EC5A][Scaffold story]]                                | STARTED | 2026-06-06 |     | Create story, wire sprint table, open scaffold PR.   |
+| [[id:8AA7D1CF-9364-4906-9DF0-D78CB888EC5A][Scaffold story]]                                | DONE | 2026-06-06 | 2026-06-06 | Create story, wire sprint table, open scaffold PR.   |
 | [[id:35A9C9B7-08B2-42E3-90FD-3BF09F6DB448][Research JS libraries and org-mode parsing]]    | BACKLOG |            |     | Evaluate libraries; produce feasibility assessment.  |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/story.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: B6D4D06E-6699-476E-89ED-4623DC3DF62A
+:END:
+#+title: Story: Agile dashboard PoC: JavaScript UI over org-mode data
+#+description: Investigate feasibility of a read-only JavaScript agile dashboard that reads org-mode files and optionally the knowledge-graph database, deployable on GitHub Pages and locally.
+#+type: story
+#+level: s2
+#+filetags: :poc:agile:javascript:ui:github-pages:sprint_20:v0:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Determine whether a lightweight, read-only JavaScript agile dashboard is
+feasible for this project: a single-page application that parses org-mode
+files (and optionally the knowledge-graph SQLite database) to render sprints,
+stories, and tasks in an interactive kanban/list view.  The deliverable is a
+PoC that can be served from GitHub Pages and run locally without a backend.
+
+* Status
+
+| Field         | Value                                                              |
+|---------------+--------------------------------------------------------------------|
+| State         | STARTED                                                            |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]          |
+| Now           | Scaffolding story; first task is BACKLOG.                          |
+| Waiting on    | Nothing.                                                           |
+| Next          | Pick up the research task and evaluate org-mode parsing libraries. |
+| Last touched  | 2026-06-06                                                         |
+
+* Acceptance
+
+- A PoC page loads in a browser (GitHub Pages URL and =file://= / local dev
+  server) and displays the current sprint with its stories and tasks.
+- Clicking a story expands its details (goal, status, acceptance).
+- Data is sourced exclusively from checked-in org files and/or the
+  knowledge-graph database; no additional backend is required.
+- A brief written assessment covers: feasibility, chosen libraries, known
+  limitations, and a recommended path forward (or a clear "not worth it"
+  verdict with rationale).
+
+* Tasks
+
+| Task                                                                                          | State   | Start      | End | Description                                          |
+|-----------------------------------------------------------------------------------------------+---------+------------+-----+------------------------------------------------------|
+| [[id:8AA7D1CF-9364-4906-9DF0-D78CB888EC5A][Scaffold story]]                                | STARTED | 2026-06-06 |     | Create story, wire sprint table, open scaffold PR.   |
+| [[id:35A9C9B7-08B2-42E3-90FD-3BF09F6DB448][Research JS libraries and org-mode parsing]]    | BACKLOG |            |     | Evaluate libraries; produce feasibility assessment.  |
+
+* Decisions
+
+* Out of scope
+
+- Any write or edit capability — this PoC is strictly read-only.
+- Real-time data sync or webhooks.
+- Authentication or access control.
+- Integration with external agile tools (Jira, Linear, etc.).

--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_implement_agile_dashboard_poc.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_implement_agile_dashboard_poc.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 35A9C9B7-08B2-42E3-90FD-3BF09F6DB448
+:END:
+#+title: Task: Research JavaScript libraries and assess org-mode parsing options
+#+description: Initial task for: Agile dashboard PoC: JavaScript UI over org-mode data
+#+type: task
+#+level: s1
+#+filetags: :agile_dashboard_poc:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Evaluate JavaScript libraries for parsing org-mode files in the browser and
+assess whether a static PoC dashboard (GitHub Pages + local) is achievable
+without a backend.  Produce a written feasibility report and, if viable, a
+minimal working prototype.
+
+* Status
+
+| Field        | Value                                                                                          |
+|--------------+------------------------------------------------------------------------------------------------|
+| State        | BACKLOG                                                                                        |
+| Parent story | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] |
+| Now          | Not yet started.                                                                               |
+| Waiting on   | Scaffold PR merged.                                                                            |
+| Next         | Survey available org-mode JS parsers and pick a UI framework candidate.                        |
+| Last touched | 2026-06-06                                                                                     |
+
+* Acceptance
+
+- At least two org-mode parsing libraries evaluated with a pro/con summary.
+- At least two UI framework candidates evaluated (e.g. React, Vue, Svelte,
+  vanilla JS) against the constraints: static hosting, no build step preferred,
+  small bundle.
+- Decision recorded: proceed with PoC or abandon with rationale.
+- If proceeding: a working page that loads sprint data from a static org file
+  and renders sprint/story/task hierarchy with click-to-expand details.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
@@ -26,11 +26,11 @@ scaffold PR so the story is visible in the agile history from day one.
 
 | Field        | Value                                                                                          |
 |--------------+------------------------------------------------------------------------------------------------|
-| State        | STARTED                                                                                        |
+| State        | DONE                                                                                        |
 | Parent story | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] |
-| Now          | Filling prose; about to wire sprint table and open PR.                                         |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                                                                                       |
-| Next         | Commit, open scaffold PR, close this task before merging.                                      |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                                                                                     |
 
 * Acceptance
@@ -60,3 +60,5 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Story created, sprint wired, scaffold PR #1149 open.

--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 8AA7D1CF-9364-4906-9DF0-D78CB888EC5A
+:END:
+#+title: Task: Scaffold story: Agile dashboard PoC: JavaScript UI over org-mode data
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :agile_dashboard_poc:sprint_20:v0:
+#+owner: marco
+#+branch: feature/agile-dashboard-poc
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-06
+#+updated: 2026-06-06
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create the story document, wire it into the sprint table, and open the
+scaffold PR so the story is visible in the agile history from day one.
+
+* Status
+
+| Field        | Value                                                                                          |
+|--------------+------------------------------------------------------------------------------------------------|
+| State        | STARTED                                                                                        |
+| Parent story | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] |
+| Now          | Filling prose; about to wire sprint table and open PR.                                         |
+| Waiting on   | Nothing.                                                                                       |
+| Next         | Commit, open scaffold PR, close this task before merging.                                      |
+| Last touched | 2026-06-06                                                                                     |
+
+* Acceptance
+
+- Story org file has Goal, Acceptance, Tasks table, and Out of scope filled in.
+- Sprint 20 =* Stories= table has a row for this story.
+- Scaffold PR is open and this task is marked DONE before the PR merges.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
+++ b/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.org
@@ -8,7 +8,7 @@
 #+filetags: :agile_dashboard_poc:sprint_20:v0:
 #+owner: marco
 #+branch: feature/agile-dashboard-poc
-#+pr:
+#+pr: 1149
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -51,7 +51,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1149][#1149]] | [agile] Start story: Agile dashboard PoC: JavaScript UI over org-mode data |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -134,6 +134,7 @@ LLM-driven workflow frictionless.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | STARTED | 2026-06-06 | | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
+| [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | STARTED | 2026-06-06 | | PoC: read-only JS dashboard over org files, deployable on GitHub Pages and locally. |
 
 ** Hotfixes
 


### PR DESCRIPTION
## Summary

Scaffold the PoC story for a read-only JavaScript agile dashboard over org-mode files, wire it into Sprint 20, and open the scaffold PR.

## Changes

- Add story.org with goal, acceptance, tasks table, decisions, and out-of-scope sections.
- Add scaffold task and first research task (BACKLOG).
- Wire story into Sprint 20 Agile table.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Agile dashboard PoC: JavaScript UI over org-mode data](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/story.html) | B6D4D06E-6699-476E-89ED-4623DC3DF62A |
| Task | [Scaffold story: Agile dashboard PoC: JavaScript UI over org-mode data](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_dashboard_poc/task_scaffold_agile_dashboard_poc.html) | 8AA7D1CF-9364-4906-9DF0-D78CB888EC5A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)