### PR TITLE
[agile] Start story: Agile timeline — bucketed activity summaries

### DIFF
--- a/doc/agile/product_backlog/inbox/compass_wait_for_ci.org
+++ b/doc/agile/product_backlog/inbox/compass_wait_for_ci.org
@@ -1,0 +1,49 @@
+:PROPERTIES:
+:ID: 3480A8FC-364B-4F81-A842-D7200F8A6100
+:END:
+#+title: Add a compass wait-for-CI command
+#+description: Poll a PR's CI checks in a sleep/poll/report loop until the checks of interest are green, harvesting failure logs into the project tmp dir when red.
+#+type: capture
+#+level: cross
+#+filetags: :compass:github:ci:tooling:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+A =compass pr wait= (or =compass ci wait=) command that sleeps, polls all
+the CI checks on a PR, prints a status update, and sleeps again until done.
+Behaviour:
+
+- Polls /all/ checks each round but the user can name the checks they are
+  /interested in/ (e.g. =--only check,claude-review=); the command finishes
+  when the interested set is green, regardless of the rest.
+- All interested checks green: exit success. If only a subset was watched,
+  say so explicitly — "watched checks green; merge will need
+  =compass pr merge --force= while the others are pending".
+- Any interested check red: stop, fetch useful failure information from
+  GitHub (failed job log, annotations) and copy it into the project tmp
+  dir — suggested layout =tmp/ci/<run-number>/= — then tell the user to
+  investigate that directory.
+
+* Why
+
+Today the post-push ritual is manual: repeatedly running =compass pr
+checks=, eyeballing the output, and digging through the GitHub UI when
+something goes red. An LLM session burns context doing this polling
+inline, and failure logs end up pasted piecemeal into the conversation. A
+single blocking command makes "wait for CI then merge" a one-liner for
+both humans and LLM sessions, and lands failure evidence in a predictable
+local place for investigation.
+
+* References
+
+- =compass pr checks= — the existing one-shot status command this builds on.
+- proj:projects/ores.compass/src/compass_review.py — gh api plumbing.
+- =tmp/= — project scratch directory convention for the harvested logs.
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/task_new_switches_branches.org
+++ b/doc/agile/product_backlog/inbox/task_new_switches_branches.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: DD4A0265-9134-4A95-8677-68873357F043
+:END:
+#+title: compass task new switches branches mid-scaffold
+#+description: Each compass task new creates AND checks out its own branch. Scaffolding a story with several task new calls leaves the worktree on the last task's branch, so the scaffold commit and PR ride the wrong branch (saw with PR 1165: scaffold rode feature/timeline-environment-stamp). task new should create the branch without switching, or restore the original branch.
+#+type: capture
+#+level: cross
+#+filetags: :compass:bug:agile:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -37,9 +37,11 @@ event counts over time with click-through to each bucket's log.
 
 * Acceptance
 
-- =compass timeline= lists stories/tasks/captures changed within a given
-  window (with a "now" convenience for the recent past) including what
-  changed and links to the documents.
+- =compass timeline= has two behaviours: /generate/ — list
+  stories/tasks/captures changed within a given window (with a "now"
+  convenience for the recent past), what changed, and links: the input
+  for the LLM snapshot; and /view/ — show the last N buckets sourced
+  purely from the sprint's timeline/ folder.
 - Documents record which environment touched them, so snapshots can
   attribute work per environment.
 - Snapshots are org files under the sprint's =timeline/= folder, named
@@ -55,7 +57,7 @@ event counts over time with click-through to each bucket's log.
 | Task                                                                                              | State   | Start      | End | Description                                                       |
 |----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
-| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | List documents changed in a period.                               |
+| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | BACKLOG |            |     | Event-count chart with click-through to bucket snapshots.         |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -62,6 +62,13 @@ event counts over time with click-through to each bucket's log.
 
 * Decisions
 
+- /Bucket size is an experiment, not a constant/ :: 20 minutes was an
+  arbitrary starting point. The real constraint is readability: a bucket
+  must not hold more events than can be scanned at a glance. Window size
+  is configurable in both the command and the skill; tune it with real
+  data, and consider event-count-capped buckets (split a window when it
+  exceeds N events) over fixed durations if busy periods overwhelm.
+
 * Out of scope
 
 - Real-time push/streaming updates — snapshots are written on demand or on

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -32,7 +32,7 @@ event counts over time with click-through to each bucket's log.
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
 | Now           | Scaffolding story and tasks.                                 |
 | Waiting on    | Nothing.                                                     |
