### PR TITLE
[ores.shell] Hotfix: export the new shell public surface

### DIFF
--- a/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/story.org
+++ b/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/story.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: A87B7D14-2CB9-47E0-A8EA-1FDCF485860B
+:END:
+#+title: Story: Hotfix: ores.shell tests fail to link on Windows
+#+description: ores.shell.tests.exe fails to link on windows-clang-release-ninja: parse_args, parsed_args::flag_set and the other new command_args/command_feedback/script_runner symbols lack ORES_SHELL_EXPORT, so the DLL does not export them.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:shell:windows:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The Continuous Windows workflow fails linking ores.shell.tests.exe
+(windows-clang-release-ninja): the test binary references
+=parse_args=, =parsed_args::flag_set= and the rest of the new
+command_args / command_feedback / script_runner surface, but those
+declarations were added (PR #1121) without =ORES_SHELL_EXPORT=, so
+the ores.shell DLL does not export them. Linux builds pass because
+symbols are visible by default there. The fix exports the new public
+surface, restoring a green Windows build.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-07                               |
+
+* Acceptance
+
+- ores.shell.tests.exe links on windows-clang-release-ninja; the
+  Continuous Windows workflow is green.
+- Linux build and the shell test suite remain green.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
+++ b/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
@@ -8,7 +8,7 @@
 #+filetags: :shell_windows_tests_link:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-shell-windows-tests-link
-#+pr:
+#+pr: 1166
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -55,7 +55,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1166][#1166]] | [ores.shell] Hotfix: export the new shell public surface |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
+++ b/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :shell_windows_tests_link:sprint_20:v0:
 #+owner: marco
-#+branch: feature/implement-shell-windows-tests-link
+#+branch: hotfix/shell-windows-tests-link
 #+pr: 1166
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
+++ b/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: ACC9BA10-ED57-423C-9565-56624DF42E0D
+:END:
+#+title: Task: Export the new ores.shell public surface
+#+description: Initial task for: Hotfix: ores.shell tests fail to link on Windows
+#+type: task
+#+level: s1
+#+filetags: :shell_windows_tests_link:sprint_20:v0:
+#+owner: marco
+#+branch: feature/implement-shell-windows-tests-link
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add =ORES_SHELL_EXPORT= (ores.shell/export.hpp, Boost symbol macros)
+to the public surface introduced by the provisioning-commands story:
+=parsed_args= and the four parser functions in command_args,
+=command_feedback= and =fail()= in command_feedback, and
+=run_script= in script_runner — the symbols ores.shell.tests.exe
+references across the DLL boundary on Windows.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+- All symbols referenced by the test binary carry the export macro.
+- Linux build + tests stay green (verified locally); Windows link
+  verified by CI on the PR.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+* Result
+
+ORES_SHELL_EXPORT added to parsed_args, parse_args,
+parse_positive_seconds, parse_uint32, parse_uint64 (command_args),
+command_feedback and fail() (command_feedback), and run_script
+(script_runner); export.hpp included in all three headers. Linux
+build and the 23-case shell suite verified green locally; Windows
+link verified by the PR's CI.

--- a/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_scaffold_shell_windows_tests_link.org
+++ b/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_scaffold_shell_windows_tests_link.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: E9BF8CD7-F71B-4EBF-B2CA-B24CC182B787
+:END:
+#+title: Task: Scaffold story: Hotfix: ores.shell tests fail to link on Windows
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :shell_windows_tests_link:sprint_20:v0:
+#+owner: marco
+#+branch: hotfix/shell-windows-tests-link
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -154,6 +154,7 @@ LLM-driven workflow frictionless.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
+| [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] | STARTED | 2026-06-07 | | New command_args/command_feedback/script_runner symbols lack ORES_SHELL_EXPORT; Windows test exe cannot link against the DLL. |
 | [[id:E9CC8354-318C-4B08-B307-25910F536F2E][Hotfix: shell bundles gcc build]] | DONE | 2026-06-06 | 2026-06-06 | linux-gcc-debug-ninja red: four shell command files built std::string from std::vector<std::byte> iterators; converted to ores::nats::as_string_view. PR [[https://github.com/OreStudio/OreStudio/pull/1133][#1133]]. |
 
 * Health Review

--- a/projects/ores.shell/include/ores.shell/app/command_args.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_args.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_SHELL_APP_COMMAND_ARGS_HPP
 #define ORES_SHELL_APP_COMMAND_ARGS_HPP
 
+#include "ores.shell/export.hpp"
 #include <chrono>
 #include <cstdint>
 #include <expected>
@@ -49,7 +50,7 @@ struct flag_spec {
 /**
  * @brief Result of parsing a command's argument tokens.
  */
-struct parsed_args {
+struct ORES_SHELL_EXPORT parsed_args {
     /// Arguments that are not flags, in order of appearance.
     std::vector<std::string> positionals;
     /// Flag name to effective value; switches hold "true"/"false".
@@ -70,7 +71,7 @@ struct parsed_args {
  * direct display to the user. The cli library hands commands plain
  * strings; this is the single place that turns them into options.
  */
-std::expected<parsed_args, std::string>
+ORES_SHELL_EXPORT std::expected<parsed_args, std::string>
 parse_args(const std::vector<std::string>& tokens,
            const std::vector<flag_spec>& specs);
 
@@ -78,20 +79,20 @@ parse_args(const std::vector<std::string>& tokens,
  * @brief Parse a duration flag value as a positive whole number of
  * seconds. Rejects partial numbers ("30x"), zero and negatives.
  */
-std::optional<std::chrono::seconds>
+ORES_SHELL_EXPORT std::optional<std::chrono::seconds>
 parse_positive_seconds(const std::string& value);
 
 /**
  * @brief Parse a flag value as an unsigned 32-bit integer.
  * Rejects partial numbers, negatives and out-of-range values.
  */
-std::optional<std::uint32_t> parse_uint32(const std::string& value);
+ORES_SHELL_EXPORT std::optional<std::uint32_t> parse_uint32(const std::string& value);
 
 /**
  * @brief Parse a flag value as an unsigned 64-bit integer.
  * Rejects partial numbers, negatives and out-of-range values.
  */
-std::optional<std::uint64_t> parse_uint64(const std::string& value);
+ORES_SHELL_EXPORT std::optional<std::uint64_t> parse_uint64(const std::string& value);
 
 }
 

--- a/projects/ores.shell/include/ores.shell/app/command_feedback.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_feedback.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_SHELL_APP_COMMAND_FEEDBACK_HPP
 #define ORES_SHELL_APP_COMMAND_FEEDBACK_HPP
 
+#include "ores.shell/export.hpp"
 #include <iosfwd>
 
 namespace ores::shell::app {
@@ -37,7 +38,7 @@ namespace ores::shell::app {
  * one thread, and nested script executions share the same flag so an
  * inner abort propagates to the outer script.
  */
-class command_feedback final {
+class ORES_SHELL_EXPORT command_feedback final {
 public:
     command_feedback() = delete;
 
@@ -57,7 +58,7 @@ public:
  *
  * Usage: fail(out) << "Request failed: " << e.what() << std::endl;
  */
-std::ostream& fail(std::ostream& out);
+ORES_SHELL_EXPORT std::ostream& fail(std::ostream& out);
 
 }
 

--- a/projects/ores.shell/include/ores.shell/app/script_runner.hpp
+++ b/projects/ores.shell/include/ores.shell/app/script_runner.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_SHELL_APP_SCRIPT_RUNNER_HPP
 #define ORES_SHELL_APP_SCRIPT_RUNNER_HPP
 
+#include "ores.shell/export.hpp"
 #include <functional>
 #include <iosfwd>
 #include <string>
@@ -51,7 +52,7 @@ struct script_result {
  * the keep-going behaviour. The runner is separated from the load
  * command so these semantics are unit-testable without a cli session.
  */
-script_result run_script(std::istream& in,
+ORES_SHELL_EXPORT script_result run_script(std::istream& in,
                          const std::function<void(const std::string&)>& feed,
                          std::ostream& out,
                          bool continue_on_error);


### PR DESCRIPTION
## Summary

Continuous Windows is red: ores.shell.tests.exe cannot link on windows-clang-release-ninja because the command_args/command_feedback/script_runner surface added by the provisioning-commands story (PR #1121) carries no ORES_SHELL_EXPORT — the DLL does not export the symbols the test binary references, while Linux passes on default visibility. Adds the export macro (Boost symbol macros via ores.shell/export.hpp) to parsed_args, the four parser functions, command_feedback, fail() and run_script. Linux build and the 23-case shell suite verified locally; Windows link to be confirmed by this PR's CI.

## Changes

- ORES_SHELL_EXPORT on the new public surface across the three headers; export.hpp included.
- Hotfix story wired into the sprint Hotfixes table; both tasks closed on the branch.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: ores.shell tests fail to link on Windows](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/story.html) | A87B7D14-2CB9-47E0-A8EA-1FDCF485860B |
| Task | [Export the new ores.shell public surface](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/shell_windows_tests_link/task_implement_shell_windows_tests_link.html) | ACC9BA10-ED57-423C-9565-56624DF42E0D |

🤖 Generated with [Claude Code](https://claude.com/claude-code)