### PR TITLE
[agile] Close task EC539224: Improve the Developer Links page

### DIFF
--- a/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_improve_developer_links.org
+++ b/doc/agile/versions/v0/sprint_20/clean_codegen_masd_docs/task_improve_developer_links.org
@@ -29,11 +29,11 @@ orient quickly and follow the correct process without searching.
 
 | Field        | Value                                                                       |
 |--------------+-----------------------------------------------------------------------------|
-| State        | STARTED                                                                     |
+| State        | DONE                                                                     |
 | Parent story | [[id:6654934D-D372-4B7B-A66D-5E0E5A145775][Story: Clean up codegen documentation and MASD alignment]] |
-| Now          | Rewriting developer.org.                                                    |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                                                                    |
-| Next         | PR.                                                                         |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                                                                  |
 
 * Acceptance
@@ -69,3 +69,11 @@ sub-section per phase, each containing a table of recipe links.
 |   |                 |      |          |       |
 
 * Result
+
+=doc/developer.org= rewritten from a 6-link URL index into a
+workflow-recipe guide. Eight sections keyed to the developer
+lifecycle: Setup (4 recipes), Build (4), Test (5), Develop (14),
+PR and Review (6), Deploy (5), Release (3), Agile (5). External-URL
+tables (GitHub, CI, CDash, community, code style, design/UX) moved
+into a dedicated =* External Resources= section. 30 recipe links
+total. Delivered in PR [[https://github.com/OreStudio/OreStudio/pull/1189][#1189]].


### PR DESCRIPTION
## Summary

- Writes the `* Result` section in `task_improve_developer_links.org`
- State: DONE

Closes task EC539224. The content change (developer.org rewrite) was in PR #1189.

## Test plan

- [ ] Task state DONE, Result filled
- [ ] `pr-gate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)