-| Next          | Pick up the compass timeline command task.                   |
+| Next          | Temporal-coherence analysis gates the implementation tasks.  |
 | Last touched  | 2026-06-07                                                   |
 
 * Acceptance
@@ -57,6 +57,7 @@ event counts over time with click-through to each bucket's log.
 | Task                                                                                              | State   | Start      | End | Description                                                       |
 |----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
+| [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | BACKLOG | | | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -54,7 +54,7 @@ event counts over time with click-through to each bucket's log.
 
 | Task                                                                                              | State   | Start      | End | Description                                                       |
 |----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
-| [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | STARTED | 2026-06-07 |     | Create story, tasks, sprint wiring, scaffold PR.                  |
+| [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | List documents changed in a period.                               |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 3697D889-BF01-43D4-9EF7-3AF6B70A8122
+:END:
+#+title: Story: Agile timeline: bucketed summaries of recent activity
+#+description: Keep up with parallel work without missing problems: a compass timeline command that finds documents changed in a period, LLM-written snapshot summaries bucketed per time window and stored under the sprint, and a dashboard timeline view with event counts over time and click-through to each bucket's log.
+#+type: story
+#+level: s2
+#+filetags: :agile:compass:org-js:timeline:llm:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+With several environments and LLM sessions working in parallel, it is hard
+to keep up with what happened and to catch problems as they arise.  This
+story delivers a timeline: a *compass timeline* command that lists the
+documents changed in a period (e.g. "timeline now" → last 20 minutes); an
+LLM skill that buckets those changes and writes a snapshot per time window
+— "environment local1 worked on story X, tasks Y1, Y2; this is a new story
+not in the sprint; task Y1 had problem P0" — highlighting problems and
+suspicious LLM decisions; and a timeline view in the agile board showing
+event counts over time with click-through to each bucket's log.
+
+* Status
+
+| Field         | Value                                                        |
+|---------------+--------------------------------------------------------------|
+| State         | STARTED                                                      |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
+| Now           | Scaffolding story and tasks.                                 |
+| Waiting on    | Nothing.                                                     |
+| Next          | Pick up the compass timeline command task.                   |
+| Last touched  | 2026-06-07                                                   |
+
+* Acceptance
+
+- =compass timeline= lists stories/tasks/captures changed within a given
+  window (with a "now" convenience for the recent past) including what
+  changed and links to the documents.
+- Documents record which environment touched them, so snapshots can
+  attribute work per environment.
+- Snapshots are org files under the sprint's =timeline/= folder, named
+  =<ISO-from>-<ISO-to>.org=, bucketed (stories raised, tasks raised,
+  worked on, problems, suspicious decisions) — tables over prose where
+  possible, with id links to the documents.
+- The agile board has a timeline view: counts of events per time bucket as
+  a clickable chart; clicking a bucket shows its snapshot; defaults to the
+  latest bucket.
+
+* Tasks
+
+| Task                                                                                              | State   | Start      | End | Description                                                       |
+|----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
+| [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | STARTED | 2026-06-07 |     | Create story, tasks, sprint wiring, scaffold PR.                  |
+| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | List documents changed in a period.                               |
+| [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
+| [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
+| [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | BACKLOG |            |     | Event-count chart with click-through to bucket snapshots.         |
+
+* Decisions
+
+* Out of scope
+
+- Real-time push/streaming updates — snapshots are written on demand or on
+  a cadence, not live.
+- Timeline for non-agile documents (knowledge, manuals) — agile docs first;
+  generalise later if useful.
+- Alerting/notifications — the timeline is a pull-based review tool.

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_implement_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_implement_agile_timeline.org
@@ -34,7 +34,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Window is a parameter (e.g. --since/--from/--to); "now" is a convenience
+  default, not a hard-coded 20 minutes.
+- Lists stories/tasks/captures changed in the window with what changed and
+  id links.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_implement_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_implement_agile_timeline.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 49BE7DB0-0577-4C30-A370-610C0B48FC7F
+:END:
+#+title: Task: Add compass timeline command to list documents changed in a period
+#+description: Initial task for: Agile timeline: bucketed summaries of recent activity
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
@@ -8,7 +8,7 @@
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
 #+branch: feature/agile-timeline
-#+pr:
+#+pr: 1165
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -51,7 +51,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1165][#1165]] | [agile] Start story: Agile timeline — bucketed activity summaries |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 8B8361ED-768B-4B8B-B008-83155D0956B7
+:END:
+#+title: Task: Scaffold story: Agile timeline: bucketed summaries of recent activity
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch: feature/agile-timeline
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create the story and its four tasks, wire the story into the sprint table,
+and open the scaffold PR.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Docs filled; wiring sprint table and opening the PR.            |
+| Waiting on   | Nothing.                                                        |
+| Next         | Commit, open scaffold PR, close this task before merging.       |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+- Story has goal, acceptance, tasks table and out-of-scope filled in.
+- Sprint 20 Stories table has a row for this story.
+- Scaffold PR open; this task DONE before it merges.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
-#+branch: feature/agile-timeline
+#+branch: feature/timeline-environment-stamp
 #+pr: 1165
 #+blocked_on:
 #+blocked_since:
@@ -26,11 +26,11 @@ and open the scaffold PR.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Docs filled; wiring sprint table and opening the PR.            |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                                                        |
-| Next         | Commit, open scaffold PR, close this task before merging.       |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
@@ -60,3 +60,5 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Story, four implementation tasks, sprint wiring; scaffold PR #1165.

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.org
@@ -57,7 +57,12 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Scaffold task branch field wrong | task_scaffold_agile_timeline.org | Accepted | Already fixed pre-review in b1fa5bac3. |
+| 1 | Compass command task file breaks naming pattern | task_timeline_compass_command.org | Accepted | Renamed from task_implement_agile_timeline.org. |
+| 1 | Generic placeholder description on command task | task_timeline_compass_command.org | Accepted | Real description written. |
+| 1 | Missing branch on command task | task_timeline_compass_command.org | Accepted | feature/timeline-compass-command pre-filled. |
+| 1 | BACKLOG Goal sections are placeholders | task_timeline_*.org | Declined | Convention: filled at pickup; Acceptance already populated. |
+| 1 | Pre-wire blocked_on dependencies | task_timeline_*.org | Declined | blocked_on drives BLOCKED state when actually blocked; ordering lives in the story table. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
@@ -2,7 +2,7 @@
 :ID: 49BE7DB0-0577-4C30-A370-610C0B48FC7F
 :END:
 #+title: Task: Add compass timeline command to list documents changed in a period
-#+description: Add a compass timeline command that lists stories, tasks and captures changed in a given time window, with a now convenience alias for the recent past.
+#+description: Add a compass timeline command with two behaviours: generate the changed-document inputs for an LLM bucket summary, and view the existing timeline (last N buckets) from the sprint's timeline folder.
 #+type: task
 #+level: s1
 #+filetags: :agile_timeline:sprint_20:v0:
@@ -34,10 +34,16 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
-- Window is a parameter (e.g. --since/--from/--to); "now" is a convenience
+Two distinct behaviours:
+
+- /Generate/ (input for the LLM summary): list stories/tasks/captures
+  changed in a window with what changed and id links — the raw material
+  the snapshot skill buckets and writes to the sprint's timeline/ folder.
+  Window is a parameter (e.g. --since/--from/--to); "now" is a convenience
   default, not a hard-coded 20 minutes.
-- Lists stories/tasks/captures changed in the window with what changed and
-  id links.
+- /View/ (read the timeline): show the last N buckets sourced purely from
+  the sprint's timeline/ folder — no change detection, just render what
+  the snapshots already say (e.g. =compass timeline show [-n N]=).
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
@@ -2,12 +2,12 @@
 :ID: 49BE7DB0-0577-4C30-A370-610C0B48FC7F
 :END:
 #+title: Task: Add compass timeline command to list documents changed in a period
-#+description: Initial task for: Agile timeline: bucketed summaries of recent activity
+#+description: Add a compass timeline command that lists stories, tasks and captures changed in a given time window, with a now convenience alias for the recent past.
 #+type: task
 #+level: s1
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/timeline-compass-command
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: EF9E326A-D7A6-42A8-8DB2-53D90A265FED
+:END:
+#+title: Task: Add timeline view to the agile board
+#+description: Third view in ores.org-js/agile: event counts over time buckets (stories raised, tasks raised, stories/tasks worked) as a clickable chart; clicking a bar shows that bucket's snapshot log; defaults to the latest bucket.
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch: feature/timeline-dashboard-view
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -34,7 +34,14 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Assessment first: determine whether graphdata.json and the existing
+  ores.org-js/site infrastructure already carry everything the view needs
+  (snapshot files get :ID:s, so they flow into the export automatically),
+  or whether the export/build needs extending. Record the answer in
+  * Decisions on the story.
+- Timeline view: event counts per time bucket (stories raised, tasks
+  raised, stories/tasks worked) as a clickable chart.
+- Clicking a bucket shows its snapshot log; defaults to the latest bucket.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
@@ -2,7 +2,7 @@
 :ID: 8E94E4FD-9C0D-4467-8126-4E224CEBE6CE
 :END:
 #+title: Task: Stamp the working environment on documents compass touches
-#+description: There is no record of which environment worked on a task or story. Add an environment stamp (e.g. #+environment: from the .env label) written by compass task start/done and journal updates, so timeline snapshots can attribute work per environment.
+#+description: There is no record of which environment worked on a task or story. Add an environment stamp (e.g. #+environment: from the .env label) written by compass task start/done and journal updates — on tasks, and on stories too (which environment started the story) — so timeline snapshots can attribute work per environment.
 #+type: task
 #+level: s1
 #+filetags: :agile_timeline:sprint_20:v0:
@@ -34,7 +34,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Tasks record the environment that worked on them (stamped by compass
+  task start/done from the .env label).
+- Stories record the environment that started them (stamped when the
+  story moves to STARTED).
+- Existing documents are unaffected until next touched; no backfill.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 8E94E4FD-9C0D-4467-8126-4E224CEBE6CE
+:END:
+#+title: Task: Stamp the working environment on documents compass touches
+#+description: There is no record of which environment worked on a task or story. Add an environment stamp (e.g. #+environment: from the .env label) written by compass task start/done and journal updates, so timeline snapshots can attribute work per environment.
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch: feature/timeline-environment-stamp
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: D47C04DD-51F7-4DDB-B4B8-2B4499DEF793
+:END:
+#+title: Task: Add LLM snapshot summarisation skill and sprint timeline storage
+#+description: Skill that runs compass timeline over a window, buckets the changes (new stories, tasks worked, problems, suspicious LLM decisions) and writes a snapshot org file to the sprint's timeline/ folder named <ISO-from>-<ISO-to>.org.
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch: feature/timeline-snapshot-skill
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
@@ -40,6 +40,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
   environment), problems, suspicious LLM decisions.
 - Every row links to the document by id so detail is one click away.
 - Stored under the sprint's timeline/ folder as <ISO-from>-<ISO-to>.org.
+- Bucket size is tunable and treated as an experiment: start around 20
+  minutes, adjust against real activity. A bucket with too many events to
+  scan quickly is a failure — prefer splitting busy windows (event-count
+  cap) over letting buckets grow.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
@@ -34,7 +34,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Snapshots are scan-first: bullet points and tables, not prose. We have
+  too much information already — the snapshot must be readable in seconds.
+- Buckets: stories raised, tasks raised, stories/tasks worked on (per
+  environment), problems, suspicious LLM decisions.
+- Every row links to the document by id so detail is one click away.
+- Stored under the sprint's timeline/ folder as <ISO-from>-<ISO-to>.org.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_temporal_analysis.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_temporal_analysis.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7
+:END:
+#+title: Task: Analyse temporal commands end-to-end for conceptual coherence
+#+description: We now have fleet (what is everyone doing), journal (what was I doing) and the planned timeline (what was everyone doing, reviewed in detail) — discrete commands capturing different aspects of temporality. Step back, analyse end-to-end, and design one coherent model; produce an analysis document the story links to. Gates the implementation tasks.
+#+type: task
+#+level: s1
+#+filetags: :agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -160,6 +160,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | DONE | 2026-06-06 | 2026-06-06 | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
 | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | DONE | 2026-06-06 | 2026-06-07 | PoC succeeded: ores.org-js agile board over graphdata.json, deployed with the site. |
 | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] | STARTED | 2026-06-07 | | Periodic health checks; housekeeping tasks added as the sprint progresses. |
+| [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] | STARTED | 2026-06-07 | | compass timeline command; environment stamping; LLM snapshot skill; board timeline view. |
 
 ** Hotfixes
 


### PR DESCRIPTION
## Summary

Scaffold the agile timeline story: keep up with parallel work across environments without missing problems. Four implementation tasks: a compass timeline command listing documents changed in a period; environment stamping on documents compass touches; an LLM snapshot summarisation skill writing bucketed org files under the sprint's timeline/ folder; and a timeline view in the agile board with event counts and click-through to bucket logs.

## Changes

- Add story with goal, acceptance, tasks table and out-of-scope.
- Add scaffold task plus four implementation tasks (compass command, environment stamp, snapshot skill, board view).
- Wire the story into the Sprint 20 Agile table.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Agile timeline: bucketed summaries of recent activity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/story.html) | 3697D889-BF01-43D4-9EF7-3AF6B70A8122 |
| Task | [Scaffold story: Agile timeline: bucketed summaries of recent activity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/task_scaffold_agile_timeline.html) | 8B8361ED-768B-4B8B-B008-83155D0956B7 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)