### PR TITLE
[agile] Sprint 20 housekeeping: close stories, fix status drift

### DIFF
--- a/doc/agile/versions/v0/sprint_20/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_20/commission_currency/story.org
@@ -26,12 +26,12 @@ same checklist applies.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | STARTED                                |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Qt verification in progress; history timestamps blocked on timestamp unification story. |
+| Now           | Blocked — Qt task waiting on timestamp unification story (inbox). |
 | Waiting on    | [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp fields]] — currency history shows epoch until fixed. |
 | Next          | Resume task_verify_qt once timestamp story is DONE.   |
-| Last touched  | 2026-06-03                                            |
+| Last touched  | 2026-06-07                                            |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_20/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_20/commission_currency/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :product:refdata:commissioning:currency:sprint_20:v0:
 #+created: 2026-05-29
-#+updated: 2026-06-06
+#+updated: 2026-06-07
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -77,6 +77,6 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 | [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]] | DONE | 2026-05-29 | 2026-05-30 | SQL zero-diff; component path fix in three auxiliaries; currency_domain_entity.json confirmed unnecessary; C++ drift filed. |
 | [[id:1816FAA3-B987-4307-B265-EBF6EDEE93AA][Verify and fix currency CLI commands]] | DONE | 2026-05-29 | 2026-05-29 | Confirm list/add/remove exist; implement missing; run against live service. |
 | [[id:3D394DE4-7101-4E4B-A774-DD583BC5F0B0][Verify currency shell commands and NATS integration]] | DONE | 2026-05-29 | 2026-05-31 | Run list/add/remove/history in shell; validates NATS end-to-end. |
-| [[id:E276A541-93EA-46EC-8CD8-D40803FEE587][Verify currency Qt UI end-to-end post-NATS]] | BACKLOG | | | Manually test MDI list, detail, history, delete, eventing. |
+| [[id:E276A541-93EA-46EC-8CD8-D40803FEE587][Verify currency Qt UI end-to-end post-NATS]] | BLOCKED | | | Manually test MDI list, detail, history, delete, eventing. Blocked on timestamp unification story. |
 | [[id:C6870B89-A806-4657-B75B-7B333946281D][Fix duplicate refdata rows: add tenant filters to auxiliary repositories]] | DONE | 2026-06-04 | 2026-06-05 | Rounding/monetary-nature/market-tier repos read unfiltered; apply change_reason tenant-filter pattern. |
 | [[id:B3788A76-208E-4422-B277-17DF8FF3A78C][Write currency documentation (manual chapter, recipes, NATS reference)]] | DONE | 2026-06-06 | 2026-06-06 | Manual chapter, CLI recipe, shell recipe, NATS message reference. |

--- a/doc/agile/versions/v0/sprint_20/open_sprint_20/story.org
+++ b/doc/agile/versions/v0/sprint_20/open_sprint_20/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :agile:sprint:ceremony:sprint_20:v0:
 #+created: 2026-06-06
-#+updated: 2026-06-06
+#+updated: 2026-06-07
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.

--- a/doc/agile/versions/v0/sprint_20/open_sprint_20/story.org
+++ b/doc/agile/versions/v0/sprint_20/open_sprint_20/story.org
@@ -20,12 +20,12 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED |
+| State         | DONE                                   |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | PR 2: open sprint 20 (this PR). |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Merge PR 2; close the ceremony task. |
-| Last touched  | 2026-06-06                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-07                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -159,6 +159,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 |-------+-------+-------+-----+-------------|
 | [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | DONE | 2026-06-06 | 2026-06-06 | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
 | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | DONE | 2026-06-06 | 2026-06-07 | PoC succeeded: ores.org-js agile board over graphdata.json, deployed with the site. |
+| [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] | STARTED | 2026-06-07 | | Periodic health checks; housekeeping tasks added as the sprint progresses. |
 
 ** Hotfixes
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -7,7 +7,7 @@
 #+level: s3
 #+filetags: :v0:
 #+created: 2026-06-06
-#+updated: 2026-06-06
+#+updated: 2026-06-07
 #+todo: STARTED | DONE
 
 #+startup: inlineimages

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -51,7 +51,7 @@ by file move — IDs and task history intact.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] | STARTED | 2026-06-06 | | Carried at 6/8: codegen, SQL, CLI, shell verified; documentation in flight on feature/currency-write-docs; Qt verification blocked. |
+| [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] | STARTED | 2026-06-06 | | 7/8 tasks done; Qt verification blocked on timestamp unification story (inbox). |
 | [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] | BLOCKED | 2026-06-06 | | Verify Qt + shell + CLI (existing); manual; Wt/HTTP captures. |
 | [[id:FA87AB1F-E0ED-4AC3-A41E-43321626B77C][Commission: party]] | BACKLOG | | | Verify Qt; implement shell + CLI; manual; Wt/HTTP captures. |
 | [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] | BACKLOG | | | Verify Qt; implement shell + CLI; manual; Wt/HTTP captures. |
