### PR TITLE
[doc] Gate the PR review round on unaddressed comments

### DIFF
--- a/doc/agile/product_backlog/inbox/shell_visibility_hidden_straggler.org
+++ b/doc/agile/product_backlog/inbox/shell_visibility_hidden_straggler.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 9B90399C-09DF-45A7-8097-59F39338DE00
+:END:
+#+title: Apply -fvisibility=hidden to ores.shell (visibility-migration straggler)
+#+description: The symbol-visibility migration set -fvisibility=hidden per shared library, but ores.shell never received the flag (it was slated to become static instead and stayed shared). Its Linux .so exports ~34k symbols by default, which masked the missing ORES_SHELL_EXPORT macros that broke the Windows test link (hotfix PR #1166). Add the flag (and -fvisibility-inlines-hidden) to projects/ores.shell/src/CMakeLists.txt like its peers, fix whatever additional exports surface, so Linux catches missing macros at dev time.
+#+type: capture
+#+level: cross
+#+filetags: :shell:build:infrastructure:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
@@ -30,7 +30,7 @@ captures, story search by exact folder name, and a task move command.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                                   |
+| State         | STARTED                                   |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | All 10 tasks shipped and merged.       |
 | Waiting on    | Nothing.                               |
@@ -63,6 +63,7 @@ captures, story search by exact folder name, and a task move command.
 | [[id:BCA13EA7-BB80-4EE6-8347-CC5D4DD098BB][Boost recipe results for 'how do' queries]] | DONE | 2026-06-06 | 2026-06-06 | When a search query starts with 'how do', rank recipe docs first regardless of FTS score — recipes are titled as the question they answer and are almost always the right result. |
 | [[id:53CE8498-7469-4063-863D-EEC4F901571E][Add scoped search to compass]] | BACKLOG | | | compass search cannot be restricted to a repo path or doc type; backlog-only full-text search currently requires raw grep. |
 | [[id:1BD08842-A987-4FD0-AFFC-FA73FEEC7077][compass capture promote copies the capture's What section in…]] | BACKLOG | | | compass capture promote copies the capture's What section into the task Goal verbatim, including the '(One paragraph: the idea.)' template placeholder when the capture body was never filled in, and appends an all-placeholder 'Promoted from capture' section. Promote should detect placeholder What/Why/References/See-also content (the literal template strings), fall back to the capture description for the goal, and omit empty placeholder subsections from the promoted body. |
+| [[id:9A548F0C-659A-4DE9-A44D-97DA0365309F][Gate the PR review round on unaddressed comments]] | DONE | 2026-06-07 | 2026-06-07 | pr-address-review and its runbook synced/rebased before checking whether a round existed, churning CI and force-pushing for nothing. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_gate_pr_review_round.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_gate_pr_review_round.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:runbook:pr:compass_quality_of_life:sprint_20:v0:
 #+owner: marco
 #+branch: feature/pr-review-round-gate
-#+pr:
+#+pr: 1169
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -48,7 +48,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1169][#1169]] | [doc] Gate the PR review round on unaddressed comments |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_gate_pr_review_round.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_gate_pr_review_round.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 9A548F0C-659A-4DE9-A44D-97DA0365309F
+:END:
+#+title: Task: Gate the PR review round on unaddressed comments
+#+description: pr-address-review and its runbook synced/rebased before checking whether a round existed, churning CI and force-pushing for nothing.
+#+type: task
+#+level: s1
+#+filetags: :llm:runbook:pr:compass_quality_of_life:sprint_20:v0:
+#+owner: marco
+#+branch: feature/pr-review-round-gate
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a step-0 gate to the handle-PR-review-round runbook and the pr-address-review skill: read the comments first; stop (without syncing) when no comments exist yet, the reviewer is still running, or every comment is already replied and resolved. Sync/rebase only when there is an actual round to handle.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-07                               |
+
+* Acceptance
+
+- Runbook and skill both lead with the gate; deployed skill regenerated.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+* Result
+
+Gate added as step 0 of the handle-PR-review-round runbook and step 1
+of the pr-address-review skill; skills rebuilt. Trigger: review
+rounds run on PR #1163 synced and force-pushed before discovering the
+reviewers had not even posted yet.

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -25,6 +25,15 @@ Handle one complete review round: sync with main, read all review comments, deci
 
 In execution order:
 
+0. /Gate: confirm there is a round to handle./ =compass review list <N>
+   --detail= before anything else:
+   - No comments yet, or the reviewer is still running ("Working on
+     review…" placeholders) → stop and wait; do not sync.
+   - Every comment already has a reply and all threads are resolved →
+     the round is done; stop.
+   Only proceed when unaddressed comments exist. Syncing first churns
+   CI and forces a force-push even when there is nothing to do.
+
 1. /Sync with main./ =compass pr sync= — fetch, rebase, and report; on conflicts it stops with the conflicted files and the ways out. Never address review comments on a stale branch.
 
 2. /Check CI status./ Before reading comments, inspect the current CI state:

--- a/doc/llm/skills/pr-address-review/SKILL.org
+++ b/doc/llm/skills/pr-address-review/SKILL.org
@@ -24,7 +24,13 @@ Review comments arrived on a PR: handle one complete round — sync, read, decid
 
 * How to use this skill
 
-1. /Sync with main first/:
+1. /Gate — confirm there is a round to handle/: =compass review list
+   <N> --detail=. No comments yet, or the reviewer still running →
+   stop and wait. Every comment replied and threads resolved → round
+   already done; stop. Never sync/rebase when there is nothing to
+   address — it churns CI and forces a force-push.
+
+2. /Sync with main/:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh pr sync


### PR DESCRIPTION
## Summary

The pr-address-review skill and its runbook started every round with compass pr sync — even when the reviewers had not posted yet or every comment was already handled — rebasing the branch, churning CI and forcing force-pushes for nothing (observed live on PR #1163). Both now lead with a gate: read the comments first, and stop without syncing when there is no round to handle. Task closed on the branch.

## Changes

- Runbook handle_pr_review_round: step-0 gate before sync.
- Skill pr-address-review: gate as step 1.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality of life](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.html) | EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38 |
| Task | [Gate the PR review round on unaddressed comments](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_gate_pr_review_round.html) | 9A548F0C-659A-4DE9-A44D-97DA0365309F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)