### PR TITLE
[agile] Scaffold story: Clean up codegen docs and MASD alignment

### DIFF
--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
@@ -51,6 +51,7 @@ facet, facet group) is used consistently throughout.
 | [[id:62A7D749-835E-497A-836F-6217C8894611][Audit and update the MASD document]] | BACKLOG | | | Review and update projects/modeling/masd.org: update facet catalogue to link to literate template org files; align transformation model section with the LLM-based approach. |
 | [[id:1C69ACB1-DC76-4A1D-BF45-8940BDE97ED3][Cross-link template org files into the org-roam graph]] | BACKLOG | | | Add MASD and modeling facet reference doc links from each template group and facet org file; add reciprocal links in the modeling facet docs. |
 | [[id:8B96FDF2-88C6-4C21-8167-04974E102C29][Audit and correct MASD terminology across codegen docs]] | BACKLOG | | | Sweep template org files for "pipeline" → "projection"; clarify facet vs facet group; remove loose meta-model usage. |
+| [[id:EC539224-AC10-4804-86BD-BEEAF2CC78D4][Improve the Developer Links page with workflow recipes]] | BACKLOG | | | Rewrite doc/developer.org from a bare external-URL index into a practical developer guide: add sections linking to the key compass and cmake recipes (build, configure, run tests, setup environment, start services, deploy site/skills/settings, format); group by workflow phase (setup, build, test, develop, release). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: 6654934D-D372-4B7B-A66D-5E0E5A145775
+:END:
+#+title: Story: Clean up codegen documentation and MASD alignment
+#+description: Update the MASD document's facet catalogue to link to the literate template org files; cross-link template org files into the org-roam graph via the MASD doc and modeling facet reference docs; audit and correct MASD terminology (projection, facet, facet group) across codegen documentation.
+#+type: story
+#+level: s2
+#+filetags: :codegen:masd:documentation:literate:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
@@ -47,7 +47,7 @@ facet, facet group) is used consistently throughout.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:DE742543-0BED-47B4-87DA-CF7C31EE65A7][Scaffold story: Clean up codegen documentation and MASD alignment]] | STARTED | 2026-06-07 | | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
+| [[id:DE742543-0BED-47B4-87DA-CF7C31EE65A7][Scaffold story: Clean up codegen documentation and MASD alignment]] | DONE | 2026-06-07 | 2026-06-07 | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
 | [[id:62A7D749-835E-497A-836F-6217C8894611][Audit and update the MASD document]] | BACKLOG | | | Review and update projects/modeling/masd.org: update facet catalogue to link to literate template org files; align transformation model section with the LLM-based approach. |
 | [[id:1C69ACB1-DC76-4A1D-BF45-8940BDE97ED3][Cross-link template org files into the org-roam graph]] | BACKLOG | | | Add MASD and modeling facet reference doc links from each template group and facet org file; add reciprocal links in the modeling facet docs. |
 | [[id:8B96FDF2-88C6-4C21-8167-04974E102C29][Audit and correct MASD terminology across codegen docs]] | BACKLOG | | | Sweep template org files for "pipeline" → "projection"; clarify facet vs facet group; remove loose meta-model usage. |

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.org
@@ -14,7 +14,11 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+The codegen documentation tells a coherent story: the [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] document's
+facet catalogue links to the literate template org files that implement
+each facet; each template org file links back to the MASD doc and to the
+relevant modeling facet reference docs; and MASD terminology (projection,
+facet, facet group) is used consistently throughout.
 
 * Status
 
