### PR TITLE
[agile] Close tasks: capture --commit (#1142) and folder-name search (#1147)

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_add_support_to_compass_to_search_stories_by_folder_name.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_add_support_to_compass_to_search_stories_by_folder_name.org
@@ -27,11 +27,11 @@ without having to do this.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -81,6 +81,15 @@ Two changes in =compass.py=:
 |   |                 |      |          |       |
 
 * Result
+
+Folder-slug queries (e.g. =user_manual_pdf_build=) now split on underscores
+to build a proper OR query instead of a single FTS5 phrase. Folder-local docs
+are injected directly from the doc index so the story always ranks first even
+when component words are too common to surface in the FTS top-N. =resolve_story=
+gains current-sprint preference when a slug matches stories across multiple
+sprints, reporting candidates when still ambiguous. Two follow-on BACKLOG tasks
+wired into the story: inbound-link-count ranking boost and recipe-first float
+for =how do= queries.
 
 * Promoted from capture
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_commit_option.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_commit_option.org
@@ -32,11 +32,11 @@ trailer.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-06                               |
 
 * Acceptance
@@ -69,6 +69,14 @@ task closes. Plans do not outlive their task.)
 | 2 | Build the commit message by joining non-empty parts, not hardcoded newlines | projects/ores.compass/src/compass.py | Accepted | Fixed in 2895ba87b; retested live. |
 
 * Result
+
+Shipped =--commit= on =compass add capture= / =compass capture --note=.
+Stages only the capture file and regenerated bucket indexes, commits with
+=[agile] Capture: <title>=, description as body, and the house
+=Co-Authored-By:= trailer. Two review findings addressed in =2895ba87b=:
+fail fast on non-zero regen exit code; join non-empty message parts rather
+than hardcoded newlines. All acceptance criteria met; behaviour without
+=--commit= unchanged.
 
 * Promoted from capture
 


### PR DESCRIPTION
## Summary

Recovers the task closure commit stranded on `feature/add-support-to-compass-to-search-stories-by-folder-name` after PRs #1142 and #1147 squash-merged. One commit, two task docs closed.

## Changes

- `task_add_support_to_compass_to_search_stories_by_folder_name.org`: State STARTED → DONE; Result section filled in.
- `task_capture_commit_option.org`: State STARTED → DONE; Result section filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)