### PR TITLE
[iam,tests] Fix flaky IAM repository tests

### DIFF
--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/story.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/story.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505
+:END:
+#+title: Story: Fix flaky IAM repository tests
+#+description: Eliminate duplicate-key failures in IAM repository tests caused by email-suffix collision in generated test accounts.
+#+type: story
+#+level: s2
+#+filetags: :iam:tests:flaky:ci:infrastructure:sprint_20:v0:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+IAM repository tests pass consistently on every parallel CI run with no
+spurious duplicate-key failures. The fix addresses the root cause — not
+a retry loop or test ordering workaround.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Investigation complete; ready to implement. |
+| Waiting on    | Nothing.                               |
+| Next          | Fix email suffix and verify no recurrence. |
+| Last touched  | 2026-06-08                               |
+
+* Acceptance
+
+- CI canary runs 10 consecutive times with no =accounts_email_uniq_idx=
+  failure (manual spot-check after merge).
+- The fix is in the generation layer — tests themselves need no changes.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:F94637CA-06CE-4A61-BEEC-9A090649C3FC][Fix email-suffix collision]] | BACKLOG | | | Use full-UUID random tail as email suffix; one-line change to account_generator.cpp. |
+
+* Decisions
+
+- Fix in generation layer, not in the test fixture. Tests should remain
+  unaware of uniqueness mechanics; the generator must produce unique
+  output unconditionally.
+
+* Out of scope
+
+- Broader UUID v7 monotonicity improvements (separate concern).
+- Parallelism-related isolation for other entity generators (capture if found).

--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
@@ -1,0 +1,107 @@
+:PROPERTIES:
+:ID: F94637CA-06CE-4A61-BEEC-9A090649C3FC
+:END:
+#+title: Task: Fix email-suffix collision in account test data generation
+#+description: Widen the UUID-derived suffix used for generated account email addresses so tests running in the same millisecond never produce duplicate emails.
+#+type: task
+#+level: s1
+#+filetags: :iam:tests:flaky:generation:infrastructure:fix_flaky_iam_tests:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Change =account_generator.cpp= so that generated email addresses are
+unique even when many accounts are created in the same millisecond on
+parallel CI workers.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] |
+| Now          | Investigation complete; fix is clear.  |
+| Waiting on   | Nothing.                               |
+| Next         | Apply fix, build, run tests locally.   |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- =accounts_email_uniq_idx= violation never occurs when the full IAM test
+  suite runs with maximum parallelism (=CTEST_PARALLEL_LEVEL=$(nproc)=).
+- No other unique constraints in IAM tests begin failing.
+
+* Plan
+
+1. In =projects/ores.iam/api/src/generators/account_generator.cpp= change
+   line 45 from =id_str.substr(0, 8)= to =id_str.substr(24)=.
+   This uses the last 12 hex characters of the UUID, which map entirely
+   to the random bits (bytes 10–15). Those bits are drawn from the
+   per-engine =mt19937_64= state, which is seeded independently by
+   =std::random_device= — they will differ across parallel test processes
+   even if the millisecond timestamp is identical.
+
+2. Build the =ores.iam.api= target and run the full IAM test suite
+   locally to confirm no regressions.
+
+3. Raise PR; CI canary must pass.
+
+* Notes
+
+** Root cause analysis (2026-06-08)
+
+Failing test: =repository_account_role_repository_tests.cpp:53=
+
+Error: =duplicate key value violates unique constraint "accounts_email_uniq_idx"=
+
+The CI canary runs with =CTEST_PARALLEL_LEVEL=$(nproc)= so multiple test
+binaries execute concurrently. Each binary creates its own
+=generation_engine= seeded from =std::random_device=. The UUID v7
+implementation in =generation_engine::generate_uuid()= places the current
+millisecond timestamp in bytes 0–5 of the UUID. The first 8 hex
+characters of the formatted string (=id_str.substr(0, 8)=) therefore
+encode bytes 0–3 — the upper 32 bits of the millisecond counter — which
+are *identical* for every UUID generated in the same millisecond.
+
+When two parallel processes both call =generate_synthetic_account()=
+within the same millisecond they produce the same 8-character suffix,
+and since the =faker= first/last names can also collide, the resulting
+email addresses are occasionally identical. PostgreSQL then rejects the
+second INSERT with the unique-constraint violation.
+
+*Files involved*:
+- =projects/ores.iam/api/src/generators/account_generator.cpp= (the fix)
+- =projects/ores.utility/src/generation/generation_engine.cpp= (UUID v7 source; not changed)
+
+*One-line fix*:
+#+begin_src diff
+-    const auto suffix = id_str.substr(0, 8);
++    const auto suffix = id_str.substr(24);  // random tail — 12 hex chars from bytes 10-15
+#+end_src
+
+The random tail (bytes 10–15) is drawn entirely from the =mt19937_64=
+engine state and is independent of the timestamp. Collisions are
+astronomically unlikely with 48 bits of independent randomness per suffix.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
@@ -8,7 +8,7 @@
 #+filetags: :iam:tests:flaky:generation:infrastructure:fix_flaky_iam_tests:sprint_20:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1195
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -96,7 +96,7 @@ astronomically unlikely with 48 bits of independent randomness per suffix.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1195][#1195]] | [iam,tests] Fix flaky IAM repository tests |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -154,6 +154,7 @@ LLM-driven workflow frictionless.
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. Slipped in sprints 18 and 19. |
 | [[id:3F7752F8-B719-40B4-BA89-09223410999E][Retune CI for tens of merges an hour]] | STARTED | 2026-06-06 | | Path-classified PR jobs behind one pr-gate check; main matrices on staggered 2h/3h/4h schedules with a doc-only skip guard; Claude review replaces Gemini. |
 | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI]] | DONE | 2026-06-08 | 2026-06-08 | Unpin clang-format-18; apply drift to 181 files; restore bot-PR approach. PR #1187. |
+| [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] | BACKLOG | | | Eliminate duplicate-key failures caused by UUID v7 timestamp collision in email generation; one-line fix in account_generator.cpp. |
 
 ** Site
 


### PR DESCRIPTION
## Summary

Story and task scaffolding for eliminating duplicate-key failures in IAM repository tests. Root cause identified: UUID v7 email suffix uses only the 8-char timestamp prefix; parallel test workers in the same millisecond collide on accounts_email_uniq_idx. Fix is one line in account_generator.cpp.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix flaky IAM repository tests](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/story.html) | C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505 |
| Task | [Fix email-suffix collision in account test data generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.html) | F94637CA-06CE-4A61-BEEC-9A090649C3FC |

🤖 Generated with [Claude Code](https://claude.com/claude-code)