@@ -22,20 +26,31 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Not yet started.                       |
+| Now           | Scaffold task in flight (PR #1162).    |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Audit and update the MASD document.    |
 | Last touched  | 2026-06-07                               |
 
 * Acceptance
 
--
+- The MASD document's facet catalogue links to the literate template org
+  files for each facet (cpp_domain, cpp_repository, sql_schema, etc.).
+- Each template group and facet org file carries a link to [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] and, where
+  a modeling facet reference doc exists, a link to that doc.
+- The modeling facet reference docs (type_definition_facet.org,
+  sql_facet.org, etc.) link back to the corresponding template org files.
+- "Projection" is used consistently in template prose where MASD
+  terminology applies; loose uses of "meta-model" in template comments
+  are resolved.
 
 * Tasks
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:DE742543-0BED-47B4-87DA-CF7C31EE65A7][Scaffold story: Clean up codegen documentation and MASD alignment]] | STARTED | 2026-06-07 | | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
+| [[id:62A7D749-835E-497A-836F-6217C8894611][Audit and update the MASD document]] | BACKLOG | | | Review and update projects/modeling/masd.org: update facet catalogue to link to literate template org files; align transformation model section with the LLM-based approach. |
+| [[id:1C69ACB1-DC76-4A1D-BF45-8940BDE97ED3][Cross-link template org files into the org-roam graph]] | BACKLOG | | | Add MASD and modeling facet reference doc links from each template group and facet org file; add reciprocal links in the modeling facet docs. |
+| [[id:8B96FDF2-88C6-4C21-8167-04974E102C29][Audit and correct MASD terminology across codegen docs]] | BACKLOG | | | Sweep template org files for "pipeline" → "projection"; clarify facet vs facet group; remove loose meta-model usage. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 8B96FDF2-88C6-4C21-8167-04974E102C29
+:END:
+#+title: Task: Audit and correct MASD terminology across codegen docs
+#+description: Review all literate template org files and modeling facet reference docs for terminology consistency: ensure 'projection' is used instead of 'pipeline' where appropriate; clarify 'facet' vs 'facet group'; remove loose use of 'meta-model' in template prose.
+#+type: task
+#+level: s1
+#+filetags: :clean_codegen_masd_docs:sprint_20:v0:
+#+owner: marco
+#+branch: feature/audit-masd-terminology
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_cross_link_template_org_files.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_cross_link_template_org_files.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 1C69ACB1-DC76-4A1D-BF45-8940BDE97ED3
+:END:
+#+title: Task: Cross-link template org files into the org-roam graph
+#+description: Add [[id:...][MASD]] links and links to modeling facet reference docs from each template group and facet org file; add reciprocal links in the modeling facet docs (type_definition_facet.org, sql_facet.org, etc.) back to the template org files.
+#+type: task
+#+level: s1
+#+filetags: :clean_codegen_masd_docs:sprint_20:v0:
+#+owner: marco
+#+branch: feature/cross-link-template-org-files
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_cross_link_template_org_files.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_cross_link_template_org_files.org
@@ -2,7 +2,7 @@
 :ID: 1C69ACB1-DC76-4A1D-BF45-8940BDE97ED3
 :END:
 #+title: Task: Cross-link template org files into the org-roam graph
-#+description: Add [[id:...][MASD]] links and links to modeling facet reference docs from each template group and facet org file; add reciprocal links in the modeling facet docs (type_definition_facet.org, sql_facet.org, etc.) back to the template org files.
+#+description: Add [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] links and links to modeling facet reference docs from each template group and facet org file; add reciprocal links in the modeling facet docs (type_definition_facet.org, sql_facet.org, etc.) back to the template org files.
 #+type: task
 #+level: s1
 #+filetags: :clean_codegen_masd_docs:sprint_20:v0:

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 62A7D749-835E-497A-836F-6217C8894611
+:END:
+#+title: Task: Audit and update the MASD document
+#+description: Initial task for: Clean up codegen documentation and MASD alignment
+#+type: task
+#+level: s1
+#+filetags: :clean_codegen_masd_docs:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
@@ -2,7 +2,7 @@
 :ID: 62A7D749-835E-497A-836F-6217C8894611
 :END:
 #+title: Task: Audit and update the MASD document
-#+description: Initial task for: Clean up codegen documentation and MASD alignment
+#+description: Review projects/modeling/masd.org: update the facet catalogue to link to each literate template org file (cpp_domain, cpp_repository, sql_schema, etc.) rather than the old profile-name references; align the transformation model section with the LLM-based codegen approach; fix any terminology inconsistencies in the document itself.
 #+type: task
 #+level: s1
 #+filetags: :clean_codegen_masd_docs:sprint_20:v0:

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_improve_developer_links.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_improve_developer_links.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: EC539224-AC10-4804-86BD-BEEAF2CC78D4
+:END:
+#+title: Task: Improve the Developer Links page with workflow recipes
+#+description: Rewrite doc/developer.org from a bare external-URL index into a practical developer guide: add sections linking to the key compass and cmake recipes (build, configure, run tests, setup environment, start services, deploy site/skills/settings, format); group by workflow phase (setup, build, test, develop, release).
+#+type: task
+#+level: s1
+#+filetags: :clean_codegen_masd_docs:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Story: Clean up codegen documentation and MASD alignment]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Story: Clean up codegen documentation and MASD alignment]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -54,6 +54,10 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Tasks table empty in story.org | story.org | Fixed in 34b851d | All four tasks linked with IDs |
+| 2 | State/Now inconsistency (STARTED + "Not yet started") | story.org, task_scaffold | Fixed in 34b851d | Now → "Scaffold PR in flight" |
+| 3 | Generic description in task_implement | task_implement | Fixed in 34b851d | Replaced with task-specific prose |
+| 4 | [[id:...][MASD]] placeholder not resolved | task_cross_link | Fixed in 34b851d | Resolved to BA0E3273 |
+| 5 | Rename task_implement to task_audit_masd_document | task_implement | Not changed | IDs are navigation surface; filename change has no benefit |
 
 * Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: DE742543-0BED-47B4-87DA-CF7C31EE65A7