@@ -150,14 +150,14 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | STARTED | 2026-06-07 | | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. |
+| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-07 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | STARTED | 2026-06-06 | | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
+| [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | DONE | 2026-06-06 | 2026-06-06 | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
 | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | DONE | 2026-06-06 | 2026-06-07 | PoC succeeded: ores.org-js agile board over graphdata.json, deployed with the site. |
 
 ** Hotfixes

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: 3FBD411B-B795-48C5-9EF8-1B76A96B12B5
+:END:
+#+title: Story: Sprint health review — System 2 analysis
+#+description: Periodic System 2 health checks for sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict written into sprint.org.
+#+type: story
+#+level: s2
+#+filetags: :agile:review:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Periodic System 2 health checks for sprint 20 using the
+=sprint-reviewer= skill. Each review produces a structured health
+report written into =sprint.org= under =* Health Review=, covering
+goal alignment, load, PR velocity, story/task balance, focus signal,
+and an overall red/amber/green verdict. Reviews are deliberately slow
+and critical — they question whether stories serve sprint goals and
+whether the team is focused — rather than merely summarising status.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                                |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Health review 1 done; sprint in flight. |
+| Waiting on    | Nothing.                               |
+| Next          | Add further review tasks as the sprint progresses. |
+| Last touched  | 2026-06-07                               |
+
+* Acceptance
+
+- Each invocation of =sprint-reviewer= produces a =* Health Review=
+  section written into =sprint.org= covering:
+  - *Goal alignment* — story coverage per sprint goal; uncovered goals
+    and stories with no clear goal flagged.
+  - *Sprint load* — commit count, elapsed days, commits/day, projected
+    total; verdict against ≤ 300 commit / ≤ 7 day targets.
+  - *PR velocity* — PRs merged per day, open PRs, WIP accumulation.
+  - *Story and task balance* — undecomposed stories, longest-open STARTED
+    stories, DONE/total ratio.
+  - *Focus signal* — simultaneously STARTED stories; cross-cutting themes.
+  - *Overall verdict* — red/amber/green per dimension, one-paragraph narrative.
+- The section is idempotent: re-running replaces the existing block.
+- Each review round is recorded in a dedicated task with the full findings
+  in =* Result=; only a short summary link remains in =sprint.org=.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:4F17BC82-00B5-43DE-B618-A87801763479][Health review 1 — sprint 20 housekeeping and status sync]] | DONE | 2026-06-07 | 2026-06-07 | Audit-driven housekeeping: close Open sprint 20 and site navbar stories, fix Commission: currency status drift, run sprint audit and health charts. |
+
+* Decisions
+
+- Uses the existing [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]] pattern
+  established in sprint 18/19; no new tooling required.
+- Full review content lives in the task =* Result= section, not in
+  =sprint.org=, to keep the sprint doc concise.
+
+* Out of scope
+
+- Automated remediation of story or task state.
+- Historical comparison across sprints.
+- Blocking CI or PRs on health verdicts.

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_health_review_1_housekeeping.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_health_review_1_housekeeping.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 4F17BC82-00B5-43DE-B618-A87801763479
+:END:
+#+title: Task: Health review 1 — sprint 20 housekeeping and status sync
+#+description: Audit-driven housekeeping: close Open sprint 20 and site navbar stories, fix Commission: currency status drift, run sprint audit and health charts.
+#+type: task
+#+level: s1
+#+filetags: :agile:review:sprint_20:v0:sprint_health_review:
+#+owner: marco
+#+branch: chore/sprint-housekeeping
+#+pr: 1167
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Run =compass sprint audit= to surface state drift; close the "Open
+sprint 20" and "Replace site navbar" stories; update Commission:
+currency status to surface the Qt task block; run =compass sprint
+charts= to generate the first sprint 20 health charts.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+- Sprint audit run; findings actioned.
+- "Open sprint 20" story closed (State → DONE).
+- "Replace site navbar" sprint table row corrected to DONE.
+- Commission: currency =Now= field updated to surface the block.
+- Sprint health charts generated.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1167][#1167]] | [agile] Sprint 20 housekeeping: close stories, fix status drift |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Sprint audit (14 → 12 findings) surfaced three state-drift items.
+Actioned: "Open sprint 20" story closed (State DONE, Now Nothing.);
+sprint table row for "Replace site navbar" corrected to DONE with end
+date 2026-06-07; Commission: currency story =Now= updated from "Qt
+verification in progress" to "Blocked — Qt task waiting on timestamp
+unification story (inbox)". Sprint health charts generated: 3 days,
+60 merged PRs, 8 story transitions.


### PR DESCRIPTION
## Summary

Sprint 20 agile housekeeping following the merge of PR #1164 (site nav). Marks 'Replace site navbar' and 'Open sprint 20' DONE in the sprint table and story files; clarifies that Commission: currency's Qt task is blocked on the timestamp unification story in the inbox.

## Changes

- `sprint.org`: mark 'Replace site navbar' and 'Open sprint 20' DONE with end dates; correct currency row description to 7/8 tasks done.
- `open_sprint_20/story.org`: State STARTED → DONE, status fields cleared.
- `commission_currency/story.org`: `Now` updated to clearly surface the Qt task block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)