### PR TITLE
[modeling] Correct MASD terminology in literate template docs

### DIFF
--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
@@ -2,7 +2,7 @@
 :ID: 8B96FDF2-88C6-4C21-8167-04974E102C29
 :END:
 #+title: Task: Audit and correct MASD terminology across codegen docs
-#+description: Review all literate template org files and modeling facet reference docs for terminology consistency: ensure 'projection' is used instead of 'pipeline' where appropriate; clarify 'facet' vs 'facet group'; remove loose use of 'meta-model' in template prose.
+#+description: Review all literate template org files and modeling docs for MASD terminology consistency: replace 'facet' where it means 'archetype'; remove 'facet group' (not a real MASD term); replace 'pipeline' with 'projection' where appropriate; tighten loose use of 'meta-model'.
 #+type: task
 #+level: s1
 #+filetags: :clean_codegen_masd_docs:sprint_20:v0:
@@ -19,10 +19,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-All literate template org files and modeling docs use consistent MASD
-terminology throughout — "projection" not "pipeline", "facet" vs "facet
-group" clarified, no loose "meta-model" in template prose, and no
-references to non-existent profiles.
+All literate template org files and modeling docs use the four canonical
+MASD terms (TS, Part, Facet, Archetype) precisely: "archetype" is used
+where individual file templates are meant; "facet group" (not a real MASD
+term) is removed; "projection" is used instead of "pipeline" for the
+logical→physical transformation; "meta-model" is used only for actual
+meta-model concepts.
 
 * Status
 
@@ -37,10 +39,10 @@ references to non-existent profiles.
 
 * Acceptance
 
-- All instances of "pipeline" replaced with "projection" where the MASD meaning applies.
-- "Facet" and "facet group" are used precisely and consistently.
-- No loose "meta-model" in template prose where a more specific term applies.
-- No references to profiles that do not exist in profiles.json.
+- "facet" is never used to mean "archetype" — the individual-file template.
+- "facet group" does not appear (it is not a MASD term; the real term is "facet").
+- "pipeline" is replaced with "projection" wherever the logical→physical transformation is described.
+- "meta-model" is used only for actual MASD meta-model concepts (PMM, VMM, logical meta-model).
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
@@ -8,7 +8,7 @@
 #+filetags: :clean_codegen_masd_docs:sprint_20:v0:
 #+owner: marco
 #+branch: feature/audit-masd-terminology
-#+pr:
+#+pr: 1176
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -56,7 +56,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1176][#1176]] | [modeling] Correct MASD terminology in literate template docs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.org
@@ -19,22 +19,28 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+All literate template org files and modeling docs use consistent MASD
+terminology throughout — "projection" not "pipeline", "facet" vs "facet
+group" clarified, no loose "meta-model" in template prose, and no
+references to non-existent profiles.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
-| Now          | Not yet started.                       |
+| Now          | Auditing docs for terminology issues.  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Fix identified issues, raise PR.       |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
 
--
+- All instances of "pipeline" replaced with "projection" where the MASD meaning applies.
+- "Facet" and "facet group" are used precisely and consistently.
+- No loose "meta-model" in template prose where a more specific term applies.
+- No references to profiles that do not exist in profiles.json.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_implement_clean_codegen_masd_docs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Clean up codegen documentation and MASD alignment]] |
-| Now          | Review round 2 complete; awaiting merge.          |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                                          |
-| Next         | Merge PR, close task.                             |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
@@ -69,3 +69,10 @@ plan itself stays — it is the historical record of what we did.)
 | 13 | protocol model_types missing "schema" in variability_model.org | variability_model.org:90 | Decline | File already has "domain_entity, schema" — reviewer saw stale state |
 
 * Result
+
+PR #1168 merged. Added MASD knowledge docs (masd.org, physical_space.org,
+technical_space.org, facet.org, variability.org) and ORE Studio physical model
+docs (technical_spaces.org, technical_space_cpp.org, technical_spaces_other.org,
+variability_model.org). Two review rounds addressed: generator facet separation,
+profile name corrections (no =--profile table=), archetype count updates
+(8→9 facets, ~58→57 archetypes), and dangling org-id fixes.