+:END:
+#+title: Task: Scaffold story: Clean up codegen documentation and MASD alignment
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :clean_codegen_masd_docs:sprint_20:v0:
+#+owner: marco
+#+branch: feature/clean-codegen-masd-docs
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -27,9 +27,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Scaffold PR #1162 in flight.           |
+| Waiting on   | PR merge.                              |
+| Next         | Merge scaffold PR; close scaffold task.|
 | Last touched | 2026-06-07                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -63,3 +63,8 @@ plan itself stays — it is the historical record of what we did.)
 | R3 | New task_improve_developer_links well-formed; scope-fit observation | task_improve | No action | Bundling is deliberate; developer-links is adjacent scope |
 
 * Result
+
+Story scaffolded with five tasks: audit MASD document, cross-link
+template org files, audit MASD terminology, improve Developer Links.
+Story wired into sprint 20 Codegen epic. Tasks table, Goal, Acceptance,
+and status fields all populated. MASD ID placeholder resolved.

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
-| Now          | Scaffold PR #1162 in flight.           |
+| Now          | Nothing. |
 | Waiting on   | PR merge.                              |
-| Next         | Merge scaffold PR; close scaffold task.|
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -8,7 +8,7 @@
 #+filetags: :clean_codegen_masd_docs:sprint_20:v0:
 #+owner: marco
 #+branch: feature/clean-codegen-masd-docs
-#+pr:
+#+pr: 1162
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -48,7 +48,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1162][#1162]] | [agile] Scaffold story: Clean up codegen docs and MASD alignment |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.org
@@ -59,5 +59,7 @@ plan itself stays — it is the historical record of what we did.)
 | 3 | Generic description in task_implement | task_implement | Fixed in 34b851d | Replaced with task-specific prose |
 | 4 | [[id:...][MASD]] placeholder not resolved | task_cross_link | Fixed in 34b851d | Resolved to BA0E3273 |
 | 5 | Rename task_implement to task_audit_masd_document | task_implement | Not changed | IDs are navigation surface; filename change has no benefit |
+| R2 | Round 2 verification: all round 1 fixes confirmed | all | No action | Both reviewers said "ready to merge" |
+| R3 | New task_improve_developer_links well-formed; scope-fit observation | task_improve | No action | Bundling is deliberate; developer-links is adjacent scope |
 
 * Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -120,6 +120,7 @@ the safety and CI guardrails so generated code stays trustworthy. Carried from s
 | [[id:7AA5B5C3-F7DE-4A17-84A0-75FB3761D43E][Codegen unified model — Phase 1: Qt derivation]] | BACKLOG | | | Derive Qt fields from conventions; drop explicit NATS protocol class names from models. |
 | [[id:AE89AD39-05D0-4A45-8BF4-FDC44BBB8A09][Codegen unified model — Phase 3: unify temporal templates]] | BACKLOG | | | Merge temporal and non-temporal C++ template families into single model-controlled templates. |
 | [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org]] | STARTED | 2026-06-06 | | Each .mustache template tangled from a facet-documenting org doc; three-level literate hierarchy (template ← facet ← group ← overview); zero-diff drift check. |
+| [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] | STARTED | 2026-06-07 | | Update MASD doc facet catalogue to link to literate template org files; cross-link template docs into org-roam graph; audit and correct MASD terminology. |
 
 *** Epic: Compass
 


### PR DESCRIPTION
## Summary

Scaffold a new story to clean up codegen documentation: update the MASD doc's facet catalogue, cross-link template org files into the org-roam graph, and correct MASD terminology.

## Changes

- Add story and three tasks: audit MASD doc, cross-link template org files, audit terminology
- Wire story into sprint 20 Codegen epic

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clean up codegen documentation and MASD alignment](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.html) | 6654934D-D372-4B7B-A66D-5E0E5A145775 |
| Task | [Scaffold story: Clean up codegen documentation and MASD alignment](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_scaffold_clean_codegen_masd_docs.html) | DE742543-0BED-47B4-87DA-CF7C31EE65A7 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)