### PR TITLE
[org-js] Add timeline view to the agile board

### DIFF
--- a/doc/agile/product_backlog/inbox/version_site_asset_links.org
+++ b/doc/agile/product_backlog/inbox/version_site_asset_links.org
@@ -1,0 +1,40 @@
+:PROPERTIES:
+:ID: 97C772E4-C613-4C35-B993-99448D763542
+:END:
+#+title: Cache-bust site asset links at build time
+#+description: Version the stylesheet and asset links the site build emits (e.g. style.css?v=<short-sha>) so returning visitors do not see stale CSS after a restyle.
+#+type: capture
+#+level: cross
+#+filetags: :site:build:css:emacs:
+#+created: 2026-06-07
+#+updated: 2026-06-07
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+The site build emits plain asset links — =<link rel="stylesheet"
+href="/OreStudio/assets/style.css">= in =html-header=, the nav-injection
+in =ores-inject-site-nav=, and the org-publish pages — with no version
+token. Append a build-time cache-buster (e.g. =style.css?v=<short-sha>=
+from =git rev-parse --short HEAD=) in =ores-build-site.el= wherever asset
+URLs are emitted, so a restyle invalidates browser caches automatically.
+
+* Why
+
+After the hierarchical menu landed, a returning browser on the locally
+served site kept the pre-menu =assets/style.css= and rendered all
+dropdowns permanently expanded with bullets — diagnosed as stale CSS
+cache, fixed only by a hard refresh. GitHub Pages visitors hit the same
+class of problem after any restyle: HTML revalidates but subresources
+often do not.
+
+* References
+
+- proj:projects/ores.lisp/src/ores-build-site.el — =html-header=,
+  =site-html-preamble=, =ores-inject-site-nav=.
+- Observed 2026-06-07 testing the agile board timeline view.
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -61,7 +61,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
-| [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | STARTED | 2026-06-07 |     | Event-count chart with click-through to bucket snapshots.         |
+| [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -61,7 +61,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
-| [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | BACKLOG |            |     | Event-count chart with click-through to bucket snapshots.         |
+| [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | STARTED | 2026-06-07 |     | Event-count chart with click-through to bucket snapshots.         |
 
 * Decisions
 
@@ -75,6 +75,11 @@ event counts over time with click-through to each bucket's log.
   timeline from a fresh checkout. Journals are never a timeline input;
   environment attribution comes from the document stamps; every snapshot
   carries a window-scoped audit section reporting bookkeeping drift.
+- /Board timeline view needs no infrastructure extension/ :: Verified:
+  snapshot files carry =:ID:=s, so =org-roam-db-sync= indexes them and the
+  existing =graphdata.json= export delivers their full org content to the
+  browser — the board view consumes them exactly like stories and tasks.
+  No changes to the export, the site build, or the data pipeline.
 - /Bucket size is an experiment, not a constant/ :: 20 minutes was an
   arbitrary starting point. The real constraint is readability: a bucket
   must not hold more events than can be scanned at a glance. Window size

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -8,7 +8,7 @@
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
 #+branch: feature/timeline-dashboard-view
-#+pr:
+#+pr: 1178
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -69,7 +69,7 @@ them like any story or task, no pipeline change.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1178][#1178]] | [org-js] Add timeline view to the agile board |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -27,11 +27,11 @@ the latest.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Implemented and verified; opening the PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR, close task; env stamp and snapshot skill remain. |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -75,7 +75,13 @@ them like any story or task, no pipeline change.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Dead total + hidden empty text in StackedBars | charts.js | Accepted | Removed. |
+| 1 | Axis label slices possibly-arbitrary filename | data.js, app.js | Accepted | label computed in loadTimelineBuckets with fallback. |
+| 1 | No null guard on index.timeline | app.js | Accepted | index.timeline ?? []. |
+| 1 | replace only first underscore | app.js | Accepted | replaceAll. |
+| 1 | #NNN links to /pull/ (404s on issues) | render.js | Accepted | Switched to /issues/ (redirects to PR when applicable). |
+| 1 | view-state comment missing 'timeline' | app.js | Accepted | Comment updated. |
+| 1 | problems detection ignores tables | data.js | Declined | Depends on snapshot skill format; revisit when formalised. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.org
@@ -19,17 +19,19 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add a timeline view to the agile board: event counts per bucket as a
+clickable chart, click-through to each bucket's snapshot, defaulting to
+the latest.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Not yet started.                       |
+| Now          | Implemented and verified; opening the PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR, close task; env stamp and snapshot skill remain. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
@@ -45,9 +47,21 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Assessment confirmed first (recorded in the story Decisions): snapshot
+files carry =:ID:=s, so =org-roam-db-sync= indexes them and the existing
+=graphdata.json= export ships their full org content — the board consumes
+them like any story or task, no pipeline change.
+
+- =data.js= =loadTimelineBuckets=: collect =.../timeline/*.org= nodes from
+  the graph, parse window from the =<ISO-from>-<ISO-to>= filename, count
+  rows in each snapshot's section tables, flag buckets whose
+  problems/suspicious section is non-empty.
+- =charts.js= =StackedBars=: one clickable bar per bucket, a coloured
+  segment per category, ⚠ over buckets with reported problems.
+- =app.js= Timeline view: third toolbar toggle; the chart plus the
+  selected bucket's snapshot rendered via uniorg; defaults to the latest.
+- =render.js=: linkify bare =#NNN= references to GitHub PRs in rendered
+  snapshot/drawer HTML.
 
 * Notes
 
@@ -64,3 +78,12 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Timeline view shipped. Third board view (Sprints / Backlog / Timeline):
+stacked-bar chart, one bar per snapshot bucket, segments coloured per
+category (stories/tasks/captures/PRs), ⚠ flag on buckets reporting
+problems; click a bar to read that bucket's snapshot (uniorg-rendered,
+in-app id-link navigation, bare #NNN now linking to GitHub PRs); defaults
+to the latest bucket. Assessment held: no export/build/pipeline change —
+snapshots reach the browser through the existing graphdata.json. Verified
+against the six test snapshots for 2026-06-07.

--- a/doc/agile/versions/v0/sprint_20/commission_currency/task_entity_view_document.org
+++ b/doc/agile/versions/v0/sprint_20/commission_currency/task_entity_view_document.org
@@ -15,7 +15,7 @@
 #+updated: 2026-06-07
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
-This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 

--- a/doc/agile/versions/v0/sprint_20/commission_currency/task_sync_sql_codegen_currency_auxiliaries.org
+++ b/doc/agile/versions/v0/sprint_20/commission_currency/task_sync_sql_codegen_currency_auxiliaries.org
@@ -79,7 +79,7 @@ The known drift (as of 2026-06-07, from running =codegen regenerate --component 
 
 The session began by establishing the =ores_{component}_{entity_plural}= naming
 convention for PostgreSQL LISTEN/NOTIFY channels (documented in
-[[id:81AB065B-E2DA-4762-9DDE-88E9D5D5C8E8][postgresql_architecture.org]]). All 72 trigger files and the C++ =application.cpp=
+[[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][postgresql_architecture.org]]). All 72 trigger files and the C++ =application.cpp=
 registrations were updated accordingly (commit =4d082ca9a=).
 
 ** Template bug: validate function missing from drop script (2026-06-07)

--- a/projects/ores.org-js/agile/src/app.js
+++ b/projects/ores.org-js/agile/src/app.js
@@ -10,9 +10,9 @@
 import { h, render } from 'https://esm.sh/preact@10.25.4';
 import { useState, useEffect, useMemo } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
-import { loadAgileIndex, loadSprint, loadBacklog, velocity, burnup } from './data.js';
+import { loadAgileIndex, loadSprint, loadBacklog, loadTimelineBuckets, velocity, burnup } from './data.js';
 import { section, fieldTable, linkText } from './orgparse.js';
-import { BarChart, LineChart } from './charts.js';
+import { BarChart, LineChart, StackedBars } from './charts.js';
 import { orgToHtml } from './render.js';
 
 const html = htm.bind(h);
@@ -370,12 +370,52 @@ function BacklogBoard({ buckets, filter, onSelect }) {
     </div>`;
 }
 
+const TL_COLORS = {
+  stories: 'var(--accent)', tasks: 'var(--state-done)',
+  captures: '#c792ea', prs: '#f78c6c',
+};
+
+function TimelineView({ buckets, selected, onPick, onNav }) {
+  if (!buckets.length) return html`
+    <div class="loading">No timeline snapshots yet — they are written by
+    the snapshot skill (see the agile timeline story).</div>`;
+  const chart = buckets.map(b => ({
+    label: b.from.slice(11),
+    flag: b.hasProblems,
+    segments: Object.entries(b.counts).map(([k, v]) => ({
+      label: k, value: v, color: TL_COLORS[k] })),
+  }));
+  const b = buckets[selected];
+  return html`
+    <div class="timeline-view">
+      <div class="tl-chart">
+        <${StackedBars} buckets=${chart} selected=${selected}
+                        onPick=${onPick} title="Events per bucket — click a bar" />
+        <div class="tl-legend">
+          ${Object.entries(TL_COLORS).map(([k, c]) => html`
+            <span class="tl-key"><span class="tl-swatch" style="background:${c}"></span>${k}</span>`)}
+          <span class="tl-key">⚠ problems reported</span>
+        </div>
+      </div>
+      <div class="tl-snapshot">
+        <div class="tl-snapshot-header">
+          <h2>${b.from} → ${b.to}</h2>
+          ${b.hasProblems && html`<span class="badge blocked">PROBLEMS</span>`}
+          <span class="muted">${b.sprint.replace('_', ' ')}</span>
+        </div>
+        <${OrgDoc} doc=${b.doc} onNav=${onNav} />
+        <${DocLink} doc=${b.doc} />
+      </div>
+    </div>`;
+}
+
 function App() {
   const [index, setIndex] = useState(null);
   const [view, setView] = useState('sprints'); // 'sprints' | 'backlog'
   const [sprintName, setSprintName] = useState(null);
   const [selected, setSelected] = useState(null); // {story, task|null}
   const [capture, setCapture] = useState(null);
+  const [tlSelected, setTlSelected] = useState(null);
   const [showSprint, setShowSprint] = useState(false);
   const [pendingId, setPendingId] = useState(null);
   const [filter, setFilter] = useState('');
@@ -400,6 +440,8 @@ function App() {
   const vel = useMemo(() => index ? velocity(index) : [], [index]);
   const buckets = useMemo(
     () => index ? loadBacklog(index.backlog) : [], [index]);
+  const tlBuckets = useMemo(
+    () => index ? loadTimelineBuckets(index.timeline) : [], [index]);
 
   useEffect(() => { setEpic(null); setShowSprint(false); }, [sprintName]);
 
@@ -466,6 +508,8 @@ function App() {
                   onClick=${() => setView('sprints')}>Sprints</button>
           <button class=${view === 'backlog' ? 'active' : ''}
                   onClick=${() => setView('backlog')}>Backlog</button>
+          <button class=${view === 'timeline' ? 'active' : ''}
+                  onClick=${() => setView('timeline')}>Timeline</button>
         </div>
         ${view === 'sprints' && html`
           <select value=${sprintName} onChange=${e => setSprintName(e.target.value)}>
@@ -485,6 +529,11 @@ function App() {
       `}
       ${view === 'backlog' && html`
         <${BacklogBoard} buckets=${buckets} filter=${filter} onSelect=${setCapture} />
+      `}
+      ${view === 'timeline' && html`
+        <${TimelineView} buckets=${tlBuckets}
+                         selected=${tlSelected ?? Math.max(0, tlBuckets.length - 1)}
+                         onPick=${setTlSelected} onNav=${onNav} />
       `}
       ${selected && view === 'sprints' && html`
         <${StoryDetail} story=${selected.story} task=${selected.task}

--- a/projects/ores.org-js/agile/src/app.js
+++ b/projects/ores.org-js/agile/src/app.js
@@ -380,7 +380,7 @@ function TimelineView({ buckets, selected, onPick, onNav }) {
     <div class="loading">No timeline snapshots yet — they are written by
     the snapshot skill (see the agile timeline story).</div>`;
   const chart = buckets.map(b => ({
-    label: b.from.slice(11),
+    label: b.label,
     flag: b.hasProblems,
     segments: Object.entries(b.counts).map(([k, v]) => ({
       label: k, value: v, color: TL_COLORS[k] })),
@@ -401,7 +401,7 @@ function TimelineView({ buckets, selected, onPick, onNav }) {
         <div class="tl-snapshot-header">
           <h2>${b.from} → ${b.to}</h2>
           ${b.hasProblems && html`<span class="badge blocked">PROBLEMS</span>`}
-          <span class="muted">${b.sprint.replace('_', ' ')}</span>
+          <span class="muted">${b.sprint.replaceAll('_', ' ')}</span>
         </div>
         <${OrgDoc} doc=${b.doc} onNav=${onNav} />
         <${DocLink} doc=${b.doc} />
@@ -411,7 +411,7 @@ function TimelineView({ buckets, selected, onPick, onNav }) {
 
 function App() {
   const [index, setIndex] = useState(null);
-  const [view, setView] = useState('sprints'); // 'sprints' | 'backlog'
+  const [view, setView] = useState('sprints'); // 'sprints' | 'backlog' | 'timeline'
   const [sprintName, setSprintName] = useState(null);
   const [selected, setSelected] = useState(null); // {story, task|null}
   const [capture, setCapture] = useState(null);
@@ -441,7 +441,7 @@ function App() {
   const buckets = useMemo(
     () => index ? loadBacklog(index.backlog) : [], [index]);
   const tlBuckets = useMemo(
-    () => index ? loadTimelineBuckets(index.timeline) : [], [index]);
+    () => index ? loadTimelineBuckets(index.timeline ?? []) : [], [index]);
 
   useEffect(() => { setEpic(null); setShowSprint(false); }, [sprintName]);
 

--- a/projects/ores.org-js/agile/src/charts.js
+++ b/projects/ores.org-js/agile/src/charts.js
@@ -96,7 +96,6 @@ export function StackedBars({ buckets, selected, onPick, title }) {
       <div class="panel-title">${title}</div>
       <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet">
         ${buckets.map((b, i) => {
-          const total = b.segments.reduce((n, s) => n + s.value, 0);
           const x = PAD.l + i * bw + bw * 0.12;
           let y = PAD.t + IH;
           const segs = b.segments.map(s => {
@@ -121,8 +120,6 @@ export function StackedBars({ buckets, selected, onPick, title }) {
                       text-anchor="middle" class="chart-flag">⚠</text>`}
               <text x=${x + bw * 0.38} y=${H - PAD.b + 14}
                     text-anchor="middle" class="chart-label">${b.label}</text>
-              ${total > 0 && html`
-                <text x=${x + bw * 0.38} y=${PAD.t + IH + 12} visibility="hidden"></text>`}
             </g>`;
         })}
       </svg>

--- a/projects/ores.org-js/agile/src/charts.js
+++ b/projects/ores.org-js/agile/src/charts.js
@@ -81,3 +81,50 @@ export function LineChart({ points, title, color = 'var(--state-done)' }) {
       </svg>
     </div>`;
 }
+
+/**
+ * Clickable stacked bars — one bar per timeline bucket, one segment
+ * per event category. A ⚠ above a bar flags buckets whose snapshot
+ * reports problems.
+ */
+export function StackedBars({ buckets, selected, onPick, title }) {
+  const max = Math.max(1, ...buckets.map(b =>
+    b.segments.reduce((n, s) => n + s.value, 0)));
+  const bw = IW / Math.max(1, buckets.length);
+  return html`
+    <div class="panel">
+      <div class="panel-title">${title}</div>
+      <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet">
+        ${buckets.map((b, i) => {
+          const total = b.segments.reduce((n, s) => n + s.value, 0);
+          const x = PAD.l + i * bw + bw * 0.12;
+          let y = PAD.t + IH;
+          const segs = b.segments.map(s => {
+            const h = (s.value / max) * IH;
+            y -= h;
+            return { ...s, y, h };
+          });
+          return html`
+            <g class="tl-bar ${i === selected ? 'selected' : ''}"
+               onClick=${() => onPick(i)}>
+              <rect x=${x - bw * 0.06} y=${PAD.t - 4}
+                    width=${bw * 0.88} height=${IH + 8}
+                    fill="transparent" stroke=${i === selected ? 'var(--accent)' : 'none'}
+                    stroke-width="1" rx="4"/>
+              ${segs.map(s => html`
+                <rect x=${x} y=${s.y} width=${bw * 0.76} height=${s.h}
+                      fill=${s.color} rx="1">
+                  <title>${b.label}: ${s.label} ${s.value}</title>
+                </rect>`)}
+              ${b.flag && html`
+                <text x=${x + bw * 0.38} y=${Math.min(...segs.map(s => s.y), PAD.t + IH) - 5}
+                      text-anchor="middle" class="chart-flag">⚠</text>`}
+              <text x=${x + bw * 0.38} y=${H - PAD.b + 14}
+                    text-anchor="middle" class="chart-label">${b.label}</text>
+              ${total > 0 && html`
+                <text x=${x + bw * 0.38} y=${PAD.t + IH + 12} visibility="hidden"></text>`}
+            </g>`;
+        })}
+      </svg>
+    </div>`;
+}

--- a/projects/ores.org-js/agile/src/data.js
+++ b/projects/ores.org-js/agile/src/data.js
@@ -263,6 +263,9 @@ export function loadTimelineBuckets(timeline) {
       sprint: t.sprint,
       from: m ? fmt(m[1]) : t.name,
       to: m ? fmt(m[2]) : '',
+      // Axis label: end time HH:MM for a well-formed window, else the
+      // raw filename so a non-standard snapshot name stays legible.
+      label: m ? fmt(m[2]).slice(11) : t.name,
       counts,
       hasProblems: real.length > 0,
     };

--- a/projects/ores.org-js/agile/src/data.js
+++ b/projects/ores.org-js/agile/src/data.js
@@ -22,6 +22,7 @@ export function graphDataUrl() {
 }
 
 const AGILE_RE = /doc\/agile\/versions\/([^/]+)\/(sprint_\d+)\//;
+const TIMELINE_RE = /doc\/agile\/versions\/[^/]+\/(sprint_\d+)\/timeline\/([^/]+)\.html$/;
 const BACKLOG_RE = /doc\/agile\/product_backlog\/(inbox|next|deferred|discarded)\//;
 export const BUCKETS = ['inbox', 'next', 'deferred', 'discarded'];
 
@@ -38,6 +39,7 @@ export async function loadAgileIndex() {
   const graph = await res.json();
 
   const versions = new Map();
+  const timeline = [];
   const backlog = new Map(BUCKETS.map(b => [b, []]));
   const byId = new Map();
   const byUrl = new Map();
@@ -46,6 +48,11 @@ export async function loadAgileIndex() {
     if (node.id) byId.set(node.id.toUpperCase(), node);
     if (node.level === 0 && node.file) byUrl.set(node.file, node);
     if (node.level !== 0 || !node.content) continue;
+    const tl = (node.file || '').match(TIMELINE_RE);
+    if (tl) {
+      timeline.push({ node, sprint: tl[1], name: tl[2] });
+      continue;
+    }
     const b = (node.file || '').match(BACKLOG_RE);
     if (b) {
       const bucket = b[1];
@@ -70,7 +77,8 @@ export async function loadAgileIndex() {
       .map(([sname, nodes]) => ({ name: sname, nodes }));
     out.push({ name, sprints: ss });
   }
-  return { versions: out, backlog, byId, byUrl, locById };
+  timeline.sort((a, b) => a.name.localeCompare(b.name));
+  return { versions: out, timeline, backlog, byId, byUrl, locById };
 }
 
 /**
@@ -218,4 +226,45 @@ export function burnup(model) {
   for (const d of ends) byDay.set(d, (byDay.get(d) || 0) + 1);
   let cum = 0;
   return [...byDay.entries()].map(([x, n]) => ({ x, y: (cum += n) }));
+}
+
+
+/**
+ * Parse timeline snapshot nodes into buckets for the timeline view:
+ *   [{doc, name, sprint, from, to, counts, hasProblems}]
+ * Window comes from the <ISO-from>-<ISO-to> filename; counts from the
+ * snapshot's section tables; hasProblems from a non-empty problems
+ * section (ignoring an explicit "None observed").
+ */
+export function loadTimelineBuckets(timeline) {
+  const fmt = w =>
+    `${w.slice(0, 4)}-${w.slice(4, 6)}-${w.slice(6, 8)} ` +
+    `${w.slice(9, 11)}:${w.slice(11, 13)}`;
+  return timeline.map(t => {
+    const doc = parseOrg(t.node.content);
+    doc.url = t.node.file;
+    doc.raw = t.node.content;
+    const m = t.name.match(/^(\d{8}T\d{4})-(\d{8}T\d{4})$/);
+    const counts = {};
+    for (const [key, title] of [
+      ['stories', 'Stories'], ['tasks', 'Tasks'],
+      ['captures', 'Captures'], ['prs', 'Pull requests']]) {
+      const s = section(doc, title);
+      counts[key] = s && s.tables.length ? s.tables[0].rows.length : 0;
+    }
+    const probs = section(doc, 'Problems and suspicious decisions');
+    const real = probs
+      ? [...probs.items, ...probs.prose]
+          .filter(x => !/^none observed/i.test(x.trim()))
+      : [];
+    return {
+      doc,
+      name: t.name,
+      sprint: t.sprint,
+      from: m ? fmt(m[1]) : t.name,
+      to: m ? fmt(m[2]) : '',
+      counts,
+      hasProblems: real.length > 0,
+    };
+  });
 }

--- a/projects/ores.org-js/agile/src/render.js
+++ b/projects/ores.org-js/agile/src/render.js
@@ -20,6 +20,8 @@ const GITHUB_REPO = 'https://github.com/OreStudio/OreStudio';
 
 /**
  * Linkify bare PR/issue references (#1234) in the rendered HTML.
+ * Uses /issues/NNN, which GitHub redirects to the PR when NNN is a PR,
+ * so both kinds of reference resolve (unlike /pull/NNN for an issue).
  * Operates only on text between tags so attributes and existing
  * anchors are untouched.
  */
@@ -27,7 +29,7 @@ function linkifyPrRefs(html) {
   return html.replace(/(^|>)([^<]*)/g, (m, lead, text) =>
     lead + text.replace(
       /#(\d{3,6})\b/g,
-      `<a href="${GITHUB_REPO}/pull/$1" target="_blank" rel="noopener">#$1</a>`));
+      `<a href="${GITHUB_REPO}/issues/$1" target="_blank" rel="noopener">#$1</a>`));
 }
 
 /**

--- a/projects/ores.org-js/agile/src/render.js
+++ b/projects/ores.org-js/agile/src/render.js
@@ -16,14 +16,29 @@ const processor = unified()
   .use(uniorg2rehype)
   .use(rehypeStringify);
 
+const GITHUB_REPO = 'https://github.com/OreStudio/OreStudio';
+
+/**
+ * Linkify bare PR/issue references (#1234) in the rendered HTML.
+ * Operates only on text between tags so attributes and existing
+ * anchors are untouched.
+ */
+function linkifyPrRefs(html) {
+  return html.replace(/(^|>)([^<]*)/g, (m, lead, text) =>
+    lead + text.replace(
+      /#(\d{3,6})\b/g,
+      `<a href="${GITHUB_REPO}/pull/$1" target="_blank" rel="noopener">#$1</a>`));
+}
+
 /**
  * Strip the file-level :PROPERTIES: drawer and #+keyword header — the
  * drawer header already shows title/description/state — then render
- * the remaining org source to an HTML string.
+ * the remaining org source to an HTML string. Bare #NNN references
+ * become GitHub PR links.
  */
 export function orgToHtml(src) {
   let s = src;
   s = s.replace(/^:PROPERTIES:\n(?:.*\n)*?:END:\n/, '');
   s = s.replace(/^#\+[A-Za-z_]+:.*\n/gm, '');
-  return String(processor.processSync(s));
+  return linkifyPrRefs(String(processor.processSync(s)));
 }

--- a/projects/ores.org-js/agile/style.css
+++ b/projects/ores.org-js/agile/style.css
@@ -352,3 +352,23 @@ table.fields td { font-size: 0.85rem; padding: 0.25rem 0; }
 
 /* Story card age line */
 .card-age { color: var(--text-muted); font-size: 0.7rem; margin-top: 0.3rem; }
+
+/* Timeline view */
+.timeline-view { max-width: 75rem; }
+.tl-chart { max-width: 46rem; }
+.tl-bar { cursor: pointer; }
+.tl-bar:hover rect[fill="transparent"] { stroke: var(--accent-hover); }
+.chart-flag { fill: var(--state-blocked); font-size: 11px; }
+.tl-legend { display: flex; gap: 1rem; flex-wrap: wrap; margin: 0.4rem 0.2rem; }
+.tl-key { color: var(--text-muted); font-size: 0.75rem; display: inline-flex; align-items: center; gap: 0.35rem; }
+.tl-swatch { width: 0.7rem; height: 0.7rem; border-radius: 2px; display: inline-block; }
+.tl-snapshot {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.3rem;
+    margin-top: 1rem;
+    max-width: 60rem;
+}
+.tl-snapshot-header { display: flex; align-items: center; gap: 0.7rem; }
+.tl-snapshot-header h2 { margin: 0; font-size: 1.05rem; }


### PR DESCRIPTION
## Summary

Final task of the agile timeline story: a third board view (Sprints / Backlog / Timeline) over the LLM-curated snapshot buckets. They reach the browser through the existing graphdata.json export — the assessment in the story's Decisions confirmed snapshot files get :ID:s and flow through org-roam-db-sync with no pipeline change. A clickable stacked-bar chart shows event counts per bucket coloured by category with a warning flag on buckets reporting problems; selecting a bar renders that bucket's snapshot via uniorg, defaulting to the latest. Bare #NNN references now link to GitHub PRs. Includes six test snapshots already merged in #1175.

## Changes

- data.js loadTimelineBuckets: collect timeline nodes, parse window/counts/problems from each snapshot.
- charts.js StackedBars: clickable per-bucket stacked bars with a problems flag.
- app.js: Timeline toggle and view; defaults to the latest bucket; uniorg-rendered snapshot with id-link navigation.
- render.js: linkify bare #NNN references to GitHub PRs.
- Record the no-infrastructure-change assessment in the story Decisions.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Agile timeline: bucketed summaries of recent activity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/story.html) | 3697D889-BF01-43D4-9EF7-3AF6B70A8122 |
| Task | [Add timeline view to the agile board](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_dashboard_view.html) | EF9E326A-D7A6-42A8-8DB2-53D90A265FED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)