--- a/projects/modeling/technical_spaces_other.org
+++ b/projects/modeling/technical_spaces_other.org
@@ -99,7 +99,7 @@ for each document type.
 | Field group org-model | =doc_field_group.org= — nested value struct model file |
 | Dataset overview | =doc_dataset.org= — dataset documentation |
 | Facet doc | =doc_facet.org= — facet reference document |
-| Facet group doc | =doc_facet_group.org= — facet group reference document |
+| Template group doc | =doc_facet_group.org= — template group reference document |
 
 Profile: =--profile doc=. Literate source: [[id:FC51B2C6-353F-4D72-BBBC-0E2B7DF78000][doc]].
 
@@ -121,7 +121,7 @@ commands, agile artefact scaffolding, journal, PR workflow).
 
 No code generation is applied to Lisp artefacts — they are authored
 directly. The Lisp TS is a dependency of the build system (CMake invokes
-Emacs in batch mode for tangle targets), not of the entity codegen pipeline.
+Emacs in batch mode for tangle targets), not of the entity codegen projection.
 
 ** Python Technical Space
 

--- a/projects/ores.codegen/library/templates/assets.org
+++ b/projects/ores.codegen/library/templates/assets.org
@@ -696,6 +696,6 @@ SERVICE_NAMES=(
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_component.org
+++ b/projects/ores.codegen/library/templates/cpp_component.org
@@ -187,6 +187,6 @@ Per-component shared-library export/import macros. All component profiles.
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_domain.org
+++ b/projects/ores.codegen/library/templates/cpp_domain.org
@@ -29,7 +29,7 @@ faker-based test-data generator pair (=generator= profile).
 
 * The cpp_domain facet
 
-The top of the entity's C++ pipeline ([[id:608675E1-4284-4902-99AC-4DA565390AFB][entity lifecycle]]): the value
+The top of the entity's C++ projection ([[id:608675E1-4284-4902-99AC-4DA565390AFB][entity lifecycle]]): the value
 type every other layer converts to and from, its serialised form, and
 synthetic instances for tests. Column loops dispatch on per-field
 type flags to choose C++ types, defaults and faker calls.
@@ -609,6 +609,6 @@ ORES_{{component_upper}}_EXPORT std::ostream& operator<<(std::ostream& s, const 
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_messaging.org
+++ b/projects/ores.codegen/library/templates/cpp_messaging.org
@@ -1143,6 +1143,6 @@ private:
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_model_types.org
+++ b/projects/ores.codegen/library/templates/cpp_model_types.org
@@ -32,7 +32,7 @@ rather than from an entity.
 
 Standalone model formats: an enum org-model or field-group org-model
 is a first-class codegen input that produces exactly one header.
-Unlike the entity facets there is no layered pipeline — one model,
+Unlike the entity facets there is no layered projection — one model,
 one artefact.
 
 * Enum (cpp_enum.hpp.mustache)
@@ -212,6 +212,6 @@ struct {{field_group.entity_singular}} {
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_qt.org
+++ b/projects/ores.codegen/library/templates/cpp_qt.org
@@ -2927,6 +2927,6 @@ private:
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_repository.org
+++ b/projects/ores.codegen/library/templates/cpp_repository.org
@@ -30,7 +30,7 @@ entity, and the repository exposing CRUD and temporal queries.
 
 * The cpp_repository facet
 
-The persistence layer of the /entity/ pipeline ([[id:608675E1-4284-4902-99AC-4DA565390AFB][entity lifecycle]]):
+The persistence layer of the /entity/ projection ([[id:608675E1-4284-4902-99AC-4DA565390AFB][entity lifecycle]]):
 the database round-trip entity ↔ mapper ↔ repository over sqlgen.
 Declarations in =.hpp=, out-of-class implementations in =.cpp=, with
 custom-method paste points from the entity org-model where the
@@ -1453,6 +1453,6 @@ public:
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_service_app.org
+++ b/projects/ores.codegen/library/templates/cpp_service_app.org
@@ -673,6 +673,6 @@ TEST_CASE("parse_version_does_not_throw", tags) {
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/cpp_table.org
+++ b/projects/ores.codegen/library/templates/cpp_table.org
@@ -259,6 +259,6 @@ ORES_{{component_upper}}_EXPORT std::ostream& operator<<(std::ostream& s, const 
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/doc.org
+++ b/projects/ores.codegen/library/templates/doc.org
@@ -396,7 +396,7 @@ line of every block is the output-neutral GENERATED FILE header:)
 
 ,* See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.
 #+end_src
@@ -1174,6 +1174,6 @@ Deferred to later versions:
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/doc.org
+++ b/projects/ores.codegen/library/templates/doc.org
@@ -726,7 +726,7 @@ Dual-axis bar chart. PRs (left axis) and commits (right axis) per day.
 A high commits-to-PR ratio may indicate scope creep.
 
 ,#+attr_html: :width 100%
-[[file:prs_commits.png]]
+[[proj:{{parent_dir}}/{{slug}}/prs_commits.png]]
 
 ,** Daily Line Churn
 
@@ -734,7 +734,7 @@ Lines added (green) and deleted (red) per day. Building work produces
 mostly additions; refactoring produces a mix.
 
 ,#+attr_html: :width 100%
-[[file:line_churn.png]]
+[[proj:{{parent_dir}}/{{slug}}/line_churn.png]]
 
 ,** PR Cycle Time
 
@@ -742,7 +742,7 @@ Hours from PR open to merge, one bar per PR. Long bars indicate
 review bottlenecks.
 
 ,#+attr_html: :width 100%
-[[file:pr_cycle.png]]
+[[proj:{{parent_dir}}/{{slug}}/pr_cycle.png]]
 
 ,** Cumulative Stories Done
 
@@ -750,7 +750,7 @@ Line chart tracking stories marked DONE during the sprint.
 Steady upward slope is healthy; plateauing signals a stall.
 
 ,#+attr_html: :width 100%
-[[file:stories_done.png]]
+[[proj:{{parent_dir}}/{{slug}}/stories_done.png]]
 
 ,* 📊 Time Summary
 
@@ -942,7 +942,7 @@ Dual-axis bar chart. PRs (left axis) and commits (right axis) per day.
 A high commits-to-PR ratio may indicate scope creep.
 
 ,#+attr_html: :width 100%
-[[file:prs_commits.png]]
+[[proj:{{parent_dir}}/{{slug}}/prs_commits.png]]
 
 ,** Daily Line Churn
 
@@ -951,7 +951,7 @@ mostly additions; refactoring produces a mix. Days with no churn may
 indicate blockers.
 
 ,#+attr_html: :width 100%
-[[file:line_churn.png]]
+[[proj:{{parent_dir}}/{{slug}}/line_churn.png]]
 
 ,** PR Cycle Time
 
@@ -959,7 +959,7 @@ Hours from PR open to merge, one bar per PR. Long bars indicate
 review bottlenecks. Generated only when PR data is available.
 
 ,#+attr_html: :width 100%
-[[file:pr_cycle.png]]
+[[proj:{{parent_dir}}/{{slug}}/pr_cycle.png]]
 
 ,** Cumulative Stories Done
 
@@ -967,7 +967,7 @@ Line chart tracking stories marked DONE during the sprint.
 Steady upward slope is healthy; plateauing signals a stall.
 
 ,#+attr_html: :width 100%
-[[file:stories_done.png]]
+[[proj:{{parent_dir}}/{{slug}}/stories_done.png]]
 
 ,* Retrospective
 

--- a/projects/ores.codegen/library/templates/doc_facet.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_facet.org.mustache
@@ -55,6 +55,6 @@ line of every block is the output-neutral GENERATED FILE header:)
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/doc_release_notes.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_release_notes.org.mustache
@@ -50,7 +50,7 @@ Dual-axis bar chart. PRs (left axis) and commits (right axis) per day.
 A high commits-to-PR ratio may indicate scope creep.
 
 #+attr_html: :width 100%
-[[file:prs_commits.png]]
+[[proj:{{parent_dir}}/{{slug}}/prs_commits.png]]
 
 ** Daily Line Churn
 
@@ -58,7 +58,7 @@ Lines added (green) and deleted (red) per day. Building work produces
 mostly additions; refactoring produces a mix.
 
 #+attr_html: :width 100%
-[[file:line_churn.png]]
+[[proj:{{parent_dir}}/{{slug}}/line_churn.png]]
 
 ** PR Cycle Time
 
@@ -66,7 +66,7 @@ Hours from PR open to merge, one bar per PR. Long bars indicate
 review bottlenecks.
 
 #+attr_html: :width 100%
-[[file:pr_cycle.png]]
+[[proj:{{parent_dir}}/{{slug}}/pr_cycle.png]]
 
 ** Cumulative Stories Done
 
@@ -74,7 +74,7 @@ Line chart tracking stories marked DONE during the sprint.
 Steady upward slope is healthy; plateauing signals a stall.
 
 #+attr_html: :width 100%
-[[file:stories_done.png]]
+[[proj:{{parent_dir}}/{{slug}}/stories_done.png]]
 
 * 📊 Time Summary
 

--- a/projects/ores.codegen/library/templates/doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_sprint.org.mustache
@@ -65,7 +65,7 @@ Dual-axis bar chart. PRs (left axis) and commits (right axis) per day.
 A high commits-to-PR ratio may indicate scope creep.
 
 #+attr_html: :width 100%
-[[file:prs_commits.png]]
+[[proj:{{parent_dir}}/{{slug}}/prs_commits.png]]
 
 ** Daily Line Churn
 
@@ -74,7 +74,7 @@ mostly additions; refactoring produces a mix. Days with no churn may
 indicate blockers.
 
 #+attr_html: :width 100%
-[[file:line_churn.png]]
+[[proj:{{parent_dir}}/{{slug}}/line_churn.png]]
 
 ** PR Cycle Time
 
@@ -82,7 +82,7 @@ Hours from PR open to merge, one bar per PR. Long bars indicate
 review bottlenecks. Generated only when PR data is available.
 
 #+attr_html: :width 100%
-[[file:pr_cycle.png]]
+[[proj:{{parent_dir}}/{{slug}}/pr_cycle.png]]
 
 ** Cumulative Stories Done
 
@@ -90,7 +90,7 @@ Line chart tracking stories marked DONE during the sprint.
 Steady upward slope is healthy; plateauing signals a stall.
 
 #+attr_html: :width 100%
-[[file:stories_done.png]]
+[[proj:{{parent_dir}}/{{slug}}/stories_done.png]]
 
 * Retrospective
 

--- a/projects/ores.codegen/library/templates/overview.org
+++ b/projects/ores.codegen/library/templates/overview.org
@@ -2,7 +2,7 @@
 :ID: 3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5
 :END:
 #+title: Codegen template library
-#+description: Top of the literate template hierarchy: how the 116 mustache templates are organised into facet groups and facets, how tangling works, and where to add a new template.
+#+description: Top of the literate template hierarchy: how the 116 mustache templates are organised into template groups (one per technical space) and facets, how tangling works, and where to add a new template.
 #+type: knowledge
 #+level: cross
 #+filetags: :codegen:templates:literate:
@@ -18,8 +18,8 @@ facet docs hold the template sources themselves.
 * Summary
 
 The 116 mustache templates consumed by =generator.py= are organised
-into five facet groups — [[id:B5AC7383-3535-4F40-9109-08B77587EEF5][cmake]], [[id:74AB7037-B54A-43AB-A1FA-E9E16746879D][cpp]], [[id:C68F8B0E-27B6-40C7-AD18-EDD2492BF941][sql]], [[id:1BBCEB58-83E0-40F7-BC85-FE2B98E9D2FD][doc]] and [[id:4A21E18E-EBA7-4734-BF3F-16574DF0CA8E][assets]] — each a
-namespace of /facets/ in the [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] sense: coherent families of
+into five template groups — [[id:B5AC7383-3535-4F40-9109-08B77587EEF5][cmake]], [[id:74AB7037-B54A-43AB-A1FA-E9E16746879D][cpp]], [[id:C68F8B0E-27B6-40C7-AD18-EDD2492BF941][sql]], [[id:1BBCEB58-83E0-40F7-BC85-FE2B98E9D2FD][doc]] and [[id:4A21E18E-EBA7-4734-BF3F-16574DF0CA8E][assets]] — each
+corresponding to a [[id:E7B74138-9ADA-4B4B-A983-23B3FDB55F44][technical space]] and containing one or more /facets/ in the [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] sense: coherent families of
 artefacts projected from a model element. Every facet is a literate
 org document in this directory whose =mustache= blocks tangle to the
 sibling =.mustache= artefacts; the =.mustache= files are generated
@@ -86,6 +86,6 @@ fixtures from an untracked venv.)
 
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][Model Assisted Software Development]] — what a facet is.
 - [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]] — the api/core/service split the templates serve.
