### PR TITLE
[compass] Add timeline command: generate and show

### DIFF
--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -58,7 +58,7 @@ event counts over time with click-through to each bucket's log.
 |----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
 | [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | DONE | 2026-06-07 | 2026-06-07 | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
-| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | STARTED | 2026-06-07 |     | Generate LLM inputs (changed docs per window); view last N buckets. |
+| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | BACKLOG |            |     | Event-count chart with click-through to bucket snapshots.         |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -58,7 +58,7 @@ event counts over time with click-through to each bucket's log.
 |----------------------------------------------------------------------------------------------------+---------+------------+-----+-------------------------------------------------------------------|
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
 | [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | DONE | 2026-06-07 | 2026-06-07 | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
-| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | BACKLOG |            |     | Generate LLM inputs (changed docs per window); view last N buckets. |
+| [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | STARTED | 2026-06-07 |     | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | BACKLOG |            |     | Event-count chart with click-through to bucket snapshots.         |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
@@ -28,11 +28,11 @@ folder).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
@@ -87,3 +87,13 @@ New =compass_timeline.py= module following the =compass_review.py=
 |   |                 |      |          |       |
 
 * Result
+
+=compass timeline= shipped (PR #1175) with generate (consistent-substrate
+events: doc created/state/updated from origin/main git history +
+environment stamps when present + gh PR opened/merged; --since/--from/--to
+windows; pretty and json), the now alias, and show -n over the sprint
+timeline/ folders. Scan-ability guards built in: bulk sweeps collapse to a
+single line and repeated updates of one document coalesce with a count.
+Verified against real history (6h window: state transitions, creations,
+two 297-doc sweeps collapsed, PR stream) and from-fresh-checkout semantics
+hold by construction (origin/main only).

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
@@ -8,7 +8,7 @@
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
 #+branch: feature/timeline-compass-command
-#+pr:
+#+pr: 1175
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -78,7 +78,7 @@ New =compass_timeline.py= module following the =compass_review.py=
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1175][#1175]] | [compass] Add timeline command: generate and show |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.org
@@ -19,13 +19,16 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add =compass timeline= with the two behaviours the story defines: generate
+(the changed-document event list for a window, from consistent data only)
+and show (render the last N snapshot buckets from the sprint's timeline/
+folder).
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
@@ -51,9 +54,23 @@ Two distinct behaviours:
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+New =compass_timeline.py= module following the =compass_review.py=
+=run(argv, project_root)= pattern, early-dispatched from =compass.py=.
+
+- =timeline generate [--since 20m | --from A --to B] [-f pretty|json]=:
+  events mined from =git log origin/main -- doc/agile= within the window —
+  file adds become /created/ events; modifications are diffed for the
+  Status table's State row (old vs new via =git show sha^:path= /
+  =sha:path=) to become /state/ or /updated/ events. Each event carries
+  time, action, doc type, title, :ID:, path, state transition, the
+  =#+environment:= stamp when present (forward-compatible with the
+  stamping task), and commit sha. PR events (opened/merged in window)
+  joined from gh; degrade with a warning when gh is unavailable.
+- =timeline now= — alias for generate with the default window.
+- =timeline show [-n N]=: glob =doc/agile/versions/*/sprint_*/timeline/*.org=,
+  sort by the ISO-range filename, print the newest N.
+- No journal input anywhere, per the
+  [[id:551FC710-7E3C-484B-AB52-7F2C8DAF3B6F][coherence investigation]]: identical output from any fresh checkout.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T0000-20260607T0800.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T0000-20260607T0800.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 0B71165B-8234-4391-97F2-2929D95D440C
+:END:
+#+title: Timeline: 2026-06-07 00:00 → 08:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Overnight push: agile dashboard PoC finished and merged; two new
+  stories scaffolded (codegen docs/MASD cleanup, site navbar); CI
+  classifier and staggered-build work landed; provisioning script
+  work started.
+
+* Stories
+
+| Story | Event | Notes |
+|-------+-------+-------|
+| [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC]] | STARTED → DONE | PoC success; merged PR #1157. |
+| [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] | created (STARTED) | Scaffold + 3 tasks; PR #1162 merged 02:11. |
+| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | created (STARTED) | Scaffold; design task picked up immediately. |
+
+* Tasks
+
+| Task | Event | Notes |
+|------+-------+-------|
+| Research JS libraries / org-mode parsing | BACKLOG → STARTED → DONE | The PoC implementation task, full lifecycle in one session. |
+| Move main builds to staggered schedules | BACKLOG → STARTED → DONE | PRs #1159/#1160. |
+| Design and implement the site navigation menu | BACKLOG → STARTED | |
+| Write the end-to-end provision_all script | BACKLOG → STARTED | |
+
+* Captures
+
+| Capture | Notes |
+|---------+-------|
+| Enforce task result written before PR merge | Process gap found during close-outs. |
+| Port serve-site.sh to compass | From dashboard PoC verification. |
+| compass review reply 404s on conversation comments | Tooling bug found addressing PoC review. |
+| Synthetic parties created Active, bypassing party seeder | Product bug. |
+| System wizard single-tenant default hostname collision | Product bug. |
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1156 | merged | PR classifier and pr-gate workflow |
+| #1157 | opened+merged | org-js agile board PoC |
+| #1158, #1160 | opened+merged | agile bookkeeping |
+| #1159 | opened+merged | staggered continuous builds |
+| #1161 | opened | codegen proj: link type (large sweep) |
+| #1162 | opened+merged | codegen docs story scaffold |
+| #1163, #1164 | opened | provisioning script; navbar |
+
+* Problems and suspicious decisions
+
+- PR #1157 was admin-merged with =--force= while CI was still pending —
+  deliberate (user instructed) but worth tracking as a pattern.
+- Five captures in one window suggests healthy problem surfacing, but
+  two are product bugs (synthetic parties, wizard hostname) with no
+  linked story yet.
+
+* Audit
+
+- No environment stamps exist yet (stamping task pending) — per-event
+  attribution unavailable in this window.

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T0900-20260607T1000.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T0900-20260607T1000.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 9860C550-503F-4A2A-8F06-BB2DDFD1BACB
+:END:
+#+title: Timeline: 2026-06-07 09:00 → 10:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Navbar story closed; provisioning scripts task closed; the #1161
+  proj-link sweep merged, touching 297 documents — twice.
+
+* Stories
+
+| Story | Event | Notes |
+|-------+-------+-------|
+| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | STARTED → DONE | Same-day story: scaffolded 02:23, done 09:53. |
+
+* Tasks
+
+| Task | Event | Notes |
+|------+-------+-------|
+| Design and implement the site navigation menu | STARTED → DONE | |
+| Create the script library in ores.shell | STARTED → DONE | |
+| Write the end-to-end provision_all script | STARTED → DONE | |
+
+* Captures
+
+| Capture | Notes |
+|---------+-------|
+| Create MASD personas and link to cybernetic levels | |
+| Consider extending compass to use vector database techniques | *Created twice* — see audit. |
+| Parameterize raw SQL in the synthetic organisation publisher | |
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1161 | merged | codegen proj: link type across documentation |
+
+* Problems and suspicious decisions
+
+- The #1161 sweep applied twice: commits b9ef64f0d and d01cd8f05 each
+  touch the same 297 documents with the same subject ten minutes
+  apart. Likely a rebase/re-merge artefact — harmless if idempotent,
+  but the duplicated history doubles the apparent churn.
+
+* Audit
+
+- Duplicate capture: "Consider extending compass to use vector
+  database techniques" appears created in both sweep commits —
+  verify only one file exists on main.
+- No environment stamps yet — attribution unavailable.

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T1000-20260607T1100.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T1000-20260607T1100.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: 7439BD46-5FFA-4B89-BE6F-B5E7CC4045A5
+:END:
+#+title: Timeline: 2026-06-07 10:00 → 11:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Windows shell link failure hotfixed (story created with work already
+  done); sprint 20 opening ceremony closed; timeline story PR opened.
+
+* Stories
+
+| Story | Event | Notes |
+|-------+-------+-------|
+| [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] | created (STARTED) | Tasks arrived already DONE — post-hoc bookkeeping. |
+| [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | STARTED → DONE | Opening ceremony complete. |
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1165 | opened | agile timeline story scaffold |
+| #1164 | merged | hierarchical dropdown site menu |
+| #1166 | opened | shell public-surface hotfix |
+| #1167 | opened | sprint 20 housekeeping / status drift |
+
+* Problems and suspicious decisions
+
+- The hotfix story's tasks were created in state DONE — acceptable
+  for hotfixes (work precedes paperwork) but the pattern hides cycle
+  time; flag if it spreads to non-hotfix stories.
+
+* Audit
+
+- PR #1167 ("fix status drift") existing at all means drift had
+  accumulated — the states fixed there drifted without timeline
+  visibility; exactly what these snapshots are for.
+- No environment stamps yet — attribution unavailable.

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T1100-20260607T1200.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T1100-20260607T1200.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 9863C02D-E4F7-432A-85C9-51EE8FC1CE2C
+:END:
+#+title: Timeline: 2026-06-07 11:00 → 12:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Housekeeping wave: sprint health review story created and its first
+  review completed; mustache→literate-org story closed; two stale
+  compass QoL tasks closed; review-round gate added.
+
+* Stories
+
+| Story | Event | Notes |
+|-------+-------+-------|
+| [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] | created (STARTED) | First health review task arrived DONE. |
+| [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] | DONE → STARTED | *State regression* — see audit. |
+| [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Convert codegen mustache templates to literate org]] | STARTED → DONE | |
+
+* Tasks
+
+| Task | Event | Notes |
+|------+-------+-------|
+| Replace file: links with proj: links | STARTED → DONE | Long-running; closed by housekeeping. |
+| compass search by folder name | STARTED → DONE | Closed via PR #1171. |
+| capture --commit option | STARTED → DONE | Closed via PR #1171. |
+| Gate the PR review round on unaddressed comments | created (DONE) | Process improvement, immediate. |
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1167 | merged | sprint 20 housekeeping |
+| #1168 | opened | MASD knowledge docs + TS physical model |
+| #1169 | opened | review-round gate |
+| #1170 | opened+merged | close mustache story |
+| #1171 | opened+merged | close two compass tasks |
+
+* Problems and suspicious decisions
+
+- "Compass quality of life" went DONE → STARTED: a story reopened
+  after being closed. Legitimate (new tasks added) but reopening
+  closed stories silently distorts sprint metrics — prefer successor
+  stories.
+
+* Audit
+
+- Three bookkeeping-only PRs (#1167/#1170/#1171) in one hour: states
+  had drifted from reality and were batch-corrected.
+- No environment stamps yet — attribution unavailable.

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T1200-20260607T1300.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T1200-20260607T1300.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 71A2D38B-7021-48E0-9AB6-B90C6DCBD0B4
+:END:
+#+title: Timeline: 2026-06-07 12:00 → 13:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Agile timeline story scaffolded (5 tasks) and its temporal-coherence
+  analysis task executed start-to-finish; methodology manual capture;
+  two compass bugs captured.
+
+* Stories
+
+| Story | Event | Notes |
+|-------+-------+-------|
+| [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] | created (STARTED) | Scaffold PR #1165 merged 12:19. |
+
+* Tasks
+
+| Task | Event | Notes |
+|------+-------+-------|
+| Scaffold story: agile timeline | STARTED → DONE | |
+| Analyse temporal commands for conceptual coherence | created → STARTED → DONE | Full lifecycle inside the window; investigation delivered. |
+| Audit and update the MASD document | BACKLOG → STARTED | |
+| 4 implementation tasks (timeline) | created (BACKLOG) | command, env stamp, snapshot skill, board view. |
+
+* Captures
+
+| Capture | Notes |
+|---------+-------|
+| Write the ORE Studio development methodology manual | |
+| Add a compass wait-for-CI command | Tooling friction from PR polling. |
+| compass task new switches branches mid-scaffold | Found scaffolding this very story. |
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1165 | merged | timeline story scaffold |
+| #1172 | opened | temporal coherence analysis |
+
+* Problems and suspicious decisions
+
+- The timeline scaffold PR rode the wrong branch
+  (feature/timeline-environment-stamp) due to the task-new
+  branch-switching bug — captured, bookkeeping corrected in-flight.
+
+* Audit
+
+- Analysis task shows BACKLOG → STARTED and STARTED → DONE both at
+  ~12:25: states were stamped in quick succession rather than at the
+  actual transitions. Cosmetic, but timestamps under-report duration.
+- No environment stamps yet — attribution unavailable.

--- a/doc/agile/versions/v0/sprint_20/timeline/20260607T1300-20260607T1500.org
+++ b/doc/agile/versions/v0/sprint_20/timeline/20260607T1300-20260607T1500.org
@@ -1,0 +1,42 @@
+:PROPERTIES:
+:ID: 0DC96BAD-8060-47F9-982E-6CF33D52ACD5
+:END:
+#+title: Timeline: 2026-06-07 13:00 → 15:00
+#+description: LLM-curated snapshot of agile activity in this window, from the consistent substrate (origin/main + GitHub).
+#+type: timeline
+#+level: cross
+#+filetags: :timeline:sprint_20:v0:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+* Summary
+
+- Merge window: five PRs landed (shell hotfix, provisioning script,
+  review gate, temporal analysis, MASD modeling); four new PRs opened
+  including the timeline command itself. No agile doc changes — all
+  motion was in code and PRs.
+
+* Pull requests
+
+| PR | Event | Title |
+|----+-------+-------|
+| #1166 | merged | shell public-surface hotfix |
+| #1163 | merged | provision_all end-to-end script |
+| #1169 | merged | review-round gate |
+| #1172 | merged | temporal coherence analysis |
+| #1168 | merged | MASD knowledge docs |
+| #1173 | opened | tangle_shell_scripts emacs target |
+| #1174 | opened | branch protection → pr-gate |
+| #1175 | opened | compass timeline command |
+| #1176 | opened | MASD terminology corrections |
+
+* Problems and suspicious decisions
+
+- None observed.
+
+* Audit
+
+- Quiet on the document side while five PRs merged — close-out
+  bookkeeping for some merges may follow later; check the next
+  window for the corresponding task/story state updates.
+- No environment stamps yet — attribution unavailable.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4265,6 +4265,9 @@ def main():
         sys.exit(cmd_shell(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "review":
         sys.exit(cmd_review(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "timeline":
+        import compass_timeline
+        sys.exit(compass_timeline.run(sys.argv[2:], PROJECT_ROOT))
     if len(sys.argv) >= 2 and sys.argv[1] == "pr":
         sys.exit(cmd_pr(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ("bearings", "orient"):
@@ -4278,7 +4281,7 @@ def main():
             "index", "search", "find", "debug", "where", "status", "fleet",
             "list", "show", "add", "sprint", "story", "task", "journal",
             "env", "nats", "db", "sql", "services", "client", "test", "build",
-            "shell", "review", "pr", "bearings", "orient",
+            "shell", "review", "pr", "bearings", "orient", "timeline",
             "capture",
             "inbox", "next", "deferred", "discarded", "backlog",
         ]
@@ -4294,7 +4297,7 @@ def main():
 
     _EPILOG = (
         "Pillars:\n"
-        "  Orient:    where, fleet\n"
+        "  Orient:    where, fleet, timeline\n"
         "  Search:    search (find), list, show\n"
         "  Scaffold:  story, task, add\n"
         "  Capture:   capture, inbox, next, deferred, discarded, backlog\n"
@@ -4400,6 +4403,9 @@ def main():
                           help="PR: pull-request lifecycle verbs via gh — "
                                "'pr checks [--watch]', 'pr create', 'pr merge [--force]', "
                                "'pr record'; 'pr --help'")
+    subparsers.add_parser("timeline",
+                          help="Timeline: everyone × past — 'timeline generate [--since 20m]', "
+                               "'timeline now', 'timeline show [-n N]'; 'timeline --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/compass_timeline.py
+++ b/projects/ores.compass/src/compass_timeline.py
@@ -1,0 +1,397 @@
+"""compass timeline — the everyone × past quadrant of the temporal grid.
+
+Two behaviours (see the temporal command coherence investigation,
+551FC710-7E3C-484B-AB52-7F2C8DAF3B6F):
+
+- generate: mine the *consistent substrate* — the agile documents'
+  git history on origin/main plus the GitHub PR record — for events in
+  a time window. Never reads per-worktree journals, so any fresh
+  checkout of main produces identical output.
+- show: render the last N LLM-curated snapshot buckets from the
+  sprint timeline/ folders.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+AGILE_SUBDIR = "doc/agile"
+DEFAULT_WINDOW = "20m"
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(args, cwd):
+    p = subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def _parse_duration(spec):
+    """'20m' / '2h' / '1d' / '45s' -> timedelta, else None."""
+    m = re.fullmatch(r"(\d+)([smhd])", spec.strip())
+    if not m:
+        return None
+    n, unit = int(m.group(1)), m.group(2)
+    return timedelta(**{{"s": "seconds", "m": "minutes",
+                         "h": "hours", "d": "days"}[unit]: n})
+
+
+def _parse_when(spec):
+    """ISO timestamp (date or datetime, naive = local) -> aware datetime."""
+    try:
+        dt = datetime.fromisoformat(spec)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt
+
+
+def _resolve_window(args):
+    """(from, to) aware datetimes from --since / --from/--to."""
+    now = datetime.now(timezone.utc).astimezone()
+    if args.frm or args.to:
+        if not (args.frm and args.to):
+            print("❌ --from and --to must be given together.",
+                  file=sys.stderr)
+            return None
+        start, end = _parse_when(args.frm), _parse_when(args.to)
+        if not start or not end or start >= end:
+            print("❌ bad --from/--to window.", file=sys.stderr)
+            return None
+        return start, end
+    spec = args.since or DEFAULT_WINDOW
+    delta = _parse_duration(spec)
+    if delta:
+        return now - delta, now
+    start = _parse_when(spec)
+    if start:
+        return start, now
+    print(f"❌ cannot parse --since '{spec}' (try 20m, 2h, 1d or ISO).",
+          file=sys.stderr)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Document field extraction (from a blob, not the working tree)
+# ---------------------------------------------------------------------------
+
+_ID_RE = re.compile(r"^:ID:\s*([0-9A-Fa-f-]+)", re.M)
+_KW_RE = re.compile(r"^#\+(\w+):\s*(.*)$", re.M)
+_STATE_RE = re.compile(r"^\|\s*State\s*\|\s*([A-Za-z]+)\s*\|", re.M)
+
+
+def _doc_fields(blob):
+    """id, title, type, environment, state from org source (best effort)."""
+    fields = {"id": None, "title": "", "type": "",
+              "environment": "", "state": ""}
+    if not blob:
+        return fields
+    m = _ID_RE.search(blob)
+    if m:
+        fields["id"] = m.group(1).upper()
+    for k, v in _KW_RE.findall(blob):
+        k = k.lower()
+        if k in ("title", "type", "environment"):
+            fields[k] = v.strip()
+    m = _STATE_RE.search(blob)
+    if m:
+        fields["state"] = m.group(1).upper()
+    return fields
+
+
+def _git_blob(project_root, ref, path):
+    rc, out, _ = _run(["git", "show", f"{ref}:{path}"], project_root)
+    return out if rc == 0 else None
+
+
+# ---------------------------------------------------------------------------
+# generate — events from the consistent substrate
+# ---------------------------------------------------------------------------
+
+
+def _doc_events(project_root, start, end):
+    """Mine origin/main commits in the window for agile doc events."""
+    rc, out, err = _run(
+        ["git", "log", "origin/main",
+         f"--since={start.isoformat()}", f"--until={end.isoformat()}",
+         "--pretty=%H|%cI|%s", "--name-status", "--", AGILE_SUBDIR],
+        project_root)
+    if rc != 0:
+        print(err.strip() or "❌ git log failed.", file=sys.stderr)
+        return None
+
+    events = []
+    sha = when = subject = None
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        if "|" in line and re.match(r"^[0-9a-f]{40}\|", line):
+            sha, when, subject = line.split("|", 2)
+            continue
+        m = re.match(r"^([AMD])\t(.+)$", line)
+        if not m or not sha:
+            continue
+        status, path = m.group(1), m.group(2)
+        if not path.endswith(".org"):
+            continue
+
+        new = _git_blob(project_root, sha, path)
+        fields = _doc_fields(new)
+        event = {
+            "time": when,
+            "sha": sha[:9],
+            "subject": subject,
+            "path": path,
+            "doc_type": fields["type"],
+            "title": re.sub(r"^(Story|Task):\s*", "", fields["title"]),
+            "id": fields["id"],
+            "environment": fields["environment"],
+        }
+        if status == "A":
+            event["action"] = "created"
+            event["state"] = fields["state"]
+        elif status == "D":
+            old_fields = _doc_fields(_git_blob(project_root, f"{sha}^", path))
+            event.update(action="deleted", doc_type=old_fields["type"],
+                         title=re.sub(r"^(Story|Task):\s*", "",
+                                      old_fields["title"]),
+                         id=old_fields["id"])
+        else:
+            old = _doc_fields(_git_blob(project_root, f"{sha}^", path))
+            if old["state"] != fields["state"] and fields["state"]:
+                event["action"] = "state"
+                event["from"] = old["state"]
+                event["to"] = fields["state"]
+            else:
+                event["action"] = "updated"
+        events.append(event)
+    events.sort(key=lambda e: e["time"])
+    return events
+
+
+def _pr_events(project_root, start, end):
+    """Opened and merged PRs in the window, via gh. Best effort."""
+    prs = []
+
+    def search(flavour, query, fields):
+        rc, out, err = _run(
+            ["gh", "pr", "list", "--state", "all", "--limit", "200",
+             "--search", query, "--json", fields], project_root)
+        if rc != 0:
+            print(f"⚠️  gh unavailable for {flavour} PRs "
+                  f"({(err or '').strip().splitlines()[:1]}); skipping.",
+                  file=sys.stderr)
+            return []
+        return json.loads(out or "[]")
+
+    fmt = "%Y-%m-%dT%H:%M:%S"
+    a = start.astimezone(timezone.utc).strftime(fmt)
+    b = end.astimezone(timezone.utc).strftime(fmt)
+
+    def local(ts):
+        # gh returns UTC; align with the doc events' local-offset ISO.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")) \
+            .astimezone().isoformat()
+
+    for pr in search("created", f"created:{a}Z..{b}Z",
+                     "number,title,createdAt,author"):
+        prs.append({"time": local(pr["createdAt"]), "action": "pr-opened",
+                    "number": pr["number"], "title": pr["title"]})
+    for pr in search("merged", f"merged:{a}Z..{b}Z",
+                     "number,title,mergedAt,author"):
+        prs.append({"time": local(pr["mergedAt"]), "action": "pr-merged",
+                    "number": pr["number"], "title": pr["title"]})
+    prs.sort(key=lambda e: e["time"])
+    return prs
+
+
+_ACTION_ICON = {"created": "✨", "state": "🔁", "updated": "📝",
+                "deleted": "🗑️", "pr-opened": "🔀", "pr-merged": "✅"}
+
+_PLURAL = {"story": "Stories", "task": "Tasks", "capture": "Captures",
+           "sprint": "Sprints"}
+
+# A commit touching more than this many docs with plain "updated" events
+# is a bulk sweep (mass renames, link rewrites); collapse it to one line
+# so it cannot drown the real activity. State changes and creations are
+# never collapsed.
+BULK_THRESHOLD = 5
+
+
+def _split_bulk(doc_events):
+    """(events, bulk) — pull plain updates of oversized commits aside."""
+    updates_per_sha = {}
+    for e in doc_events:
+        if e["action"] == "updated":
+            updates_per_sha.setdefault(e["sha"], []).append(e)
+    bulk_shas = {sha for sha, es in updates_per_sha.items()
+                 if len(es) > BULK_THRESHOLD}
+    kept = [e for e in doc_events
+            if not (e["action"] == "updated" and e["sha"] in bulk_shas)]
+    # Coalesce repeated plain updates of the same document across
+    # commits: one line with a count, stamped with the latest time.
+    seen = {}
+    coalesced = []
+    for e in kept:
+        if e["action"] == "updated" and e["id"]:
+            if e["id"] in seen:
+                prior = seen[e["id"]]
+                prior["count"] = prior.get("count", 1) + 1
+                prior["time"] = e["time"]
+                continue
+            seen[e["id"]] = e
+        coalesced.append(e)
+    kept = coalesced
+    bulk = [{"sha": sha, "time": es[0]["time"], "subject": es[0]["subject"],
+             "count": len(es)}
+            for sha, es in updates_per_sha.items() if sha in bulk_shas]
+    bulk.sort(key=lambda b: b["time"])
+    return kept, bulk
+
+
+def _print_pretty(window, doc_events, pr_events):
+    start, end = window
+    print(f"🧭 ores.compass — timeline: "
+          f"{start.strftime('%Y-%m-%d %H:%M')} → "
+          f"{end.strftime('%Y-%m-%d %H:%M')}")
+    if not doc_events and not pr_events:
+        print("\n(no agile activity in the window)")
+        return
+    doc_events, bulk = _split_bulk(doc_events)
+
+    by_type = {}
+    for e in doc_events:
+        by_type.setdefault(e["doc_type"] or "other", []).append(e)
+    for doc_type in ("story", "task", "capture", "sprint"):
+        group = by_type.pop(doc_type, [])
+        if not group:
+            continue
+        print(f"\n{_PLURAL[doc_type]}:")
+        for e in group:
+            icon = _ACTION_ICON.get(e["action"], "•")
+            when = e["time"][11:16]
+            count = e.get("count", 1)
+            what = {
+                "created": "created" + (f" ({e['state']})"
+                                        if e.get("state") else ""),
+                "state": f"{e.get('from', '?')} → {e.get('to', '?')}",
+                "updated": "updated" + (f" ×{count}" if count > 1 else ""),
+                "deleted": "deleted",
+            }[e["action"]]
+            env = f"  [{e['environment']}]" if e["environment"] else ""
+            print(f"  {icon} {when}  {e['title']}  — {what}{env}")
+            if e["id"]:
+                print(f"       compass show {e['id']}")
+    for doc_type, group in sorted(by_type.items()):
+        print(f"\nOther ({doc_type}):")
+        for e in group:
+            print(f"  • {e['time'][11:16]}  {e['path']} — {e['action']}")
+    if bulk:
+        print("\nBulk sweeps (collapsed):")
+        for b in bulk:
+            print(f"  🧹 {b['time'][11:16]}  {b['count']} docs updated by "
+                  f"{b['sha']} — {b['subject']}")
+    if pr_events:
+        print("\nPull requests:")
+        for e in pr_events:
+            icon = _ACTION_ICON[e["action"]]
+            print(f"  {icon} {e['time'][11:16]}  #{e['number']}  "
+                  f"{e['title']}  — {e['action'][3:]}")
+
+
+def _cmd_generate(args, project_root):
+    window = _resolve_window(args)
+    if not window:
+        return 1
+    start, end = window
+    # The consistent substrate is origin/main as last fetched; refresh it
+    # so "now" windows see the latest merges.
+    _run(["git", "fetch", "origin", "main"], project_root)
+    doc_events = _doc_events(project_root, start, end)
+    if doc_events is None:
+        return 1
+    pr_events = _pr_events(project_root, start, end)
+    if args.format == "json":
+        print(json.dumps({
+            "from": start.isoformat(), "to": end.isoformat(),
+            "documents": doc_events, "prs": pr_events}, indent=1))
+    else:
+        _print_pretty(window, doc_events, pr_events)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# show — render stored snapshot buckets
+# ---------------------------------------------------------------------------
+
+
+def _cmd_show(args, project_root):
+    root = Path(project_root) / "doc/agile/versions"
+    snaps = sorted(root.glob("*/sprint_*/timeline/*.org"),
+                   key=lambda p: p.name)
+    if not snaps:
+        print("(no timeline snapshots yet — see the agile timeline story; "
+              "they are written by the snapshot skill)")
+        return 0
+    picked = snaps[-args.count:][::-1]  # newest first
+    for i, p in enumerate(picked):
+        if i:
+            print("\n" + "─" * 72 + "\n")
+        print(f"📍 {p.relative_to(project_root)}\n")
+        print(p.read_text().rstrip())
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# entry point
+# ---------------------------------------------------------------------------
+
+
+def run(argv, project_root):
+    """Entry point: compass timeline <subcommand>."""
+    ap = argparse.ArgumentParser(
+        prog="compass timeline",
+        description="Timeline pillar: the everyone × past quadrant — "
+                    "events from the consistent substrate (origin/main + "
+                    "GitHub), and stored snapshot buckets.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+
+    gp = sub.add_parser(
+        "generate",
+        help="List agile documents changed in a window (LLM snapshot input)")
+    gp.add_argument("--since", default=None,
+                    help=f"Window as duration (20m, 2h, 1d) or ISO start "
+                         f"(default: {DEFAULT_WINDOW})")
+    gp.add_argument("--from", dest="frm", default=None,
+                    help="Window start (ISO; needs --to)")
+    gp.add_argument("--to", dest="to", default=None,
+                    help="Window end (ISO; needs --from)")
+    gp.add_argument("-f", "--format", choices=["pretty", "json"],
+                    default="pretty", help="Output format (default: pretty)")
+
+    np = sub.add_parser(
+        "now", help=f"Alias: generate over the last {DEFAULT_WINDOW}")
+    np.add_argument("-f", "--format", choices=["pretty", "json"],
+                    default="pretty", help="Output format (default: pretty)")
+
+    sp = sub.add_parser(
+        "show", help="Render the last N snapshot buckets from timeline/")
+    sp.add_argument("-n", "--count", type=int, default=3,
+                    help="How many buckets, newest first (default: 3)")
+
+    args = ap.parse_args(argv)
+    if args.subcmd == "now":
+        args.since, args.frm, args.to = DEFAULT_WINDOW, None, None
+        return _cmd_generate(args, project_root)
+    if args.subcmd == "generate":
+        return _cmd_generate(args, project_root)
+    if args.subcmd == "show":
+        return _cmd_show(args, project_root)
+    return 1


### PR DESCRIPTION
## Summary

First implementation task of the agile timeline story, following the temporal coherence investigation: compass timeline generate mines agile document events (created / state transitions / updates) from git history on origin/main joined with the gh PR record — the consistent substrate, never journals — so any fresh checkout reproduces the same timeline. timeline show renders the last N stored snapshot buckets; timeline now is the default-window convenience. Bulk sweeps collapse and repeated updates coalesce so output stays scannable.

## Changes

- Add compass_timeline.py: generate (--since/--from/--to, pretty and json), now alias, show -n.
- Register the timeline pillar in compass.py dispatch, help and known commands.
- Record the implementation plan in the task doc.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Agile timeline: bucketed summaries of recent activity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/story.html) | 3697D889-BF01-43D4-9EF7-3AF6B70A8122 |
| Task | [Add compass timeline command to list documents changed in a period](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_compass_command.html) | 49BE7DB0-0577-4C30-A370-610C0B48FC7F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)