### PR TITLE
[build,cpp] Fix nightly clang-format CI: version pin and formatting drift

### DIFF
--- a/.github/workflows/nightly-format.yml
+++ b/.github/workflows/nightly-format.yml
@@ -37,12 +37,12 @@ jobs:
           ref: main
 
       - name: Install clang-format
-        run: sudo apt-get install -y clang-format-18
+        run: sudo apt-get install -y clang-format
 
       - name: Run clang-format in-place
         run: |
           find projects -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
-            | xargs clang-format-18 -i
+            | xargs clang-format -i
 
       - name: Create pull request if files changed
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/nightly-format.yml
+++ b/.github/workflows/nightly-format.yml
@@ -23,7 +23,8 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:      # allow manual trigger
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   format:
@@ -43,12 +44,23 @@ jobs:
           find projects -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
             | xargs clang-format -i
 
-      - name: Fail if files changed
-        run: |
-          if ! git diff --exit-code -- projects/; then
-            echo ""
-            echo "❌ Formatting drift detected. Run the format target locally and commit:"
-            echo "   cmake --build --preset <preset> --target format"
-            exit 1
-          fi
-          echo "✅ All files match clang-format style."
+      - name: Create pull request if files changed
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/nightly-format
+          commit-message: '[format] Nightly clang-format run'
+          title: '[format] Nightly clang-format run'
+          body: |
+            Automated nightly clang-format pass.
+
+            This PR was raised by the `nightly-format` workflow because one or
+            more C++ source files differed from the canonical `.clang-format`
+            style. Review and merge to keep the tree clean.
+
+            To reproduce locally:
+            ```sh
+            cmake --build --preset <preset> --target format
+            ```
+          labels: formatting,automated
+          delete-branch: true

--- a/.github/workflows/nightly-format.yml
+++ b/.github/workflows/nightly-format.yml
@@ -23,8 +23,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:      # allow manual trigger
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   format:
@@ -44,23 +43,12 @@ jobs:
           find projects -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
             | xargs clang-format -i
 
-      - name: Create pull request if files changed
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: bot/nightly-format
-          commit-message: '[format] Nightly clang-format run'
-          title: '[format] Nightly clang-format run'
-          body: |
-            Automated nightly clang-format pass.
-
-            This PR was raised by the `nightly-format` workflow because one or
-            more C++ source files differed from the canonical `.clang-format`
-            style. Review and merge to keep the tree clean.
-
-            To reproduce locally:
-            ```sh
-            cmake --build --preset <preset> --target format
-            ```
-          labels: formatting,automated
-          delete-branch: true
+      - name: Fail if files changed
+        run: |
+          if ! git diff --exit-code -- projects/; then
+            echo ""
+            echo "❌ Formatting drift detected. Run the format target locally and commit:"
+            echo "   cmake --build --preset <preset> --target format"
+            exit 1
+          fi
+          echo "✅ All files match clang-format style."