-- [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]] — the cross-facet entity pipeline.
+- [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]] — the cross-facet entity projection.
 - [[id:1B686436-FBF6-47EB-87D5-5E13A509F7D1][Story: Convert codegen mustache templates to literate org-mode documents]]
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/sql_populate.org
+++ b/projects/ores.codegen/library/templates/sql_populate.org
@@ -1166,6 +1166,6 @@ from ores_dq_tags_artefact_tbl;
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/sql_schema.org
+++ b/projects/ores.codegen/library/templates/sql_schema.org
@@ -1445,6 +1445,6 @@ $$ language plpgsql;
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/library/templates/sql_service.org
+++ b/projects/ores.codegen/library/templates/sql_service.org
@@ -334,6 +334,6 @@ where a.account_type != 'user'
 
 * See also
 
-- (Parent facet-group doc: =<group>_group.org=.)
+- (Parent template group doc: =<group>_group.org=.)
 - [[id:3B6B9F75-BDC9-4AE9-B16E-5A05FFC3A4B5][Codegen template library]] — the groups overview.
 - [[proj:projects/ores.codegen/library/profiles.json][profiles.json]] — profile → template/output mapping.

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -520,6 +520,7 @@ def main(argv=None):
         "owner": args.owner or "marco",
         "date": today,
         "state": state,
