### PR TITLE
[agile] Close story: Convert codegen mustache templates to literate org-mode docs

### DIFF
--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/story.org
@@ -41,12 +41,12 @@ which lives on as the rollout task below.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Replacing file: links with proj: across the docs (last task). |
+| Now           | Done.                                  |
 | Waiting on    | Nothing.                               |
-| Next          | Close the story once the link cleanup merges. |
-| Last touched  | 2026-06-06                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-07                               |
 
 * Acceptance
 
@@ -68,7 +68,7 @@ which lives on as the rollout task below.
 | [[id:675045C6-61AE-405D-817F-8501064C64D2][Design the literate template layout and tangle workflow]] | DONE | 2026-06-06 | 2026-06-06 | Decide file layout, grouping, tangle tooling and drift check; prove with a pilot batch. |
 | [[id:76178191-E20D-4479-BC01-79B877247D03][Tangle all mustache templates from facet-documenting org files]] | DONE | 2026-06-06 | 2026-06-06 | Every mustache template should be tangled from an org-mode file that documents its facet (literate style, as with the gnuplot charts). Each facet group gets a 'namespace' org file documenting the group, and a top-level file describes all the groups — a three-level literate hierarchy: template <- facet doc <- group doc <- groups overview. |
 | [[id:DDE8CF4A-3883-40D1-9BC0-19706162B70A][Add facet and facet-group doc types to compass and codegen]] | DONE | 2026-06-06 | 2026-06-06 | The literate template hierarchy introduces two new document types — the facet doc (one per template family, tangling to its .mustache files) and the facet grouping doc (namespace page per group). Teach ores.codegen generate_doc and compass add to scaffold both, so facet docs are never hand-rolled from the generic knowledge type. |
-| [[id:C771C122-3A96-48FB-BCF0-AE7D38CD526E][Replace file: links with proj: links across the documentation]] | STARTED | 2026-06-06 | | Audit every org document for file: links pointing at repo files (sources, JSON, scripts, images) and convert them to proj: links, which export to GitHub blob URLs on the published site. file: links to non-org files 404 because the site build only publishes org->html; found via the profiles.json links in the template-library docs. |
+| [[id:C771C122-3A96-48FB-BCF0-AE7D38CD526E][Replace file: links with proj: links across the documentation]] | DONE | 2026-06-06 | 2026-06-07 | Audit every org document for file: links pointing at repo files (sources, JSON, scripts, images) and convert them to proj: links, which export to GitHub blob URLs on the published site. file: links to non-org files 404 because the site build only publishes org->html; found via the profiles.json links in the template-library docs. |
 | [[id:C4473D28-E366-468C-AAED-36CE8C374EDB][Refine the cpp facet grouping]] | DONE | 2026-06-06 | 2026-06-06 | The cpp group's 58 templates landed in five facets, but the split is coarse: cpp_domain_type holds 22 templates and cpp_service mixes two distinct families (component-service scaffolding vs the per-entity service pair). Analyse the set against the profiles and the MASD facet definitions and re-cut into finer, more cohesive facets. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_literate_templates/task_replace_file_links_with_proj_links.org
@@ -25,11 +25,11 @@ No org document links a repo file via file: when the target is not published as 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org-mode documents]] |
-| Now          | Audit done, links converted; awaiting PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR review, then close the story.       |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -75,3 +75,10 @@ exists.
 | 3 | Round 1 (claude bot): missing blank line after ~(load-file ...)~ before ~(defvar ores/margin-max-w)~ | =ores-build-manual.el= | Accept | Fixed in f800bb179 — minor readability nit |
 
 * Result
+
+PR #1161 merged. 491 org files updated: 63 files gained =proj:= image links
+and =id:= org-roam cross-references; 428 files had verbatim path spans
+converted to clickable =[[proj:path][=display=]]= links. A new
+=ores-link-types.el= module centralises =proj:= link handling for HTML, LaTeX,
+and Emacs inline display. The manual build gains git-hash version strings and
+log preservation. Site and manual both build cleanly.


### PR DESCRIPTION
## Summary

Recovers the story closure commit that was left on `feature/codegen-literate-templates` after PR #1161 squash-merged. The other 3 commits on that branch were already in main; only the closure bookkeeping was missing.

## Changes

- `codegen_literate_templates/story.org`: State STARTED → DONE; task row for `Replace file: links` updated to DONE with end date.
- `codegen_literate_templates/task_replace_file_links_with_proj_links.org`: State STARTED → DONE; Result section filled in (491 files updated, new `ores-link-types.el` module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)