--- a/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/story.org
+++ b/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/story.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: 10B5F44F-5EE7-4026-BFD7-4DABAB6540B8
+:END:
+#+title: Story: Fix nightly clang-format CI: permissions and formatting drift
+#+description: Nightly clang-format workflow fails: GitHub Actions lacks permission to create PRs, and 265 files have accumulated formatting drift. Fix the permission and apply the format.
+#+type: story
+#+level: s2
+#+filetags: :ci:clang_format:tooling:sprint_20:v0:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-08                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:9F20113A-1D5C-49F0-B322-DAAC0ED4FDED][Fix nightly-format workflow and apply formatting drift]] | BACKLOG | | | Enable GitHub Actions PR creation permission; run clang-format-18 over 265 drifted files and commit the result. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
@@ -1,0 +1,113 @@
+:PROPERTIES:
+:ID: 9F20113A-1D5C-49F0-B322-DAAC0ED4FDED
+:END:
+#+title: Task: Fix nightly-format workflow and apply formatting drift
+#+description: Enable GitHub Actions PR creation permission; run clang-format-18 over 265 drifted files and commit the result.
+#+type: task
+#+level: s1
+#+filetags: :ci:clang_format:tooling:sprint_20:v0:fix_clang_format_ci:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI: permissions and formatting drift]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix the =nightly-format= CI workflow so it can run end-to-end:
+
+1. Resolve the GitHub Actions PR-creation permission error that causes
+   the workflow to fail at the final step.
+2. Apply =clang-format-18= to the 265 C++ files that have accumulated
+   formatting drift since the last successful run.
+
+After this task the nightly-format workflow should complete cleanly and
+the codebase should have zero formatting drift.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI: permissions and formatting drift]] |
+| Now          | Investigating permission error and drift scope (2026-06-08). |
+| Waiting on   | Nothing.                               |
+| Next         | Apply clang-format and fix workflow permission. |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- =nightly-format= workflow completes without error.
+- Zero files differ from =clang-format-18= output after the fix PR lands.
+- Bot PR creation succeeds on the next nightly run.
+
+* Plan
+
+1. Fix the workflow permission error: either enable "Allow GitHub
+   Actions to create and approve pull requests" in repo settings, or
+   switch the workflow to use a =pull-requests: write= permission
+   already present in the workflow — investigate which is missing.
+2. Run =clang-format-18= locally over all 265 drifted files and commit
+   the result on a feature branch.
+3. Raise PR; merge.
+
+* Notes
+
+** Investigation (2026-06-08)
+
+Failing run: [[https://github.com/OreStudio/OreStudio/actions/runs/27119985802/job/80034644045]]
+
+*Root cause 1 — GitHub Actions PR permission*: the workflow's final
+step (=peter-evans/create-pull-request@v7=) fails with:
+
+#+begin_example
+GitHub Actions is not permitted to create or approve pull requests.
+#+end_example
+
+The =nightly-format.yml= workflow declares =permissions: contents: write,
+pull-requests: write=, so the token has the right scope. The error comes
+from a repository-level setting: "Allow GitHub Actions to create and
+approve pull requests" is disabled in the repo's Actions settings.
+This must be enabled by a repo admin at:
+Settings → Actions → General → Workflow permissions.
+
+*Root cause 2 — 265 files with formatting drift*: =clang-format-18 -i=
+applied to all =*.cpp= / =*.hpp= / =*.h= under =projects/= produces 265
+modified files spanning analytics, assets, cli, compute, controller,
+database, diff, dq, and many other components. This is accumulated drift
+— no single recent commit caused it; it has been building since the last
+time the format was applied.
+
+*Root cause 3 — version pin mismatch*: The workflow pinned =clang-format-18=
+but the project's local toolchain uses =clang-format 21= (Debian). Pinning
+to an older version means CI reformats files differently to local, perpetually
+re-introducing drift. Fix: change the workflow to install =clang-format= (the
+distro default) to track the same major version as local development.
+
+** Fix applied (2026-06-08)
+
+- Updated =nightly-format.yml= to install and invoke =clang-format= (no
+  version pin) instead of =clang-format-18=.
+- Applied =clang-format 21= locally to 181 files; staged for PR.
+- *Repo admin action required*: enable "Allow GitHub Actions to create
+  and approve pull requests" at Settings → Actions → General →
+  Workflow permissions.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
@@ -71,12 +71,10 @@ GitHub Actions is not permitted to create or approve pull requests.
 
 The =nightly-format.yml= workflow declares =permissions: contents: write,
 pull-requests: write=, so the token has the right scope. The setting
-"Allow GitHub Actions to create and approve pull requests" is grayed
+"Allow GitHub Actions to create and approve pull requests" was grayed
 out at the repository level — it is controlled by an organisation-level
-policy that overrides all repositories and cannot be enabled per-repo.
-Fix: remove the bot-PR approach entirely; replace with =git diff --exit-code=
-that fails the job when files are dirty. Developers run the format target
-locally; CI enforces it. No PR-creation permission required.
+policy. Resolved by enabling it in the organisation settings.
+The bot-PR approach is retained.
 
 *Root cause 2 — 265 files with formatting drift*: =clang-format-18 -i=
 applied to all =*.cpp= / =*.hpp= / =*.h= under =projects/= produces 265

--- a/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
@@ -70,11 +70,13 @@ GitHub Actions is not permitted to create or approve pull requests.
 #+end_example
 
 The =nightly-format.yml= workflow declares =permissions: contents: write,
-pull-requests: write=, so the token has the right scope. The error comes
-from a repository-level setting: "Allow GitHub Actions to create and
-approve pull requests" is disabled in the repo's Actions settings.
-This must be enabled by a repo admin at:
-Settings → Actions → General → Workflow permissions.
+pull-requests: write=, so the token has the right scope. The setting
+"Allow GitHub Actions to create and approve pull requests" is grayed
+out at the repository level — it is controlled by an organisation-level
+policy that overrides all repositories and cannot be enabled per-repo.
+Fix: remove the bot-PR approach entirely; replace with =git diff --exit-code=
+that fails the job when files are dirty. Developers run the format target
+locally; CI enforces it. No PR-creation permission required.
 
 *Root cause 2 — 265 files with formatting drift*: =clang-format-18 -i=
 applied to all =*.cpp= / =*.hpp= / =*.h= under =projects/= produces 265

--- a/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
+++ b/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.org
@@ -8,7 +8,7 @@
 #+filetags: :ci:clang_format:tooling:sprint_20:v0:fix_clang_format_ci:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1187
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -102,7 +102,7 @@ distro default) to track the same major version as local development.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1187][#1187]] | [build,cpp] Fix nightly clang-format CI: version pin and formatting drift |
 
 * Review
 

--- a/projects/ores.diff/include/ores.diff/domain/diff_result.hpp
+++ b/projects/ores.diff/include/ores.diff/domain/diff_result.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_DIFF_DOMAIN_DIFF_RESULT_HPP
 #define ORES_DIFF_DOMAIN_DIFF_RESULT_HPP
 
-#include <vector>
 #include "ores.diff/domain/diff_entry.hpp"
+#include <vector>
 
 namespace ores::diff::domain {
 

--- a/projects/ores.diff/include/ores.diff/engine/compare.hpp
+++ b/projects/ores.diff/include/ores.diff/engine/compare.hpp
@@ -20,10 +20,10 @@
 #ifndef ORES_DIFF_ENGINE_COMPARE_HPP
 #define ORES_DIFF_ENGINE_COMPARE_HPP
 
-#include <vector>
 #include "ores.diff/domain/diff_result.hpp"
 #include "ores.diff/domain/field_value.hpp"
 #include "ores.diff/export.hpp"
+#include <vector>
 
 namespace ores::diff::engine {
 
@@ -47,9 +47,8 @@ namespace ores::diff::engine {
  * @param previous The older version's fields, in mapper order.
  * @param current The newer version's fields, in mapper order.
  */
-ORES_DIFF_EXPORT domain::diff_result
-compute(const std::vector<domain::field_value>& previous,
-        const std::vector<domain::field_value>& current);
+ORES_DIFF_EXPORT domain::diff_result compute(const std::vector<domain::field_value>& previous,
+                                             const std::vector<domain::field_value>& current);
 
 }
 

--- a/projects/ores.diff/include/ores.diff/export.hpp
+++ b/projects/ores.diff/include/ores.diff/export.hpp
@@ -21,15 +21,15 @@
 #define ORES_DIFF_EXPORT_HPP
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-#  ifdef ORES_DIFF_LIBRARY
-#    define ORES_DIFF_EXPORT __declspec(dllexport)
-#  else
-#    define ORES_DIFF_EXPORT __declspec(dllimport)
-#  endif
+#    ifdef ORES_DIFF_LIBRARY
+#        define ORES_DIFF_EXPORT __declspec(dllexport)
+#    else
+#        define ORES_DIFF_EXPORT __declspec(dllimport)
+#    endif
 #elif defined(__GNUC__)
-#  define ORES_DIFF_EXPORT __attribute__((visibility("default")))
+#    define ORES_DIFF_EXPORT __attribute__((visibility("default")))
 #else
-#  define ORES_DIFF_EXPORT
+#    define ORES_DIFF_EXPORT
 #endif
 
 #endif

--- a/projects/ores.diff/src/engine/compare.cpp
+++ b/projects/ores.diff/src/engine/compare.cpp
@@ -18,16 +18,14 @@
  *
  */
 #include "ores.diff/engine/compare.hpp"
-
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace ores::diff::engine {
 
-domain::diff_result
-compute(const std::vector<domain::field_value>& previous,
-        const std::vector<domain::field_value>& current) {
+domain::diff_result compute(const std::vector<domain::field_value>& previous,
+                            const std::vector<domain::field_value>& current) {
     // Index the previous fields by name. First occurrence wins when a
     // name repeats; string_view keys borrow from `previous`, which
     // outlives the map.
@@ -49,14 +47,11 @@ compute(const std::vector<domain::field_value>& previous,
         if (it == by_name.end()) {
             // Added: absent side is empty.
             result.entries.push_back(
-                {.field_name = field.name,
-                 .old_value = {},
-                 .new_value = field.value});
+                {.field_name = field.name, .old_value = {}, .new_value = field.value});
         } else if (it->second->value != field.value) {
-            result.entries.push_back(
-                {.field_name = field.name,
-                 .old_value = it->second->value,
-                 .new_value = field.value});
+            result.entries.push_back({.field_name = field.name,
+                                      .old_value = it->second->value,
+                                      .new_value = field.value});
         }
     }
 
@@ -69,9 +64,7 @@ compute(const std::vector<domain::field_value>& previous,
 
         if (!seen_in_current.contains(field.name)) {
             result.entries.push_back(
-                {.field_name = field.name,
-                 .old_value = field.value,
-                 .new_value = {}});
+                {.field_name = field.name, .old_value = field.value, .new_value = {}});
         }
     }
 

--- a/projects/ores.diff/tests/domain_serialisation_tests.cpp
+++ b/projects/ores.diff/tests/domain_serialisation_tests.cpp
@@ -34,12 +34,9 @@ using ores::diff::domain::field_value;
 
 TEST_CASE("diff_result_round_trips_through_rfl_json", tags) {
     const diff_result original{
-        .entries = {{.field_name = "Name",
-                     .old_value = "US Dollar",
-                     .new_value = "United States Dollar"},
-                    {.field_name = "Market Tier",
-                     .old_value = "",
-                     .new_value = "Major"}}};
+        .entries = {
+            {.field_name = "Name", .old_value = "US Dollar", .new_value = "United States Dollar"},
+            {.field_name = "Market Tier", .old_value = "", .new_value = "Major"}}};
 
     const auto json = rfl::json::write(original);
     const auto restored = rfl::json::read<diff_result>(json);

--- a/projects/ores.diff/tests/engine_compare_tests.cpp
+++ b/projects/ores.diff/tests/engine_compare_tests.cpp
@@ -31,9 +31,8 @@ using ores::diff::domain::diff_entry;
 using ores::diff::engine::compute;
 
 TEST_CASE("compare_identical_inputs_yields_empty_result", tags) {
-    const std::vector<field_value> fields{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Name", .value = "US Dollar"}};
+    const std::vector<field_value> fields{{.name = "ISO Code", .value = "USD"},
+                                          {.name = "Name", .value = "US Dollar"}};
 
     const auto result = compute(fields, fields);
 
@@ -47,10 +46,8 @@ TEST_CASE("compare_both_lists_empty_yields_empty_result", tags) {
 }
 
 TEST_CASE("compare_changed_value_yields_entry_with_both_sides", tags) {
-    const std::vector<field_value> previous{
-        {.name = "Name", .value = "US Dollar"}};
-    const std::vector<field_value> current{
-        {.name = "Name", .value = "United States Dollar"}};
+    const std::vector<field_value> previous{{.name = "Name", .value = "US Dollar"}};
+    const std::vector<field_value> current{{.name = "Name", .value = "United States Dollar"}};
 
     const auto result = compute(previous, current);
 
@@ -61,14 +58,12 @@ TEST_CASE("compare_changed_value_yields_entry_with_both_sides", tags) {
 }
 
 TEST_CASE("compare_unchanged_fields_are_omitted", tags) {
-    const std::vector<field_value> previous{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Name", .value = "US Dollar"},
-        {.name = "Symbol", .value = "$"}};
-    const std::vector<field_value> current{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Name", .value = "United States Dollar"},
-        {.name = "Symbol", .value = "$"}};
+    const std::vector<field_value> previous{{.name = "ISO Code", .value = "USD"},
+                                            {.name = "Name", .value = "US Dollar"},
+                                            {.name = "Symbol", .value = "$"}};
+    const std::vector<field_value> current{{.name = "ISO Code", .value = "USD"},
+                                           {.name = "Name", .value = "United States Dollar"},
+                                           {.name = "Symbol", .value = "$"}};
 
     const auto result = compute(previous, current);
 
@@ -77,78 +72,63 @@ TEST_CASE("compare_unchanged_fields_are_omitted", tags) {
 }
 
 TEST_CASE("compare_added_field_has_empty_old_value", tags) {
-    const std::vector<field_value> previous{
-        {.name = "ISO Code", .value = "USD"}};
-    const std::vector<field_value> current{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Market Tier", .value = "Major"}};
+    const std::vector<field_value> previous{{.name = "ISO Code", .value = "USD"}};
+    const std::vector<field_value> current{{.name = "ISO Code", .value = "USD"},
+                                           {.name = "Market Tier", .value = "Major"}};
 
     const auto result = compute(previous, current);
 
     REQUIRE(result.entries.size() == 1);
-    CHECK(result.entries[0] == diff_entry{.field_name = "Market Tier",
-                                          .old_value = "",
-                                          .new_value = "Major"});
+    CHECK(result.entries[0] ==
+          diff_entry{.field_name = "Market Tier", .old_value = "", .new_value = "Major"});
 }
 
 TEST_CASE("compare_removed_field_has_empty_new_value", tags) {
-    const std::vector<field_value> previous{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Legacy Flag", .value = "true"}};
-    const std::vector<field_value> current{
-        {.name = "ISO Code", .value = "USD"}};
+    const std::vector<field_value> previous{{.name = "ISO Code", .value = "USD"},
+                                            {.name = "Legacy Flag", .value = "true"}};
+    const std::vector<field_value> current{{.name = "ISO Code", .value = "USD"}};
 
     const auto result = compute(previous, current);
 
     REQUIRE(result.entries.size() == 1);
-    CHECK(result.entries[0] == diff_entry{.field_name = "Legacy Flag",
-                                          .old_value = "true",
-                                          .new_value = ""});
+    CHECK(result.entries[0] ==
+          diff_entry{.field_name = "Legacy Flag", .old_value = "true", .new_value = ""});
 }
 
 TEST_CASE("compare_previous_empty_reports_all_fields_added", tags) {
-    const std::vector<field_value> current{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Name", .value = "US Dollar"}};
+    const std::vector<field_value> current{{.name = "ISO Code", .value = "USD"},
+                                           {.name = "Name", .value = "US Dollar"}};
 
     const auto result = compute({}, current);
 
     REQUIRE(result.entries.size() == 2);
-    CHECK(result.entries[0] == diff_entry{.field_name = "ISO Code",
-                                          .old_value = "",
-                                          .new_value = "USD"});
-    CHECK(result.entries[1] == diff_entry{.field_name = "Name",
-                                          .old_value = "",
-                                          .new_value = "US Dollar"});
+    CHECK(result.entries[0] ==
+          diff_entry{.field_name = "ISO Code", .old_value = "", .new_value = "USD"});
+    CHECK(result.entries[1] ==
+          diff_entry{.field_name = "Name", .old_value = "", .new_value = "US Dollar"});
 }
 
 TEST_CASE("compare_current_empty_reports_all_fields_removed", tags) {
-    const std::vector<field_value> previous{
-        {.name = "ISO Code", .value = "USD"},
-        {.name = "Name", .value = "US Dollar"}};
+    const std::vector<field_value> previous{{.name = "ISO Code", .value = "USD"},
+                                            {.name = "Name", .value = "US Dollar"}};
 
     const auto result = compute(previous, {});
 
     REQUIRE(result.entries.size() == 2);
-    CHECK(result.entries[0] == diff_entry{.field_name = "ISO Code",
-                                          .old_value = "USD",
-                                          .new_value = ""});
-    CHECK(result.entries[1] == diff_entry{.field_name = "Name",
-                                          .old_value = "US Dollar",
-                                          .new_value = ""});
+    CHECK(result.entries[0] ==
+          diff_entry{.field_name = "ISO Code", .old_value = "USD", .new_value = ""});
+    CHECK(result.entries[1] ==
+          diff_entry{.field_name = "Name", .old_value = "US Dollar", .new_value = ""});
 }
 
 TEST_CASE("compare_preserves_current_order_for_changes", tags) {
     // Previous deliberately lists fields in a different order; the
     // output must follow the current (mapper) order.
     const std::vector<field_value> previous{
-        {.name = "C", .value = "3"},
-        {.name = "A", .value = "1"},
-        {.name = "B", .value = "2"}};
-    const std::vector<field_value> current{
-        {.name = "A", .value = "one"},
-        {.name = "B", .value = "two"},
-        {.name = "C", .value = "three"}};
+        {.name = "C", .value = "3"}, {.name = "A", .value = "1"}, {.name = "B", .value = "2"}};
+    const std::vector<field_value> current{{.name = "A", .value = "one"},
+                                           {.name = "B", .value = "two"},
+                                           {.name = "C", .value = "three"}};
 
     const auto result = compute(previous, current);
 
@@ -159,13 +139,11 @@ TEST_CASE("compare_preserves_current_order_for_changes", tags) {
 }
 
 TEST_CASE("compare_removed_fields_follow_in_previous_order", tags) {
-    const std::vector<field_value> previous{
-        {.name = "Kept", .value = "old"},
-        {.name = "Removed Last", .value = "x"},
-        {.name = "Removed First", .value = "y"}};
-    const std::vector<field_value> current{
-        {.name = "Added", .value = "new"},
-        {.name = "Kept", .value = "new"}};
+    const std::vector<field_value> previous{{.name = "Kept", .value = "old"},
+                                            {.name = "Removed Last", .value = "x"},
+                                            {.name = "Removed First", .value = "y"}};
+    const std::vector<field_value> current{{.name = "Added", .value = "new"},
+                                           {.name = "Kept", .value = "new"}};
 
     const auto result = compute(previous, current);
 
@@ -188,18 +166,14 @@ TEST_CASE("compare_empty_values_on_both_sides_are_equal", tags) {
 }
 
 TEST_CASE("compare_duplicate_names_first_occurrence_wins", tags) {
-    const std::vector<field_value> previous{
-        {.name = "Name", .value = "first"},
-        {.name = "Name", .value = "second"}};
-    const std::vector<field_value> current{
-        {.name = "Name", .value = "changed"},
-        {.name = "Name", .value = "ignored"}};
+    const std::vector<field_value> previous{{.name = "Name", .value = "first"},
+                                            {.name = "Name", .value = "second"}};
+    const std::vector<field_value> current{{.name = "Name", .value = "changed"},
+                                           {.name = "Name", .value = "ignored"}};
 
     const auto result = compute(previous, current);
 
     REQUIRE(result.entries.size() == 1);
-    CHECK(result.entries[0] == diff_entry{.field_name = "Name",
-                                          .old_value = "first",
-                                          .new_value = "changed"});
+    CHECK(result.entries[0] ==
+          diff_entry{.field_name = "Name", .old_value = "first", .new_value = "changed"});
 }
-

--- a/projects/ores.diff/tests/main.cpp
+++ b/projects/ores.diff/tests/main.cpp
@@ -17,9 +17,9 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.testing/logging_listener.hpp"
 #include <catch2/catch_session.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
-#include "ores.testing/logging_listener.hpp"
 
 CATCH_REGISTER_LISTENER(ores::testing::logging_listener)
 

--- a/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
@@ -82,8 +82,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/include/ores.qt/BadgeDefinitionHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/BadgeDefinitionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/include/ores.qt/BadgeSeverityHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/BadgeSeverityHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/SystemSettingHistoryDialog.hpp
@@ -89,8 +89,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/include/ores.qt/TenantHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/TenantHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/include/ores.qt/TenantTypeHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/TenantTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/admin/src/AccountController.cpp
+++ b/projects/ores.qt/admin/src/AccountController.cpp
@@ -319,7 +319,7 @@ void AccountController::onShowAccountHistory(const QString& username) {
 }
 
 void AccountController::onShowSessionAudit(const boost::uuids::uuid& accountId,
-                                             const QString& username) {
+                                           const QString& username) {
     BOOST_LOG_SEV(lg(), info) << "Showing session audit for: " << username.toStdString();
 
     auto* sessionDialog = new SessionAuditDialog(clientManager_, mainWindow_);

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.qt/AccountHistoryDialog.hpp"
-#include "ui_AccountHistoryDialog.h"
 #include "ores.iam.api/messaging/protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
+#include "ui_AccountHistoryDialog.h"
 
 namespace ores::qt {
 
@@ -35,8 +35,7 @@ AccountHistoryDialog::AccountHistoryDialog(QString username,
     , clientManager_(clientManager)
     , username_(std::move(username)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating account history widget for: "
-                              << username_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating account history widget for: " << username_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
@@ -50,8 +49,7 @@ AccountHistoryDialog::AccountHistoryDialog(QString username,
 AccountHistoryDialog::~AccountHistoryDialog() = default;
 
 void AccountHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading account history for: "
-                              << username_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading account history for: " << username_.toStdString();
 
     iam::messaging::get_account_history_request request;
     request.username = username_.toStdString();
@@ -80,13 +78,11 @@ HistoryDialogBase::VersionRow AccountHistoryDialog::versionRow(int index) const 
 
 QString AccountHistoryDialog::historyTitle() const {
     const auto& latest = history_.versions.front();
-    return QString("Account History: %1")
-        .arg(QString::fromStdString(latest.data.username));
+    return QString("Account History: %1").arg(QString::fromStdString(latest.data.username));
 }
 
-HistoryDialogBase::DiffResult
-AccountHistoryDialog::calculateDiffAt(int current_index,
-                                      int previous_index) const {
+HistoryDialogBase::DiffResult AccountHistoryDialog::calculateDiffAt(int current_index,
+                                                                    int previous_index) const {
     const auto& current = history_.versions[current_index].data;
     const auto& previous = history_.versions[previous_index].data;
 
@@ -108,14 +104,12 @@ void AccountHistoryDialog::displayFullDetails(int index) {
     ui_->isAdminValue->setVisible(false);
     ui_->versionNumberValue->setText(QString::number(version.version_number));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
 }
 
 void AccountHistoryDialog::openVersionAt(int index) {
     const auto& version = history_.versions[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening account version "
-                              << version.version_number
+    BOOST_LOG_SEV(lg(), info) << "Opening account version " << version.version_number
                               << " in read-only mode";
     emit openVersionRequested(version.data, version.version_number);
 }
@@ -125,8 +119,7 @@ void AccountHistoryDialog::revertToVersionAt(int index) {
     // selected version, stamped with the latest version number.
     const auto& selected = history_.versions[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version_number;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version_number;
 
     iam::domain::account account = selected.data;
     account.version = history_.versions.front().version_number;

--- a/projects/ores.qt/admin/src/BadgeDefinitionHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/BadgeDefinitionHistoryDialog.cpp
@@ -72,8 +72,7 @@ int BadgeDefinitionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BadgeDefinitionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BadgeDefinitionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -87,8 +86,7 @@ QString BadgeDefinitionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-BadgeDefinitionHistoryDialog::calculateDiffAt(int current_index,
-                                              int previous_index) const {
+BadgeDefinitionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -114,8 +112,8 @@ void BadgeDefinitionHistoryDialog::displayFullDetails(int index) {
 
 void BadgeDefinitionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening badge definition version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening badge definition version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -124,8 +122,7 @@ void BadgeDefinitionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/admin/src/BadgeSeverityHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/BadgeSeverityHistoryDialog.cpp
@@ -72,8 +72,7 @@ int BadgeSeverityHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BadgeSeverityHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BadgeSeverityHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -87,8 +86,7 @@ QString BadgeSeverityHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-BadgeSeverityHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+BadgeSeverityHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -114,8 +112,8 @@ void BadgeSeverityHistoryDialog::displayFullDetails(int index) {
 
 void BadgeSeverityHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening badge severity version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening badge severity version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -124,8 +122,7 @@ void BadgeSeverityHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/SystemSettingHistoryDialog.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.qt/SystemSettingHistoryDialog.hpp"
-#include "ui_SystemSettingHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
+#include "ui_SystemSettingHistoryDialog.h"
 
 namespace ores::qt {
 
@@ -58,8 +58,7 @@ SystemSettingHistoryDialog::SystemSettingHistoryDialog(QString name,
 SystemSettingHistoryDialog::~SystemSettingHistoryDialog() = default;
 
 void SystemSettingHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading system setting history for: "
-                              << flagName_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading system setting history for: " << flagName_.toStdString();
 
     variability::messaging::get_setting_history_request request;
     request.name = flagName_.toStdString();
@@ -79,8 +78,7 @@ int SystemSettingHistoryDialog::historySize() const {
     return static_cast<int>(history_.size());
 }
 
-HistoryDialogBase::VersionRow
-SystemSettingHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow SystemSettingHistoryDialog::versionRow(int index) const {
     const auto& flag = history_[index];
     return {.version = flag.version,
             .cells = {enabledText(flag.value),
@@ -90,23 +88,19 @@ SystemSettingHistoryDialog::versionRow(int index) const {
 
 QString SystemSettingHistoryDialog::historyTitle() const {
     const auto& latest = history_.front();
-    return QString("System Setting History: %1")
-        .arg(QString::fromStdString(latest.name));
+    return QString("System Setting History: %1").arg(QString::fromStdString(latest.name));
 }
 
 HistoryDialogBase::DiffResult
-SystemSettingHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+SystemSettingHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = history_[current_index];
     const auto& previous = history_[previous_index];
 
     DiffResult diffs;
     if (current.value != previous.value) {
-        diffs.append({"Enabled",
-                      {enabledText(previous.value), enabledText(current.value)}});
+        diffs.append({"Enabled", {enabledText(previous.value), enabledText(current.value)}});
     }
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -119,14 +113,13 @@ void SystemSettingHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(flag.description));
     ui_->versionNumberValue->setText(QString::number(flag.version));
     ui_->modifiedByValue->setText(QString::fromStdString(flag.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(flag.recorded_at));
+    ui_->recordedAtValue->setText(relative_time_helper::format(flag.recorded_at));
 }
 
 void SystemSettingHistoryDialog::openVersionAt(int index) {
     const auto& flag = history_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening system setting version "
-                              << flag.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening system setting version " << flag.version
+                              << " in read-only mode";
     emit openVersionRequested(flag, flag.version);
 }
 
@@ -136,8 +129,7 @@ void SystemSettingHistoryDialog::revertToVersionAt(int index) {
     // the data we want to restore.
     const auto& selected = history_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/admin/src/TenantHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/TenantHistoryDialog.cpp
@@ -75,8 +75,7 @@ int TenantHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-TenantHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow TenantHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,9 +88,8 @@ QString TenantHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-TenantHistoryDialog::calculateDiffAt(int current_index,
-                                     int previous_index) const {
+HistoryDialogBase::DiffResult TenantHistoryDialog::calculateDiffAt(int current_index,
+                                                                   int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -121,8 +119,8 @@ void TenantHistoryDialog::displayFullDetails(int index) {
 
 void TenantHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening tenant version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening tenant version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -131,8 +129,7 @@ void TenantHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/admin/src/TenantTypeHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/TenantTypeHistoryDialog.cpp
@@ -72,8 +72,7 @@ int TenantTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-TenantTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow TenantTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -86,9 +85,8 @@ QString TenantTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-TenantTypeHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult TenantTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -114,8 +112,8 @@ void TenantTypeHistoryDialog::displayFullDetails(int index) {
 
 void TenantTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening tenant type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening tenant type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -124,8 +122,7 @@ void TenantTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/analytics/include/ores.qt/PricingEngineTypeHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingEngineTypeHistoryDialog.hpp
@@ -76,8 +76,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelConfigHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelConfigHistoryDialog.hpp
@@ -78,8 +78,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelProductHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelProductHistoryDialog.hpp
@@ -78,8 +78,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/analytics/include/ores.qt/PricingModelProductParameterHistoryDialog.hpp
+++ b/projects/ores.qt/analytics/include/ores.qt/PricingModelProductParameterHistoryDialog.hpp
@@ -80,8 +80,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/analytics/src/PricingEngineTypeHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingEngineTypeHistoryDialog.cpp
@@ -74,8 +74,7 @@ int PricingEngineTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PricingEngineTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PricingEngineTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,16 +88,15 @@ QString PricingEngineTypeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-PricingEngineTypeHistoryDialog::calculateDiffAt(int current_index,
-                                                int previous_index) const {
+PricingEngineTypeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Description", current.description, previous.description);
-    checkString(diffs, "Instrument Type Code", current.instrument_type_code,
-                previous.instrument_type_code);
+    checkString(
+        diffs, "Instrument Type Code", current.instrument_type_code, previous.instrument_type_code);
 
     return diffs;
 }
@@ -108,20 +106,17 @@ void PricingEngineTypeHistoryDialog::displayFullDetails(int index) {
 
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->instrumentTypeCodeValue->setText(
-        QString::fromStdString(version.instrument_type_code));
+    ui_->instrumentTypeCodeValue->setText(QString::fromStdString(version.instrument_type_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PricingEngineTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening pricing engine type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing engine type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -130,8 +125,7 @@ void PricingEngineTypeHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/analytics/src/PricingModelConfigHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelConfigHistoryDialog.cpp
@@ -84,8 +84,7 @@ int PricingModelConfigHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PricingModelConfigHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PricingModelConfigHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -99,8 +98,7 @@ QString PricingModelConfigHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-PricingModelConfigHistoryDialog::calculateDiffAt(int current_index,
-                                                 int previous_index) const {
+PricingModelConfigHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -120,16 +118,14 @@ void PricingModelConfigHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PricingModelConfigHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening pricing model configuration version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing model configuration version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -138,8 +134,7 @@ void PricingModelConfigHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/analytics/src/PricingModelProductHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelProductHistoryDialog.cpp
@@ -76,8 +76,7 @@ int PricingModelProductHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PricingModelProductHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PricingModelProductHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -91,13 +90,14 @@ QString PricingModelProductHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-PricingModelProductHistoryDialog::calculateDiffAt(int current_index,
-                                                  int previous_index) const {
+PricingModelProductHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-    checkString(diffs, "Pricing Engine Type", current.pricing_engine_type_code,
+    checkString(diffs,
+                "Pricing Engine Type",
+                current.pricing_engine_type_code,
                 previous.pricing_engine_type_code);
     checkString(diffs, "Model", current.model, previous.model);
     checkString(diffs, "Engine", current.engine, previous.engine);
@@ -114,16 +114,14 @@ void PricingModelProductHistoryDialog::displayFullDetails(int index) {
     ui_->engineValue->setText(QString::fromStdString(version.engine));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PricingModelProductHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening pricing model product version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening pricing model product version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -132,8 +130,7 @@ void PricingModelProductHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/analytics/src/PricingModelProductParameterHistoryDialog.cpp
+++ b/projects/ores.qt/analytics/src/PricingModelProductParameterHistoryDialog.cpp
@@ -113,10 +113,8 @@ void PricingModelProductParameterHistoryDialog::displayFullDetails(int index) {
     ui_->parameterValueValue->setText(QString::fromStdString(version.parameter_value));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PricingModelProductParameterHistoryDialog::openVersionAt(int index) {
@@ -131,8 +129,7 @@ void PricingModelProductParameterHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
+++ b/projects/ores.qt/api/include/ores.qt/HistoryDialogBase.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_QT_HISTORY_DIALOG_BASE_HPP
 #define ORES_QT_HISTORY_DIALOG_BASE_HPP
 
-#include <string>
-#include <expected>
-#include <optional>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/export.hpp"
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QList>
@@ -32,8 +31,9 @@
 #include <QStringList>
 #include <QWidget>
 #include <QtConcurrent>
-#include "ores.qt/ClientManager.hpp"
-#include "ores.qt/export.hpp"
+#include <expected>
+#include <optional>
+#include <string>
 
 class QAction;
 class QLabel;
@@ -177,8 +177,7 @@ protected:
      * interim seam: once server-side diffs land this renders the
      * response rows and eventually disappears.
      */
-    [[nodiscard]] virtual DiffResult
-    calculateDiffAt(int current_index, int previous_index) const;
+    [[nodiscard]] virtual DiffResult calculateDiffAt(int current_index, int previous_index) const;
 
     /**
      * @brief Renders the full-details panel for the given version.
@@ -202,24 +201,24 @@ protected:
      * @brief Optional widget rendering for a changes-table cell (e.g.
      * flag icons); return null for the default text item.
      */
-    virtual QWidget* changeCellWidget(const QString& field,
-                                      const QString& value);
+    virtual QWidget* changeCellWidget(const QString& field, const QString& value);
 
     // ---- Interim diff helpers. --------------------------------------
 
-    static void checkString(DiffResult& diffs, const QString& field,
+    static void checkString(DiffResult& diffs,
+                            const QString& field,
                             const std::string& current,
                             const std::string& previous);
-    static void checkString(DiffResult& diffs, const QString& field,
+    static void checkString(DiffResult& diffs,
+                            const QString& field,
                             const std::optional<std::string>& current,
                             const std::optional<std::string>& previous);
-    static void checkInt(DiffResult& diffs, const QString& field,
-                         int current, int previous);
-    static void checkInt(DiffResult& diffs, const QString& field,
+    static void checkInt(DiffResult& diffs, const QString& field, int current, int previous);
+    static void checkInt(DiffResult& diffs,
+                         const QString& field,
                          const std::optional<int>& current,
                          const std::optional<int>& previous);
-    static void checkBool(DiffResult& diffs, const QString& field,
-                          bool current, bool previous);
+    static void checkBool(DiffResult& diffs, const QString& field, bool current, bool previous);
 
     /**
      * @brief Runs an authenticated request off the UI thread and
@@ -229,36 +228,33 @@ protected:
      * @param on_success Invoked with the moved response on success.
      */
     template <typename Request, typename OnSuccess>
-    void runHistoryRequest(ClientManager* client_manager, Request request,
-                           OnSuccess on_success) {
-        using Response =
-            typename decltype(client_manager->process_authenticated_request(
-                std::move(request)))::value_type;
+    void runHistoryRequest(ClientManager* client_manager, Request request, OnSuccess on_success) {
+        using Response = typename decltype(client_manager->process_authenticated_request(
+            std::move(request)))::value_type;
         using Result = std::expected<Response, std::string>;
 
         QPointer<HistoryDialogBase> self = this;
         QFuture<Result> future = QtConcurrent::run(
-            [self, client_manager, request = std::move(request)]() mutable
-            -> Result {
+            [self, client_manager, request = std::move(request)]() mutable -> Result {
                 if (!client_manager || !client_manager->isConnected())
                     return std::unexpected("Disconnected from server");
-                auto result = client_manager->process_authenticated_request(
-                    std::move(request));
+                auto result = client_manager->process_authenticated_request(std::move(request));
                 if (!result)
                     return std::unexpected(result.error());
                 return std::move(*result);
             });
 
         auto* watcher = new QFutureWatcher<Result>(this);
-        connect(watcher, &QFutureWatcher<Result>::finished, this,
+        connect(watcher,
+                &QFutureWatcher<Result>::finished,
+                this,
                 [self, watcher, on_success = std::move(on_success)]() mutable {
                     if (!self)
                         return;
                     auto result = watcher->result();
                     watcher->deleteLater();
                     if (!result) {
-                        self->historyLoadFailed(
-                            QString::fromStdString(result.error()));
+                        self->historyLoadFailed(QString::fromStdString(result.error()));
                         return;
                     }
                     on_success(std::move(*result));

--- a/projects/ores.qt/api/src/HistoryDialogBase.cpp
+++ b/projects/ores.qt/api/src/HistoryDialogBase.cpp
@@ -20,7 +20,6 @@
 #include "ores.qt/HistoryDialogBase.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
-
 #include <QAction>
 #include <QHeaderView>
 #include <QLabel>
@@ -35,8 +34,8 @@ namespace ores::qt {
 namespace {
 
 const QIcon& historyIcon() {
-    static const QIcon icon = IconUtils::createRecoloredIcon(
-        Icon::History, IconUtils::DefaultIconColor);
+    static const QIcon icon =
+        IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor);
     return icon;
 }
 
@@ -54,8 +53,7 @@ HistoryDialogBase::~HistoryDialogBase() {
 }
 
 void HistoryDialogBase::markAsStale() {
-    emit statusChanged(
-        QString("%1 was modified - reloading history...").arg(code()));
+    emit statusChanged(QString("%1 was modified - reloading history...").arg(code()));
     loadHistory();
 }
 
@@ -70,21 +68,19 @@ void HistoryDialogBase::initializeHistoryUi(const HistoryWidgets& widgets) {
     setupToolbar();
 
     if (widgets_.versionList) {
-        connect(widgets_.versionList, &QTableWidget::currentCellChanged, this,
-                [this](int currentRow, int, int, int) {
-                    onVersionSelectedRow(currentRow);
-                });
-        connect(widgets_.versionList, &QTableWidget::cellDoubleClicked, this,
-                [this](int, int) { onOpenClicked(); });
+        connect(widgets_.versionList,
+                &QTableWidget::currentCellChanged,
+                this,
+                [this](int currentRow, int, int, int) { onVersionSelectedRow(currentRow); });
+        connect(widgets_.versionList, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
+            onOpenClicked();
+        });
 
         widgets_.versionList->setAlternatingRowColors(true);
-        widgets_.versionList->setSelectionMode(
-            QAbstractItemView::SingleSelection);
-        widgets_.versionList->setSelectionBehavior(
-            QAbstractItemView::SelectRows);
+        widgets_.versionList->setSelectionMode(QAbstractItemView::SingleSelection);
+        widgets_.versionList->setSelectionBehavior(QAbstractItemView::SelectRows);
         widgets_.versionList->resizeRowsToContents();
-        widgets_.versionList->verticalHeader()->setSectionResizeMode(
-            QHeaderView::ResizeToContents);
+        widgets_.versionList->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
         widgets_.versionList->horizontalHeader()->setSectionResizeMode(
             QHeaderView::ResizeToContents);
     }
@@ -96,8 +92,8 @@ void HistoryDialogBase::initializeHistoryUi(const HistoryWidgets& widgets) {
     }
 
     if (widgets_.closeButton) {
-        widgets_.closeButton->setIcon(IconUtils::createRecoloredIcon(
-            Icon::Dismiss, IconUtils::DefaultIconColor));
+        widgets_.closeButton->setIcon(
+            IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
         connect(widgets_.closeButton, &QPushButton::clicked, this, [this]() {
             if (window())
                 window()->close();
@@ -113,29 +109,25 @@ void HistoryDialogBase::setupToolbar() {
     toolBar_->setFloatable(false);
 
     reloadAction_ = new QAction(tr("Reload"), this);
-    reloadAction_->setIcon(IconUtils::createRecoloredIcon(
-        Icon::ArrowClockwise, IconUtils::DefaultIconColor));
+    reloadAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor));
     reloadAction_->setToolTip(tr("Reload history from server"));
-    connect(reloadAction_, &QAction::triggered, this,
-            &HistoryDialogBase::onReloadClicked);
+    connect(reloadAction_, &QAction::triggered, this, &HistoryDialogBase::onReloadClicked);
     toolBar_->addAction(reloadAction_);
 
     toolBar_->addSeparator();
 
     openAction_ = new QAction(tr("Open"), this);
-    openAction_->setIcon(IconUtils::createRecoloredIcon(
-        Icon::Edit, IconUtils::DefaultIconColor));
+    openAction_->setIcon(IconUtils::createRecoloredIcon(Icon::Edit, IconUtils::DefaultIconColor));
     openAction_->setToolTip(tr("Open this version in read-only mode"));
-    connect(openAction_, &QAction::triggered, this,
-            &HistoryDialogBase::onOpenClicked);
+    connect(openAction_, &QAction::triggered, this, &HistoryDialogBase::onOpenClicked);
     toolBar_->addAction(openAction_);
 
     revertAction_ = new QAction(tr("Revert"), this);
-    revertAction_->setIcon(IconUtils::createRecoloredIcon(
-        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(Icon::ArrowRotateCounterclockwise,
+                                                          IconUtils::DefaultIconColor));
     revertAction_->setToolTip(tr("Revert to this version"));
-    connect(revertAction_, &QAction::triggered, this,
-            &HistoryDialogBase::onRevertClicked);
+    connect(revertAction_, &QAction::triggered, this, &HistoryDialogBase::onRevertClicked);
     toolBar_->addAction(revertAction_);
 
     auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
@@ -161,8 +153,7 @@ void HistoryDialogBase::historyLoaded() {
         widgets_.versionList->setItem(i, 0, versionItem);
 
         for (int j = 0; j < row.cells.size(); ++j) {
-            widgets_.versionList->setItem(i, j + 1,
-                new QTableWidgetItem(row.cells[j]));
+            widgets_.versionList->setItem(i, j + 1, new QTableWidgetItem(row.cells[j]));
         }
     }
 
@@ -178,11 +169,9 @@ void HistoryDialogBase::historyLoaded() {
 }
 
 void HistoryDialogBase::historyLoadFailed(const QString& error_message) {
-    emit errorOccurred(
-        tr("Failed to load history: %1").arg(error_message));
+    emit errorOccurred(tr("Failed to load history: %1").arg(error_message));
     MessageBoxHelper::critical(
-        this, tr("History Load Error"),
-        tr("Failed to load history:\n%1").arg(error_message));
+        this, tr("History Load Error"), tr("Failed to load history:\n%1").arg(error_message));
 }
 
 int HistoryDialogBase::selectedVersionIndex() const {
@@ -193,8 +182,7 @@ HistoryDialogBase::VersionRow HistoryDialogBase::versionRow(int) const {
     return {};
 }
 
-HistoryDialogBase::DiffResult
-HistoryDialogBase::calculateDiffAt(int, int) const {
+HistoryDialogBase::DiffResult HistoryDialogBase::calculateDiffAt(int, int) const {
     return {};
 }
 
@@ -239,8 +227,7 @@ void HistoryDialogBase::displayChangesTab(int version_index) {
         return;
     }
 
-    const DiffResult diffs =
-        calculateDiffAt(version_index, version_index + 1);
+    const DiffResult diffs = calculateDiffAt(version_index, version_index + 1);
 
     if (diffs.isEmpty()) {
         placeholderRow(tr("(No field changes)"));
@@ -257,14 +244,12 @@ void HistoryDialogBase::displayChangesTab(int version_index) {
         if (QWidget* old_widget = changeCellWidget(field, old_val))
             widgets_.changesTable->setCellWidget(i, 1, old_widget);
         else
-            widgets_.changesTable->setItem(i, 1,
-                new QTableWidgetItem(old_val));
+            widgets_.changesTable->setItem(i, 1, new QTableWidgetItem(old_val));
 
         if (QWidget* new_widget = changeCellWidget(field, new_val))
             widgets_.changesTable->setCellWidget(i, 2, new_widget);
         else
-            widgets_.changesTable->setItem(i, 2,
-                new QTableWidgetItem(new_val));
+            widgets_.changesTable->setItem(i, 2, new QTableWidgetItem(new_val));
     }
 }
 
@@ -304,15 +289,16 @@ void HistoryDialogBase::onRevertClicked() {
     const VersionRow latest = versionRow(0);
     const VersionRow selected = versionRow(index);
 
-    const auto reply = MessageBoxHelper::question(
-        this, tr("Revert"),
-        tr("Are you sure you want to revert '%1' from version %2 back "
-           "to version %3?\n\nThis will create a new version with the "
-           "data from version %3.")
-            .arg(code())
-            .arg(latest.version)
-            .arg(selected.version),
-        QMessageBox::Yes | QMessageBox::No);
+    const auto reply =
+        MessageBoxHelper::question(this,
+                                   tr("Revert"),
+                                   tr("Are you sure you want to revert '%1' from version %2 back "
+                                      "to version %3?\n\nThis will create a new version with the "
+                                      "data from version %3.")
+                                       .arg(code())
+                                       .arg(latest.version)
+                                       .arg(selected.version),
+                                   QMessageBox::Yes | QMessageBox::No);
 
     if (reply != QMessageBox::Yes)
         return;
@@ -320,17 +306,17 @@ void HistoryDialogBase::onRevertClicked() {
     revertToVersionAt(index);
 }
 
-void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
+void HistoryDialogBase::checkString(DiffResult& diffs,
+                                    const QString& field,
                                     const std::string& current,
                                     const std::string& previous) {
     if (current != previous) {
-        diffs.append({field,
-                      {QString::fromStdString(previous),
-                       QString::fromStdString(current)}});
+        diffs.append({field, {QString::fromStdString(previous), QString::fromStdString(current)}});
     }
 }
 
-void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
+void HistoryDialogBase::checkString(DiffResult& diffs,
+                                    const QString& field,
                                     const std::optional<std::string>& current,
                                     const std::optional<std::string>& previous) {
     if (current != previous) {
@@ -341,15 +327,17 @@ void HistoryDialogBase::checkString(DiffResult& diffs, const QString& field,
     }
 }
 
-void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
-                                 int current, int previous) {
+void HistoryDialogBase::checkInt(DiffResult& diffs,
+                                 const QString& field,
+                                 int current,
+                                 int previous) {
     if (current != previous) {
-        diffs.append({field,
-                      {QString::number(previous), QString::number(current)}});
+        diffs.append({field, {QString::number(previous), QString::number(current)}});
     }
 }
 
-void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
+void HistoryDialogBase::checkInt(DiffResult& diffs,
+                                 const QString& field,
                                  const std::optional<int>& current,
                                  const std::optional<int>& previous) {
     if (current != previous) {
@@ -360,10 +348,14 @@ void HistoryDialogBase::checkInt(DiffResult& diffs, const QString& field,
     }
 }
 
-void HistoryDialogBase::checkBool(DiffResult& diffs, const QString& field,
-                                  bool current, bool previous) {
+void HistoryDialogBase::checkBool(DiffResult& diffs,
+                                  const QString& field,
+                                  bool current,
+                                  bool previous) {
     if (current != previous) {
-        auto text = [](bool b) { return b ? tr("Yes") : tr("No"); };
+        auto text = [](bool b) {
+            return b ? tr("Yes") : tr("No");
+        };
         diffs.append({field, {text(previous), text(current)}});
     }
 }

--- a/projects/ores.qt/application/src/SessionAuditDialog.cpp
+++ b/projects/ores.qt/application/src/SessionAuditDialog.cpp
@@ -187,7 +187,7 @@ void SessionAuditModel::clear() {
 }
 
 void SessionAuditModel::updateActiveBytesFromClient(std::uint64_t bytes_sent,
-                                                      std::uint64_t bytes_received) {
+                                                    std::uint64_t bytes_received) {
     for (std::size_t i = 0; i < sessions_.size(); ++i) {
         if (!sessions_[i].end_time) {
             sessions_[i].bytes_sent = bytes_sent;
@@ -276,8 +276,7 @@ void SessionAuditDialog::setupUi() {
     layout->addLayout(buttonLayout);
 }
 
-void SessionAuditDialog::setAccount(const boost::uuids::uuid& accountId,
-                                      const QString& username) {
+void SessionAuditDialog::setAccount(const boost::uuids::uuid& accountId, const QString& username) {
     accountId_ = accountId;
     username_ = username;
     setWindowTitle(tr("Session Audit - %1").arg(username));
@@ -339,7 +338,7 @@ void SessionAuditDialog::onSessionsLoaded() {
 }
 
 void SessionAuditDialog::onSessionSelectionChanged(const QItemSelection& selected,
-                                                     const QItemSelection&) {
+                                                   const QItemSelection&) {
 
     if (selected.isEmpty())
         return;

--- a/projects/ores.qt/compute/include/ores.qt/AppHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/AppHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/include/ores.qt/AppVersionHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/AppVersionHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyHistoryDialog.hpp
@@ -76,8 +76,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/include/ores.qt/ReportDefinitionHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportDefinitionHistoryDialog.hpp
@@ -78,8 +78,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/include/ores.qt/ReportInstanceHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportInstanceHistoryDialog.hpp
@@ -78,8 +78,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/include/ores.qt/ReportTypeHistoryDialog.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/compute/src/AppHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/AppHistoryDialog.cpp
@@ -55,8 +55,7 @@ AppHistoryDialog::AppHistoryDialog(const boost::uuids::uuid& id,
 AppHistoryDialog::~AppHistoryDialog() = default;
 
 void AppHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for compute app: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for compute app: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     compute::messaging::get_app_history_request request;
@@ -77,8 +76,7 @@ int AppHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-AppHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow AppHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -91,16 +89,14 @@ QString AppHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-AppHistoryDialog::calculateDiffAt(int current_index,
-                                  int previous_index) const {
+HistoryDialogBase::DiffResult AppHistoryDialog::calculateDiffAt(int current_index,
+                                                                int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -112,16 +108,14 @@ void AppHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void AppHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening compute app version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening compute app version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -130,8 +124,7 @@ void AppHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/compute/src/AppVersionHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/AppVersionHistoryDialog.cpp
@@ -55,8 +55,7 @@ AppVersionHistoryDialog::AppVersionHistoryDialog(const boost::uuids::uuid& id,
 AppVersionHistoryDialog::~AppVersionHistoryDialog() = default;
 
 void AppVersionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for app version: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for app version: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     compute::messaging::get_app_version_history_request request;
@@ -77,8 +76,7 @@ int AppVersionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-AppVersionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow AppVersionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -91,19 +89,15 @@ QString AppVersionHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-AppVersionHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult AppVersionHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-    checkString(diffs, "Wrapper Version", current.wrapper_version,
-                previous.wrapper_version);
-    checkString(diffs, "Name", current.wrapper_version,
-                previous.wrapper_version);
-    checkString(diffs, "Description", current.engine_version,
-                previous.engine_version);
+    checkString(diffs, "Wrapper Version", current.wrapper_version, previous.wrapper_version);
+    checkString(diffs, "Name", current.wrapper_version, previous.wrapper_version);
+    checkString(diffs, "Description", current.engine_version, previous.engine_version);
 
     return diffs;
 }
@@ -113,20 +107,17 @@ void AppVersionHistoryDialog::displayFullDetails(int index) {
 
     ui_->codeValue->setText(QString::fromStdString(version.wrapper_version));
     ui_->nameValue->setText(QString::fromStdString(version.engine_version));
-    ui_->descriptionValue->setText(
-        QString::fromStdString(version.engine_version));
+    ui_->descriptionValue->setText(QString::fromStdString(version.engine_version));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void AppVersionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening app version version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening app version version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -135,8 +126,7 @@ void AppVersionHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/compute/src/ConcurrencyPolicyHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ConcurrencyPolicyHistoryDialog.cpp
@@ -52,8 +52,7 @@ ConcurrencyPolicyHistoryDialog::ConcurrencyPolicyHistoryDialog(const QString& co
 ConcurrencyPolicyHistoryDialog::~ConcurrencyPolicyHistoryDialog() = default;
 
 void ConcurrencyPolicyHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for concurrency policy: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for concurrency policy: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     reporting::messaging::get_concurrency_policy_history_request request;
@@ -74,8 +73,7 @@ int ConcurrencyPolicyHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ConcurrencyPolicyHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ConcurrencyPolicyHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,16 +87,14 @@ QString ConcurrencyPolicyHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-ConcurrencyPolicyHistoryDialog::calculateDiffAt(int current_index,
-                                                int previous_index) const {
+ConcurrencyPolicyHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -111,16 +107,14 @@ void ConcurrencyPolicyHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ConcurrencyPolicyHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening concurrency policy version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening concurrency policy version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -129,8 +123,7 @@ void ConcurrencyPolicyHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/compute/src/ReportDefinitionHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportDefinitionHistoryDialog.cpp
@@ -55,8 +55,7 @@ ReportDefinitionHistoryDialog::ReportDefinitionHistoryDialog(const boost::uuids:
 ReportDefinitionHistoryDialog::~ReportDefinitionHistoryDialog() = default;
 
 void ReportDefinitionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report definition: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report definition: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     reporting::messaging::get_report_definition_history_request request;
@@ -77,8 +76,7 @@ int ReportDefinitionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ReportDefinitionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ReportDefinitionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,21 +90,18 @@ QString ReportDefinitionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-ReportDefinitionHistoryDialog::calculateDiffAt(int current_index,
-                                               int previous_index) const {
+ReportDefinitionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
-    checkString(diffs, "Report Type", current.report_type,
-                previous.report_type);
-    checkString(diffs, "Schedule (cron)", current.schedule_expression,
-                previous.schedule_expression);
-    checkString(diffs, "Concurrency Policy", current.concurrency_policy,
-                previous.concurrency_policy);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Report Type", current.report_type, previous.report_type);
+    checkString(
+        diffs, "Schedule (cron)", current.schedule_expression, previous.schedule_expression);
+    checkString(
+        diffs, "Concurrency Policy", current.concurrency_policy, previous.concurrency_policy);
 
     return diffs;
 }
@@ -117,22 +112,18 @@ void ReportDefinitionHistoryDialog::displayFullDetails(int index) {
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->reportTypeValue->setText(QString::fromStdString(version.report_type));
-    ui_->scheduleExpressionValue->setText(
-        QString::fromStdString(version.schedule_expression));
-    ui_->concurrencyPolicyValue->setText(
-        QString::fromStdString(version.concurrency_policy));
+    ui_->scheduleExpressionValue->setText(QString::fromStdString(version.schedule_expression));
+    ui_->concurrencyPolicyValue->setText(QString::fromStdString(version.concurrency_policy));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ReportDefinitionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening report definition version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening report definition version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -141,8 +132,7 @@ void ReportDefinitionHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/compute/src/ReportInstanceHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportInstanceHistoryDialog.cpp
@@ -55,8 +55,7 @@ ReportInstanceHistoryDialog::ReportInstanceHistoryDialog(const boost::uuids::uui
 ReportInstanceHistoryDialog::~ReportInstanceHistoryDialog() = default;
 
 void ReportInstanceHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report instance: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report instance: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     reporting::messaging::get_report_instance_history_request request;
@@ -77,8 +76,7 @@ int ReportInstanceHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ReportInstanceHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ReportInstanceHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,17 +90,14 @@ QString ReportInstanceHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-ReportInstanceHistoryDialog::calculateDiffAt(int current_index,
-                                             int previous_index) const {
+ReportInstanceHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
-    checkString(diffs, "Output", current.output_message,
-                previous.output_message);
+    checkString(diffs, "Description", current.description, previous.description);
+    checkString(diffs, "Output", current.output_message, previous.output_message);
 
     return diffs;
 }
@@ -115,16 +110,14 @@ void ReportInstanceHistoryDialog::displayFullDetails(int index) {
     ui_->outputValue->setText(QString::fromStdString(version.output_message));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ReportInstanceHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening report instance version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening report instance version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -133,8 +126,7 @@ void ReportInstanceHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/compute/src/ReportTypeHistoryDialog.cpp
+++ b/projects/ores.qt/compute/src/ReportTypeHistoryDialog.cpp
@@ -52,8 +52,7 @@ ReportTypeHistoryDialog::ReportTypeHistoryDialog(const QString& code,
 ReportTypeHistoryDialog::~ReportTypeHistoryDialog() = default;
 
 void ReportTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for report type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for report type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     reporting::messaging::get_report_type_history_request request;
@@ -74,8 +73,7 @@ int ReportTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ReportTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ReportTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -88,17 +86,15 @@ QString ReportTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-ReportTypeHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult ReportTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -111,16 +107,14 @@ void ReportTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ReportTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening report type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening report type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -129,8 +123,7 @@ void ReportTypeHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/include/ores.qt/BusinessCentreHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessCentreHistoryDialog.hpp
@@ -76,8 +76,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/BusinessUnitHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessUnitHistoryDialog.hpp
@@ -78,8 +78,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/BusinessUnitTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/BusinessUnitTypeHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/ContactTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/ContactTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/CounterpartyHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/CounterpartyHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/PartyHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/PartyIdSchemeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyIdSchemeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/PartyStatusHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyStatusHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/include/ores.qt/PartyTypeHistoryDialog.hpp
+++ b/projects/ores.qt/party/include/ores.qt/PartyTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/party/src/BusinessCentreHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessCentreHistoryDialog.cpp
@@ -53,8 +53,7 @@ BusinessCentreHistoryDialog::BusinessCentreHistoryDialog(const QString& code,
 BusinessCentreHistoryDialog::~BusinessCentreHistoryDialog() = default;
 
 void BusinessCentreHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business centre: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business centre: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_business_centre_history_request request;
@@ -75,8 +74,7 @@ int BusinessCentreHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BusinessCentreHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BusinessCentreHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,8 +88,7 @@ QString BusinessCentreHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-BusinessCentreHistoryDialog::calculateDiffAt(int current_index,
-                                             int previous_index) const {
+BusinessCentreHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -99,10 +96,8 @@ BusinessCentreHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Source", current.source, previous.source);
     checkString(diffs, "Description", current.description, previous.description);
-    checkString(diffs, "Coding Scheme", current.coding_scheme_code,
-                previous.coding_scheme_code);
-    checkString(diffs, "Country", current.country_alpha2_code,
-                previous.country_alpha2_code);
+    checkString(diffs, "Coding Scheme", current.coding_scheme_code, previous.coding_scheme_code);
+    checkString(diffs, "Country", current.country_alpha2_code, previous.country_alpha2_code);
 
     return diffs;
 }
@@ -113,22 +108,18 @@ void BusinessCentreHistoryDialog::displayFullDetails(int index) {
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->sourceValue->setText(QString::fromStdString(version.source));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
-    ui_->codingSchemeValue->setText(
-        QString::fromStdString(version.coding_scheme_code));
-    ui_->countryAlpha2Value->setText(
-        QString::fromStdString(version.country_alpha2_code));
+    ui_->codingSchemeValue->setText(QString::fromStdString(version.coding_scheme_code));
+    ui_->countryAlpha2Value->setText(QString::fromStdString(version.country_alpha2_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void BusinessCentreHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening business centre version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening business centre version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -137,8 +128,7 @@ void BusinessCentreHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/BusinessUnitHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessUnitHistoryDialog.cpp
@@ -54,8 +54,7 @@ BusinessUnitHistoryDialog::BusinessUnitHistoryDialog(const boost::uuids::uuid& i
 BusinessUnitHistoryDialog::~BusinessUnitHistoryDialog() = default;
 
 void BusinessUnitHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_business_unit_history_request request;
@@ -76,8 +75,7 @@ int BusinessUnitHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BusinessUnitHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BusinessUnitHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,17 +88,16 @@ QString BusinessUnitHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-BusinessUnitHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult BusinessUnitHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Unit Code", current.unit_code, previous.unit_code);
     checkString(diffs, "Unit Name", current.unit_name, previous.unit_name);
-    checkString(diffs, "Business Centre", current.business_centre_code,
-                previous.business_centre_code);
+    checkString(
+        diffs, "Business Centre", current.business_centre_code, previous.business_centre_code);
 
     return diffs;
 }
@@ -110,20 +107,17 @@ void BusinessUnitHistoryDialog::displayFullDetails(int index) {
 
     ui_->codeValue->setText(QString::fromStdString(version.unit_code));
     ui_->nameValue->setText(QString::fromStdString(version.unit_name));
-    ui_->businessCentreValue->setText(
-        QString::fromStdString(version.business_centre_code));
+    ui_->businessCentreValue->setText(QString::fromStdString(version.business_centre_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void BusinessUnitHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening business unit version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening business unit version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -132,8 +126,7 @@ void BusinessUnitHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/BusinessUnitTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/BusinessUnitTypeHistoryDialog.cpp
@@ -53,8 +53,7 @@ BusinessUnitTypeHistoryDialog::BusinessUnitTypeHistoryDialog(const boost::uuids:
 BusinessUnitTypeHistoryDialog::~BusinessUnitTypeHistoryDialog() = default;
 
 void BusinessUnitTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for business unit type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_business_unit_type_history_request request;
@@ -75,8 +74,7 @@ int BusinessUnitTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BusinessUnitTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BusinessUnitTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,8 +88,7 @@ QString BusinessUnitTypeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-BusinessUnitTypeHistoryDialog::calculateDiffAt(int current_index,
-                                               int previous_index) const {
+BusinessUnitTypeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -99,8 +96,7 @@ BusinessUnitTypeHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Name", current.name, previous.name);
     checkInt(diffs, "Level", current.level, previous.level);
-    checkString(diffs, "Coding Scheme", current.coding_scheme_code,
-                previous.coding_scheme_code);
+    checkString(diffs, "Coding Scheme", current.coding_scheme_code, previous.coding_scheme_code);
     checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
@@ -112,20 +108,17 @@ void BusinessUnitTypeHistoryDialog::displayFullDetails(int index) {
     ui_->codeValue->setText(QString::fromStdString(version.code));
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->levelValue->setText(QString::number(version.level));
-    ui_->codingSchemeValue->setText(
-        QString::fromStdString(version.coding_scheme_code));
+    ui_->codingSchemeValue->setText(QString::fromStdString(version.coding_scheme_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void BusinessUnitTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening business unit type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening business unit type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -134,8 +127,7 @@ void BusinessUnitTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/ContactTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/ContactTypeHistoryDialog.cpp
@@ -51,8 +51,7 @@ ContactTypeHistoryDialog::ContactTypeHistoryDialog(const QString& code,
 ContactTypeHistoryDialog::~ContactTypeHistoryDialog() = default;
 
 void ContactTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for contact type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for contact type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_contact_type_history_request request;
@@ -73,8 +72,7 @@ int ContactTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ContactTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ContactTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -87,9 +85,8 @@ QString ContactTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-ContactTypeHistoryDialog::calculateDiffAt(int current_index,
-                                          int previous_index) const {
+HistoryDialogBase::DiffResult ContactTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                        int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -109,16 +106,14 @@ void ContactTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ContactTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening contact type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening contact type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -127,8 +122,7 @@ void ContactTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/CounterpartyHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/CounterpartyHistoryDialog.cpp
@@ -56,8 +56,7 @@ CounterpartyHistoryDialog::CounterpartyHistoryDialog(const boost::uuids::uuid& i
 CounterpartyHistoryDialog::~CounterpartyHistoryDialog() = default;
 
 void CounterpartyHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for counterparty: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for counterparty: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_counterparty_history_request request;
@@ -78,8 +77,7 @@ int CounterpartyHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CounterpartyHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CounterpartyHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,9 +90,8 @@ QString CounterpartyHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-CounterpartyHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult CounterpartyHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -102,19 +99,16 @@ CounterpartyHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Short Code", current.short_code, previous.short_code);
     checkString(diffs, "Full Name", current.full_name, previous.full_name);
 
-    if (current.transliterated_name.value_or("") !=
-        previous.transliterated_name.value_or("")) {
-        diffs.append(
-            {"Transliterated Name",
-             {QString::fromStdString(previous.transliterated_name.value_or("")),
-              QString::fromStdString(
-                  current.transliterated_name.value_or(""))}});
+    if (current.transliterated_name.value_or("") != previous.transliterated_name.value_or("")) {
+        diffs.append({"Transliterated Name",
+                      {QString::fromStdString(previous.transliterated_name.value_or("")),
+                       QString::fromStdString(current.transliterated_name.value_or(""))}});
     }
 
     checkString(diffs, "Party Type", current.party_type, previous.party_type);
     checkString(diffs, "Status", current.status, previous.status);
-    checkString(diffs, "Business Center", current.business_center_code,
-                previous.business_center_code);
+    checkString(
+        diffs, "Business Center", current.business_center_code, previous.business_center_code);
 
     return diffs;
 }
@@ -128,20 +122,17 @@ void CounterpartyHistoryDialog::displayFullDetails(int index) {
         QString::fromStdString(version.transliterated_name.value_or("")));
     ui_->partyTypeValue->setText(QString::fromStdString(version.party_type));
     ui_->statusValue->setText(QString::fromStdString(version.status));
-    ui_->businessCenterValue->setText(
-        QString::fromStdString(version.business_center_code));
+    ui_->businessCenterValue->setText(QString::fromStdString(version.business_center_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void CounterpartyHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening counterparty version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening counterparty version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -150,8 +141,7 @@ void CounterpartyHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/PartyHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyHistoryDialog.cpp
@@ -56,8 +56,7 @@ PartyHistoryDialog::PartyHistoryDialog(const boost::uuids::uuid& id,
 PartyHistoryDialog::~PartyHistoryDialog() = default;
 
 void PartyHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_party_history_request request;
@@ -78,8 +77,7 @@ int PartyHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PartyHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PartyHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,9 +90,8 @@ QString PartyHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-PartyHistoryDialog::calculateDiffAt(int current_index,
-                                    int previous_index) const {
+HistoryDialogBase::DiffResult PartyHistoryDialog::calculateDiffAt(int current_index,
+                                                                  int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -102,21 +99,17 @@ PartyHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Short Code", current.short_code, previous.short_code);
     checkString(diffs, "Full Name", current.full_name, previous.full_name);
 
-    if (current.transliterated_name.value_or("") !=
-        previous.transliterated_name.value_or("")) {
-        diffs.append(
-            {"Transliterated Name",
-             {QString::fromStdString(previous.transliterated_name.value_or("")),
-              QString::fromStdString(
-                  current.transliterated_name.value_or(""))}});
+    if (current.transliterated_name.value_or("") != previous.transliterated_name.value_or("")) {
+        diffs.append({"Transliterated Name",
+                      {QString::fromStdString(previous.transliterated_name.value_or("")),
+                       QString::fromStdString(current.transliterated_name.value_or(""))}});
     }
 
-    checkString(diffs, "Category", current.party_category,
-                previous.party_category);
+    checkString(diffs, "Category", current.party_category, previous.party_category);
     checkString(diffs, "Party Type", current.party_type, previous.party_type);
     checkString(diffs, "Status", current.status, previous.status);
-    checkString(diffs, "Business Center", current.business_center_code,
-                previous.business_center_code);
+    checkString(
+        diffs, "Business Center", current.business_center_code, previous.business_center_code);
 
     return diffs;
 }
@@ -128,24 +121,20 @@ void PartyHistoryDialog::displayFullDetails(int index) {
     ui_->nameValue->setText(QString::fromStdString(version.full_name));
     ui_->transliteratedNameValue->setText(
         QString::fromStdString(version.transliterated_name.value_or("")));
-    ui_->partyCategoryValue->setText(
-        QString::fromStdString(version.party_category));
+    ui_->partyCategoryValue->setText(QString::fromStdString(version.party_category));
     ui_->partyTypeValue->setText(QString::fromStdString(version.party_type));
     ui_->statusValue->setText(QString::fromStdString(version.status));
-    ui_->businessCenterValue->setText(
-        QString::fromStdString(version.business_center_code));
+    ui_->businessCenterValue->setText(QString::fromStdString(version.business_center_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PartyHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening party version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening party version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -154,8 +143,7 @@ void PartyHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/PartyIdSchemeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyIdSchemeHistoryDialog.cpp
@@ -51,8 +51,7 @@ PartyIdSchemeHistoryDialog::PartyIdSchemeHistoryDialog(const QString& code,
 PartyIdSchemeHistoryDialog::~PartyIdSchemeHistoryDialog() = default;
 
 void PartyIdSchemeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party ID scheme: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party ID scheme: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_party_id_scheme_history_request request;
@@ -73,8 +72,7 @@ int PartyIdSchemeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PartyIdSchemeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PartyIdSchemeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -88,8 +86,7 @@ QString PartyIdSchemeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-PartyIdSchemeHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+PartyIdSchemeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -109,16 +106,14 @@ void PartyIdSchemeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PartyIdSchemeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening party ID scheme version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening party ID scheme version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -127,8 +122,7 @@ void PartyIdSchemeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/PartyStatusHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyStatusHistoryDialog.cpp
@@ -51,8 +51,7 @@ PartyStatusHistoryDialog::PartyStatusHistoryDialog(const QString& code,
 PartyStatusHistoryDialog::~PartyStatusHistoryDialog() = default;
 
 void PartyStatusHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party status: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party status: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_party_status_history_request request;
@@ -73,8 +72,7 @@ int PartyStatusHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PartyStatusHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PartyStatusHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -87,9 +85,8 @@ QString PartyStatusHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-PartyStatusHistoryDialog::calculateDiffAt(int current_index,
-                                          int previous_index) const {
+HistoryDialogBase::DiffResult PartyStatusHistoryDialog::calculateDiffAt(int current_index,
+                                                                        int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -109,16 +106,14 @@ void PartyStatusHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PartyStatusHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening party status version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening party status version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -127,8 +122,7 @@ void PartyStatusHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/party/src/PartyTypeHistoryDialog.cpp
+++ b/projects/ores.qt/party/src/PartyTypeHistoryDialog.cpp
@@ -51,8 +51,7 @@ PartyTypeHistoryDialog::PartyTypeHistoryDialog(const QString& code,
 PartyTypeHistoryDialog::~PartyTypeHistoryDialog() = default;
 
 void PartyTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for party type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for party type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_party_type_history_request request;
@@ -73,8 +72,7 @@ int PartyTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PartyTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PartyTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -87,9 +85,8 @@ QString PartyTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-PartyTypeHistoryDialog::calculateDiffAt(int current_index,
-                                        int previous_index) const {
+HistoryDialogBase::DiffResult PartyTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                      int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -109,16 +106,14 @@ void PartyTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PartyTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening party type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening party type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -127,8 +122,7 @@ void PartyTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/include/ores.qt/BusinessDayConventionTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BusinessDayConventionTypeHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CatalogHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CatalogHistoryDialog.hpp
@@ -72,8 +72,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonCategoryHistoryDialog.hpp
@@ -41,8 +41,7 @@ class ChangeReasonCategoryHistoryDialog final : public HistoryDialogBase {
     Q_OBJECT
 
 private:
-    inline static std::string_view logger_name =
-        "ores.qt.change_reason_category_history_dialog";
+    inline static std::string_view logger_name = "ores.qt.change_reason_category_history_dialog";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
@@ -84,8 +83,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ChangeReasonHistoryDialog.hpp
@@ -82,8 +82,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CodeDomainHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodeDomainHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CodingSchemeAuthorityTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodingSchemeAuthorityTypeHistoryDialog.hpp
@@ -71,8 +71,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CodingSchemeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CodingSchemeHistoryDialog.hpp
@@ -69,8 +69,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CountryHistoryDialog.hpp
@@ -95,13 +95,11 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;
-    QWidget* changeCellWidget(const QString& field,
-                              const QString& value) override;
+    QWidget* changeCellWidget(const QString& field, const QString& value) override;
 
 private:
     std::unique_ptr<Ui::CountryHistoryDialog> ui_;

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyHistoryDialog.hpp
@@ -98,13 +98,11 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;
-    QWidget* changeCellWidget(const QString& field,
-                              const QString& value) override;
+    QWidget* changeCellWidget(const QString& field, const QString& value) override;
 
 private:
     std::unique_ptr<Ui::CurrencyHistoryDialog> ui_;

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyMarketTierHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyMarketTierHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/DataDomainHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DataDomainHistoryDialog.hpp
@@ -69,8 +69,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/DatasetBundleHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DatasetBundleHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/DatasetHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DatasetHistoryDialog.hpp
@@ -68,8 +68,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/DayCountFractionTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DayCountFractionTypeHistoryDialog.hpp
@@ -76,8 +76,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/FloatingIndexTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FloatingIndexTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/FraConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FraConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/FxConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/FxConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/LegTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/LegTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/MethodologyHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/MethodologyHistoryDialog.hpp
@@ -70,8 +70,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/MonetaryNatureHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/MonetaryNatureHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/NatureDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/NatureDimensionHistoryDialog.hpp
@@ -69,8 +69,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/OisConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OisConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/OriginDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OriginDimensionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/PaymentFrequencyTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/PaymentFrequencyTypeHistoryDialog.hpp
@@ -76,8 +76,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/PurposeTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/PurposeTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/RoundingTypeHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/RoundingTypeHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/SubjectAreaHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/SubjectAreaHistoryDialog.hpp
@@ -70,8 +70,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/TreatmentDimensionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/TreatmentDimensionHistoryDialog.hpp
@@ -69,8 +69,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/include/ores.qt/ZeroConventionHistoryDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ZeroConventionHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/refdata/src/BusinessDayConventionTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/BusinessDayConventionTypeHistoryDialog.cpp
@@ -73,8 +73,7 @@ int BusinessDayConventionTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BusinessDayConventionTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BusinessDayConventionTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -113,8 +112,8 @@ void BusinessDayConventionTypeHistoryDialog::displayFullDetails(int index) {
 
 void BusinessDayConventionTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening business day convention type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening business day convention type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -123,8 +122,7 @@ void BusinessDayConventionTypeHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/CatalogHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CatalogHistoryDialog.cpp
@@ -62,8 +62,7 @@ CatalogHistoryDialog::CatalogHistoryDialog(const QString& name,
 CatalogHistoryDialog::~CatalogHistoryDialog() = default;
 
 void CatalogHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for catalog: "
-                               << name_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for catalog: " << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_catalog_history_request request;
@@ -84,8 +83,7 @@ int CatalogHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CatalogHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CatalogHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -97,9 +95,8 @@ QString CatalogHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(name_);
 }
 
-HistoryDialogBase::DiffResult
-CatalogHistoryDialog::calculateDiffAt(int current_index,
-                                      int previous_index) const {
+HistoryDialogBase::DiffResult CatalogHistoryDialog::calculateDiffAt(int current_index,
+                                                                    int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -124,8 +121,8 @@ void CatalogHistoryDialog::displayFullDetails(int index) {
 
 void CatalogHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening catalog version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening catalog version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -134,8 +131,7 @@ void CatalogHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/CdsConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CdsConventionHistoryDialog.cpp
@@ -60,8 +60,7 @@ CdsConventionHistoryDialog::CdsConventionHistoryDialog(const QString& code,
 CdsConventionHistoryDialog::~CdsConventionHistoryDialog() = default;
 
 void CdsConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for CDS convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for CDS convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_cds_convention_history_request request;
@@ -82,8 +81,7 @@ int CdsConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CdsConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CdsConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -97,8 +95,7 @@ QString CdsConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-CdsConventionHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+CdsConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -106,24 +103,26 @@ CdsConventionHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Id", current.id, previous.id);
     checkString(diffs, "Calendar", current.calendar, previous.calendar);
     checkString(diffs, "Frequency", current.frequency, previous.frequency);
-    checkString(diffs, "Payment Convention", current.payment_convention,
-                previous.payment_convention);
+    checkString(
+        diffs, "Payment Convention", current.payment_convention, previous.payment_convention);
     checkString(diffs, "Rule", current.rule, previous.rule);
-    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
-                previous.day_count_fraction);
-    checkInt(diffs, "Settlement Days", current.settlement_days,
-             previous.settlement_days);
+    checkString(
+        diffs, "Day Count Fraction", current.day_count_fraction, previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days, previous.settlement_days);
 
     if (current.upfront_settlement_days != previous.upfront_settlement_days) {
         diffs.append(
             {"Upfront Settlement Days",
              {previous.upfront_settlement_days ?
-                  QString::number(*previous.upfront_settlement_days) : tr("(unset)"),
-              current.upfront_settlement_days ?
-                  QString::number(*current.upfront_settlement_days) : tr("(unset)")}});
+                  QString::number(*previous.upfront_settlement_days) :
+                  tr("(unset)"),
+              current.upfront_settlement_days ? QString::number(*current.upfront_settlement_days) :
+                                                tr("(unset)")}});
     }
 
-    checkString(diffs, "Last Period DCF", current.last_period_day_count_fraction,
+    checkString(diffs,
+                "Last Period DCF",
+                current.last_period_day_count_fraction,
                 previous.last_period_day_count_fraction);
 
     if (current.settles_accrual != previous.settles_accrual) {
@@ -166,8 +165,8 @@ void CdsConventionHistoryDialog::displayFullDetails(int index) {
 
 void CdsConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening CDS convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening CDS convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -176,8 +175,7 @@ void CdsConventionHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonCategoryHistoryDialog.cpp
@@ -18,24 +18,24 @@
  *
  */
 #include "ores.qt/ChangeReasonCategoryHistoryDialog.hpp"
-#include "ui_ChangeReasonCategoryHistoryDialog.h"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
+#include "ui_ChangeReasonCategoryHistoryDialog.h"
 
 namespace ores::qt {
 
 using namespace ores::logging;
 
-ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(
-    QString code, ClientManager* clientManager, QWidget* parent)
+ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(QString code,
+                                                                     ClientManager* clientManager,
+                                                                     QWidget* parent)
     : HistoryDialogBase(parent)
     , ui_(new Ui::ChangeReasonCategoryHistoryDialog)
     , clientManager_(clientManager)
     , code_(std::move(code)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating category history widget for: "
-                              << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating category history widget for: " << code_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
@@ -49,8 +49,7 @@ ChangeReasonCategoryHistoryDialog::ChangeReasonCategoryHistoryDialog(
 ChangeReasonCategoryHistoryDialog::~ChangeReasonCategoryHistoryDialog() = default;
 
 void ChangeReasonCategoryHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading category history for: "
-                              << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading category history for: " << code_.toStdString();
 
     dq::messaging::get_change_reason_category_history_request request;
     request.code = code_.toStdString();
@@ -70,8 +69,7 @@ int ChangeReasonCategoryHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ChangeReasonCategoryHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ChangeReasonCategoryHistoryDialog::versionRow(int index) const {
     const auto& category = versions_[index];
     return {.version = category.version,
             .cells = {relative_time_helper::format(category.recorded_at),
@@ -81,13 +79,11 @@ ChangeReasonCategoryHistoryDialog::versionRow(int index) const {
 
 QString ChangeReasonCategoryHistoryDialog::historyTitle() const {
     const auto& latest = versions_.front();
-    return QString("Category History: %1")
-        .arg(QString::fromStdString(latest.code));
+    return QString("Category History: %1").arg(QString::fromStdString(latest.code));
 }
 
 HistoryDialogBase::DiffResult
-ChangeReasonCategoryHistoryDialog::calculateDiffAt(int current_index,
-                                                   int previous_index) const {
+ChangeReasonCategoryHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -102,14 +98,11 @@ void ChangeReasonCategoryHistoryDialog::displayFullDetails(int index) {
     const auto& category = versions_[index];
 
     ui_->codeValue->setText(QString::fromStdString(category.code));
-    ui_->descriptionValue->setText(
-        QString::fromStdString(category.description));
+    ui_->descriptionValue->setText(QString::fromStdString(category.description));
     ui_->versionNumberValue->setText(QString::number(category.version));
     ui_->modifiedByValue->setText(QString::fromStdString(category.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(category.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(category.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(category.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(category.change_commentary));
 }
 
 void ChangeReasonCategoryHistoryDialog::openVersionAt(int index) {
@@ -124,8 +117,7 @@ void ChangeReasonCategoryHistoryDialog::revertToVersionAt(int index) {
     // selected version, stamped with the latest version number.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     dq::domain::change_reason_category category = selected;
     category.version = versions_.front().version;

--- a/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ChangeReasonHistoryDialog.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.qt/ChangeReasonHistoryDialog.hpp"
-#include "ui_ChangeReasonHistoryDialog.h"
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
+#include "ui_ChangeReasonHistoryDialog.h"
 
 namespace ores::qt {
 
@@ -50,8 +50,7 @@ ChangeReasonHistoryDialog::ChangeReasonHistoryDialog(QString code,
 ChangeReasonHistoryDialog::~ChangeReasonHistoryDialog() = default;
 
 void ChangeReasonHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading change reason history for: "
-                              << code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading change reason history for: " << code_.toStdString();
 
     dq::messaging::get_change_reason_history_request request;
     request.code = code_.toStdString();
@@ -81,29 +80,23 @@ HistoryDialogBase::VersionRow ChangeReasonHistoryDialog::versionRow(int index) c
 
 QString ChangeReasonHistoryDialog::historyTitle() const {
     const auto& latest = versions_.front();
-    return QString("Change Reason History: %1")
-        .arg(QString::fromStdString(latest.code));
+    return QString("Change Reason History: %1").arg(QString::fromStdString(latest.code));
 }
 
-HistoryDialogBase::DiffResult
-ChangeReasonHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult ChangeReasonHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Description", current.description, previous.description);
-    checkString(diffs, "Category Code", current.category_code,
-                previous.category_code);
-    checkBool(diffs, "Applies to Amend", current.applies_to_amend,
-              previous.applies_to_amend);
-    checkBool(diffs, "Applies to Delete", current.applies_to_delete,
-              previous.applies_to_delete);
-    checkBool(diffs, "Requires Commentary", current.requires_commentary,
-              previous.requires_commentary);
-    checkInt(diffs, "Display Order", current.display_order,
-             previous.display_order);
+    checkString(diffs, "Category Code", current.category_code, previous.category_code);
+    checkBool(diffs, "Applies to Amend", current.applies_to_amend, previous.applies_to_amend);
+    checkBool(diffs, "Applies to Delete", current.applies_to_delete, previous.applies_to_delete);
+    checkBool(
+        diffs, "Requires Commentary", current.requires_commentary, previous.requires_commentary);
+    checkInt(diffs, "Display Order", current.display_order, previous.display_order);
 
     return diffs;
 }
@@ -113,25 +106,21 @@ void ChangeReasonHistoryDialog::displayFullDetails(int index) {
 
     ui_->codeValue->setText(QString::fromStdString(reason.code));
     ui_->descriptionValue->setText(QString::fromStdString(reason.description));
-    ui_->categoryCodeValue->setText(
-        QString::fromStdString(reason.category_code));
+    ui_->categoryCodeValue->setText(QString::fromStdString(reason.category_code));
     ui_->appliesToAmendValue->setText(reason.applies_to_amend ? "Yes" : "No");
     ui_->appliesToDeleteValue->setText(reason.applies_to_delete ? "Yes" : "No");
-    ui_->requiresCommentaryValue->setText(
-        reason.requires_commentary ? "Yes" : "No");
+    ui_->requiresCommentaryValue->setText(reason.requires_commentary ? "Yes" : "No");
     ui_->displayOrderValue->setText(QString::number(reason.display_order));
     ui_->versionNumberValue->setText(QString::number(reason.version));
     ui_->modifiedByValue->setText(QString::fromStdString(reason.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(reason.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(reason.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(reason.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(reason.change_commentary));
 }
 
 void ChangeReasonHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening change reason version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening change reason version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -140,8 +129,7 @@ void ChangeReasonHistoryDialog::revertToVersionAt(int index) {
     // selected version, stamped with the latest version number.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     dq::domain::change_reason reason = selected;
     reason.version = versions_.front().version;

--- a/projects/ores.qt/refdata/src/CodeDomainHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodeDomainHistoryDialog.cpp
@@ -52,8 +52,7 @@ CodeDomainHistoryDialog::CodeDomainHistoryDialog(const QString& code,
 CodeDomainHistoryDialog::~CodeDomainHistoryDialog() = default;
 
 void CodeDomainHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for code domain: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for code domain: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_code_domain_history_request request;
@@ -74,8 +73,7 @@ int CodeDomainHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CodeDomainHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CodeDomainHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -88,9 +86,8 @@ QString CodeDomainHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-CodeDomainHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult CodeDomainHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -116,8 +113,8 @@ void CodeDomainHistoryDialog::displayFullDetails(int index) {
 
 void CodeDomainHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening code domain version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening code domain version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +123,7 @@ void CodeDomainHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/CodingSchemeAuthorityTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodingSchemeAuthorityTypeHistoryDialog.cpp
@@ -75,8 +75,7 @@ int CodingSchemeAuthorityTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CodingSchemeAuthorityTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CodingSchemeAuthorityTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -115,8 +114,8 @@ void CodingSchemeAuthorityTypeHistoryDialog::displayFullDetails(int index) {
 
 void CodingSchemeAuthorityTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme authority type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme authority type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -125,8 +124,7 @@ void CodingSchemeAuthorityTypeHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/CodingSchemeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CodingSchemeHistoryDialog.cpp
@@ -54,8 +54,7 @@ CodingSchemeHistoryDialog::CodingSchemeHistoryDialog(const QString& code,
 CodingSchemeHistoryDialog::~CodingSchemeHistoryDialog() = default;
 
 void CodingSchemeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for coding scheme: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for coding scheme: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_coding_scheme_history_request request;
@@ -76,8 +75,7 @@ int CodingSchemeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CodingSchemeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CodingSchemeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,18 +87,15 @@ QString CodingSchemeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-CodingSchemeHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult CodingSchemeHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Authority Type", current.authority_type,
-                previous.authority_type);
-    checkString(diffs, "Subject Area", current.subject_area_name,
-                previous.subject_area_name);
+    checkString(diffs, "Authority Type", current.authority_type, previous.authority_type);
+    checkString(diffs, "Subject Area", current.subject_area_name, previous.subject_area_name);
     checkString(diffs, "Domain", current.domain_name, previous.domain_name);
     checkString(diffs, "URI", current.uri, previous.uri);
     checkString(diffs, "Description", current.description, previous.description);
@@ -126,8 +121,8 @@ void CodingSchemeHistoryDialog::displayFullDetails(int index) {
 
 void CodingSchemeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening coding scheme version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -136,8 +131,7 @@ void CodingSchemeHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CountryHistoryDialog.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.qt/CountryHistoryDialog.hpp"
-#include "ui_CountryHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
+#include "ui_CountryHistoryDialog.h"
 #include <QLabel>
 #include <boost/uuid/uuid_io.hpp>
 
@@ -63,8 +63,7 @@ CountryHistoryDialog::CountryHistoryDialog(QString alpha2_code,
 CountryHistoryDialog::~CountryHistoryDialog() = default;
 
 void CountryHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading country history for: "
-                              << alpha2Code_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading country history for: " << alpha2Code_.toStdString();
 
     refdata::messaging::get_country_history_request request;
     request.alpha2_code = alpha2Code_.toStdString();
@@ -100,9 +99,8 @@ QString CountryHistoryDialog::historyTitle() const {
         .arg(QString::fromStdString(latest.name));
 }
 
-HistoryDialogBase::DiffResult
-CountryHistoryDialog::calculateDiffAt(int current_index,
-                                      int previous_index) const {
+HistoryDialogBase::DiffResult CountryHistoryDialog::calculateDiffAt(int current_index,
+                                                                    int previous_index) const {
     const auto& current = history_[current_index];
     const auto& previous = history_[previous_index];
 
@@ -112,22 +110,17 @@ CountryHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Numeric Code", current.numeric_code, previous.numeric_code);
     checkString(diffs, "Name", current.name, previous.name);
     checkString(diffs, "Official Name", current.official_name, previous.official_name);
-    checkString(diffs, "Change Reason", current.change_reason_code,
-                previous.change_reason_code);
-    checkString(diffs, "Commentary", current.change_commentary,
-                previous.change_commentary);
+    checkString(diffs, "Change Reason", current.change_reason_code, previous.change_reason_code);
+    checkString(diffs, "Commentary", current.change_commentary, previous.change_commentary);
 
     if (current.image_id != previous.image_id) {
-        diffs.append({"Flag",
-                      {formatImageId(previous.image_id),
-                       formatImageId(current.image_id)}});
+        diffs.append({"Flag", {formatImageId(previous.image_id), formatImageId(current.image_id)}});
     }
 
     return diffs;
 }
 
-QWidget* CountryHistoryDialog::changeCellWidget(const QString& field,
-                                                const QString& value) {
+QWidget* CountryHistoryDialog::changeCellWidget(const QString& field, const QString& value) {
     // Show flag icons instead of image UUIDs.
     if (field != "Flag" || !imageCache_)
         return nullptr;
@@ -179,8 +172,7 @@ void CountryHistoryDialog::revertToVersionAt(int index) {
     // selected version, stamped with the latest version number.
     const auto& selected = history_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     refdata::domain::country countryToRevert = selected;
     countryToRevert.version = history_.front().version;

--- a/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyHistoryDialog.cpp
@@ -18,11 +18,11 @@
  *
  */
 #include "ores.qt/CurrencyHistoryDialog.hpp"
-#include "ui_CurrencyHistoryDialog.h"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
+#include "ui_CurrencyHistoryDialog.h"
 #include <QCloseEvent>
 #include <QHeaderView>
 #include <QLabel>
@@ -40,8 +40,7 @@ CurrencyHistoryDialog::CurrencyHistoryDialog(QString iso_code,
     , imageCache_(nullptr)
     , isoCode_(std::move(iso_code)) {
 
-    BOOST_LOG_SEV(lg(), info) << "Creating currency history widget for: "
-                              << isoCode_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Creating currency history widget for: " << isoCode_.toStdString();
 
     ui_->setupUi(this);
     WidgetUtils::setupComboBoxes(this);
@@ -54,15 +53,13 @@ CurrencyHistoryDialog::CurrencyHistoryDialog(QString iso_code,
     ui_->detailsTableWidget->horizontalHeader()->setStretchLastSection(true);
     ui_->detailsTableWidget->setColumnWidth(0, 200);
 
-    resize(UiPersistence::restoreSize(QLatin1String("CurrencyHistoryDialog"),
-                                      sizeHint()));
+    resize(UiPersistence::restoreSize(QLatin1String("CurrencyHistoryDialog"), sizeHint()));
 }
 
 CurrencyHistoryDialog::~CurrencyHistoryDialog() = default;
 
 void CurrencyHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), info) << "Loading currency history for: "
-                              << isoCode_.toStdString();
+    BOOST_LOG_SEV(lg(), info) << "Loading currency history for: " << isoCode_.toStdString();
 
     refdata::messaging::get_currency_history_request request;
     request.iso_code = isoCode_.toStdString();
@@ -98,23 +95,21 @@ QString CurrencyHistoryDialog::historyTitle() const {
         .arg(QString::fromStdString(latest.data.name));
 }
 
-HistoryDialogBase::DiffResult
-CurrencyHistoryDialog::calculateDiffAt(int current_index,
-                                       int /*previous_index*/) const {
+HistoryDialogBase::DiffResult CurrencyHistoryDialog::calculateDiffAt(int current_index,
+                                                                     int /*previous_index*/) const {
     // The server computes the diff; this renders its rows verbatim.
     DiffResult diffs;
     const auto& changes = history_.versions[current_index].changes;
     diffs.reserve(static_cast<qsizetype>(changes.entries.size()));
     for (const auto& entry : changes.entries) {
-        diffs.append({QString::fromStdString(entry.field_name),
-                      {QString::fromStdString(entry.old_value),
-                       QString::fromStdString(entry.new_value)}});
+        diffs.append(
+            {QString::fromStdString(entry.field_name),
+             {QString::fromStdString(entry.old_value), QString::fromStdString(entry.new_value)}});
     }
     return diffs;
 }
 
-QWidget* CurrencyHistoryDialog::changeCellWidget(const QString& field,
-                                                 const QString& value) {
+QWidget* CurrencyHistoryDialog::changeCellWidget(const QString& field, const QString& value) {
     // Show flag icons instead of image UUIDs.
     if (field != "Flag" || !imageCache_)
         return nullptr;
@@ -159,20 +154,17 @@ void CurrencyHistoryDialog::displayFullDetails(int index) {
     };
 
     for (const auto& field : version.fields) {
-        addRow(QString::fromStdString(field.name),
-               QString::fromStdString(field.value));
+        addRow(QString::fromStdString(field.name), QString::fromStdString(field.value));
     }
 
     addRow(tr("Version"), QString::number(version.version_number));
     addRow(tr("Modified By"), QString::fromStdString(version.modified_by));
-    addRow(tr("Recorded At"),
-           relative_time_helper::format(version.recorded_at));
+    addRow(tr("Recorded At"), relative_time_helper::format(version.recorded_at));
 }
 
 void CurrencyHistoryDialog::openVersionAt(int index) {
     const auto& version = history_.versions[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening currency version "
-                              << version.version_number
+    BOOST_LOG_SEV(lg(), info) << "Opening currency version " << version.version_number
                               << " in read-only mode";
     emit openVersionRequested(version.data, version.version_number);
 }
@@ -182,8 +174,7 @@ void CurrencyHistoryDialog::revertToVersionAt(int index) {
     // selected version, stamped with the latest version number.
     const auto& selected = history_.versions[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version_number;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version_number;
 
     refdata::domain::currency currency = selected.data;
     currency.version = history_.versions.front().version_number;

--- a/projects/ores.qt/refdata/src/CurrencyMarketTierHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyMarketTierHistoryDialog.cpp
@@ -74,8 +74,7 @@ int CurrencyMarketTierHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-CurrencyMarketTierHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow CurrencyMarketTierHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,8 +88,7 @@ QString CurrencyMarketTierHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-CurrencyMarketTierHistoryDialog::calculateDiffAt(int current_index,
-                                                 int previous_index) const {
+CurrencyMarketTierHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -116,8 +114,8 @@ void CurrencyMarketTierHistoryDialog::displayFullDetails(int index) {
 
 void CurrencyMarketTierHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening currency market tier version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening currency market tier version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +124,7 @@ void CurrencyMarketTierHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/DataDomainHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DataDomainHistoryDialog.cpp
@@ -54,8 +54,7 @@ DataDomainHistoryDialog::DataDomainHistoryDialog(const QString& name,
 DataDomainHistoryDialog::~DataDomainHistoryDialog() = default;
 
 void DataDomainHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for data domain: "
-                               << name_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for data domain: " << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_data_domain_history_request request;
@@ -76,8 +75,7 @@ int DataDomainHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-DataDomainHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow DataDomainHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,9 +87,8 @@ QString DataDomainHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(name_);
 }
 
-HistoryDialogBase::DiffResult
-DataDomainHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult DataDomainHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -114,8 +111,8 @@ void DataDomainHistoryDialog::displayFullDetails(int index) {
 
 void DataDomainHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening data domain version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening data domain version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -124,8 +121,7 @@ void DataDomainHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/DatasetBundleHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DatasetBundleHistoryDialog.cpp
@@ -55,8 +55,7 @@ DatasetBundleHistoryDialog::DatasetBundleHistoryDialog(const boost::uuids::uuid&
 DatasetBundleHistoryDialog::~DatasetBundleHistoryDialog() = default;
 
 void DatasetBundleHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset bundle: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset bundle: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_dataset_bundle_history_request request;
@@ -77,8 +76,7 @@ int DatasetBundleHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-DatasetBundleHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow DatasetBundleHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,8 +90,7 @@ QString DatasetBundleHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-DatasetBundleHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+DatasetBundleHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -119,8 +116,8 @@ void DatasetBundleHistoryDialog::displayFullDetails(int index) {
 
 void DatasetBundleHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening dataset bundle version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening dataset bundle version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -129,8 +126,7 @@ void DatasetBundleHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/DatasetHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DatasetHistoryDialog.cpp
@@ -59,8 +59,7 @@ QString DatasetHistoryDialog::code() const {
 }
 
 void DatasetHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset: "
-                               << boost::uuids::to_string(id_);
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for dataset: " << boost::uuids::to_string(id_);
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_dataset_history_request request;
@@ -81,8 +80,7 @@ int DatasetHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-DatasetHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow DatasetHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -94,20 +92,17 @@ QString DatasetHistoryDialog::historyTitle() const {
     return QString("Dataset History");
 }
 
-HistoryDialogBase::DiffResult
-DatasetHistoryDialog::calculateDiffAt(int current_index,
-                                      int previous_index) const {
+HistoryDialogBase::DiffResult DatasetHistoryDialog::calculateDiffAt(int current_index,
+                                                                    int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
     checkString(diffs, "Catalog", current.catalog_name, previous.catalog_name);
-    checkString(diffs, "Subject Area", current.subject_area_name,
-                previous.subject_area_name);
+    checkString(diffs, "Subject Area", current.subject_area_name, previous.subject_area_name);
     checkString(diffs, "Domain", current.domain_name, previous.domain_name);
-    checkString(diffs, "Source System", current.source_system_id,
-                previous.source_system_id);
+    checkString(diffs, "Source System", current.source_system_id, previous.source_system_id);
     checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
@@ -130,8 +125,8 @@ void DatasetHistoryDialog::displayFullDetails(int index) {
 
 void DatasetHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening dataset version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening dataset version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -140,8 +135,7 @@ void DatasetHistoryDialog::revertToVersionAt(int index) {
     // selected version. The server handles versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/DayCountFractionTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DayCountFractionTypeHistoryDialog.cpp
@@ -74,8 +74,7 @@ int DayCountFractionTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-DayCountFractionTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow DayCountFractionTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,8 +88,7 @@ QString DayCountFractionTypeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-DayCountFractionTypeHistoryDialog::calculateDiffAt(int current_index,
-                                                   int previous_index) const {
+DayCountFractionTypeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -108,16 +106,14 @@ void DayCountFractionTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void DayCountFractionTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening day count fraction type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening day count fraction type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +122,7 @@ void DayCountFractionTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/DepositConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/DepositConventionHistoryDialog.cpp
@@ -34,8 +34,7 @@ QString optionalText(const std::optional<std::string>& value) {
 }
 
 QString optionalBoolText(const std::optional<bool>& value) {
-    return value ? (*value ? QObject::tr("true") : QObject::tr("false"))
-                 : QObject::tr("(unset)");
+    return value ? (*value ? QObject::tr("true") : QObject::tr("false")) : QObject::tr("(unset)");
 }
 
 QString optionalIntText(const std::optional<int>& value) {
@@ -69,8 +68,7 @@ DepositConventionHistoryDialog::DepositConventionHistoryDialog(const QString& co
 DepositConventionHistoryDialog::~DepositConventionHistoryDialog() = default;
 
 void DepositConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for deposit convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for deposit convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_deposit_convention_history_request request;
@@ -91,8 +89,7 @@ int DepositConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-DepositConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow DepositConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -106,8 +103,7 @@ QString DepositConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-DepositConventionHistoryDialog::calculateDiffAt(int current_index,
-                                                int previous_index) const {
+DepositConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -117,13 +113,13 @@ DepositConventionHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Index", current.index, previous.index);
     checkString(diffs, "Calendar", current.calendar, previous.calendar);
     checkString(diffs, "Convention", current.convention, previous.convention);
-    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
-                previous.day_count_fraction);
+    checkString(
+        diffs, "Day Count Fraction", current.day_count_fraction, previous.day_count_fraction);
 
     if (current.end_of_month != previous.end_of_month) {
-        diffs.append({"End Of Month",
-                      {optionalBoolText(previous.end_of_month),
-                       optionalBoolText(current.end_of_month)}});
+        diffs.append(
+            {"End Of Month",
+             {optionalBoolText(previous.end_of_month), optionalBoolText(current.end_of_month)}});
     }
 
     if (current.settlement_days != previous.settlement_days) {
@@ -148,16 +144,14 @@ void DepositConventionHistoryDialog::displayFullDetails(int index) {
     ui_->settlementDaysValue->setText(optionalIntText(version.settlement_days));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void DepositConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening deposit convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening deposit convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -166,8 +160,7 @@ void DepositConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/FloatingIndexTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FloatingIndexTypeHistoryDialog.cpp
@@ -74,8 +74,7 @@ int FloatingIndexTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-FloatingIndexTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow FloatingIndexTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,8 +88,7 @@ QString FloatingIndexTypeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-FloatingIndexTypeHistoryDialog::calculateDiffAt(int current_index,
-                                                int previous_index) const {
+FloatingIndexTypeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -108,16 +106,14 @@ void FloatingIndexTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void FloatingIndexTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening floating index type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening floating index type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +122,7 @@ void FloatingIndexTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/FraConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FraConventionHistoryDialog.cpp
@@ -52,8 +52,7 @@ FraConventionHistoryDialog::FraConventionHistoryDialog(const QString& code,
 FraConventionHistoryDialog::~FraConventionHistoryDialog() = default;
 
 void FraConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for FRA convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FRA convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_fra_convention_history_request request;
@@ -74,8 +73,7 @@ int FraConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-FraConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow FraConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,8 +87,7 @@ QString FraConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-FraConventionHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+FraConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -108,16 +105,14 @@ void FraConventionHistoryDialog::displayFullDetails(int index) {
     ui_->indexValue->setText(QString::fromStdString(version.index));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void FraConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening FRA convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening FRA convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +121,7 @@ void FraConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/FxConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/FxConventionHistoryDialog.cpp
@@ -34,8 +34,7 @@ QString optionalText(const std::optional<std::string>& value) {
 }
 
 QString optionalBoolText(const std::optional<bool>& value) {
-    return value ? (*value ? QObject::tr("true") : QObject::tr("false"))
-                 : QObject::tr("(unset)");
+    return value ? (*value ? QObject::tr("true") : QObject::tr("false")) : QObject::tr("(unset)");
 }
 
 }
@@ -65,8 +64,7 @@ FxConventionHistoryDialog::FxConventionHistoryDialog(const QString& code,
 FxConventionHistoryDialog::~FxConventionHistoryDialog() = default;
 
 void FxConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for FX convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FX convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_fx_convention_history_request request;
@@ -87,8 +85,7 @@ int FxConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-FxConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow FxConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -101,33 +98,29 @@ QString FxConventionHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-FxConventionHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult FxConventionHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Id", current.id, previous.id);
-    checkString(diffs, "Source Currency", current.source_currency,
-                previous.source_currency);
-    checkString(diffs, "Target Currency", current.target_currency,
-                previous.target_currency);
+    checkString(diffs, "Source Currency", current.source_currency, previous.source_currency);
+    checkString(diffs, "Target Currency", current.target_currency, previous.target_currency);
     checkInt(diffs, "Spot Days", current.spot_days, previous.spot_days);
-    checkString(diffs, "Advance Calendar", current.advance_calendar,
-                previous.advance_calendar);
+    checkString(diffs, "Advance Calendar", current.advance_calendar, previous.advance_calendar);
     checkString(diffs, "Convention", current.convention, previous.convention);
 
     if (current.spot_relative != previous.spot_relative) {
-        diffs.append({"Spot Relative",
-                      {optionalBoolText(previous.spot_relative),
-                       optionalBoolText(current.spot_relative)}});
+        diffs.append(
+            {"Spot Relative",
+             {optionalBoolText(previous.spot_relative), optionalBoolText(current.spot_relative)}});
     }
 
     if (current.end_of_month != previous.end_of_month) {
-        diffs.append({"End Of Month",
-                      {optionalBoolText(previous.end_of_month),
-                       optionalBoolText(current.end_of_month)}});
+        diffs.append(
+            {"End Of Month",
+             {optionalBoolText(previous.end_of_month), optionalBoolText(current.end_of_month)}});
     }
 
     return diffs;
@@ -137,10 +130,8 @@ void FxConventionHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->sourceCurrencyValue->setText(
-        QString::fromStdString(version.source_currency));
-    ui_->targetCurrencyValue->setText(
-        QString::fromStdString(version.target_currency));
+    ui_->sourceCurrencyValue->setText(QString::fromStdString(version.source_currency));
+    ui_->targetCurrencyValue->setText(QString::fromStdString(version.target_currency));
     ui_->spotDaysValue->setText(QString::number(version.spot_days));
     ui_->advanceCalendarValue->setText(optionalText(version.advance_calendar));
     ui_->conventionValue->setText(optionalText(version.convention));
@@ -148,16 +139,14 @@ void FxConventionHistoryDialog::displayFullDetails(int index) {
     ui_->endOfMonthValue->setText(optionalBoolText(version.end_of_month));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void FxConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening FX convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening FX convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -166,8 +155,7 @@ void FxConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/IborIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/IborIndexConventionHistoryDialog.cpp
@@ -74,8 +74,7 @@ int IborIndexConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-IborIndexConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow IborIndexConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,20 +88,19 @@ QString IborIndexConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-IborIndexConventionHistoryDialog::calculateDiffAt(int current_index,
-                                                  int previous_index) const {
+IborIndexConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Id", current.id, previous.id);
-    checkString(diffs, "Fixing Calendar", current.fixing_calendar,
-                previous.fixing_calendar);
-    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
-                previous.day_count_fraction);
-    checkInt(diffs, "Settlement Days", current.settlement_days,
-             previous.settlement_days);
-    checkString(diffs, "Business Day Convention", current.business_day_convention,
+    checkString(diffs, "Fixing Calendar", current.fixing_calendar, previous.fixing_calendar);
+    checkString(
+        diffs, "Day Count Fraction", current.day_count_fraction, previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days, previous.settlement_days);
+    checkString(diffs,
+                "Business Day Convention",
+                current.business_day_convention,
                 previous.business_day_convention);
     checkBool(diffs, "End Of Month", current.end_of_month, previous.end_of_month);
 
@@ -113,26 +111,22 @@ void IborIndexConventionHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixingCalendarValue->setText(
-        QString::fromStdString(version.fixing_calendar));
-    ui_->dayCountFractionValue->setText(
-        QString::fromStdString(version.day_count_fraction));
+    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
     ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
     ui_->businessDayConventionValue->setText(
         QString::fromStdString(version.business_day_convention));
     ui_->endOfMonthValue->setText(version.end_of_month ? tr("true") : tr("false"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void IborIndexConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening IBOR index convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening IBOR index convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -141,8 +135,7 @@ void IborIndexConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/LegTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/LegTypeHistoryDialog.cpp
@@ -52,8 +52,7 @@ LegTypeHistoryDialog::LegTypeHistoryDialog(const QString& code,
 LegTypeHistoryDialog::~LegTypeHistoryDialog() = default;
 
 void LegTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for leg type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for leg type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     trading::messaging::get_leg_type_history_request request;
@@ -74,8 +73,7 @@ int LegTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-LegTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow LegTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -88,9 +86,8 @@ QString LegTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-LegTypeHistoryDialog::calculateDiffAt(int current_index,
-                                      int previous_index) const {
+HistoryDialogBase::DiffResult LegTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                    int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -108,16 +105,14 @@ void LegTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void LegTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening leg type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening leg type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -126,8 +121,7 @@ void LegTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/MethodologyHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/MethodologyHistoryDialog.cpp
@@ -83,8 +83,7 @@ int MethodologyHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-MethodologyHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow MethodologyHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -96,19 +95,17 @@ QString MethodologyHistoryDialog::historyTitle() const {
     return QString("Methodology History");
 }
 
-HistoryDialogBase::DiffResult
-MethodologyHistoryDialog::calculateDiffAt(int current_index,
-                                          int previous_index) const {
+HistoryDialogBase::DiffResult MethodologyHistoryDialog::calculateDiffAt(int current_index,
+                                                                        int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
     checkString(diffs, "Description", current.description, previous.description);
-    checkString(diffs, "Logic Reference", current.logic_reference,
-                previous.logic_reference);
-    checkString(diffs, "Implementation", current.implementation_details,
-                previous.implementation_details);
+    checkString(diffs, "Logic Reference", current.logic_reference, previous.logic_reference);
+    checkString(
+        diffs, "Implementation", current.implementation_details, previous.implementation_details);
 
     return diffs;
 }
@@ -119,20 +116,17 @@ void MethodologyHistoryDialog::displayFullDetails(int index) {
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->logicReferenceValue->setText(optionalText(version.logic_reference));
-    ui_->implementationValue->setText(
-        optionalText(version.implementation_details));
+    ui_->implementationValue->setText(optionalText(version.implementation_details));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void MethodologyHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening methodology version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening methodology version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -141,8 +135,7 @@ void MethodologyHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/MonetaryNatureHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/MonetaryNatureHistoryDialog.cpp
@@ -52,8 +52,7 @@ MonetaryNatureHistoryDialog::MonetaryNatureHistoryDialog(const QString& code,
 MonetaryNatureHistoryDialog::~MonetaryNatureHistoryDialog() = default;
 
 void MonetaryNatureHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for monetary nature: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for monetary nature: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_monetary_nature_history_request request;
@@ -74,8 +73,7 @@ int MonetaryNatureHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-MonetaryNatureHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow MonetaryNatureHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,8 +87,7 @@ QString MonetaryNatureHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-MonetaryNatureHistoryDialog::calculateDiffAt(int current_index,
-                                             int previous_index) const {
+MonetaryNatureHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -110,16 +107,14 @@ void MonetaryNatureHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void MonetaryNatureHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening monetary nature version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening monetary nature version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -128,8 +123,7 @@ void MonetaryNatureHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/NatureDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/NatureDimensionHistoryDialog.cpp
@@ -54,8 +54,7 @@ NatureDimensionHistoryDialog::NatureDimensionHistoryDialog(const QString& code,
 NatureDimensionHistoryDialog::~NatureDimensionHistoryDialog() = default;
 
 void NatureDimensionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for nature dimension: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for nature dimension: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_nature_dimension_history_request request;
@@ -76,8 +75,7 @@ int NatureDimensionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-NatureDimensionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow NatureDimensionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,8 +88,7 @@ QString NatureDimensionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-NatureDimensionHistoryDialog::calculateDiffAt(int current_index,
-                                              int previous_index) const {
+NatureDimensionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -110,16 +107,14 @@ void NatureDimensionHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void NatureDimensionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening nature dimension version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening nature dimension version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -128,8 +123,7 @@ void NatureDimensionHistoryDialog::revertToVersionAt(int index) {
     // versioning.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/OisConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OisConventionHistoryDialog.cpp
@@ -60,8 +60,7 @@ OisConventionHistoryDialog::OisConventionHistoryDialog(const QString& code,
 OisConventionHistoryDialog::~OisConventionHistoryDialog() = default;
 
 void OisConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for OIS convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for OIS convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_ois_convention_history_request request;
@@ -82,8 +81,7 @@ int OisConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-OisConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow OisConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -97,8 +95,7 @@ QString OisConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-OisConventionHistoryDialog::calculateDiffAt(int current_index,
-                                            int previous_index) const {
+OisConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -106,31 +103,28 @@ OisConventionHistoryDialog::calculateDiffAt(int current_index,
     checkString(diffs, "Id", current.id, previous.id);
     checkString(diffs, "Index", current.index, previous.index);
     checkInt(diffs, "Spot Lag", current.spot_lag, previous.spot_lag);
-    checkString(diffs, "Fixed Day Count Fraction",
+    checkString(diffs,
+                "Fixed Day Count Fraction",
                 current.fixed_day_count_fraction,
                 previous.fixed_day_count_fraction);
-    checkString(diffs, "Fixed Calendar", current.fixed_calendar,
-                previous.fixed_calendar);
+    checkString(diffs, "Fixed Calendar", current.fixed_calendar, previous.fixed_calendar);
     checkInt(diffs, "Payment Lag", current.payment_lag, previous.payment_lag);
-    checkString(diffs, "Fixed Frequency", current.fixed_frequency,
-                previous.fixed_frequency);
-    checkString(diffs, "Fixed Convention", current.fixed_convention,
-                previous.fixed_convention);
-    checkString(diffs, "Fixed Payment Convention",
+    checkString(diffs, "Fixed Frequency", current.fixed_frequency, previous.fixed_frequency);
+    checkString(diffs, "Fixed Convention", current.fixed_convention, previous.fixed_convention);
+    checkString(diffs,
+                "Fixed Payment Convention",
                 current.fixed_payment_convention,
                 previous.fixed_payment_convention);
     checkString(diffs, "Rule", current.rule, previous.rule);
-    checkString(diffs, "Payment Calendar", current.payment_calendar,
-                previous.payment_calendar);
+    checkString(diffs, "Payment Calendar", current.payment_calendar, previous.payment_calendar);
     checkInt(diffs, "Rate Cutoff", current.rate_cutoff, previous.rate_cutoff);
 
     if (current.end_of_month != previous.end_of_month) {
         auto boolText = [this](const std::optional<bool>& v) {
             return v ? (*v ? tr("true") : tr("false")) : tr("(unset)");
         };
-        diffs.append({"End Of Month",
-                      {boolText(previous.end_of_month),
-                       boolText(current.end_of_month)}});
+        diffs.append(
+            {"End Of Month", {boolText(previous.end_of_month), boolText(current.end_of_month)}});
     }
 
     return diffs;
@@ -145,32 +139,27 @@ void OisConventionHistoryDialog::displayFullDetails(int index) {
     ui_->fixedDayCountFractionValue->setText(
         QString::fromStdString(version.fixed_day_count_fraction));
     ui_->fixedCalendarValue->setText(optionalText(version.fixed_calendar));
-    ui_->paymentLagValue->setText(version.payment_lag ?
-                                      QString::number(*version.payment_lag) :
-                                      tr("(unset)"));
+    ui_->paymentLagValue->setText(version.payment_lag ? QString::number(*version.payment_lag) :
+                                                        tr("(unset)"));
     ui_->fixedFrequencyValue->setText(optionalText(version.fixed_frequency));
     ui_->fixedConventionValue->setText(optionalText(version.fixed_convention));
-    ui_->fixedPaymentConventionValue->setText(
-        optionalText(version.fixed_payment_convention));
+    ui_->fixedPaymentConventionValue->setText(optionalText(version.fixed_payment_convention));
     ui_->ruleValue->setText(optionalText(version.rule));
     ui_->paymentCalendarValue->setText(optionalText(version.payment_calendar));
-    ui_->rateCutoffValue->setText(version.rate_cutoff ?
-                                      QString::number(*version.rate_cutoff) :
-                                      tr("(unset)"));
+    ui_->rateCutoffValue->setText(version.rate_cutoff ? QString::number(*version.rate_cutoff) :
+                                                        tr("(unset)"));
     ui_->endOfMonthValue->setText(
         version.end_of_month ? (*version.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void OisConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening OIS convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening OIS convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -179,8 +168,7 @@ void OisConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/OriginDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OriginDimensionHistoryDialog.cpp
@@ -75,8 +75,7 @@ int OriginDimensionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-OriginDimensionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow OriginDimensionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,15 +88,13 @@ QString OriginDimensionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-OriginDimensionHistoryDialog::calculateDiffAt(int current_index,
-                                              int previous_index) const {
+OriginDimensionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -110,16 +107,14 @@ void OriginDimensionHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void OriginDimensionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening origin dimension version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening origin dimension version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -128,8 +123,7 @@ void OriginDimensionHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/OvernightIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/OvernightIndexConventionHistoryDialog.cpp
@@ -73,8 +73,7 @@ int OvernightIndexConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-OvernightIndexConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow OvernightIndexConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -95,12 +94,10 @@ OvernightIndexConventionHistoryDialog::calculateDiffAt(int current_index,
 
     DiffResult diffs;
     checkString(diffs, "Id", current.id, previous.id);
-    checkString(diffs, "Fixing Calendar", current.fixing_calendar,
-                previous.fixing_calendar);
-    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
-                previous.day_count_fraction);
-    checkInt(diffs, "Settlement Days", current.settlement_days,
-             previous.settlement_days);
+    checkString(diffs, "Fixing Calendar", current.fixing_calendar, previous.fixing_calendar);
+    checkString(
+        diffs, "Day Count Fraction", current.day_count_fraction, previous.day_count_fraction);
+    checkInt(diffs, "Settlement Days", current.settlement_days, previous.settlement_days);
 
     return diffs;
 }
@@ -109,23 +106,19 @@ void OvernightIndexConventionHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixingCalendarValue->setText(
-        QString::fromStdString(version.fixing_calendar));
-    ui_->dayCountFractionValue->setText(
-        QString::fromStdString(version.day_count_fraction));
+    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
     ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void OvernightIndexConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening overnight index convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening overnight index convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -134,8 +127,7 @@ void OvernightIndexConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/PaymentFrequencyTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/PaymentFrequencyTypeHistoryDialog.cpp
@@ -74,8 +74,7 @@ int PaymentFrequencyTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PaymentFrequencyTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PaymentFrequencyTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,15 +88,13 @@ QString PaymentFrequencyTypeHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-PaymentFrequencyTypeHistoryDialog::calculateDiffAt(int current_index,
-                                                   int previous_index) const {
+PaymentFrequencyTypeHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -109,16 +106,14 @@ void PaymentFrequencyTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PaymentFrequencyTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening payment frequency type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening payment frequency type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -127,8 +122,7 @@ void PaymentFrequencyTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/PurposeTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/PurposeTypeHistoryDialog.cpp
@@ -54,8 +54,7 @@ PurposeTypeHistoryDialog::PurposeTypeHistoryDialog(const QString& code,
 PurposeTypeHistoryDialog::~PurposeTypeHistoryDialog() = default;
 
 void PurposeTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for purpose type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for purpose type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_purpose_type_history_request request;
@@ -76,8 +75,7 @@ int PurposeTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PurposeTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PurposeTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,17 +88,15 @@ QString PurposeTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-PurposeTypeHistoryDialog::calculateDiffAt(int current_index,
-                                          int previous_index) const {
+HistoryDialogBase::DiffResult PurposeTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                        int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -113,16 +109,14 @@ void PurposeTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PurposeTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening purpose type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening purpose type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -131,8 +125,7 @@ void PurposeTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/RoundingTypeHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/RoundingTypeHistoryDialog.cpp
@@ -52,8 +52,7 @@ RoundingTypeHistoryDialog::RoundingTypeHistoryDialog(const QString& code,
 RoundingTypeHistoryDialog::~RoundingTypeHistoryDialog() = default;
 
 void RoundingTypeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for rounding type: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for rounding type: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_rounding_type_history_request request;
@@ -74,8 +73,7 @@ int RoundingTypeHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-RoundingTypeHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow RoundingTypeHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -88,17 +86,15 @@ QString RoundingTypeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-RoundingTypeHistoryDialog::calculateDiffAt(int current_index,
-                                           int previous_index) const {
+HistoryDialogBase::DiffResult RoundingTypeHistoryDialog::calculateDiffAt(int current_index,
+                                                                         int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Code", current.code, previous.code);
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -111,16 +107,14 @@ void RoundingTypeHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void RoundingTypeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening rounding type version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening rounding type version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -129,8 +123,7 @@ void RoundingTypeHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/SubjectAreaHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/SubjectAreaHistoryDialog.cpp
@@ -56,8 +56,7 @@ SubjectAreaHistoryDialog::SubjectAreaHistoryDialog(const QString& name,
 SubjectAreaHistoryDialog::~SubjectAreaHistoryDialog() = default;
 
 void SubjectAreaHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for subject area: "
-                               << name_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for subject area: " << name_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     dq::messaging::get_subject_area_history_request request;
@@ -79,8 +78,7 @@ int SubjectAreaHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-SubjectAreaHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow SubjectAreaHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -92,15 +90,13 @@ QString SubjectAreaHistoryDialog::historyTitle() const {
     return QString("History for: %1 (Domain: %2)").arg(name_, domain_name_);
 }
 
-HistoryDialogBase::DiffResult
-SubjectAreaHistoryDialog::calculateDiffAt(int current_index,
-                                          int previous_index) const {
+HistoryDialogBase::DiffResult SubjectAreaHistoryDialog::calculateDiffAt(int current_index,
+                                                                        int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -113,16 +109,14 @@ void SubjectAreaHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void SubjectAreaHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening subject area version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening subject area version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -131,8 +125,7 @@ void SubjectAreaHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/SwapConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/SwapConventionHistoryDialog.cpp
@@ -60,8 +60,7 @@ SwapConventionHistoryDialog::SwapConventionHistoryDialog(const QString& code,
 SwapConventionHistoryDialog::~SwapConventionHistoryDialog() = default;
 
 void SwapConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for swap convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for swap convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_swap_convention_history_request request;
@@ -82,8 +81,7 @@ int SwapConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-SwapConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow SwapConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -97,26 +95,23 @@ QString SwapConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-SwapConventionHistoryDialog::calculateDiffAt(int current_index,
-                                             int previous_index) const {
+SwapConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Id", current.id, previous.id);
-    checkString(diffs, "Fixed Frequency", current.fixed_frequency,
-                previous.fixed_frequency);
-    checkString(diffs, "Fixed Day Count Fraction",
+    checkString(diffs, "Fixed Frequency", current.fixed_frequency, previous.fixed_frequency);
+    checkString(diffs,
+                "Fixed Day Count Fraction",
                 current.fixed_day_count_fraction,
                 previous.fixed_day_count_fraction);
     checkString(diffs, "Index", current.index, previous.index);
-    checkString(diffs, "Fixed Calendar", current.fixed_calendar,
-                previous.fixed_calendar);
-    checkString(diffs, "Fixed Convention", current.fixed_convention,
-                previous.fixed_convention);
-    checkString(diffs, "Float Frequency", current.float_frequency,
-                previous.float_frequency);
-    checkString(diffs, "Sub-Periods Coupon Type",
+    checkString(diffs, "Fixed Calendar", current.fixed_calendar, previous.fixed_calendar);
+    checkString(diffs, "Fixed Convention", current.fixed_convention, previous.fixed_convention);
+    checkString(diffs, "Float Frequency", current.float_frequency, previous.float_frequency);
+    checkString(diffs,
+                "Sub-Periods Coupon Type",
                 current.sub_periods_coupon_type,
                 previous.sub_periods_coupon_type);
 
@@ -127,28 +122,24 @@ void SwapConventionHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->fixedFrequencyValue->setText(
-        QString::fromStdString(version.fixed_frequency));
+    ui_->fixedFrequencyValue->setText(QString::fromStdString(version.fixed_frequency));
     ui_->fixedDayCountFractionValue->setText(
         QString::fromStdString(version.fixed_day_count_fraction));
     ui_->indexValue->setText(QString::fromStdString(version.index));
     ui_->fixedCalendarValue->setText(optionalText(version.fixed_calendar));
     ui_->fixedConventionValue->setText(optionalText(version.fixed_convention));
     ui_->floatFrequencyValue->setText(optionalText(version.float_frequency));
-    ui_->subPeriodsCouponTypeValue->setText(
-        optionalText(version.sub_periods_coupon_type));
+    ui_->subPeriodsCouponTypeValue->setText(optionalText(version.sub_periods_coupon_type));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void SwapConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening swap convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening swap convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -157,8 +148,7 @@ void SwapConventionHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/TreatmentDimensionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/TreatmentDimensionHistoryDialog.cpp
@@ -75,8 +75,7 @@ int TreatmentDimensionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-TreatmentDimensionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow TreatmentDimensionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -89,15 +88,13 @@ QString TreatmentDimensionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-TreatmentDimensionHistoryDialog::calculateDiffAt(int current_index,
-                                                 int previous_index) const {
+TreatmentDimensionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Description", current.description,
-                previous.description);
+    checkString(diffs, "Description", current.description, previous.description);
 
     return diffs;
 }
@@ -110,16 +107,14 @@ void TreatmentDimensionHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void TreatmentDimensionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening treatment dimension version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening treatment dimension version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -128,8 +123,7 @@ void TreatmentDimensionHistoryDialog::revertToVersionAt(int index) {
     // versioning, so simply request the revert to the selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/refdata/src/ZeroConventionHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/ZeroConventionHistoryDialog.cpp
@@ -60,8 +60,7 @@ ZeroConventionHistoryDialog::ZeroConventionHistoryDialog(const QString& code,
 ZeroConventionHistoryDialog::~ZeroConventionHistoryDialog() = default;
 
 void ZeroConventionHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for zero convention: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for zero convention: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_zero_convention_history_request request;
@@ -82,8 +81,7 @@ int ZeroConventionHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-ZeroConventionHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow ZeroConventionHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -97,25 +95,22 @@ QString ZeroConventionHistoryDialog::historyTitle() const {
 }
 
 HistoryDialogBase::DiffResult
-ZeroConventionHistoryDialog::calculateDiffAt(int current_index,
-                                             int previous_index) const {
+ZeroConventionHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Id", current.id, previous.id);
-    checkString(diffs, "Day Count Fraction", current.day_count_fraction,
-                previous.day_count_fraction);
-    checkString(diffs, "Compounding", current.compounding,
-                previous.compounding);
-    checkString(diffs, "Compounding Frequency", current.compounding_frequency,
+    checkString(
+        diffs, "Day Count Fraction", current.day_count_fraction, previous.day_count_fraction);
+    checkString(diffs, "Compounding", current.compounding, previous.compounding);
+    checkString(diffs,
+                "Compounding Frequency",
+                current.compounding_frequency,
                 previous.compounding_frequency);
-    checkString(diffs, "Tenor Calendar", current.tenor_calendar,
-                previous.tenor_calendar);
-    checkString(diffs, "Spot Calendar", current.spot_calendar,
-                previous.spot_calendar);
-    checkString(diffs, "Roll Convention", current.roll_convention,
-                previous.roll_convention);
+    checkString(diffs, "Tenor Calendar", current.tenor_calendar, previous.tenor_calendar);
+    checkString(diffs, "Spot Calendar", current.spot_calendar, previous.spot_calendar);
+    checkString(diffs, "Roll Convention", current.roll_convention, previous.roll_convention);
 
     return diffs;
 }
@@ -124,26 +119,22 @@ void ZeroConventionHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
-    ui_->dayCountFractionValue->setText(
-        QString::fromStdString(version.day_count_fraction));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
     ui_->compoundingValue->setText(optionalText(version.compounding));
-    ui_->compoundingFrequencyValue->setText(
-        optionalText(version.compounding_frequency));
+    ui_->compoundingFrequencyValue->setText(optionalText(version.compounding_frequency));
     ui_->tenorCalendarValue->setText(optionalText(version.tenor_calendar));
     ui_->spotCalendarValue->setText(optionalText(version.spot_calendar));
     ui_->rollConventionValue->setText(optionalText(version.roll_convention));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void ZeroConventionHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening zero convention version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening zero convention version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -152,8 +143,7 @@ void ZeroConventionHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionAuditDialog.hpp
+++ b/projects/ores.qt/scheduler/include/ores.qt/JobDefinitionAuditDialog.hpp
@@ -54,9 +54,9 @@ private:
 
 public:
     explicit JobDefinitionAuditDialog(const boost::uuids::uuid& job_definition_id,
-                                        const QString& job_name,
-                                        ClientManager* clientManager,
-                                        QWidget* parent = nullptr);
+                                      const QString& job_name,
+                                      ClientManager* clientManager,
+                                      QWidget* parent = nullptr);
     ~JobDefinitionAuditDialog() override;
 
     void refresh();

--- a/projects/ores.qt/scheduler/src/JobDefinitionAuditDialog.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionAuditDialog.cpp
@@ -59,9 +59,9 @@ QString format_duration(const scheduler::domain::job_instance& instance) {
 } // anonymous namespace
 
 JobDefinitionAuditDialog::JobDefinitionAuditDialog(const boost::uuids::uuid& job_definition_id,
-                                                       const QString& job_name,
-                                                       ClientManager* clientManager,
-                                                       QWidget* parent)
+                                                   const QString& job_name,
+                                                   ClientManager* clientManager,
+                                                   QWidget* parent)
     : QWidget(parent)
     , ui_(new Ui::JobDefinitionAuditDialog)
     , job_definition_id_(job_definition_id)

--- a/projects/ores.qt/scheduler/src/JobDefinitionController.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionController.cpp
@@ -21,8 +21,8 @@
 #include "ores.qt/ChangeReasonCache.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
-#include "ores.qt/JobDefinitionDetailDialog.hpp"
 #include "ores.qt/JobDefinitionAuditDialog.hpp"
+#include "ores.qt/JobDefinitionDetailDialog.hpp"
 #include "ores.qt/JobDefinitionMdiWindow.hpp"
 #include <QMdiSubWindow>
 #include <QMessageBox>
@@ -257,11 +257,9 @@ void JobDefinitionController::showDetailWindow(
     show_managed_window(detailWindow, listMdiSubWindow_);
 }
 
-void JobDefinitionController::showAuditWindow(
-    const scheduler::domain::job_definition& definition) {
+void JobDefinitionController::showAuditWindow(const scheduler::domain::job_definition& definition) {
     const QString code = QString::fromStdString(definition.job_name);
-    BOOST_LOG_SEV(lg(), info) << "Opening audit window for job definition: "
-                              << definition.job_name;
+    BOOST_LOG_SEV(lg(), info) << "Opening audit window for job definition: " << definition.job_name;
 
     const QString windowKey = build_window_key("audit", code);
 

--- a/projects/ores.qt/scheduler/src/JobDefinitionMdiWindow.cpp
+++ b/projects/ores.qt/scheduler/src/JobDefinitionMdiWindow.cpp
@@ -110,8 +110,7 @@ void JobDefinitionMdiWindow::setupToolbar() {
         IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor), tr("Audit"));
     auditAction_->setToolTip(tr("View job execution audit"));
     auditAction_->setEnabled(false);
-    connect(
-        auditAction_, &QAction::triggered, this, &JobDefinitionMdiWindow::viewAuditSelected);
+    connect(auditAction_, &QAction::triggered, this, &JobDefinitionMdiWindow::viewAuditSelected);
 }
 
 void JobDefinitionMdiWindow::setupTable() {

--- a/projects/ores.qt/trading/include/ores.qt/BookHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/BookHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/trading/include/ores.qt/BookStatusHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/BookStatusHistoryDialog.hpp
@@ -75,8 +75,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/trading/include/ores.qt/PortfolioHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/PortfolioHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/trading/include/ores.qt/TradeHistoryDialog.hpp
+++ b/projects/ores.qt/trading/include/ores.qt/TradeHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/trading/src/BookHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/BookHistoryDialog.cpp
@@ -91,16 +91,15 @@ QString BookHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-BookHistoryDialog::calculateDiffAt(int current_index, int previous_index) const {
+HistoryDialogBase::DiffResult BookHistoryDialog::calculateDiffAt(int current_index,
+                                                                 int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
     checkString(diffs, "Ledger Currency", current.ledger_ccy, previous.ledger_ccy);
-    checkString(diffs, "GL Account Ref", current.gl_account_ref,
-                previous.gl_account_ref);
+    checkString(diffs, "GL Account Ref", current.gl_account_ref, previous.gl_account_ref);
     checkString(diffs, "Cost Center", current.cost_center, previous.cost_center);
     checkString(diffs, "Status", current.book_status, previous.book_status);
 
@@ -117,16 +116,13 @@ void BookHistoryDialog::displayFullDetails(int index) {
     ui_->bookStatusValue->setText(QString::fromStdString(version.book_status));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void BookHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening book version " << version.version
-                              << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening book version " << version.version << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -135,8 +131,7 @@ void BookHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/trading/src/BookStatusHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/BookStatusHistoryDialog.cpp
@@ -54,8 +54,7 @@ BookStatusHistoryDialog::BookStatusHistoryDialog(const QString& code,
 BookStatusHistoryDialog::~BookStatusHistoryDialog() = default;
 
 void BookStatusHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for book status: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for book status: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_book_status_history_request request;
@@ -76,8 +75,7 @@ int BookStatusHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-BookStatusHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow BookStatusHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -90,9 +88,8 @@ QString BookStatusHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-BookStatusHistoryDialog::calculateDiffAt(int current_index,
-                                         int previous_index) const {
+HistoryDialogBase::DiffResult BookStatusHistoryDialog::calculateDiffAt(int current_index,
+                                                                       int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
@@ -112,16 +109,14 @@ void BookStatusHistoryDialog::displayFullDetails(int index) {
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void BookStatusHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening book status version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening book status version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -130,8 +125,7 @@ void BookStatusHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/trading/src/PortfolioHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/PortfolioHistoryDialog.cpp
@@ -55,8 +55,7 @@ PortfolioHistoryDialog::PortfolioHistoryDialog(const boost::uuids::uuid& id,
 PortfolioHistoryDialog::~PortfolioHistoryDialog() = default;
 
 void PortfolioHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for portfolio: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for portfolio: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     refdata::messaging::get_portfolio_history_request request;
@@ -77,8 +76,7 @@ int PortfolioHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-PortfolioHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow PortfolioHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -91,18 +89,15 @@ QString PortfolioHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-PortfolioHistoryDialog::calculateDiffAt(int current_index,
-                                        int previous_index) const {
+HistoryDialogBase::DiffResult PortfolioHistoryDialog::calculateDiffAt(int current_index,
+                                                                      int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
-    checkString(diffs, "Purpose Type", current.purpose_type,
-                previous.purpose_type);
-    checkString(diffs, "Aggregation Currency", current.aggregation_ccy,
-                previous.aggregation_ccy);
+    checkString(diffs, "Purpose Type", current.purpose_type, previous.purpose_type);
+    checkString(diffs, "Aggregation Currency", current.aggregation_ccy, previous.aggregation_ccy);
 
     return diffs;
 }
@@ -112,20 +107,17 @@ void PortfolioHistoryDialog::displayFullDetails(int index) {
 
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->purposeTypeValue->setText(QString::fromStdString(version.purpose_type));
-    ui_->aggregationCcyValue->setText(
-        QString::fromStdString(version.aggregation_ccy));
+    ui_->aggregationCcyValue->setText(QString::fromStdString(version.aggregation_ccy));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void PortfolioHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening portfolio version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening portfolio version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -134,8 +126,7 @@ void PortfolioHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/trading/src/TradeHistoryDialog.cpp
+++ b/projects/ores.qt/trading/src/TradeHistoryDialog.cpp
@@ -63,8 +63,7 @@ TradeHistoryDialog::TradeHistoryDialog(const boost::uuids::uuid& id,
 TradeHistoryDialog::~TradeHistoryDialog() = default;
 
 void TradeHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for trade: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for trade: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     trading::messaging::get_trade_history_request request;
@@ -98,29 +97,34 @@ QString TradeHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-TradeHistoryDialog::calculateDiffAt(int current_index,
-                                    int previous_index) const {
+HistoryDialogBase::DiffResult TradeHistoryDialog::calculateDiffAt(int current_index,
+                                                                  int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
-    checkString(diffs, "External ID", current.identity.external_id,
-                previous.identity.external_id);
-    checkString(diffs, "Trade Type", current.classification.trade_type,
-                previous.classification.trade_type);
-    checkString(diffs, "Lifecycle Event",
+    checkString(diffs, "External ID", current.identity.external_id, previous.identity.external_id);
+    checkString(
+        diffs, "Trade Type", current.classification.trade_type, previous.classification.trade_type);
+    checkString(diffs,
+                "Lifecycle Event",
                 current.classification.activity_type_code,
                 previous.classification.activity_type_code);
-    checkString(diffs, "Netting Set", current.classification.netting_set_id,
+    checkString(diffs,
+                "Netting Set",
+                current.classification.netting_set_id,
                 previous.classification.netting_set_id);
-    checkString(diffs, "Trade Date", current.lifecycle.trade_date,
-                previous.lifecycle.trade_date);
-    checkString(diffs, "Effective Date", current.lifecycle.effective_date,
+    checkString(diffs, "Trade Date", current.lifecycle.trade_date, previous.lifecycle.trade_date);
+    checkString(diffs,
+                "Effective Date",
+                current.lifecycle.effective_date,
                 previous.lifecycle.effective_date);
-    checkString(diffs, "Termination Date", current.lifecycle.termination_date,
+    checkString(diffs,
+                "Termination Date",
+                current.lifecycle.termination_date,
                 previous.lifecycle.termination_date);
-    checkString(diffs, "Execution Timestamp",
+    checkString(diffs,
+                "Execution Timestamp",
                 current.lifecycle.execution_timestamp,
                 previous.lifecycle.execution_timestamp);
 
@@ -130,34 +134,24 @@ TradeHistoryDialog::calculateDiffAt(int current_index,
 void TradeHistoryDialog::displayFullDetails(int index) {
     const auto& version = versions_[index];
 
-    ui_->externalIdValue->setText(
-        QString::fromStdString(version.identity.external_id));
-    ui_->tradeTypeValue->setText(
-        QString::fromStdString(version.classification.trade_type));
+    ui_->externalIdValue->setText(QString::fromStdString(version.identity.external_id));
+    ui_->tradeTypeValue->setText(QString::fromStdString(version.classification.trade_type));
     ui_->lifecycleEventValue->setText(
         QString::fromStdString(version.classification.activity_type_code));
-    ui_->nettingSetIdValue->setText(
-        QString::fromStdString(version.classification.netting_set_id));
+    ui_->nettingSetIdValue->setText(QString::fromStdString(version.classification.netting_set_id));
     ui_->tradeDateValue->setText(optionalText(version.lifecycle.trade_date));
-    ui_->effectiveDateValue->setText(
-        optionalText(version.lifecycle.effective_date));
-    ui_->terminationDateValue->setText(
-        optionalText(version.lifecycle.termination_date));
-    ui_->executionTimestampValue->setText(
-        optionalText(version.lifecycle.execution_timestamp));
+    ui_->effectiveDateValue->setText(optionalText(version.lifecycle.effective_date));
+    ui_->terminationDateValue->setText(optionalText(version.lifecycle.termination_date));
+    ui_->executionTimestampValue->setText(optionalText(version.lifecycle.execution_timestamp));
     ui_->versionNumberValue->setText(QString::number(version.identity.version));
-    ui_->modifiedByValue->setText(
-        QString::fromStdString(version.audit.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.audit.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.audit.change_commentary));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.audit.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.audit.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.audit.change_commentary));
 }
 
 void TradeHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening trade version "
-                              << version.identity.version
+    BOOST_LOG_SEV(lg(), info) << "Opening trade version " << version.identity.version
                               << " in read-only mode";
     emit openVersionRequested(version, version.identity.version);
 }
@@ -167,8 +161,7 @@ void TradeHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.identity.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.identity.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
+++ b/projects/ores.qt/workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
@@ -77,8 +77,7 @@ protected:
     [[nodiscard]] int historySize() const override;
     [[nodiscard]] VersionRow versionRow(int index) const override;
     [[nodiscard]] QString historyTitle() const override;
-    [[nodiscard]] DiffResult
-    calculateDiffAt(int current_index, int previous_index) const override;
+    [[nodiscard]] DiffResult calculateDiffAt(int current_index, int previous_index) const override;
     void displayFullDetails(int index) override;
     void openVersionAt(int index) override;
     void revertToVersionAt(int index) override;

--- a/projects/ores.qt/workspace/src/WorkspaceHistoryDialog.cpp
+++ b/projects/ores.qt/workspace/src/WorkspaceHistoryDialog.cpp
@@ -55,8 +55,7 @@ WorkspaceHistoryDialog::WorkspaceHistoryDialog(const boost::uuids::uuid& id,
 WorkspaceHistoryDialog::~WorkspaceHistoryDialog() = default;
 
 void WorkspaceHistoryDialog::loadHistory() {
-    BOOST_LOG_SEV(lg(), debug) << "Loading history for workspace: "
-                               << code_.toStdString();
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for workspace: " << code_.toStdString();
     emit statusChanged(tr("Loading history..."));
 
     workspace::messaging::get_workspace_history_request request;
@@ -77,8 +76,7 @@ int WorkspaceHistoryDialog::historySize() const {
     return static_cast<int>(versions_.size());
 }
 
-HistoryDialogBase::VersionRow
-WorkspaceHistoryDialog::versionRow(int index) const {
+HistoryDialogBase::VersionRow WorkspaceHistoryDialog::versionRow(int index) const {
     const auto& version = versions_[index];
     return {.version = version.version,
             .cells = {relative_time_helper::format(version.recorded_at),
@@ -91,34 +89,28 @@ QString WorkspaceHistoryDialog::historyTitle() const {
     return QString("History for: %1").arg(code_);
 }
 
-HistoryDialogBase::DiffResult
-WorkspaceHistoryDialog::calculateDiffAt(int current_index,
-                                        int previous_index) const {
+HistoryDialogBase::DiffResult WorkspaceHistoryDialog::calculateDiffAt(int current_index,
+                                                                      int previous_index) const {
     const auto& current = versions_[current_index];
     const auto& previous = versions_[previous_index];
 
     DiffResult diffs;
     checkString(diffs, "Name", current.name, previous.name);
     checkString(diffs, "Description", current.description, previous.description);
-    checkString(diffs, "Source Path", current.source_path,
-                previous.source_path);
+    checkString(diffs, "Source Path", current.source_path, previous.source_path);
 
     if (current.parent_workspace_id != previous.parent_workspace_id) {
         auto to_s = [](const std::optional<boost::uuids::uuid>& o) {
-            return o ? QString::fromStdString(boost::uuids::to_string(*o))
-                     : QString{};
+            return o ? QString::fromStdString(boost::uuids::to_string(*o)) : QString{};
         };
-        diffs.append({"Parent",
-                      {to_s(previous.parent_workspace_id),
-                       to_s(current.parent_workspace_id)}});
+        diffs.append(
+            {"Parent", {to_s(previous.parent_workspace_id), to_s(current.parent_workspace_id)}});
     }
 
     if (current.owner_id != previous.owner_id) {
-        diffs.append(
-            {"Owner",
-             {QString::fromStdString(boost::uuids::to_string(previous.owner_id)),
-              QString::fromStdString(
-                  boost::uuids::to_string(current.owner_id))}});
+        diffs.append({"Owner",
+                      {QString::fromStdString(boost::uuids::to_string(previous.owner_id)),
+                       QString::fromStdString(boost::uuids::to_string(current.owner_id))}});
     }
 
     checkString(diffs, "Status", current.status_code, previous.status_code);
@@ -134,24 +126,20 @@ void WorkspaceHistoryDialog::displayFullDetails(int index) {
     ui_->sourcePathValue->setText(QString::fromStdString(version.source_path));
     ui_->parentValue->setText(
         version.parent_workspace_id ?
-            QString::fromStdString(
-                boost::uuids::to_string(*version.parent_workspace_id)) :
+            QString::fromStdString(boost::uuids::to_string(*version.parent_workspace_id)) :
             QString{});
-    ui_->ownerValue->setText(
-        QString::fromStdString(boost::uuids::to_string(version.owner_id)));
+    ui_->ownerValue->setText(QString::fromStdString(boost::uuids::to_string(version.owner_id)));
     ui_->statusValue->setText(QString::fromStdString(version.status_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
-    ui_->recordedAtValue->setText(
-        relative_time_helper::format(version.recorded_at));
-    ui_->changeCommentaryValue->setText(
-        QString::fromStdString(version.change_commentary));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
 }
 
 void WorkspaceHistoryDialog::openVersionAt(int index) {
     const auto& version = versions_[index];
-    BOOST_LOG_SEV(lg(), info) << "Opening workspace version "
-                              << version.version << " in read-only mode";
+    BOOST_LOG_SEV(lg(), info) << "Opening workspace version " << version.version
+                              << " in read-only mode";
     emit openVersionRequested(version, version.version);
 }
 
@@ -160,8 +148,7 @@ void WorkspaceHistoryDialog::revertToVersionAt(int index) {
     // selected version.
     const auto& selected = versions_[index];
 
-    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version "
-                              << selected.version;
+    BOOST_LOG_SEV(lg(), info) << "Requesting revert to version " << selected.version;
 
     emit revertVersionRequested(selected);
 }

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/currency_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/currency_handler.hpp
@@ -159,8 +159,7 @@ public:
         try {
             auto h = svc.get_currency_history(req->iso_code);
             currency_version_history cvh;
-            cvh.versions =
-                presentation::currency_field_mapper::build_versions(h);
+            cvh.versions = presentation::currency_field_mapper::build_versions(h);
             BOOST_LOG_SEV(currency_handler_lg(), debug) << "Completed " << msg.subject;
             reply(nats_,
                   msg,

--- a/projects/ores.refdata/core/include/ores.refdata.core/presentation/currency_field_mapper.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/presentation/currency_field_mapper.hpp
@@ -20,11 +20,11 @@
 #ifndef ORES_REFDATA_CORE_PRESENTATION_CURRENCY_FIELD_MAPPER_HPP
 #define ORES_REFDATA_CORE_PRESENTATION_CURRENCY_FIELD_MAPPER_HPP
 
-#include <vector>
 #include "ores.diff/domain/field_value.hpp"
 #include "ores.refdata.api/domain/currency.hpp"
 #include "ores.refdata.api/domain/currency_version.hpp"
 #include "ores.refdata.core/export.hpp"
+#include <vector>
 
 namespace ores::refdata::presentation {
 

--- a/projects/ores.refdata/core/src/presentation/currency_field_mapper.cpp
+++ b/projects/ores.refdata/core/src/presentation/currency_field_mapper.cpp
@@ -33,30 +33,25 @@ std::string image_id_text(const std::optional<boost::uuids::uuid>& id) {
 
 }
 
-std::vector<ores::diff::domain::field_value>
-currency_field_mapper::map(const domain::currency& c) {
-    return {
-        {.name = "ISO Code", .value = c.iso_code},
-        {.name = "Name", .value = c.name},
-        {.name = "Numeric Code", .value = c.numeric_code},
-        {.name = "Symbol", .value = c.symbol},
-        {.name = "Fraction Symbol", .value = c.fraction_symbol},
-        {.name = "Rounding Type", .value = c.rounding_type},
-        {.name = "Format", .value = c.format},
-        {.name = "Monetary Nature", .value = c.monetary_nature},
-        {.name = "Market Tier", .value = c.market_tier},
-        {.name = "Fractions Per Unit",
-         .value = std::to_string(c.fractions_per_unit)},
-        {.name = "Rounding Precision",
-         .value = std::to_string(c.rounding_precision)},
-        {.name = "Change Reason", .value = c.change_reason_code},
-        {.name = "Commentary", .value = c.change_commentary},
-        {.name = "Flag", .value = image_id_text(c.image_id)}};
+std::vector<ores::diff::domain::field_value> currency_field_mapper::map(const domain::currency& c) {
+    return {{.name = "ISO Code", .value = c.iso_code},
+            {.name = "Name", .value = c.name},
+            {.name = "Numeric Code", .value = c.numeric_code},
+            {.name = "Symbol", .value = c.symbol},
+            {.name = "Fraction Symbol", .value = c.fraction_symbol},
+            {.name = "Rounding Type", .value = c.rounding_type},
+            {.name = "Format", .value = c.format},
+            {.name = "Monetary Nature", .value = c.monetary_nature},
+            {.name = "Market Tier", .value = c.market_tier},
+            {.name = "Fractions Per Unit", .value = std::to_string(c.fractions_per_unit)},
+            {.name = "Rounding Precision", .value = std::to_string(c.rounding_precision)},
+            {.name = "Change Reason", .value = c.change_reason_code},
+            {.name = "Commentary", .value = c.change_commentary},
+            {.name = "Flag", .value = image_id_text(c.image_id)}};
 }
 
 std::vector<domain::currency_version>
-currency_field_mapper::build_versions(
-    const std::vector<domain::currency>& currencies) {
+currency_field_mapper::build_versions(const std::vector<domain::currency>& currencies) {
     std::vector<domain::currency_version> r;
     r.reserve(currencies.size());
 
@@ -73,8 +68,7 @@ currency_field_mapper::build_versions(
     // Versions arrive newest first; each diffs against the next older
     // one. The oldest keeps empty changes.
     for (std::size_t i = 0; i + 1 < r.size(); ++i)
-        r[i].changes = ores::diff::engine::compute(r[i + 1].fields,
-                                                   r[i].fields);
+        r[i].changes = ores::diff::engine::compute(r[i + 1].fields, r[i].fields);
 
     return r;
 }

--- a/projects/ores.refdata/core/tests/presentation_currency_field_mapper_tests.cpp
+++ b/projects/ores.refdata/core/tests/presentation_currency_field_mapper_tests.cpp
@@ -141,8 +141,7 @@ TEST_CASE("build_versions_diffs_consecutive_pairs", tags) {
     REQUIRE(versions[1].changes.entries.size() == 1);
     CHECK(versions[1].changes.entries[0].field_name == "Name");
     CHECK(versions[1].changes.entries[0].old_value == "US Dollar");
-    CHECK(versions[1].changes.entries[0].new_value ==
-          "United States Dollar");
+    CHECK(versions[1].changes.entries[0].new_value == "United States Dollar");
 
     CHECK(versions[2].changes.entries.empty());
 }

--- a/projects/ores.refdata/service/src/app/application.cpp
+++ b/projects/ores.refdata/service/src/app/application.cpp
@@ -127,7 +127,9 @@ boost::asio::awaitable<void> application::run(boost::asio::io_context& io_ctx,
         "ores.refdata.counterparty_contact_information",
         "ores_refdata_counterparty_contact_informations");
     ev::service::registrar::register_mapping<rdev::counterparty_identifier_changed_event>(
-        event_source, "ores.refdata.counterparty_identifier", "ores_refdata_counterparty_identifiers");
+        event_source,
+        "ores.refdata.counterparty_identifier",
+        "ores_refdata_counterparty_identifiers");
     ev::service::registrar::register_mapping<rdev::country_changed_event>(
         event_source, "ores.refdata.country", "ores_refdata_countries");
     ev::service::registrar::register_mapping<rdev::currency_changed_event>(
@@ -139,7 +141,9 @@ boost::asio::awaitable<void> application::run(boost::asio::io_context& io_ctx,
     ev::service::registrar::register_mapping<rdev::party_changed_event>(
         event_source, "ores.refdata.party", "ores_refdata_parties");
     ev::service::registrar::register_mapping<rdev::party_contact_information_changed_event>(
-        event_source, "ores.refdata.party_contact_information", "ores_refdata_party_contact_informations");
+        event_source,
+        "ores.refdata.party_contact_information",
+        "ores_refdata_party_contact_informations");
     ev::service::registrar::register_mapping<rdev::party_identifier_changed_event>(
         event_source, "ores.refdata.party_identifier", "ores_refdata_party_identifiers");
     ev::service::registrar::register_mapping<rdev::portfolio_changed_event>(

--- a/projects/ores.shell/include/ores.shell/app/command_args.hpp
+++ b/projects/ores.shell/include/ores.shell/app/command_args.hpp
@@ -77,8 +77,7 @@ struct parsed_args {
  * strings; this is the single place that turns them into options.
  */
 ORES_SHELL_EXPORT std::expected<parsed_args, std::string>
-parse_args(const std::vector<std::string>& tokens,
-           const std::vector<flag_spec>& specs);
+parse_args(const std::vector<std::string>& tokens, const std::vector<flag_spec>& specs);
 
 /**
  * @brief Parse a duration flag value as a positive whole number of

--- a/projects/ores.shell/include/ores.shell/app/commands/account_parties_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/account_parties_commands.hpp
@@ -41,8 +41,7 @@ namespace ores::shell::app::commands {
  */
 class account_parties_commands {
 private:
-    inline static std::string_view logger_name =
-        "ores.shell.app.commands.account_parties_commands";
+    inline static std::string_view logger_name = "ores.shell.app.commands.account_parties_commands";
 
     static auto& lg() {
         using namespace ores::logging;
@@ -57,14 +56,12 @@ public:
      * Creates the account-parties submenu with list and add
      * operations.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief List existing account-party associations.
      */
-    static void process_list(std::ostream& out,
-                             ores::nats::service::nats_client& session);
+    static void process_list(std::ostream& out, ores::nats::service::nats_client& session);
 
     /**
      * @brief Associate an account with a party (both UUIDs).

--- a/projects/ores.shell/include/ores.shell/app/commands/bundles_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/bundles_commands.hpp
@@ -57,14 +57,12 @@ public:
      *
      * Creates the bundles submenu with list and publish operations.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief List the dataset bundles available on the server.
      */
-    static void process_list(std::ostream& out,
-                             ores::nats::service::nats_client& session);
+    static void process_list(std::ostream& out, ores::nats::service::nats_client& session);
 
     /**
      * @brief Publish a bundle: bundles publish <code> [--wait]

--- a/projects/ores.shell/include/ores.shell/app/commands/lei_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/lei_commands.hpp
@@ -56,14 +56,12 @@ public:
      *
      * Creates the lei submenu with countries and entities operations.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief List the countries that have LEI entities.
      */
-    static void process_countries(std::ostream& out,
-                                  ores::nats::service::nats_client& session);
+    static void process_countries(std::ostream& out, ores::nats::service::nats_client& session);
 
     /**
      * @brief List a country's LEI entities: lei entities <country>

--- a/projects/ores.shell/include/ores.shell/app/commands/parties_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/parties_commands.hpp
@@ -56,8 +56,7 @@ public:
      *
      * Creates the parties submenu with the list operation.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief List parties: parties list [--category <c>] [--status <s>].

--- a/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/provision_commands.hpp
@@ -57,8 +57,7 @@ public:
      *
      * Creates the provision submenu.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief The system provisioner flow: provision system <username>

--- a/projects/ores.shell/include/ores.shell/app/commands/reports_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/reports_commands.hpp
@@ -55,8 +55,7 @@ public:
      *
      * Creates the reports submenu with the templates operation.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief List report definition templates:

--- a/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/synthetic_commands.hpp
@@ -60,8 +60,7 @@ public:
      *
      * Creates the synthetic submenu with the generate operation.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief Generate a synthetic organisation:

--- a/projects/ores.shell/include/ores.shell/app/commands/workflow_commands.hpp
+++ b/projects/ores.shell/include/ores.shell/app/commands/workflow_commands.hpp
@@ -57,8 +57,7 @@ public:
      *
      * Creates the workflow submenu with steps and wait operations.
      */
-    static void register_commands(cli::Menu& root_menu,
-                                  ores::nats::service::nats_client& session);
+    static void register_commands(cli::Menu& root_menu, ores::nats::service::nats_client& session);
 
     /**
      * @brief Display the current steps of a workflow instance.

--- a/projects/ores.shell/include/ores.shell/app/script_runner.hpp
+++ b/projects/ores.shell/include/ores.shell/app/script_runner.hpp
@@ -53,9 +53,9 @@ struct script_result {
  * command so these semantics are unit-testable without a cli session.
  */
 ORES_SHELL_EXPORT script_result run_script(std::istream& in,
-                         const std::function<void(const std::string&)>& feed,
-                         std::ostream& out,
-                         bool continue_on_error);
+                                           const std::function<void(const std::string&)>& feed,
+                                           std::ostream& out,
+                                           bool continue_on_error);
 
 }
 

--- a/projects/ores.shell/src/app/command_args.cpp
+++ b/projects/ores.shell/src/app/command_args.cpp
@@ -25,17 +25,15 @@
 
 namespace ores::shell::app {
 
-std::expected<parsed_args, std::string>
-parse_args(const std::vector<std::string>& tokens,
-           const std::vector<flag_spec>& specs) {
+std::expected<parsed_args, std::string> parse_args(const std::vector<std::string>& tokens,
+                                                   const std::vector<flag_spec>& specs) {
     parsed_args r;
     for (const auto& spec : specs)
-        r.flags[spec.name] = spec.requires_value ? spec.default_value
-                                                 : std::string("false");
+        r.flags[spec.name] = spec.requires_value ? spec.default_value : std::string("false");
 
     auto find_spec = [&](const std::string& name) {
-        return std::find_if(specs.begin(), specs.end(),
-                            [&](const auto& s) { return s.name == name; });
+        return std::find_if(
+            specs.begin(), specs.end(), [&](const auto& s) { return s.name == name; });
     };
 
     for (std::size_t i = 0; i < tokens.size(); ++i) {
@@ -60,8 +58,7 @@ parse_args(const std::vector<std::string>& tokens,
 
         if (!spec->requires_value) {
             if (has_inline_value)
-                return std::unexpected("Flag --" + body +
-                                       " does not take a value");
+                return std::unexpected("Flag --" + body + " does not take a value");
             r.flags[body] = "true";
             continue;
         }
@@ -78,8 +75,7 @@ parse_args(const std::vector<std::string>& tokens,
     return r;
 }
 
-std::optional<std::chrono::seconds>
-parse_positive_seconds(const std::string& value) {
+std::optional<std::chrono::seconds> parse_positive_seconds(const std::string& value) {
     try {
         std::size_t pos = 0;
         const long v = std::stol(value, &pos);
@@ -93,8 +89,7 @@ parse_positive_seconds(const std::string& value) {
 
 namespace {
 
-std::optional<unsigned long long> parse_unsigned(const std::string& value,
-                                                 unsigned long long max) {
+std::optional<unsigned long long> parse_unsigned(const std::string& value, unsigned long long max) {
     // Require a leading digit: stoull would otherwise skip whitespace
     // and wrap negatives (" -1") into huge unsigned values.
     if (value.empty() || !std::isdigit(static_cast<unsigned char>(value[0])))

--- a/projects/ores.shell/src/app/commands/account_parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/account_parties_commands.cpp
@@ -21,8 +21,8 @@
 #include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.iam.api/domain/account_party_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/messaging/account_party_protocol.hpp"
-#include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.nats/domain/message.hpp"
+#include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
@@ -46,11 +46,9 @@ std::optional<Response> do_auth_request(std::ostream& out,
                                         const std::string& body) {
     try {
         auto reply = session.authenticated_request(subject, body);
-        auto result = rfl::json::read<Response>(
-                ores::nats::as_string_view(reply.data));
+        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return std::nullopt;
         }
         return *result;
@@ -60,38 +58,32 @@ std::optional<Response> do_auth_request(std::ostream& out,
     }
 }
 
-std::optional<boost::uuids::uuid> parse_uuid(std::ostream& out,
-                                             const std::string& value,
-                                             std::string_view what) {
+std::optional<boost::uuids::uuid>
+parse_uuid(std::ostream& out, const std::string& value, std::string_view what) {
     try {
         return boost::lexical_cast<boost::uuids::uuid>(value);
     } catch (const boost::bad_lexical_cast&) {
-        fail(out) << "Invalid " << what << " format. Expected UUID: " << value
-                  << std::endl;
+        fail(out) << "Invalid " << what << " format. Expected UUID: " << value << std::endl;
         return std::nullopt;
     }
 }
 
 }
 
-void account_parties_commands::register_commands(cli::Menu& root_menu,
-                                                 nats_client& session) {
+void account_parties_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto menu = std::make_unique<cli::Menu>("account-parties");
 
     menu->Insert(
         "list",
-        [&session](std::ostream& out) {
-            process_list(std::ref(out), std::ref(session));
-        },
+        [&session](std::ostream& out) { process_list(std::ref(out), std::ref(session)); },
         "List account-to-party associations");
 
-    menu->Insert(
-        "add",
-        [&session](std::ostream& out, std::string account_id, std::string party_id) {
-            process_add(std::ref(out), std::ref(session), account_id, party_id);
-        },
-        "Associate an account with a party",
-        {"account_id", "party_id"});
+    menu->Insert("add",
+                 [&session](std::ostream& out, std::string account_id, std::string party_id) {
+                     process_add(std::ref(out), std::ref(session), account_id, party_id);
+                 },
+                 "Associate an account with a party",
+                 {"account_id", "party_id"});
 
     root_menu.Insert(std::move(menu));
 }
@@ -139,12 +131,12 @@ void account_parties_commands::process_add(std::ostream& out,
     refdata::messaging::get_parties_request parties_req;
     parties_req.limit = 1000;
     auto parties = do_auth_request<refdata::messaging::get_parties_response>(
-        out, session, std::string(parties_req.nats_subject),
-        rfl::json::write(parties_req));
+        out, session, std::string(parties_req.nats_subject), rfl::json::write(parties_req));
     if (!parties)
         return;
 
-    const auto party = std::find_if(parties->parties.begin(), parties->parties.end(),
+    const auto party = std::find_if(parties->parties.begin(),
+                                    parties->parties.end(),
                                     [&](const auto& p) { return p.id == *party_uuid; });
     if (party == parties->parties.end()) {
         fail(out) << "Party not found: " << party_id << std::endl;
@@ -170,14 +162,12 @@ void account_parties_commands::process_add(std::ostream& out,
         return;
 
     if (!result->success) {
-        fail(out) << "Failed to associate account with party: " << result->message
-                  << std::endl;
+        fail(out) << "Failed to associate account with party: " << result->message << std::endl;
         return;
     }
-    out << "✓ Account " << account_id << " associated with party '" << party->full_name
-        << "'." << std::endl;
-    BOOST_LOG_SEV(lg(), info) << "Account " << account_id << " associated with party "
-                              << party_id;
+    out << "✓ Account " << account_id << " associated with party '" << party->full_name << "'."
+        << std::endl;
+    BOOST_LOG_SEV(lg(), info) << "Account " << account_id << " associated with party " << party_id;
 }
 
 }

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "ores.shell/app/commands/accounts_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/account_table_io.hpp"         // IWYU pragma: keep.
 #include "ores.iam.api/domain/account_version_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/domain/login_info_table_io.hpp"      // IWYU pragma: keep.
@@ -29,6 +28,7 @@
 #include "ores.iam.api/messaging/login_protocol.hpp"
 #include "ores.iam.api/messaging/session_protocol.hpp"
 #include "ores.platform/time/datetime.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/rbac_commands.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>

--- a/projects/ores.shell/src/app/commands/bundles_commands.cpp
+++ b/projects/ores.shell/src/app/commands/bundles_commands.cpp
@@ -26,8 +26,8 @@
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/workflow_commands.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
-#include <cli/cli.h>
 #include <chrono>
+#include <cli/cli.h>
 #include <functional>
 #include <ostream>
 #include <rfl/json.hpp>
@@ -45,19 +45,17 @@ constexpr std::chrono::minutes publish_timeout(5);
 constexpr std::chrono::seconds default_wait_timeout(300);
 
 template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body,
-                                        std::chrono::milliseconds timeout =
-                                            std::chrono::seconds(30)) {
+std::optional<Response>
+do_auth_request(std::ostream& out,
+                nats_client& session,
+                const std::string& subject,
+                const std::string& body,
+                std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
     try {
         auto reply = session.authenticated_request(subject, body, timeout);
-        auto result = rfl::json::read<Response>(
-            ores::nats::as_string_view(reply.data));
+        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return std::nullopt;
         }
         return *result;
@@ -74,19 +72,16 @@ void bundles_commands::register_commands(cli::Menu& root_menu, nats_client& sess
 
     bundles_menu->Insert(
         "list",
-        [&session](std::ostream& out) {
-            process_list(std::ref(out), std::ref(session));
-        },
+        [&session](std::ostream& out) { process_list(std::ref(out), std::ref(session)); },
         "List the dataset bundles available for publication");
 
-    bundles_menu->Insert(
-        "publish",
-        [&session](std::ostream& out, std::vector<std::string> args) {
-            process_publish(std::ref(out), std::ref(session), args);
-        },
-        "Publish a dataset bundle (dispatches a workflow; --wait blocks on it)",
-        {"code [--wait] [--root-lei <lei>] [--party-id <id>] [--dataset <code>] "
-         "[--timeout <seconds>]"});
+    bundles_menu->Insert("publish",
+                         [&session](std::ostream& out, std::vector<std::string> args) {
+                             process_publish(std::ref(out), std::ref(session), args);
+                         },
+                         "Publish a dataset bundle (dispatches a workflow; --wait blocks on it)",
+                         {"code [--wait] [--root-lei <lei>] [--party-id <id>] [--dataset <code>] "
+                          "[--timeout <seconds>]"});
 
     root_menu.Insert(std::move(bundles_menu));
 }
@@ -100,22 +95,21 @@ void bundles_commands::process_list(std::ostream& out, nats_client& session) {
     if (!result)
         return;
 
-    BOOST_LOG_SEV(lg(), info) << "Successfully retrieved " << result->bundles.size()
-                              << " bundles.";
+    BOOST_LOG_SEV(lg(), info) << "Successfully retrieved " << result->bundles.size() << " bundles.";
     out << result->bundles << std::endl;
 }
 
 void bundles_commands::process_publish(std::ostream& out,
                                        nats_client& session,
                                        const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "wait"},
-        {.name = "root-lei", .requires_value = true, .default_value = ""},
-        {.name = "party-id", .requires_value = true, .default_value = ""},
-        {.name = "dataset", .requires_value = true, .default_value = ""},
-        {.name = "timeout", .requires_value = true,
-         .default_value = std::to_string(default_wait_timeout.count())}
-    });
+    auto parsed = parse_args(args,
+                             {{.name = "wait"},
+                              {.name = "root-lei", .requires_value = true, .default_value = ""},
+                              {.name = "party-id", .requires_value = true, .default_value = ""},
+                              {.name = "dataset", .requires_value = true, .default_value = ""},
+                              {.name = "timeout",
+                               .requires_value = true,
+                               .default_value = std::to_string(default_wait_timeout.count())}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -137,8 +131,8 @@ void bundles_commands::process_publish(std::ostream& out,
     if (parsed->flag_set("wait")) {
         wait_timeout = parse_positive_seconds(parsed->flag("timeout"));
         if (!wait_timeout) {
-            fail(out) << "Timeout must be a positive number of seconds: "
-                      << parsed->flag("timeout") << std::endl;
+            fail(out) << "Timeout must be a positive number of seconds: " << parsed->flag("timeout")
+                      << std::endl;
             return;
         }
     }
@@ -149,8 +143,8 @@ void bundles_commands::process_publish(std::ostream& out,
     if (!parsed->flag("dataset").empty())
         params.opted_in_datasets.push_back(parsed->flag("dataset"));
     if (!parsed->flag("root-lei").empty())
-        params.lei_parties = dq::messaging::lei_parties_params{
-            .root_lei = parsed->flag("root-lei")};
+        params.lei_parties =
+            dq::messaging::lei_parties_params{.root_lei = parsed->flag("root-lei")};
     if (!parsed->flag("party-id").empty())
         params.party_id = parsed->flag("party-id");
 
@@ -159,18 +153,17 @@ void bundles_commands::process_publish(std::ostream& out,
     req.mode = dq::domain::publication_mode::upsert;
     req.published_by = session.auth().username;
     req.atomic = true;
-    const bool has_params = !params.opted_in_datasets.empty() ||
-        params.lei_parties.has_value() || params.party_id.has_value();
+    const bool has_params = !params.opted_in_datasets.empty() || params.lei_parties.has_value() ||
+                            params.party_id.has_value();
     if (has_params)
         req.params_json = dq::messaging::build_params_json(params);
 
-    BOOST_LOG_SEV(lg(), info) << "Publishing bundle: " << code
-                              << " (params: " << req.params_json << ")";
+    BOOST_LOG_SEV(lg(), info) << "Publishing bundle: " << code << " (params: " << req.params_json
+                              << ")";
     out << "Publishing bundle '" << code << "'..." << std::endl;
 
     auto result = do_auth_request<dq::messaging::publish_bundle_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req),
-        publish_timeout);
+        out, session, std::string(req.nats_subject), rfl::json::write(req), publish_timeout);
     if (!result)
         return;
 
@@ -179,8 +172,8 @@ void bundles_commands::process_publish(std::ostream& out,
         return;
     }
 
-    out << "✓ Dispatched " << result->datasets_dispatched << " dataset(s); workflow instance: "
-        << result->instance_id << std::endl;
+    out << "✓ Dispatched " << result->datasets_dispatched
+        << " dataset(s); workflow instance: " << result->instance_id << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Bundle " << code << " dispatched; instance "
                               << result->instance_id;
 
@@ -188,9 +181,11 @@ void bundles_commands::process_publish(std::ostream& out,
         out << "Follow progress with: workflow wait " << result->instance_id << std::endl;
         return;
     }
-    workflow_commands::wait_for_instance(
-        out, session, result->instance_id, *wait_timeout,
-        static_cast<std::size_t>(result->datasets_dispatched));
+    workflow_commands::wait_for_instance(out,
+                                         session,
+                                         result->instance_id,
+                                         *wait_timeout,
+                                         static_cast<std::size_t>(result->datasets_dispatched));
 }
 
 }

--- a/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
@@ -18,9 +18,9 @@
  *
  */
 #include "ores.shell/app/commands/change_reason_categories_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.dq.api/domain/change_reason_category_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>

--- a/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
@@ -18,9 +18,9 @@
  *
  */
 #include "ores.shell/app/commands/change_reasons_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.dq.api/domain/change_reason_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_management_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -18,11 +18,11 @@
  *
  */
 #include "ores.shell/app/commands/connection_commands.hpp"
-#include "ores.shell/app/command_args.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/messaging/bootstrap_protocol.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/config/nats_options.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
@@ -68,7 +68,8 @@ void check_bootstrap_status(nats_client& session, std::ostream& out) {
 
 } // anonymous namespace
 
-void connection_commands::register_commands(cli::Menu& root_menu, nats_client& session,
+void connection_commands::register_commands(cli::Menu& root_menu,
+                                            nats_client& session,
                                             nats::config::nats_options connection_template) {
     root_menu.Insert(
         "connect",
@@ -91,12 +92,12 @@ void connection_commands::process_connect(std::ostream& out,
                                           nats_client& session,
                                           const nats::config::nats_options& connection_template,
                                           const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "tls-ca", .requires_value = true, .default_value = ""},
-        {.name = "tls-cert", .requires_value = true, .default_value = ""},
-        {.name = "tls-key", .requires_value = true, .default_value = ""},
-        {.name = "subject-prefix", .requires_value = true, .default_value = ""}
-    });
+    auto parsed =
+        parse_args(args,
+                   {{.name = "tls-ca", .requires_value = true, .default_value = ""},
+                    {.name = "tls-cert", .requires_value = true, .default_value = ""},
+                    {.name = "tls-key", .requires_value = true, .default_value = ""},
+                    {.name = "subject-prefix", .requires_value = true, .default_value = ""}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -104,7 +105,8 @@ void connection_commands::process_connect(std::ostream& out,
     if (parsed->positionals.size() > 2) {
         fail(out) << "Usage: connect [host] [port] | connect <nats-url> "
                      "[--tls-ca <p>] [--tls-cert <p>] [--tls-key <p>] "
-                     "[--subject-prefix <p>]" << std::endl;
+                     "[--subject-prefix <p>]"
+                  << std::endl;
         return;
     }
 
@@ -149,8 +151,8 @@ void connection_commands::process_connect(std::ostream& out,
     if (!parsed->flag("subject-prefix").empty())
         opts.subject_prefix = parsed->flag("subject-prefix");
 
-    const bool has_tls = !opts.tls_ca_cert.empty() || !opts.tls_client_cert.empty() ||
-        !opts.tls_client_key.empty();
+    const bool has_tls =
+        !opts.tls_ca_cert.empty() || !opts.tls_client_cert.empty() || !opts.tls_client_key.empty();
 
     try {
         const auto url = opts.url;
@@ -164,7 +166,8 @@ void connection_commands::process_connect(std::ostream& out,
         if (!has_tls)
             out << "  If the server requires TLS, pass: --tls-ca <ca.crt> "
                    "--tls-cert <client.crt> --tls-key <client.key> "
-                   "[--subject-prefix <prefix>]" << std::endl;
+                   "[--subject-prefix <prefix>]"
+                << std::endl;
     }
 }
 

--- a/projects/ores.shell/src/app/commands/countries_commands.cpp
+++ b/projects/ores.shell/src/app/commands/countries_commands.cpp
@@ -18,9 +18,9 @@
  *
  */
 #include "ores.shell/app/commands/countries_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.refdata.api/domain/country_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/country_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>

--- a/projects/ores.shell/src/app/commands/currencies_commands.cpp
+++ b/projects/ores.shell/src/app/commands/currencies_commands.cpp
@@ -18,11 +18,11 @@
  *
  */
 #include "ores.shell/app/commands/currencies_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.refdata.api/domain/currency_table_io.hpp"         // IWYU pragma: keep.
 #include "ores.refdata.api/domain/currency_version_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/currency_history_protocol.hpp"
 #include "ores.refdata.api/messaging/currency_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <algorithm>
 #include <cli/cli.h>
@@ -306,8 +306,7 @@ void currencies_commands::process_get_currency_history(std::ostream& out,
 void currencies_commands::process_get_currency_history_diff(std::ostream& out,
                                                             nats_client& session,
                                                             std::string iso_code) {
-    BOOST_LOG_SEV(lg(), debug) << "Initiating get currency history diff for: "
-                               << iso_code;
+    BOOST_LOG_SEV(lg(), debug) << "Initiating get currency history diff for: " << iso_code;
 
     if (!session.is_logged_in()) {
         fail(out) << "You must be logged in to get currency history." << std::endl;
@@ -362,9 +361,9 @@ void currencies_commands::process_get_currency_history_diff(std::ostream& out,
 
         // Context and changes in field order; removed fields follow.
         for (const auto& f : current.fields) {
-            const auto entry = std::find_if(
-                current.changes.entries.begin(), current.changes.entries.end(),
-                [&](const auto& e) { return e.field_name == f.name; });
+            const auto entry = std::find_if(current.changes.entries.begin(),
+                                            current.changes.entries.end(),
+                                            [&](const auto& e) { return e.field_name == f.name; });
             if (entry == current.changes.entries.end()) {
                 out << " " << f.name << ": " << f.value << "\n";
             } else {
@@ -374,9 +373,10 @@ void currencies_commands::process_get_currency_history_diff(std::ostream& out,
         }
         for (const auto& e : current.changes.entries) {
             if (e.new_value.empty() && !e.old_value.empty()) {
-                const auto in_fields = std::any_of(
-                    current.fields.begin(), current.fields.end(),
-                    [&](const auto& f) { return f.name == e.field_name; });
+                const auto in_fields =
+                    std::any_of(current.fields.begin(), current.fields.end(), [&](const auto& f) {
+                        return f.name == e.field_name;
+                    });
                 if (!in_fields)
                     out << "-" << e.field_name << ": " << e.old_value << "\n";
             }

--- a/projects/ores.shell/src/app/commands/lei_commands.cpp
+++ b/projects/ores.shell/src/app/commands/lei_commands.cpp
@@ -43,19 +43,16 @@ fetch_entities(std::ostream& out, nats_client& session, const std::string& count
     req.country_filter = country_filter;
 
     try {
-        auto reply = session.authenticated_request(std::string(req.nats_subject),
-                                                   rfl::json::write(req));
-        auto result =
-            rfl::json::read<dq::messaging::get_lei_entities_summary_response>(
-                ores::nats::as_string_view(reply.data));
+        auto reply =
+            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
+        auto result = rfl::json::read<dq::messaging::get_lei_entities_summary_response>(
+            ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return std::nullopt;
         }
         if (!result->success) {
-            fail(out) << "Failed to fetch LEI entities: " << result->error_message
-                      << std::endl;
+            fail(out) << "Failed to fetch LEI entities: " << result->error_message << std::endl;
             return std::nullopt;
         }
         return *result;
@@ -66,8 +63,7 @@ fetch_entities(std::ostream& out, nats_client& session, const std::string& count
 }
 
 std::string to_lower_copy(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
@@ -78,18 +74,15 @@ void lei_commands::register_commands(cli::Menu& root_menu, nats_client& session)
 
     lei_menu->Insert(
         "countries",
-        [&session](std::ostream& out) {
-            process_countries(std::ref(out), std::ref(session));
-        },
+        [&session](std::ostream& out) { process_countries(std::ref(out), std::ref(session)); },
         "List the countries that have LEI entities");
 
-    lei_menu->Insert(
-        "entities",
-        [&session](std::ostream& out, std::vector<std::string> args) {
-            process_entities(std::ref(out), std::ref(session), args);
-        },
-        "List a country's LEI entities, optionally filtered by legal name",
-        {"country [--filter <text>]"});
+    lei_menu->Insert("entities",
+                     [&session](std::ostream& out, std::vector<std::string> args) {
+                         process_entities(std::ref(out), std::ref(session), args);
+                     },
+                     "List a country's LEI entities, optionally filtered by legal name",
+                     {"country [--filter <text>]"});
 
     root_menu.Insert(std::move(lei_menu));
 }
@@ -120,9 +113,8 @@ void lei_commands::process_countries(std::ostream& out, nats_client& session) {
 void lei_commands::process_entities(std::ostream& out,
                                     nats_client& session,
                                     const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "filter", .requires_value = true, .default_value = ""}
-    });
+    auto parsed =
+        parse_args(args, {{.name = "filter", .requires_value = true, .default_value = ""}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -139,8 +131,8 @@ void lei_commands::process_entities(std::ostream& out,
     const auto& country = parsed->positionals.front();
     const auto filter = to_lower_copy(parsed->flag("filter"));
 
-    BOOST_LOG_SEV(lg(), debug) << "Fetching LEI entities for country: " << country
-                               << " (filter: '" << filter << "')";
+    BOOST_LOG_SEV(lg(), debug) << "Fetching LEI entities for country: " << country << " (filter: '"
+                               << filter << "')";
 
     auto result = fetch_entities(out, session, country);
     if (!result)
@@ -152,8 +144,7 @@ void lei_commands::process_entities(std::ostream& out,
             to_lower_copy(entity.entity_legal_name).find(filter) == std::string::npos)
             continue;
         out << std::left << std::setw(22) << entity.lei << std::setw(8) << entity.country
-            << std::setw(18) << entity.entity_category << entity.entity_legal_name
-            << std::endl;
+            << std::setw(18) << entity.entity_category << entity.entity_legal_name << std::endl;
         ++shown;
     }
     out << shown << " of " << result->entities.size() << " entit"

--- a/projects/ores.shell/src/app/commands/parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/parties_commands.cpp
@@ -18,9 +18,9 @@
  *
  */
 #include "ores.shell/app/commands/parties_commands.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.refdata.api/domain/party_table_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.api/messaging/party_protocol.hpp"
-#include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
@@ -41,8 +41,7 @@ namespace {
 constexpr int list_limit = 1000;
 
 std::string to_lower_copy(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
@@ -55,13 +54,12 @@ bool matches(const std::string& value, const std::string& filter_lower) {
 void parties_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto parties_menu = std::make_unique<cli::Menu>("parties");
 
-    parties_menu->Insert(
-        "list",
-        [&session](std::ostream& out, std::vector<std::string> args) {
-            process_list(std::ref(out), std::ref(session), args);
-        },
-        "List parties, optionally filtered by category and status",
-        {"[--category <c>] [--status <s>]"});
+    parties_menu->Insert("list",
+                         [&session](std::ostream& out, std::vector<std::string> args) {
+                             process_list(std::ref(out), std::ref(session), args);
+                         },
+                         "List parties, optionally filtered by category and status",
+                         {"[--category <c>] [--status <s>]"});
 
     root_menu.Insert(std::move(parties_menu));
 }
@@ -69,10 +67,9 @@ void parties_commands::register_commands(cli::Menu& root_menu, nats_client& sess
 void parties_commands::process_list(std::ostream& out,
                                     nats_client& session,
                                     const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "category", .requires_value = true, .default_value = ""},
-        {.name = "status", .requires_value = true, .default_value = ""}
-    });
+    auto parsed = parse_args(args,
+                             {{.name = "category", .requires_value = true, .default_value = ""},
+                              {.name = "status", .requires_value = true, .default_value = ""}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -90,20 +87,19 @@ void parties_commands::process_list(std::ostream& out,
     const auto category = to_lower_copy(parsed->flag("category"));
     const auto status = to_lower_copy(parsed->flag("status"));
 
-    BOOST_LOG_SEV(lg(), debug) << "Listing parties (category: '" << category
-                               << "', status: '" << status << "').";
+    BOOST_LOG_SEV(lg(), debug) << "Listing parties (category: '" << category << "', status: '"
+                               << status << "').";
 
     refdata::messaging::get_parties_request req;
     req.limit = list_limit;
 
     try {
-        auto reply = session.authenticated_request(std::string(req.nats_subject),
-                                                   rfl::json::write(req));
+        auto reply =
+            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
         auto result = rfl::json::read<refdata::messaging::get_parties_response>(
-                ores::nats::as_string_view(reply.data));
+            ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return;
         }
 
@@ -113,11 +109,11 @@ void parties_commands::process_list(std::ostream& out,
                 filtered.push_back(party);
         }
 
-        BOOST_LOG_SEV(lg(), info) << "Retrieved " << result->parties.size()
-                                  << " parties; showing " << filtered.size() << ".";
+        BOOST_LOG_SEV(lg(), info) << "Retrieved " << result->parties.size() << " parties; showing "
+                                  << filtered.size() << ".";
         out << filtered << std::endl;
-        out << filtered.size() << " of " << result->total_available_count
-            << " parties shown." << std::endl;
+        out << filtered.size() << " of " << result->total_available_count << " parties shown."
+            << std::endl;
     } catch (const std::exception& e) {
         fail(out) << "Request failed: " << e.what() << std::endl;
     }

--- a/projects/ores.shell/src/app/commands/provision_commands.cpp
+++ b/projects/ores.shell/src/app/commands/provision_commands.cpp
@@ -18,22 +18,22 @@
  *
  */
 #include "ores.shell/app/commands/provision_commands.hpp"
-#include "ores.iam.api/messaging/bootstrap_protocol.hpp"
-#include "ores.nats/domain/message.hpp"
-#include "ores.shell/app/command_args.hpp"
-#include "ores.shell/app/command_feedback.hpp"
-#include "ores.shell/app/commands/accounts_commands.hpp"
-#include "ores.shell/app/commands/synthetic_commands.hpp"
-#include "ores.shell/app/commands/workflow_commands.hpp"
 #include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.dq.api/messaging/dataset_bundle_protocol.hpp"
 #include "ores.dq.api/messaging/publish_bundle_protocol.hpp"
 #include "ores.dq.api/messaging/report_definition_template_protocol.hpp"
 #include "ores.iam.api/domain/account_party.hpp"
 #include "ores.iam.api/messaging/account_party_protocol.hpp"
+#include "ores.iam.api/messaging/bootstrap_protocol.hpp"
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.reporting.api/messaging/report_definition_protocol.hpp"
+#include "ores.shell/app/command_args.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/commands/accounts_commands.hpp"
+#include "ores.shell/app/commands/synthetic_commands.hpp"
+#include "ores.shell/app/commands/workflow_commands.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
 #include <boost/lexical_cast.hpp>
@@ -68,20 +68,22 @@ constexpr std::size_t min_password_length = 8;
 
 template <typename Request>
 std::optional<typename Request::response_type>
-do_request(std::ostream& out, nats_client& session, const Request& req,
+do_request(std::ostream& out,
+           nats_client& session,
+           const Request& req,
            std::chrono::milliseconds timeout = std::chrono::seconds(30),
            bool authenticated = false) {
     using Response = typename Request::response_type;
     try {
         const auto body = rfl::json::write(req);
         // The unauthenticated request overload has no timeout knob.
-        auto reply = authenticated
-            ? session.authenticated_request(std::string(req.nats_subject), body, timeout)
-            : session.request(std::string(req.nats_subject), body);
+        auto reply =
+            authenticated ?
+                session.authenticated_request(std::string(req.nats_subject), body, timeout) :
+                session.request(std::string(req.nats_subject), body);
         auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return std::nullopt;
         }
         return *result;
@@ -91,12 +93,16 @@ do_request(std::ostream& out, nats_client& session, const Request& req,
     }
 }
 
-bool validate_account(std::ostream& out, std::string_view what,
-                      const std::string& username, const std::string& email,
+bool validate_account(std::ostream& out,
+                      std::string_view what,
+                      const std::string& username,
+                      const std::string& email,
                       const std::string& password) {
     if (!std::regex_match(username, username_regex)) {
-        fail(out) << what << " username must be 3-50 characters, starting with a "
-                     "letter (letters, digits, underscore): " << username << std::endl;
+        fail(out) << what
+                  << " username must be 3-50 characters, starting with a "
+                     "letter (letters, digits, underscore): "
+                  << username << std::endl;
         return false;
     }
     if (!std::regex_match(email, email_regex)) {
@@ -104,8 +110,8 @@ bool validate_account(std::ostream& out, std::string_view what,
         return false;
     }
     if (password.size() < min_password_length) {
-        fail(out) << what << " password must be at least " << min_password_length
-                  << " characters." << std::endl;
+        fail(out) << what << " password must be at least " << min_password_length << " characters."
+                  << std::endl;
         return false;
     }
     return true;
@@ -138,15 +144,14 @@ void provision_commands::register_commands(cli::Menu& root_menu, nats_client& se
         {"[--bundle <code>] [--source gleif|synthetic] [--root-lei <lei>] "
          "[--timeout <seconds>] [synthetic generation knobs — see synthetic generate]"});
 
-    provision_menu->Insert(
-        "party",
-        [&session](std::ostream& out, std::vector<std::string> args) {
-            process_party(std::ref(out), std::ref(session), args);
-        },
-        "Provision a party: import counterparties, publish its organisation "
-        "bundle, create report definitions and activate it",
-        {"party-uuid-or-full-name [--dataset-size small|large] "
-         "[--reports all|none|<name,...>] [--timeout <seconds>]"});
+    provision_menu->Insert("party",
+                           [&session](std::ostream& out, std::vector<std::string> args) {
+                               process_party(std::ref(out), std::ref(session), args);
+                           },
+                           "Provision a party: import counterparties, publish its organisation "
+                           "bundle, create report definitions and activate it",
+                           {"party-uuid-or-full-name [--dataset-size small|large] "
+                            "[--reports all|none|<name,...>] [--timeout <seconds>]"});
 
     root_menu.Insert(std::move(provision_menu));
 }
@@ -154,24 +159,26 @@ void provision_commands::register_commands(cli::Menu& root_menu, nats_client& se
 void provision_commands::process_system(std::ostream& out,
                                         nats_client& session,
                                         const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "tenant-admin-password", .requires_value = true, .default_value = ""},
-        {.name = "tenant-code", .requires_value = true, .default_value = "default"},
-        {.name = "tenant-name", .requires_value = true, .default_value = "Default Tenant"},
-        {.name = "tenant-type", .requires_value = true, .default_value = "evaluation"},
-        {.name = "tenant-hostname", .requires_value = true, .default_value = "localhost"},
-        {.name = "tenant-description", .requires_value = true,
-         .default_value = "Default tenant for single-tenant deployment"},
-        {.name = "tenant-admin", .requires_value = true, .default_value = "tenant_admin"},
-        {.name = "tenant-admin-email", .requires_value = true, .default_value = ""}
-    });
+    auto parsed = parse_args(
+        args,
+        {{.name = "tenant-admin-password", .requires_value = true, .default_value = ""},
+         {.name = "tenant-code", .requires_value = true, .default_value = "default"},
+         {.name = "tenant-name", .requires_value = true, .default_value = "Default Tenant"},
+         {.name = "tenant-type", .requires_value = true, .default_value = "evaluation"},
+         {.name = "tenant-hostname", .requires_value = true, .default_value = "localhost"},
+         {.name = "tenant-description",
+          .requires_value = true,
+          .default_value = "Default tenant for single-tenant deployment"},
+         {.name = "tenant-admin", .requires_value = true, .default_value = "tenant_admin"},
+         {.name = "tenant-admin-email", .requires_value = true, .default_value = ""}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
     }
     if (parsed->positionals.size() != 3) {
         fail(out) << "Usage: provision system <username> <password> <email> "
-                     "--tenant-admin-password <pw> [--tenant-* flags]" << std::endl;
+                     "--tenant-admin-password <pw> [--tenant-* flags]"
+                  << std::endl;
         return;
     }
 
@@ -182,22 +189,22 @@ void provision_commands::process_system(std::ostream& out,
     const auto& tenant_admin = parsed->flag("tenant-admin");
     const auto& tenant_admin_password = parsed->flag("tenant-admin-password");
     // The wizard pre-fills the tenant admin email from the tenant code.
-    const auto tenant_admin_email = parsed->flag("tenant-admin-email").empty()
-        ? "admin@" + tenant_code + ".com"
-        : parsed->flag("tenant-admin-email");
+    const auto tenant_admin_email = parsed->flag("tenant-admin-email").empty() ?
+                                        "admin@" + tenant_code + ".com" :
+                                        parsed->flag("tenant-admin-email");
 
     // Validate everything before touching the backend, as the wizard
     // pages do.
     if (tenant_admin_password.empty()) {
-        fail(out) << "--tenant-admin-password is required (no wizard default exists)."
-                  << std::endl;
+        fail(out) << "--tenant-admin-password is required (no wizard default exists)." << std::endl;
         return;
     }
     // Tenant code first: the tenant admin email derives from it, so a
     // bad code must not surface as a confusing derived-email error.
     if (!std::regex_match(tenant_code, tenant_code_regex)) {
         fail(out) << "Tenant code must start with a lowercase letter (lowercase, "
-                     "digits, underscore, max 50): " << tenant_code << std::endl;
+                     "digits, underscore, max 50): "
+                  << tenant_code << std::endl;
         return;
     }
     if (parsed->flag("tenant-name").empty() || parsed->flag("tenant-hostname").empty()) {
@@ -206,12 +213,13 @@ void provision_commands::process_system(std::ostream& out,
     }
     if (!validate_account(out, "Admin", username, email, password))
         return;
-    if (!validate_account(out, "Tenant admin", tenant_admin, tenant_admin_email,
-                          tenant_admin_password))
+    if (!validate_account(
+            out, "Tenant admin", tenant_admin, tenant_admin_email, tenant_admin_password))
         return;
     if (session.is_logged_in()) {
         fail(out) << "Already logged in; provision system runs against a fresh, "
-                     "bootstrap-mode system. Log out first." << std::endl;
+                     "bootstrap-mode system. Log out first."
+                  << std::endl;
         return;
     }
 
@@ -239,8 +247,7 @@ void provision_commands::process_system(std::ostream& out,
     if (!admin)
         return;
     if (!admin->success) {
-        fail(out) << "Failed to create admin account: " << admin->error_message
-                  << std::endl;
+        fail(out) << "Failed to create admin account: " << admin->error_message << std::endl;
         return;
     }
     out << "  Account created (ID: " << admin->account_id << ")." << std::endl;
@@ -263,8 +270,7 @@ void provision_commands::process_system(std::ostream& out,
     tenant_req.principal = tenant_admin;
     tenant_req.password = tenant_admin_password;
     tenant_req.email = tenant_admin_email;
-    auto tenant = do_request(out, session, tenant_req, provision_timeout,
-                             true /*authenticated*/);
+    auto tenant = do_request(out, session, tenant_req, provision_timeout, true /*authenticated*/);
     if (!tenant)
         return;
     if (!tenant->success) {
@@ -272,10 +278,10 @@ void provision_commands::process_system(std::ostream& out,
         return;
     }
 
-    out << "✓ System provisioned. Tenant '" << tenant_req.name << "' (ID: "
-        << tenant->tenant_id << "), admin '" << tenant_admin << "'." << std::endl;
-    out << "Next: logout, then: login " << tenant_admin << "@"
-        << tenant_req.hostname << " <password>  — the tenant is in bootstrap mode; "
+    out << "✓ System provisioned. Tenant '" << tenant_req.name << "' (ID: " << tenant->tenant_id
+        << "), admin '" << tenant_admin << "'." << std::endl;
+    out << "Next: logout, then: login " << tenant_admin << "@" << tenant_req.hostname
+        << " <password>  — the tenant is in bootstrap mode; "
         << "run provision tenant." << std::endl;
     BOOST_LOG_SEV(lg(), info) << "System provisioned; tenant " << tenant->tenant_id;
 }
@@ -287,7 +293,8 @@ void provision_commands::process_tenant(std::ostream& out,
     specs.push_back({.name = "bundle", .requires_value = true, .default_value = ""});
     specs.push_back({.name = "source", .requires_value = true, .default_value = "gleif"});
     specs.push_back({.name = "root-lei", .requires_value = true, .default_value = ""});
-    specs.push_back({.name = "timeout", .requires_value = true,
+    specs.push_back({.name = "timeout",
+                     .requires_value = true,
                      .default_value = std::to_string(default_wait_timeout.count())});
 
     auto parsed = parse_args(args, specs);
@@ -296,8 +303,7 @@ void provision_commands::process_tenant(std::ostream& out,
         return;
     }
     if (!parsed->positionals.empty()) {
-        fail(out) << "provision tenant takes no positional arguments; see help."
-                  << std::endl;
+        fail(out) << "provision tenant takes no positional arguments; see help." << std::endl;
         return;
     }
 
@@ -312,8 +318,8 @@ void provision_commands::process_tenant(std::ostream& out,
     }
     auto wait_timeout = parse_positive_seconds(parsed->flag("timeout"));
     if (!wait_timeout) {
-        fail(out) << "Timeout must be a positive number of seconds: "
-                  << parsed->flag("timeout") << std::endl;
+        fail(out) << "Timeout must be a positive number of seconds: " << parsed->flag("timeout")
+                  << std::endl;
         return;
     }
     // Build (and validate) the generation request up front even though
@@ -323,7 +329,8 @@ void provision_commands::process_tenant(std::ostream& out,
         return;
     if (!session.is_logged_in()) {
         fail(out) << "Not logged in. Log in as the tenant admin of the "
-                     "bootstrap-mode tenant first." << std::endl;
+                     "bootstrap-mode tenant first."
+                  << std::endl;
         return;
     }
     const auto username = session.auth().username;
@@ -333,8 +340,7 @@ void provision_commands::process_tenant(std::ostream& out,
     auto bundle_code = parsed->flag("bundle");
     if (bundle_code.empty()) {
         dq::messaging::get_dataset_bundles_request bundles_req;
-        auto bundles = do_request(out, session, bundles_req,
-                                  std::chrono::seconds(30), true);
+        auto bundles = do_request(out, session, bundles_req, std::chrono::seconds(30), true);
         if (!bundles)
             return;
         if (bundles->bundles.empty()) {
@@ -345,8 +351,8 @@ void provision_commands::process_tenant(std::ostream& out,
         out << "Using bundle '" << bundle_code << "' (first available)." << std::endl;
     }
 
-    BOOST_LOG_SEV(lg(), info) << "Provisioning tenant: bundle " << bundle_code
-                              << ", source " << source;
+    BOOST_LOG_SEV(lg(), info) << "Provisioning tenant: bundle " << bundle_code << ", source "
+                              << source;
 
     // Phase 1: publish the bundle and wait on its workflow.
     out << "[1/4] Publishing bundle '" << bundle_code << "'..." << std::endl;
@@ -365,14 +371,16 @@ void provision_commands::process_tenant(std::ostream& out,
     if (!published)
         return;
     if (!published->success) {
-        fail(out) << "Failed to publish bundle: " << published->error_message
-                  << std::endl;
+        fail(out) << "Failed to publish bundle: " << published->error_message << std::endl;
         return;
     }
     out << "  Dispatched " << published->datasets_dispatched
         << " dataset(s); workflow instance: " << published->instance_id << std::endl;
     if (!workflow_commands::wait_for_instance(
-            out, session, published->instance_id, *wait_timeout,
+            out,
+            session,
+            published->instance_id,
+            *wait_timeout,
             static_cast<std::size_t>(published->datasets_dispatched)))
         return;
 
@@ -387,8 +395,7 @@ void provision_commands::process_tenant(std::ostream& out,
 
     // Phase 3: associate the admin with every Operational party.
     // Non-fatal, exactly as the wizard treats it.
-    out << "[3/4] Associating '" << username << "' with the operational parties..."
-        << std::endl;
+    out << "[3/4] Associating '" << username << "' with the operational parties..." << std::endl;
     int linked = 0;
     if (session.auth().account_id.empty()) {
         out << "⚠ No account id in the session; skipping party association. "
@@ -397,13 +404,12 @@ void provision_commands::process_tenant(std::ostream& out,
     } else {
         refdata::messaging::get_parties_request parties_req;
         parties_req.limit = 1000;
-        auto parties = do_request(out, session, parties_req,
-                                  std::chrono::seconds(30), true);
+        auto parties = do_request(out, session, parties_req, std::chrono::seconds(30), true);
         if (parties) {
             iam::messaging::save_account_party_request assoc_req;
             try {
-                const auto account_uuid = boost::lexical_cast<boost::uuids::uuid>(
-                    session.auth().account_id);
+                const auto account_uuid =
+                    boost::lexical_cast<boost::uuids::uuid>(session.auth().account_id);
                 for (const auto& party : parties->parties) {
                     if (party.party_category != "Operational")
                         continue;
@@ -413,51 +419,47 @@ void provision_commands::process_tenant(std::ostream& out,
                     association.party_id = party.id;
                     association.modified_by = username;
                     association.performed_by = username;
-                    association.change_reason_code = std::string(
-                        dq::domain::change_reason_constants::codes::new_record);
+                    association.change_reason_code =
+                        std::string(dq::domain::change_reason_constants::codes::new_record);
                     association.change_commentary =
                         "Tenant provisioning: tenant admin associated with party";
                     assoc_req.account_parties.push_back(std::move(association));
                 }
             } catch (const boost::bad_lexical_cast&) {
-                out << "⚠ Session account id is not a UUID; skipping association."
-                    << std::endl;
+                out << "⚠ Session account id is not a UUID; skipping association." << std::endl;
             }
             if (!assoc_req.account_parties.empty()) {
-                auto assoc = do_request(out, session, assoc_req,
-                                        std::chrono::seconds(30), true);
+                auto assoc = do_request(out, session, assoc_req, std::chrono::seconds(30), true);
                 if (assoc && assoc->success)
                     linked = static_cast<int>(assoc_req.account_parties.size());
                 else
                     out << "⚠ Party association failed; continuing (associate "
-                           "manually with account-parties add)." << std::endl;
+                           "manually with account-parties add)."
+                        << std::endl;
             }
         } else {
-            out << "⚠ Could not list parties; continuing without association."
-                << std::endl;
+            out << "⚠ Could not list parties; continuing without association." << std::endl;
         }
         // The association phase is non-fatal: clear any failure mark
         // its requests may have left so the script does not abort.
         command_feedback::reset();
     }
-    out << "  " << linked << " part" << (linked == 1 ? "y" : "ies") << " associated."
-        << std::endl;
+    out << "  " << linked << " part" << (linked == 1 ? "y" : "ies") << " associated." << std::endl;
 
     // Phase 4: clear the bootstrap flag (warn-only, as the wizard)
     // and complete provisioning (fatal).
     out << "[4/4] Finalizing tenant provisioning..." << std::endl;
     variability::messaging::save_setting_request setting_req =
-        variability::messaging::save_setting_request::from(
-            variability::domain::system_setting{
-                .name = "system.bootstrap_mode",
-                .value = "false",
-                .data_type = "boolean",
-                .description = "Bootstrap mode disabled after tenant setup",
-                .modified_by = username,
-                .change_reason_code = std::string(
-                    dq::domain::change_reason_constants::codes::new_record),
-                .change_commentary = "Tenant provisioning completed via shell",
-                .recorded_at = std::chrono::system_clock::now()});
+        variability::messaging::save_setting_request::from(variability::domain::system_setting{
+            .name = "system.bootstrap_mode",
+            .value = "false",
+            .data_type = "boolean",
+            .description = "Bootstrap mode disabled after tenant setup",
+            .modified_by = username,
+            .change_reason_code =
+                std::string(dq::domain::change_reason_constants::codes::new_record),
+            .change_commentary = "Tenant provisioning completed via shell",
+            .recorded_at = std::chrono::system_clock::now()});
     auto setting = do_request(out, session, setting_req, std::chrono::seconds(30), true);
     if (!setting || !setting->success) {
         out << "⚠ Could not clear system.bootstrap_mode; continuing." << std::endl;
@@ -465,32 +467,32 @@ void provision_commands::process_tenant(std::ostream& out,
     }
 
     iam::messaging::complete_tenant_provisioning_command complete_req;
-    auto completed = do_request(out, session, complete_req,
-                                std::chrono::seconds(30), true);
+    auto completed = do_request(out, session, complete_req, std::chrono::seconds(30), true);
     if (!completed)
         return;
     if (!completed->success) {
-        fail(out) << "Failed to complete tenant provisioning: " << completed->message
-                  << std::endl;
+        fail(out) << "Failed to complete tenant provisioning: " << completed->message << std::endl;
         return;
     }
 
-    out << "✓ Tenant provisioned: bundle '" << bundle_code << "', " << linked
-        << " part" << (linked == 1 ? "y" : "ies") << " associated." << std::endl;
+    out << "✓ Tenant provisioned: bundle '" << bundle_code << "', " << linked << " part"
+        << (linked == 1 ? "y" : "ies") << " associated." << std::endl;
     out << "Next: logout, then log back in — the party setup is per party; run "
-           "provision party <party>." << std::endl;
+           "provision party <party>."
+        << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Tenant provisioned; bundle " << bundle_code;
 }
 
 void provision_commands::process_party(std::ostream& out,
                                        nats_client& session,
                                        const std::vector<std::string>& args) {
-    auto parsed = parse_args(args, {
-        {.name = "dataset-size", .requires_value = true, .default_value = "small"},
-        {.name = "reports", .requires_value = true, .default_value = "all"},
-        {.name = "timeout", .requires_value = true,
-         .default_value = std::to_string(default_wait_timeout.count())}
-    });
+    auto parsed =
+        parse_args(args,
+                   {{.name = "dataset-size", .requires_value = true, .default_value = "small"},
+                    {.name = "reports", .requires_value = true, .default_value = "all"},
+                    {.name = "timeout",
+                     .requires_value = true,
+                     .default_value = std::to_string(default_wait_timeout.count())}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -498,20 +500,20 @@ void provision_commands::process_party(std::ostream& out,
     if (parsed->positionals.size() != 1) {
         fail(out) << "Usage: provision party <party-uuid-or-full-name> "
                      "[--dataset-size small|large] [--reports all|none|<name,...>] "
-                     "[--timeout <seconds>]" << std::endl;
+                     "[--timeout <seconds>]"
+                  << std::endl;
         return;
     }
 
     const auto& dataset_size = parsed->flag("dataset-size");
     if (dataset_size != "small" && dataset_size != "large") {
-        fail(out) << "--dataset-size must be small or large: " << dataset_size
-                  << std::endl;
+        fail(out) << "--dataset-size must be small or large: " << dataset_size << std::endl;
         return;
     }
     auto wait_timeout = parse_positive_seconds(parsed->flag("timeout"));
     if (!wait_timeout) {
-        fail(out) << "Timeout must be a positive number of seconds: "
-                  << parsed->flag("timeout") << std::endl;
+        fail(out) << "Timeout must be a positive number of seconds: " << parsed->flag("timeout")
+                  << std::endl;
         return;
     }
     if (!session.is_logged_in()) {
@@ -522,8 +524,7 @@ void provision_commands::process_party(std::ostream& out,
     const auto& party_ref = parsed->positionals.front();
 
     // Resolve the party by UUID or exact full name.
-    auto find_party = [&](std::ostream& o)
-        -> std::optional<refdata::domain::party> {
+    auto find_party = [&](std::ostream& o) -> std::optional<refdata::domain::party> {
         refdata::messaging::get_parties_request req;
         req.limit = 1000;
         auto parties = do_request(o, session, req, std::chrono::seconds(30), true);
@@ -535,28 +536,25 @@ void provision_commands::process_party(std::ostream& out,
         } catch (const boost::bad_lexical_cast&) {
         }
         for (const auto& party : parties->parties) {
-            if ((ref_uuid && party.id == *ref_uuid) ||
-                (!ref_uuid && party.full_name == party_ref))
+            if ((ref_uuid && party.id == *ref_uuid) || (!ref_uuid && party.full_name == party_ref))
                 return party;
         }
-        fail(o) << "Party not found (by UUID or exact full name): " << party_ref
-                << std::endl;
+        fail(o) << "Party not found (by UUID or exact full name): " << party_ref << std::endl;
         return std::nullopt;
     };
 
     auto party = find_party(out);
     if (!party)
         return;
-    out << "Provisioning party '" << party->full_name << "' (ID: " << party->id
-        << ")." << std::endl;
-    BOOST_LOG_SEV(lg(), info) << "Provisioning party " << party->id << " (dataset "
-                              << dataset_size << ")";
+    out << "Provisioning party '" << party->full_name << "' (ID: " << party->id << ")."
+        << std::endl;
+    BOOST_LOG_SEV(lg(), info) << "Provisioning party " << party->id << " (dataset " << dataset_size
+                              << ")";
 
     // Phase 1: publish the counterparty dataset, as the wizard's
     // counterparty import does (bundle "base", opted-in GLEIF
     // counterparties dataset of the requested size).
-    out << "[1/4] Importing counterparties (dataset " << dataset_size << ")..."
-        << std::endl;
+    out << "[1/4] Importing counterparties (dataset " << dataset_size << ")..." << std::endl;
     {
         dq::messaging::publish_bundle_request req;
         req.bundle_code = "base";
@@ -577,7 +575,10 @@ void provision_commands::process_party(std::ostream& out,
         out << "  Dispatched " << published->datasets_dispatched
             << " dataset(s); workflow instance: " << published->instance_id << std::endl;
         if (!workflow_commands::wait_for_instance(
-                out, session, published->instance_id, *wait_timeout,
+                out,
+                session,
+                published->instance_id,
+                *wait_timeout,
                 static_cast<std::size_t>(published->datasets_dispatched)))
             return;
     }
@@ -597,14 +598,17 @@ void provision_commands::process_party(std::ostream& out,
         if (!published)
             return;
         if (!published->success) {
-            fail(out) << "Failed to publish organisation bundle: "
-                      << published->error_message << std::endl;
+            fail(out) << "Failed to publish organisation bundle: " << published->error_message
+                      << std::endl;
             return;
         }
         out << "  Dispatched " << published->datasets_dispatched
             << " dataset(s); workflow instance: " << published->instance_id << std::endl;
         if (!workflow_commands::wait_for_instance(
-                out, session, published->instance_id, *wait_timeout,
+                out,
+                session,
+                published->instance_id,
+                *wait_timeout,
                 static_cast<std::size_t>(published->datasets_dispatched)))
             return;
     }
@@ -618,13 +622,11 @@ void provision_commands::process_party(std::ostream& out,
     } else {
         out << "[3/4] Creating report definitions..." << std::endl;
         dq::messaging::list_dq_report_definition_templates_request templates_req;
-        auto templates = do_request(out, session, templates_req,
-                                    std::chrono::seconds(30), true);
+        auto templates = do_request(out, session, templates_req, std::chrono::seconds(30), true);
         if (!templates)
             return;
         if (!templates->success) {
-            fail(out) << "Failed to list report templates: " << templates->message
-                      << std::endl;
+            fail(out) << "Failed to list report templates: " << templates->message << std::endl;
             return;
         }
 
@@ -648,9 +650,9 @@ void provision_commands::process_party(std::ostream& out,
                          names.push_back(current);
                      return names;
                  }()) {
-                const auto i = std::find_if(
-                    templates->templates.begin(), templates->templates.end(),
-                    [&](const auto& tpl) { return tpl.name == name; });
+                const auto i = std::find_if(templates->templates.begin(),
+                                            templates->templates.end(),
+                                            [&](const auto& tpl) { return tpl.name == name; });
                 if (i == templates->templates.end()) {
                     fail(out) << "Unknown report template: " << name << std::endl;
                     return;
@@ -663,19 +665,17 @@ void provision_commands::process_party(std::ostream& out,
         // wizard resolves it (fallback: the first party).
         refdata::messaging::get_parties_request parties_req;
         parties_req.limit = 1000;
-        auto parties = do_request(out, session, parties_req,
-                                  std::chrono::seconds(30), true);
+        auto parties = do_request(out, session, parties_req, std::chrono::seconds(30), true);
         if (!parties || parties->parties.empty()) {
-            fail(out) << "Could not resolve the System party for report ownership."
-                      << std::endl;
+            fail(out) << "Could not resolve the System party for report ownership." << std::endl;
             return;
         }
-        auto system_party = std::find_if(
-            parties->parties.begin(), parties->parties.end(),
-            [](const auto& p) { return p.party_category == "System"; });
-        const auto owner_id = system_party != parties->parties.end()
-            ? system_party->id
-            : parties->parties.front().id;
+        auto system_party =
+            std::find_if(parties->parties.begin(), parties->parties.end(), [](const auto& p) {
+                return p.party_category == "System";
+            });
+        const auto owner_id =
+            system_party != parties->parties.end() ? system_party->id : parties->parties.front().id;
 
         boost::uuids::random_generator gen;
         for (const auto& tpl : selected) {
@@ -689,8 +689,8 @@ void provision_commands::process_party(std::ostream& out,
             req.definition.party_id = owner_id;
             req.definition.modified_by = username;
             req.definition.performed_by = username;
-            req.definition.change_reason_code = std::string(
-                dq::domain::change_reason_constants::codes::new_record);
+            req.definition.change_reason_code =
+                std::string(dq::domain::change_reason_constants::codes::new_record);
             req.definition.change_commentary = "Created during party provisioning";
             req.definition.recorded_at = std::chrono::system_clock::now();
             auto saved = do_request(out, session, req, std::chrono::seconds(30), true);
@@ -715,8 +715,7 @@ void provision_commands::process_party(std::ostream& out,
     fresh->status = "Active";
     fresh->modified_by = username;
     fresh->performed_by = username;
-    fresh->change_reason_code = std::string(
-        dq::domain::change_reason_constants::codes::new_record);
+    fresh->change_reason_code = std::string(dq::domain::change_reason_constants::codes::new_record);
     fresh->change_commentary = "Party provisioning completed via shell";
 
     refdata::messaging::save_party_request save_req;

--- a/projects/ores.shell/src/app/commands/rbac_commands.cpp
+++ b/projects/ores.shell/src/app/commands/rbac_commands.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.shell/app/commands/rbac_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/permission_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/domain/role_table_io.hpp"       // IWYU pragma: keep.
 #include "ores.iam.api/messaging/authorization_protocol.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/projects/ores.shell/src/app/commands/reports_commands.cpp
+++ b/projects/ores.shell/src/app/commands/reports_commands.cpp
@@ -36,13 +36,12 @@ using ores::nats::service::nats_client;
 void reports_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto reports_menu = std::make_unique<cli::Menu>("reports");
 
-    reports_menu->Insert(
-        "templates",
-        [&session](std::ostream& out, std::vector<std::string> args) {
-            process_templates(std::ref(out), std::ref(session), args);
-        },
-        "List the report definition templates of a bundle",
-        {"[--bundle <code>]"});
+    reports_menu->Insert("templates",
+                         [&session](std::ostream& out, std::vector<std::string> args) {
+                             process_templates(std::ref(out), std::ref(session), args);
+                         },
+                         "List the report definition templates of a bundle",
+                         {"[--bundle <code>]"});
 
     root_menu.Insert(std::move(reports_menu));
 }
@@ -51,9 +50,8 @@ void reports_commands::process_templates(std::ostream& out,
                                          nats_client& session,
                                          const std::vector<std::string>& args) {
     dq::messaging::list_dq_report_definition_templates_request req;
-    auto parsed = parse_args(args, {
-        {.name = "bundle", .requires_value = true, .default_value = req.bundle_code}
-    });
+    auto parsed = parse_args(
+        args, {{.name = "bundle", .requires_value = true, .default_value = req.bundle_code}});
     if (!parsed) {
         fail(out) << parsed.error() << std::endl;
         return;
@@ -69,23 +67,19 @@ void reports_commands::process_templates(std::ostream& out,
     }
 
     req.bundle_code = parsed->flag("bundle");
-    BOOST_LOG_SEV(lg(), debug) << "Listing report templates for bundle: "
-                               << req.bundle_code;
+    BOOST_LOG_SEV(lg(), debug) << "Listing report templates for bundle: " << req.bundle_code;
 
     try {
-        auto reply = session.authenticated_request(std::string(req.nats_subject),
-                                                   rfl::json::write(req));
-        auto result =
-            rfl::json::read<dq::messaging::list_dq_report_definition_templates_response>(
-                ores::nats::as_string_view(reply.data));
+        auto reply =
+            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
+        auto result = rfl::json::read<dq::messaging::list_dq_report_definition_templates_response>(
+            ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return;
         }
         if (!result->success) {
-            fail(out) << "Failed to list report templates: " << result->message
-                      << std::endl;
+            fail(out) << "Failed to list report templates: " << result->message << std::endl;
             return;
         }
 
@@ -93,11 +87,9 @@ void reports_commands::process_templates(std::ostream& out,
             out << std::left << std::setw(34) << t.name << std::setw(16) << t.report_type
                 << std::setw(20) << t.schedule_expression << t.description << std::endl;
         }
-        out << result->templates.size() << " template"
-            << (result->templates.size() == 1 ? "" : "s") << " in bundle '"
-            << req.bundle_code << "'." << std::endl;
-        BOOST_LOG_SEV(lg(), info) << "Listed " << result->templates.size()
-                                  << " report templates.";
+        out << result->templates.size() << " template" << (result->templates.size() == 1 ? "" : "s")
+            << " in bundle '" << req.bundle_code << "'." << std::endl;
+        BOOST_LOG_SEV(lg(), info) << "Listed " << result->templates.size() << " report templates.";
     } catch (const std::exception& e) {
         fail(out) << "Request failed: " << e.what() << std::endl;
     }

--- a/projects/ores.shell/src/app/commands/script_commands.cpp
+++ b/projects/ores.shell/src/app/commands/script_commands.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.shell/app/commands/script_commands.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/script_runner.hpp"
-#include "ores.logging/make_logger.hpp"
 #include <cli/cli.h>
 #include <fstream>
 #include <ostream>
@@ -42,72 +42,62 @@ auto& anon_lg() {
 }
 
 void script_commands::register_commands(cli::Menu& root, cli::CliSession*& active_session) {
-    root.Insert("load",
-                [&active_session](std::ostream& out, std::vector<std::string> args) {
-                    auto parsed = parse_args(args, {
-                        {.name = "continue-on-error"}
-                    });
-                    if (!parsed) {
-                        fail(out) << parsed.error() << std::endl;
-                        return;
-                    }
-                    if (parsed->positionals.size() != 1) {
-                        fail(out) << "Usage: load <filename> [--continue-on-error]"
-                                  << std::endl;
-                        return;
-                    }
-                    const auto& filename = parsed->positionals.front();
-                    const bool continue_on_error =
-                        parsed->flag_set("continue-on-error");
+    root.Insert(
+        "load",
+        [&active_session](std::ostream& out, std::vector<std::string> args) {
+            auto parsed = parse_args(args, {{.name = "continue-on-error"}});
+            if (!parsed) {
+                fail(out) << parsed.error() << std::endl;
+                return;
+            }
+            if (parsed->positionals.size() != 1) {
+                fail(out) << "Usage: load <filename> [--continue-on-error]" << std::endl;
+                return;
+            }
+            const auto& filename = parsed->positionals.front();
+            const bool continue_on_error = parsed->flag_set("continue-on-error");
 
-                    if (!active_session) {
-                        fail(out) << "Error: no active session." << std::endl;
-                        return;
-                    }
+            if (!active_session) {
+                fail(out) << "Error: no active session." << std::endl;
+                return;
+            }
 
-                    std::ifstream file(filename);
-                    if (!file.is_open()) {
-                        fail(out) << "Error: cannot open file: " << filename
-                                  << std::endl;
-                        BOOST_LOG_SEV(anon_lg(), error)
-                            << "Cannot open script file: " << filename;
-                        return;
-                    }
+            std::ifstream file(filename);
+            if (!file.is_open()) {
+                fail(out) << "Error: cannot open file: " << filename << std::endl;
+                BOOST_LOG_SEV(anon_lg(), error) << "Cannot open script file: " << filename;
+                return;
+            }
 
-                    out << "Loading script: " << filename << std::endl;
-                    BOOST_LOG_SEV(anon_lg(), info) << "Loading script: " << filename;
+            out << "Loading script: " << filename << std::endl;
+            BOOST_LOG_SEV(anon_lg(), info) << "Loading script: " << filename;
 
-                    auto result = run_script(
-                        file,
-                        [&active_session](const std::string& command) {
-                            active_session->Feed(command);
-                        },
-                        out, continue_on_error);
+            auto result = run_script(
+                file,
+                [&active_session](const std::string& command) { active_session->Feed(command); },
+                out,
+                continue_on_error);
 
-                    if (result.aborted) {
-                        // fail() keeps the flag set so an enclosing load
-                        // (this command runs under run_script when scripts
-                        // nest) aborts too.
-                        fail(out) << "Script aborted at line "
-                                  << result.aborted_line << ": "
-                                  << result.aborted_command << std::endl;
-                        BOOST_LOG_SEV(anon_lg(), error)
-                            << "Script aborted at line " << result.aborted_line
-                            << " of " << filename << ": "
-                            << result.aborted_command;
-                        return;
-                    }
+            if (result.aborted) {
+                // fail() keeps the flag set so an enclosing load
+                // (this command runs under run_script when scripts
+                // nest) aborts too.
+                fail(out) << "Script aborted at line " << result.aborted_line << ": "
+                          << result.aborted_command << std::endl;
+                BOOST_LOG_SEV(anon_lg(), error)
+                    << "Script aborted at line " << result.aborted_line << " of " << filename
+                    << ": " << result.aborted_command;
+                return;
+            }
 
-                    out << "Script complete: " << result.executed << " command"
-                        << (result.executed != 1 ? "s" : "") << " executed."
-                        << std::endl;
-                    BOOST_LOG_SEV(anon_lg(), info)
-                        << "Script complete: " << result.executed
-                        << " commands executed from " << filename;
-                },
-                "Load and execute a .ores script file (aborts on first error; "
-                "--continue-on-error to keep going)",
-                {"filename [--continue-on-error]"});
+            out << "Script complete: " << result.executed << " command"
+                << (result.executed != 1 ? "s" : "") << " executed." << std::endl;
+            BOOST_LOG_SEV(anon_lg(), info)
+                << "Script complete: " << result.executed << " commands executed from " << filename;
+        },
+        "Load and execute a .ores script file (aborts on first error; "
+        "--continue-on-error to keep going)",
+        {"filename [--continue-on-error]"});
 }
 
 }

--- a/projects/ores.shell/src/app/commands/synthetic_commands.cpp
+++ b/projects/ores.shell/src/app/commands/synthetic_commands.cpp
@@ -66,39 +66,47 @@ std::vector<flag_spec> synthetic_commands::generate_flag_specs() {
     // Defaults mirror generate_organisation_request, which mirrors the
     // tenant provisioning wizard's synthetic page.
     synthetic::messaging::generate_organisation_request defaults;
-    return {
-        {.name = "country", .requires_value = true, .default_value = defaults.country},
-        {.name = "party-count", .requires_value = true,
-         .default_value = std::to_string(defaults.party_count)},
-        {.name = "party-max-depth", .requires_value = true,
-         .default_value = std::to_string(defaults.party_max_depth)},
-        {.name = "counterparty-count", .requires_value = true,
-         .default_value = std::to_string(defaults.counterparty_count)},
-        {.name = "counterparty-max-depth", .requires_value = true,
-         .default_value = std::to_string(defaults.counterparty_max_depth)},
-        {.name = "portfolio-leaf-count", .requires_value = true,
-         .default_value = std::to_string(defaults.portfolio_leaf_count)},
-        {.name = "portfolio-max-depth", .requires_value = true,
-         .default_value = std::to_string(defaults.portfolio_max_depth)},
-        {.name = "books-per-portfolio", .requires_value = true,
-         .default_value = std::to_string(defaults.books_per_leaf_portfolio)},
-        {.name = "business-unit-count", .requires_value = true,
-         .default_value = std::to_string(defaults.business_unit_count)},
-        {.name = "business-unit-max-depth", .requires_value = true,
-         .default_value = std::to_string(defaults.business_unit_max_depth)},
-        {.name = "contacts-per-party", .requires_value = true,
-         .default_value = std::to_string(defaults.contacts_per_party)},
-        {.name = "contacts-per-counterparty", .requires_value = true,
-         .default_value = std::to_string(defaults.contacts_per_counterparty)},
-        {.name = "no-addresses"},
-        {.name = "no-identifiers"},
-        {.name = "seed", .requires_value = true, .default_value = ""}
-    };
+    return {{.name = "country", .requires_value = true, .default_value = defaults.country},
+            {.name = "party-count",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.party_count)},
+            {.name = "party-max-depth",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.party_max_depth)},
+            {.name = "counterparty-count",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.counterparty_count)},
+            {.name = "counterparty-max-depth",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.counterparty_max_depth)},
+            {.name = "portfolio-leaf-count",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.portfolio_leaf_count)},
+            {.name = "portfolio-max-depth",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.portfolio_max_depth)},
+            {.name = "books-per-portfolio",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.books_per_leaf_portfolio)},
+            {.name = "business-unit-count",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.business_unit_count)},
+            {.name = "business-unit-max-depth",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.business_unit_max_depth)},
+            {.name = "contacts-per-party",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.contacts_per_party)},
+            {.name = "contacts-per-counterparty",
+             .requires_value = true,
+             .default_value = std::to_string(defaults.contacts_per_counterparty)},
+            {.name = "no-addresses"},
+            {.name = "no-identifiers"},
+            {.name = "seed", .requires_value = true, .default_value = ""}};
 }
 
 std::optional<synthetic::messaging::generate_organisation_request>
-synthetic_commands::build_generate_request(std::ostream& out,
-                                           const parsed_args& parsed) {
+synthetic_commands::build_generate_request(std::ostream& out, const parsed_args& parsed) {
     synthetic::messaging::generate_organisation_request req;
     req.country = parsed.flag("country");
 
@@ -118,8 +126,8 @@ synthetic_commands::build_generate_request(std::ostream& out,
     for (const auto& [name, target] : knobs) {
         auto v = parse_uint32(parsed.flag(name));
         if (!v) {
-            fail(out) << "Flag --" << name << " must be an unsigned integer: "
-                      << parsed.flag(name) << std::endl;
+            fail(out) << "Flag --" << name << " must be an unsigned integer: " << parsed.flag(name)
+                      << std::endl;
             return std::nullopt;
         }
         *target = *v;
@@ -131,8 +139,8 @@ synthetic_commands::build_generate_request(std::ostream& out,
     if (!parsed.flag("seed").empty()) {
         auto seed = parse_uint64(parsed.flag("seed"));
         if (!seed) {
-            fail(out) << "Flag --seed must be an unsigned integer: "
-                      << parsed.flag("seed") << std::endl;
+            fail(out) << "Flag --seed must be an unsigned integer: " << parsed.flag("seed")
+                      << std::endl;
             return std::nullopt;
         }
         req.seed = *seed;
@@ -140,24 +148,20 @@ synthetic_commands::build_generate_request(std::ostream& out,
     return req;
 }
 
-bool synthetic_commands::generate(
-    std::ostream& out, nats_client& session,
-    const synthetic::messaging::generate_organisation_request& req) {
-    BOOST_LOG_SEV(lg(), info) << "Generating synthetic organisation: "
-                              << rfl::json::write(req);
-    out << "Generating synthetic organisation (country " << req.country << ", "
-        << req.party_count << " parties)..." << std::endl;
+bool synthetic_commands::generate(std::ostream& out,
+                                  nats_client& session,
+                                  const synthetic::messaging::generate_organisation_request& req) {
+    BOOST_LOG_SEV(lg(), info) << "Generating synthetic organisation: " << rfl::json::write(req);
+    out << "Generating synthetic organisation (country " << req.country << ", " << req.party_count
+        << " parties)..." << std::endl;
 
     try {
-        auto reply = session.authenticated_request(std::string(req.nats_subject),
-                                                   rfl::json::write(req),
-                                                   generate_timeout);
-        auto result =
-            rfl::json::read<synthetic::messaging::generate_organisation_response>(
-                ores::nats::as_string_view(reply.data));
+        auto reply = session.authenticated_request(
+            std::string(req.nats_subject), rfl::json::write(req), generate_timeout);
+        auto result = rfl::json::read<synthetic::messaging::generate_organisation_response>(
+            ores::nats::as_string_view(reply.data));
         if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what()
-                      << std::endl;
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
             return false;
         }
         if (!result->success) {
@@ -165,8 +169,7 @@ bool synthetic_commands::generate(
             return false;
         }
 
-        out << "✓ Synthetic organisation generated (seed " << result->seed << "):"
-            << std::endl;
+        out << "✓ Synthetic organisation generated (seed " << result->seed << "):" << std::endl;
         out << "  parties:             " << result->parties_count << std::endl;
         out << "  counterparties:      " << result->counterparties_count << std::endl;
         out << "  business unit types: " << result->business_unit_types_count << std::endl;
@@ -193,8 +196,7 @@ void synthetic_commands::process_generate(std::ostream& out,
         return;
     }
     if (!parsed->positionals.empty()) {
-        fail(out) << "synthetic generate takes no positional arguments; see help."
-                  << std::endl;
+        fail(out) << "synthetic generate takes no positional arguments; see help." << std::endl;
         return;
     }
 

--- a/projects/ores.shell/src/app/commands/tenants_commands.cpp
+++ b/projects/ores.shell/src/app/commands/tenants_commands.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.shell/app/commands/tenants_commands.hpp"
-#include "ores.shell/app/command_feedback.hpp"
 #include "ores.iam.api/domain/tenant_table_io.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
 #include "ores.platform/time/datetime.hpp"
+#include "ores.shell/app/command_feedback.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -291,8 +291,7 @@ void tenants_commands::process_delete_tenant(std::ostream& out,
     }
 }
 
-void tenants_commands::process_complete_provisioning(std::ostream& out,
-                                                     nats_client& session) {
+void tenants_commands::process_complete_provisioning(std::ostream& out, nats_client& session) {
     if (!session.is_logged_in()) {
         fail(out) << "Not logged in." << std::endl;
         return;
@@ -307,8 +306,7 @@ void tenants_commands::process_complete_provisioning(std::ostream& out,
         return;
 
     if (!result->success) {
-        fail(out) << "Failed to complete tenant provisioning: " << result->message
-                  << std::endl;
+        fail(out) << "Failed to complete tenant provisioning: " << result->message << std::endl;
         return;
     }
     out << "✓ Tenant provisioning completed." << std::endl;

--- a/projects/ores.shell/src/app/commands/workflow_commands.cpp
+++ b/projects/ores.shell/src/app/commands/workflow_commands.cpp
@@ -55,11 +55,10 @@ fetch_steps(nats_client& session, const std::string& instance_id) {
     req.workflow_instance_id = instance_id;
 
     try {
-        auto reply = session.authenticated_request(std::string(req.nats_subject),
-                                                   rfl::json::write(req));
-        auto result =
-            rfl::json::read<workflow::messaging::get_workflow_steps_response>(
-                ores::nats::as_string_view(reply.data));
+        auto reply =
+            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
+        auto result = rfl::json::read<workflow::messaging::get_workflow_steps_response>(
+            ores::nats::as_string_view(reply.data));
         if (!result)
             return std::unexpected("Failed to parse response: " + result.error().what());
         return *result;
@@ -84,23 +83,22 @@ void print_step(std::ostream& out,
 void workflow_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto workflow_menu = std::make_unique<cli::Menu>("workflow");
 
-    workflow_menu->Insert(
-        "steps",
-        [&session](std::ostream& out, std::string instance_id) {
-            process_steps(std::ref(out), std::ref(session), instance_id);
-        },
-        "Show the steps of a workflow instance",
-        {"instance_id"});
+    workflow_menu->Insert("steps",
+                          [&session](std::ostream& out, std::string instance_id) {
+                              process_steps(std::ref(out), std::ref(session), instance_id);
+                          },
+                          "Show the steps of a workflow instance",
+                          {"instance_id"});
 
     workflow_menu->Insert(
         "wait",
         [&session](std::ostream& out, std::vector<std::string> args) {
-            auto parsed = parse_args(args, {
-                {.name = "timeout", .requires_value = true,
-                 .default_value = std::to_string(default_timeout.count())},
-                {.name = "expect-steps", .requires_value = true,
-                 .default_value = "0"}
-            });
+            auto parsed = parse_args(
+                args,
+                {{.name = "timeout",
+                  .requires_value = true,
+                  .default_value = std::to_string(default_timeout.count())},
+                 {.name = "expect-steps", .requires_value = true, .default_value = "0"}});
             if (!parsed) {
                 fail(out) << parsed.error() << std::endl;
                 return;
@@ -126,8 +124,8 @@ void workflow_commands::register_commands(cli::Menu& root_menu, nats_client& ses
                 return;
             }
 
-            wait_for_instance(std::ref(out), std::ref(session),
-                              parsed->positionals.front(), *timeout, *expected);
+            wait_for_instance(
+                std::ref(out), std::ref(session), parsed->positionals.front(), *timeout, *expected);
         },
         "Wait for a workflow instance to reach a terminal state",
         {"instance_id [--timeout <seconds>] [--expect-steps <n>]"});
@@ -186,8 +184,8 @@ bool workflow_commands::wait_for_instance(std::ostream& out,
                 BOOST_LOG_SEV(lg(), info)
                     << "Treating unsuccessful steps reply as transient: " << reason;
             ++consecutive_failures;
-            out << "⚠ Poll failed (" << consecutive_failures << "/"
-                << max_consecutive_poll_failures << "): " << reason << std::endl;
+            out << "⚠ Poll failed (" << consecutive_failures << "/" << max_consecutive_poll_failures
+                << "): " << reason << std::endl;
             BOOST_LOG_SEV(lg(), warn) << "Poll " << consecutive_failures << " failed for "
                                       << instance_id << ": " << reason;
             if (consecutive_failures >= max_consecutive_poll_failures) {
@@ -214,11 +212,11 @@ bool workflow_commands::wait_for_instance(std::ostream& out,
             std::size_t completed = 0;
             for (const auto& step : result->steps) {
                 if (step.status == "failed") {
-                    fail(out) << "Workflow failed at step " << (step.step_index + 1)
-                              << " of " << total << ": " << step.error << std::endl;
-                    BOOST_LOG_SEV(lg(), error) << "Workflow instance " << instance_id
-                                               << " failed at step " << step.step_index
-                                               << ": " << step.error;
+                    fail(out) << "Workflow failed at step " << (step.step_index + 1) << " of "
+                              << total << ": " << step.error << std::endl;
+                    BOOST_LOG_SEV(lg(), error)
+                        << "Workflow instance " << instance_id << " failed at step "
+                        << step.step_index << ": " << step.error;
                     return false;
                 }
                 if (step.status == "completed" || step.status == "completed_with_warnings")
@@ -231,18 +229,16 @@ bool workflow_commands::wait_for_instance(std::ostream& out,
             }
             if (total > 0 && completed == total && total >= expected_steps) {
                 out << "✓ All " << total << " step(s) completed." << std::endl;
-                BOOST_LOG_SEV(lg(), info) << "Workflow instance " << instance_id
-                                          << " completed.";
+                BOOST_LOG_SEV(lg(), info) << "Workflow instance " << instance_id << " completed.";
                 return true;
             }
         }
 
         if (std::chrono::steady_clock::now() + poll_interval > deadline) {
-            fail(out) << "Timed out after " << timeout.count()
-                      << "s waiting for workflow instance " << instance_id
-                      << ". Check progress with: workflow steps " << instance_id << std::endl;
-            BOOST_LOG_SEV(lg(), error) << "Timed out waiting for workflow instance "
-                                       << instance_id;
+            fail(out) << "Timed out after " << timeout.count() << "s waiting for workflow instance "
+                      << instance_id << ". Check progress with: workflow steps " << instance_id
+                      << std::endl;
+            BOOST_LOG_SEV(lg(), error) << "Timed out waiting for workflow instance " << instance_id;
             return false;
         }
         std::this_thread::sleep_for(poll_interval);

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -105,14 +105,12 @@ std::unique_ptr<cli::Cli> repl::setup_menus() {
 
     // Route cli-level errors through command_feedback so scripts abort
     // on unknown commands and uncaught exceptions too.
-    cli_instance->WrongCommandHandler(
-        [](std::ostream& out, const std::string& cmd) {
-            fail(out) << "Wrong command: " << cmd << std::endl;
-        });
+    cli_instance->WrongCommandHandler([](std::ostream& out, const std::string& cmd) {
+        fail(out) << "Wrong command: " << cmd << std::endl;
+    });
     cli_instance->StdExceptionHandler(
         [](std::ostream& out, const std::string& cmd, const std::exception& e) {
-            fail(out) << "Command failed: " << cmd << " (" << e.what() << ")"
-                      << std::endl;
+            fail(out) << "Command failed: " << cmd << " (" << e.what() << ")" << std::endl;
         });
     return cli_instance;
 }

--- a/projects/ores.shell/tests/app_command_args_tests.cpp
+++ b/projects/ores.shell/tests/app_command_args_tests.cpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.shell/app/command_args.hpp"
 #include "ores.logging/make_logger.hpp"
+#include "ores.shell/app/command_args.hpp"
 #include <catch2/catch_test_macros.hpp>
 
 namespace {
@@ -56,8 +56,7 @@ TEST_CASE("parse_args_switch_defaults_to_false", tags) {
 TEST_CASE("parse_args_switch_present", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({"file.ores", "--continue-on-error"},
-                        {{.name = "continue-on-error"}});
+    auto r = parse_args({"file.ores", "--continue-on-error"}, {{.name = "continue-on-error"}});
     REQUIRE(r.has_value());
     CHECK(r->flag_set("continue-on-error"));
 }
@@ -65,8 +64,7 @@ TEST_CASE("parse_args_switch_present", tags) {
 TEST_CASE("parse_args_switch_anywhere_among_positionals", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({"--continue-on-error", "file.ores"},
-                        {{.name = "continue-on-error"}});
+    auto r = parse_args({"--continue-on-error", "file.ores"}, {{.name = "continue-on-error"}});
     REQUIRE(r.has_value());
     CHECK(r->flag_set("continue-on-error"));
     CHECK(r->positionals == std::vector<std::string>{"file.ores"});
@@ -76,8 +74,7 @@ TEST_CASE("parse_args_value_flag_with_separate_value", tags) {
     auto lg(make_logger(test_suite));
 
     auto r = parse_args({"--seed", "42"},
-                        {{.name = "seed", .requires_value = true,
-                          .default_value = ""}});
+                        {{.name = "seed", .requires_value = true, .default_value = ""}});
     REQUIRE(r.has_value());
     CHECK(r->flag("seed") == "42");
 }
@@ -85,9 +82,8 @@ TEST_CASE("parse_args_value_flag_with_separate_value", tags) {
 TEST_CASE("parse_args_value_flag_with_inline_value", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({"--seed=42"},
-                        {{.name = "seed", .requires_value = true,
-                          .default_value = ""}});
+    auto r =
+        parse_args({"--seed=42"}, {{.name = "seed", .requires_value = true, .default_value = ""}});
     REQUIRE(r.has_value());
     CHECK(r->flag("seed") == "42");
 }
@@ -95,8 +91,8 @@ TEST_CASE("parse_args_value_flag_with_inline_value", tags) {
 TEST_CASE("parse_args_value_flag_uses_default_when_absent", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({}, {{.name = "dataset-size", .requires_value = true,
-                              .default_value = "small"}});
+    auto r = parse_args(
+        {}, {{.name = "dataset-size", .requires_value = true, .default_value = "small"}});
     REQUIRE(r.has_value());
     CHECK(r->flag("dataset-size") == "small");
 }
@@ -113,9 +109,8 @@ TEST_CASE("parse_args_unknown_flag_is_error", tags) {
 TEST_CASE("parse_args_value_flag_missing_value_is_error", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({"--seed"},
-                        {{.name = "seed", .requires_value = true,
-                          .default_value = ""}});
+    auto r =
+        parse_args({"--seed"}, {{.name = "seed", .requires_value = true, .default_value = ""}});
     REQUIRE_FALSE(r.has_value());
     CHECK(r.error().find("--seed") != std::string::npos);
 }
@@ -124,8 +119,7 @@ TEST_CASE("parse_args_value_flag_followed_by_flag_is_error", tags) {
     auto lg(make_logger(test_suite));
 
     auto r = parse_args({"--seed", "--continue-on-error"},
-                        {{.name = "seed", .requires_value = true,
-                          .default_value = ""},
+                        {{.name = "seed", .requires_value = true, .default_value = ""},
                          {.name = "continue-on-error"}});
     REQUIRE_FALSE(r.has_value());
     CHECK(r.error().find("--seed") != std::string::npos);
@@ -134,8 +128,7 @@ TEST_CASE("parse_args_value_flag_followed_by_flag_is_error", tags) {
 TEST_CASE("parse_args_switch_with_inline_value_is_error", tags) {
     auto lg(make_logger(test_suite));
 
-    auto r = parse_args({"--continue-on-error=yes"},
-                        {{.name = "continue-on-error"}});
+    auto r = parse_args({"--continue-on-error=yes"}, {{.name = "continue-on-error"}});
     REQUIRE_FALSE(r.has_value());
     CHECK(r.error().find("continue-on-error") != std::string::npos);
 }

--- a/projects/ores.shell/tests/app_script_runner_tests.cpp
+++ b/projects/ores.shell/tests/app_script_runner_tests.cpp
@@ -17,9 +17,9 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.logging/make_logger.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/script_runner.hpp"
-#include "ores.logging/make_logger.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <sstream>
@@ -68,8 +68,7 @@ TEST_CASE("run_script_executes_commands_and_skips_noise", tags) {
                           "two\n");
     std::vector<std::string> fed;
     std::ostringstream out;
-    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
-                        out, false);
+    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); }, out, false);
 
     CHECK_FALSE(r.aborted);
     CHECK(r.executed == 2);
@@ -89,8 +88,7 @@ TEST_CASE("run_script_skips_whitespace_and_cr_only_lines", tags) {
                           "two\r\n");
     std::vector<std::string> fed;
     std::ostringstream out;
-    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
-                        out, false);
+    auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); }, out, false);
 
     CHECK_FALSE(r.aborted);
     CHECK(r.executed == 2);
@@ -106,13 +104,15 @@ TEST_CASE("run_script_aborts_on_first_failure_by_default", tags) {
                           "never\n");
     std::vector<std::string> fed;
     std::ostringstream out;
-    auto r = run_script(in,
-                        [&](const std::string& c) {
-                            fed.push_back(c);
-                            if (c == "bad")
-                                command_feedback::mark_failure();
-                        },
-                        out, false);
+    auto r = run_script(
+        in,
+        [&](const std::string& c) {
+            fed.push_back(c);
+            if (c == "bad")
+                command_feedback::mark_failure();
+        },
+        out,
+        false);
 
     CHECK(r.aborted);
     CHECK(r.aborted_line == 2);
@@ -130,13 +130,15 @@ TEST_CASE("run_script_continue_on_error_keeps_going", tags) {
                           "after\n");
     std::vector<std::string> fed;
     std::ostringstream out;
-    auto r = run_script(in,
-                        [&](const std::string& c) {
-                            fed.push_back(c);
-                            if (c == "bad")
-                                command_feedback::mark_failure();
-                        },
-                        out, true);
+    auto r = run_script(
+        in,
+        [&](const std::string& c) {
+            fed.push_back(c);
+            if (c == "bad")
+                command_feedback::mark_failure();
+        },
+        out,
+        true);
 
     CHECK_FALSE(r.aborted);
     CHECK(r.executed == 3);
@@ -220,11 +222,8 @@ TEST_CASE("run_script_nested_failure_propagates", tags) {
     std::ostringstream out;
     auto inner = [&](const std::string&) {
         std::istringstream inner_in("inner-bad\n");
-        auto r = run_script(inner_in,
-                            [](const std::string&) {
-                                command_feedback::mark_failure();
-                            },
-                            out, false);
+        auto r = run_script(
+            inner_in, [](const std::string&) { command_feedback::mark_failure(); }, out, false);
         CHECK(r.aborted);
         // As load does: leave the failure flag set on abort.
         command_feedback::mark_failure();

--- a/projects/ores.synthetic/core/src/service/organisation_generator_service.cpp
+++ b/projects/ores.synthetic/core/src/service/organisation_generator_service.cpp
@@ -847,8 +847,7 @@ organisation_generator_service::generate(const domain::organisation_generation_o
         env.emplace(generation_keys::modified_by, options.modified_by);
     if (!options.tenant_id.empty())
         env.emplace(generation_keys::tenant_id, options.tenant_id);
-    generation_context ctx(options.seed.value_or(std::random_device{}()),
-                           std::move(env));
+    generation_context ctx(options.seed.value_or(std::random_device{}()), std::move(env));
 
     domain::generated_organisation result;
     result.seed = ctx.seed();

--- a/projects/ores.synthetic/core/src/service/organisation_publisher_service.cpp
+++ b/projects/ores.synthetic/core/src/service/organisation_publisher_service.cpp
@@ -126,15 +126,15 @@ organisation_publisher_service::publish(const domain::generated_organisation& or
         // is re-pointed at the generated root party (its descendants are
         // the whole generated hierarchy) before every party-scoped insert.
         const auto root_party_tenant =
-            !parties.empty() ? parties[0].tenant_id
-                             : (!bus_units.empty() ? bus_units[0].tenant_id : std::string());
-        const auto root_party_id =
-            !parties.empty() ? parties[0].id()
-                             : (!bus_units.empty() ? bus_units[0].party_id : std::string());
-        const auto set_party_sql = root_party_id.empty() ?
-            std::string("SELECT 1") :
-            "SELECT ores_iam_set_party_context_fn('" + root_party_tenant + "'::uuid, '" +
-                root_party_id + "'::uuid)";
+            !parties.empty() ? parties[0].tenant_id :
+                               (!bus_units.empty() ? bus_units[0].tenant_id : std::string());
+        const auto root_party_id = !parties.empty() ?
+                                       parties[0].id() :
+                                       (!bus_units.empty() ? bus_units[0].party_id : std::string());
+        const auto set_party_sql =
+            root_party_id.empty() ? std::string("SELECT 1") :
+                                    "SELECT ores_iam_set_party_context_fn('" + root_party_tenant +
+                                        "'::uuid, '" + root_party_id + "'::uuid)";
 
         // Insert all entities atomically in FK order within a single
         // transaction. If any insert fails, the entire transaction rolls back.


### PR DESCRIPTION
## Summary

Nightly clang-format workflow fails in two ways: (1) version pinned to clang-format-18 while local toolchain uses clang-format-21, causing perpetual version-mismatch drift; (2) GitHub Actions lacks repository permission to create the bot PR. Fix: unpin the workflow to use the distro default and apply clang-format to 181 drifted files. Note: repo admin must enable 'Allow GitHub Actions to create and approve pull requests' in Settings → Actions → General.

## Changes

- Apply clang-format 21 to 181 drifted C++ files across all components
- Change nightly-format.yml to install and invoke clang-format (unpinned) to match local toolchain
- Add story and task with investigation notes and required admin action

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix nightly clang-format CI: permissions and formatting drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/story.html) | 10B5F44F-5EE7-4026-BFD7-4DABAB6540B8 |
| Task | [Fix nightly-format workflow and apply formatting drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_clang_format_ci/task_fix_nightly_format_workflow.html) | 9F20113A-1D5C-49F0-B322-DAAC0ED4FDED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)