+        "parent_dir": str(parent_dir),
         "parent_id": (args.parent_id or "").upper(),
         "parent_title": args.parent_title,
         "predecessor_id": (args.predecessor_id or "").upper(),

--- a/projects/ores.lisp/src/ores-link-types.el
+++ b/projects/ores.lisp/src/ores-link-types.el
@@ -73,8 +73,9 @@
 ;; - org-html-paragraph wraps proj: images in <figure> with caption.
 ;; - org-latex-link takes the `imagep' path (org-latex--inline-image)
 ;;   rather than the custom-protocol path, giving full figure support.
-(add-to-list 'org-html-inline-image-rules
-             (cons "proj" "\\.\\(?:png\\|jpe?g\\|gif\\|svg\\)$"))
+(with-eval-after-load 'ox-html
+  (add-to-list 'org-html-inline-image-rules
+               (cons "proj" "\\.\\(?:png\\|jpe?g\\|gif\\|svg\\)$")))
 
 (with-eval-after-load 'ox-latex
   (add-to-list 'org-latex-inline-image-rules


### PR DESCRIPTION
## Summary

Audit and correct MASD terminology across literate template org files and modeling docs: replace 'pipeline' with 'projection' for logical→physical transformations; replace 'facet group' (non-MASD invented term) with 'template group' throughout; fix sprint/release_notes codegen templates to use proj: links for chart images.

## Changes

- Replace 'pipeline' with 'projection' in cpp_domain, cpp_repository, cpp_model_types, overview, and technical_spaces_other
- Replace 'facet group' with 'template group' in overview.org and all 13 'Parent facet-group doc' boilerplate lines across template org files
- Fix Doc TS archetype table in technical_spaces_other: 'Facet group doc' → 'Template group doc'
- Add parent_dir to doc_generate.py template variables; use proj: links in sprint and release_notes mustache templates
- Task bookkeeping: close implement_clean_codegen_masd_docs, start and fill audit_masd_terminology

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clean up codegen documentation and MASD alignment](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/story.html) | 6654934D-D372-4B7B-A66D-5E0E5A145775 |
| Task | [Audit and correct MASD terminology across codegen docs](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_audit_masd_terminology.html) | 8B96FDF2-88C6-4C21-8167-04974E102C29 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)