### PR TITLE
[ci] Improve CDash build visibility

### DIFF
--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41
+:END:
+#+title: Story: Improve CDash build visibility
+#+description: Tag canary builds with PR number; add Site category for doc builds; rename Experimental to Canary for clarity.
+#+type: story
+#+level: s2
+#+filetags: :cdash:ci:infrastructure:tooling:sprint_20:v0:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+CDash gives developers and new contributors a clear, actionable view of
+build health: each canary entry shows the PR that triggered it; site
+builds have their own category; and the build group terminology matches
+what the team calls things (Canary, not Experimental).
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Investigation complete; ready to implement. |
+| Waiting on    | Nothing.                               |
+| Next          | Task A (PR tagging) then Task B (site + naming). |
+| Last touched  | 2026-06-08                               |
+
+* Acceptance
+
+- CDash canary entries include the PR number in the build name.
+- Site builds appear under a =Site= CDash category after a site build run.
+- No references to =Experimental= remain for developer-facing CI builds.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Tag canary CDash builds with PR number]] | BACKLOG | | | Pass GITHUB_PR_NUMBER as build_postfix into CTest.cmake. |
+| [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category and clarify naming]] | BACKLOG | | | CTest script for site builds; add Site group; audit Experimental usage. |
+
+* Decisions
+
+- =build_postfix= is the right extension point — it is already wired in
+  =CTest.cmake= and appended to the build name with a hyphen.
+- Site builds use a separate CTest script (not CTest.cmake) because they
+  do not need configure/build/test phases — only a custom command and submit.
+
+* Out of scope
+
+- Changing the Nightly or Continuous group naming (they match CDash defaults).
+- Windows or macOS site builds (docs are built on Linux only).

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -51,8 +51,8 @@ exists. The build names are unchanged.
   name stays clean; the PR URL lives in the Notes section.
 - Site builds use a separate =CTest.site.cmake= (not =CTest.cmake=) because
   they do not use CMake presets or the configure/build/test pipeline.
-- =Experimental= is retained in =CTest.cmake= as a valid value for ad-hoc
-  local developer use; it is simply never invoked by any workflow.
+- =Experimental= is the designated group for local developer builds —
+  kept in =CTest.cmake= and intentionally never invoked by CI workflows.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -2,7 +2,7 @@
 :ID: 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41
 :END:
 #+title: Story: Improve CDash build visibility
-#+description: Tag canary builds with PR number; add Site category for doc builds; rename Experimental to Canary for clarity.
+#+description: Link canary CDash entries to their PR via Notes; add Site CDash category for doc builds; Experimental is kept but never invoked.
 #+type: story
 #+level: s2
 #+filetags: :cdash:ci:infrastructure:tooling:sprint_20:v0:
@@ -15,9 +15,10 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 * Goal
 
 CDash gives developers and new contributors a clear, actionable view of
-build health: each canary entry shows the PR that triggered it; site
-builds have their own category; and the build group terminology matches
-what the team calls things (Canary, not Experimental).
+build health: each canary entry links to the PR that triggered it via a
+Notes field; site builds appear in a dedicated =Site= category so
+documentation health is visible at a glance. The =Canary= category already
+exists. The build names are unchanged.
 
 * Status
 
@@ -27,28 +28,31 @@ what the team calls things (Canary, not Experimental).
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | Investigation complete; ready to implement. |
 | Waiting on    | Nothing.                               |
-| Next          | Task A (PR tagging) then Task B (site + naming). |
+| Next          | Task A (PR Notes) then Task B (Site category). |
 | Last touched  | 2026-06-08                               |
 
 * Acceptance
 
-- CDash canary entries include the PR number in the build name.
-- Site builds appear under a =Site= CDash category after a site build run.
-- No references to =Experimental= remain for developer-facing CI builds.
+- CDash canary entries show the PR URL in their Notes section.
+- Site builds appear under the =Site= CDash category after a site build run.
+- =Experimental= remains in =CTest.cmake= as a reserved valid value but is
+  not invoked by any workflow.
 
 * Tasks
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Tag canary CDash builds with PR number]] | BACKLOG | | | Pass GITHUB_PR_NUMBER as build_postfix into CTest.cmake. |
-| [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category and clarify naming]] | BACKLOG | | | CTest script for site builds; add Site group; audit Experimental usage. |
+| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | BACKLOG | | | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
+| [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category for doc builds]] | BACKLOG | | | CTest.site.cmake script; update build-site.yml to submit; Canary already exists. |
 
 * Decisions
 
-- =build_postfix= is the right extension point — it is already wired in
-  =CTest.cmake= and appended to the build name with a hyphen.
-- Site builds use a separate CTest script (not CTest.cmake) because they
-  do not need configure/build/test phases — only a custom command and submit.
+- CDash Notes (=CTEST_NOTES_FILES=) rather than =build_postfix= — the build
+  name stays clean; the PR URL lives in the Notes section.
+- Site builds use a separate =CTest.site.cmake= (not =CTest.cmake=) because
+  they do not use CMake presets or the configure/build/test pipeline.
+- =Experimental= is retained in =CTest.cmake= as a valid value for ad-hoc
+  local developer use; it is simply never invoked by any workflow.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
@@ -1,0 +1,111 @@
+:PROPERTIES:
+:ID: 9045AA11-B666-411B-B0CE-C41C3EA6508E
+:END:
+#+title: Task: Tag canary CDash builds with PR number
+#+description: Pass the GitHub PR number as build_postfix to CTest so each CDash entry shows which PR triggered it.
+#+type: task
+#+level: s1
+#+filetags: :cdash:ci:canary:github_actions:improve_cdash_visibility:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Every CDash build entry for a canary run includes the triggering PR
+number in its build name, so engineers looking at the CDash dashboard
+can immediately click through to the PR without correlating timestamps
+or run numbers.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
+| Now          | Analysis complete; fix clear.          |
+| Waiting on   | Nothing.                               |
+| Next         | Update canary-linux.yml; test locally. |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- A CDash entry for PR #1234 appears with build name
+  =linux-gcc-debug-ninja-pr1234=.
+- Non-canary builds (Nightly, Continuous) are unaffected.
+
+* Plan
+
+1. In =.github/workflows/canary-linux.yml=, extract the PR number from the
+   GitHub context and pass it as =build_postfix=:
+
+   #+begin_src yaml
+   - name: Run CTest (Canary)
+     run: |
+       export pr_number="${{ github.event.pull_request.number }}"
+       export cmake_args="build_group=Canary,preset=${preset},code_coverage=1,build_postfix=pr${pr_number}"
+       ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
+   #+end_src
+
+2. No change to =CTest.cmake= is required — =build_postfix= is already
+   parsed on line 56 and appended to the build name:
+   #+begin_example
+   set(build_name ${preset})
+   if(DEFINED build_postfix)
+       set(build_name ${build_name}-${build_postfix})
+   endif()
+   #+end_example
+
+3. Verify the resulting CDash entry shows the PR number as a suffix.
+
+* Notes
+
+** Analysis (2026-06-08)
+
+CDash build name is constructed in =CTest.cmake= lines 56–60:
+
+#+begin_example
+set(build_name ${preset})
+if(DEFINED build_postfix)
+    set(build_name ${build_name}-${build_postfix})
+endif()
+set(CTEST_BUILD_NAME "${build_name}")
+#+end_example
+
+The =build_postfix= parameter is already parsed from =CTEST_SCRIPT_ARG=
+(comma-separated key=value pairs). It is not currently passed by any
+workflow, but the wiring exists. The canary workflow invocation in
+=canary-linux.yml= is:
+
+#+begin_example
+export cmake_args="build_group=Canary,preset=${preset},code_coverage=1"
+ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
+#+end_example
+
+Adding =,build_postfix=pr${pr_number}= to =cmake_args= is the entire change.
+
+The PR number is available as =${{ github.event.pull_request.number }}=
+when the workflow is triggered via =pull_request= event (which it is, via
+=pr.yml= calling =canary-linux.yml= as a reusable workflow). The input
+must be threaded through =pr.yml= → =canary-linux.yml= as a workflow input.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
@@ -1,8 +1,8 @@
 :PROPERTIES:
 :ID: 9045AA11-B666-411B-B0CE-C41C3EA6508E
 :END:
-#+title: Task: Tag canary CDash builds with PR number
-#+description: Pass the GitHub PR number as build_postfix to CTest so each CDash entry shows which PR triggered it.
+#+title: Task: Link canary CDash builds to their PR via Notes
+#+description: Write the PR URL into a CDash Notes file (CTEST_NOTES_FILES) so each build entry links back to its PR without changing the build name.
 #+type: task
 #+level: s1
 #+filetags: :cdash:ci:canary:github_actions:improve_cdash_visibility:sprint_20:v0:
@@ -19,10 +19,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Every CDash build entry for a canary run includes the triggering PR
-number in its build name, so engineers looking at the CDash dashboard
-can immediately click through to the PR without correlating timestamps
-or run numbers.
+Every CDash build entry for a canary run shows the PR URL in its Notes
+section, so engineers can jump directly to the PR from CDash. The build
+name itself is unchanged.
 
 * Status
 
@@ -30,71 +29,79 @@ or run numbers.
 |--------------+----------------------------------------|
 | State        | BACKLOG                              |
 | Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
-| Now          | Analysis complete; fix clear.          |
+| Now          | Analysis complete; approach decided.   |
 | Waiting on   | Nothing.                               |
-| Next         | Update canary-linux.yml; test locally. |
+| Next         | Update CTest.cmake and canary-linux.yml; thread PR number through pr.yml. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
 
-- A CDash entry for PR #1234 appears with build name
-  =linux-gcc-debug-ninja-pr1234=.
-- Non-canary builds (Nightly, Continuous) are unaffected.
+- A CDash build entry triggered by PR #1234 shows a Notes section with
+  the URL =https://github.com/OreStudio/OreStudio/pull/1234=.
+- The build name (=linux-gcc-debug-ninja=) is unchanged.
+- Nightly and Continuous builds are unaffected (no =ORES_GITHUB_PR_URL=
+  env var is set in those workflows).
 
 * Plan
 
-1. In =.github/workflows/canary-linux.yml=, extract the PR number from the
-   GitHub context and pass it as =build_postfix=:
+1. In =CTest.cmake=, before =ctest_start()=, add:
 
-   #+begin_src yaml
-   - name: Run CTest (Canary)
-     run: |
-       export pr_number="${{ github.event.pull_request.number }}"
-       export cmake_args="build_group=Canary,preset=${preset},code_coverage=1,build_postfix=pr${pr_number}"
-       ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
+   #+begin_src cmake
+   if(DEFINED ENV{ORES_GITHUB_PR_URL})
+       set(notes_file "${CTEST_BINARY_DIRECTORY}/cdash_notes.txt")
+       file(WRITE "${notes_file}" "PR: $ENV{ORES_GITHUB_PR_URL}\n")
+       set(CTEST_NOTES_FILES "${notes_file}")
+   endif()
    #+end_src
 
-2. No change to =CTest.cmake= is required — =build_postfix= is already
-   parsed on line 56 and appended to the build name:
-   #+begin_example
-   set(build_name ${preset})
-   if(DEFINED build_postfix)
-       set(build_name ${build_name}-${build_postfix})
-   endif()
-   #+end_example
+   =CTEST_NOTES_FILES= is automatically uploaded by =ctest_submit()= — no
+   changes to the submit call are needed.
 
-3. Verify the resulting CDash entry shows the PR number as a suffix.
+2. In =.github/workflows/pr.yml=, add a =pr_number= input to the
+   =canary-linux.yml= call:
+
+   #+begin_src yaml
+   uses: ./.github/workflows/canary-linux.yml
+   with:
+     pr_number: ${{ github.event.pull_request.number }}
+   #+end_src
+
+3. In =.github/workflows/canary-linux.yml=, declare the input and export
+   the URL before the CTest invocation:
+
+   #+begin_src yaml
+   on:
+     workflow_call:
+       inputs:
+         pr_number:
+           type: number
+           required: false
+   ...
+   - name: Run CTest (Canary)
+     run: |
+       if [ -n "${{ inputs.pr_number }}" ]; then
+         export ORES_GITHUB_PR_URL="https://github.com/OreStudio/OreStudio/pull/${{ inputs.pr_number }}"
+       fi
+       export cmake_args="build_group=Canary,preset=${preset},code_coverage=1"
+       ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
+   #+end_src
 
 * Notes
 
 ** Analysis (2026-06-08)
 
-CDash build name is constructed in =CTest.cmake= lines 56–60:
+CDash supports a "Notes" field on each build entry via the CMake variable
+=CTEST_NOTES_FILES=: set it to a list of file paths, and their contents
+are uploaded as plain text and displayed on the CDash build page. This is
+the correct mechanism — it does not touch the build name.
 
-#+begin_example
-set(build_name ${preset})
-if(DEFINED build_postfix)
-    set(build_name ${build_name}-${build_postfix})
-endif()
-set(CTEST_BUILD_NAME "${build_name}")
-#+end_example
+The PR number is available in GitHub Actions as
+=${{ github.event.pull_request.number }}= on the =pull_request= trigger.
+Because =canary-linux.yml= is a reusable workflow called from =pr.yml=,
+the number must flow in as a =workflow_call= input.
 
-The =build_postfix= parameter is already parsed from =CTEST_SCRIPT_ARG=
-(comma-separated key=value pairs). It is not currently passed by any
-workflow, but the wiring exists. The canary workflow invocation in
-=canary-linux.yml= is:
-
-#+begin_example
-export cmake_args="build_group=Canary,preset=${preset},code_coverage=1"
-ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
-#+end_example
-
-Adding =,build_postfix=pr${pr_number}= to =cmake_args= is the entire change.
-
-The PR number is available as =${{ github.event.pull_request.number }}=
-when the workflow is triggered via =pull_request= event (which it is, via
-=pr.yml= calling =canary-linux.yml= as a reusable workflow). The input
-must be threaded through =pr.yml= → =canary-linux.yml= as a workflow input.
+The existing =ORES_BUILD_*= env vars in =canary-linux.yml= establish the
+pattern: =ORES_GITHUB_PR_URL= follows it exactly.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
@@ -8,7 +8,7 @@
 #+filetags: :cdash:ci:canary:github_actions:improve_cdash_visibility:sprint_20:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1196
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -107,7 +107,7 @@ pattern: =ORES_GITHUB_PR_URL= follows it exactly.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1196][#1196]] | [ci] Improve CDash build visibility |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
@@ -38,9 +38,10 @@ build-engineers can see at a glance whether the documentation built.
 
 - =build-site.yml= submits a CDash entry under the =Site= group after
   each successful Emacs build.
-- CDash dashboard shows two categories: =Canary= (already present) and =Site= (new).
-- =Experimental= remains in =CTest.cmake= as a valid value but is not
-  invoked by any workflow.
+- CDash dashboard shows three categories: =Canary= (CI PR builds),
+  =Site= (doc builds, new), and =Experimental= (local developer builds).
+- No CI workflow invokes =Experimental= — it is reserved for developers
+  running =ctest= locally against their own tree.
 
 * Plan
 
@@ -94,10 +95,12 @@ GitHub Pages, but submit nothing to CDash. The workflow does not invoke
 
 *Existing CDash categories*: =CTest.cmake= accepts =Nightly=, =Continuous=,
 =Canary=, =Experimental= (lines 148–157). =Canary= is already in active use
-by =canary-linux.yml=. =Experimental= is a valid reserved value in
-=CTest.cmake= but is never invoked by any workflow; there is no requirement
-to remove it — it just needs to stay unused so it does not appear in CDash
-as a spurious category.
+by =canary-linux.yml=. =Experimental= is the designated group for local
+developer builds — developers run =ctest -D Experimental= (or pass
+=build_group=Experimental= to =CTest.cmake=) when submitting results from
+their own workstation. No CI workflow should use =Experimental=; it
+appears in CDash only from developer machines, which is intentional and
+expected.
 
 *CTest.site.cmake approach*: site builds do not use CMake presets or the
 configure/build/test pipeline. A lightweight script calling

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
@@ -2,7 +2,7 @@
 :ID: FA80ED06-408E-4F48-9EC2-D9931164EB06
 :END:
 #+title: Task: Add CDash Site category and clarify build group naming
-#+description: Create a CTest script for site builds submitted under a new Site CDash category; rename Experimental references to Canary throughout.
+#+description: Create a CTest script for site builds submitted under a new Site CDash category; Canary already exists and Experimental is retained but never invoked by workflows.
 #+type: task
 #+level: s1
 #+filetags: :cdash:ci:site:build_groups:improve_cdash_visibility:sprint_20:v0:
@@ -19,10 +19,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Two outcomes: (1) site build results (Emacs/org-publish, Doxygen) appear
-as a distinct =Site= category in CDash so build-engineers can see whether
-the docs built; (2) the word =Experimental= is gone from developer-facing
-CI — all local/ad-hoc CTest runs use =Canary= as the default group.
+Site build results (Emacs/org-publish, Doxygen) appear as a distinct
+=Site= category in CDash alongside the existing =Canary= category, so
+build-engineers can see at a glance whether the documentation built.
 
 * Status
 
@@ -32,27 +31,32 @@ CI — all local/ad-hoc CTest runs use =Canary= as the default group.
 | Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
 | Now          | Analysis complete; design decided.     |
 | Waiting on   | Nothing.                               |
-| Next         | Write CTest.site.cmake; update build-site.yml; audit Experimental. |
+| Next         | Write CTest.site.cmake; update build-site.yml. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
 
-- =build-site.yml= submits a CDash entry under the =Site= group after each run.
-- =CTestConfig.cmake= lists =Site= as a recognised group (if needed by CDash).
-- Grepping the repo for =Experimental= in CI/CTest context returns zero hits.
+- =build-site.yml= submits a CDash entry under the =Site= group after
+  each successful Emacs build.
+- CDash dashboard shows two categories: =Canary= (already present) and =Site= (new).
+- =Experimental= remains in =CTest.cmake= as a valid value but is not
+  invoked by any workflow.
 
 * Plan
-
-** Part A — Site CTest script
 
 1. Create =CTest.site.cmake= (new file, parallel to =CTest.cmake=):
 
    #+begin_src cmake
-   set(CTEST_PROJECT_NAME "OreStudio")
+   include("${CMAKE_CURRENT_LIST_DIR}/CTestConfig.cmake")
+
    set(CTEST_BUILD_NAME "site-linux")
    set(CTEST_SITE "github")
    set(CTEST_SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-   set(CTEST_BINARY_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/build")
+   set(CTEST_BINARY_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/build/site")
+
+   if(DEFINED ENV{ORES_BUILD_PROVIDER})
+       set(CTEST_SITE "$ENV{ORES_BUILD_PROVIDER}")
+   endif()
 
    ctest_start("Site")
 
@@ -63,55 +67,47 @@ CI — all local/ad-hoc CTest runs use =Canary= as the default group.
    ctest_submit()
    #+end_src
 
-   This is intentionally minimal — no configure or test phases. CDash
-   records the build output (stdout/stderr) and any build warnings/errors.
+   Including =CTestConfig.cmake= picks up the CDash server URL
+   automatically. No configure or test phases — only the build output
+   (stdout/stderr from Emacs) is recorded.
 
-2. In =.github/workflows/build-site.yml=, add a CTest submit step after
-   the Emacs build step:
+2. In =.github/workflows/build-site.yml=, add a CTest step immediately
+   after the existing Emacs build step (run whether or not Emacs succeeds
+   so failures are visible in CDash):
 
    #+begin_src yaml
    - name: Submit site build to CDash
+     if: always()
      run: |
        export ORES_BUILD_PROVIDER="github"
+       mkdir -p build/site
        ctest -VV --script "CTest.site.cmake"
    #+end_src
-
-** Part B — Remove Experimental references
-
-3. Audit the repo for =Experimental= in CI/CTest context:
-   #+begin_src sh
-   grep -rn "Experimental" .github/ CTest*.cmake CMakeLists.txt
-   #+end_src
-
-   Replace any occurrence with =Canary= in developer-facing documentation
-   and comments. The =Experimental= group name in =CTest.cmake= can remain
-   as a valid (but reserved) value — it should simply not appear in
-   workflow files or developer docs.
 
 * Notes
 
 ** Analysis (2026-06-08)
 
-*Site builds (=build-site.yml=)*: currently run Emacs + Doxygen and deploy
-to GitHub Pages, but submit nothing to CDash. The =build-site.yml= does
-not invoke =ctest= at all. No existing =CTest.site.cmake= exists.
+*Site builds (=build-site.yml=)*: run Emacs + Doxygen and deploy to
+GitHub Pages, but submit nothing to CDash. The workflow does not invoke
+=ctest= at all. No =CTest.site.cmake= exists yet.
 
-*Build groups*: =CTest.cmake= accepts =Nightly=, =Continuous=, =Canary=,
-=Experimental= as valid =build_group= values (lines 148–157). The canary
-workflow already passes =build_group=Canary=. The =Experimental= group is
-declared as valid but never used by any workflow — it is the CTest default
-when a developer runs =ctest -D Experimental= locally. It is confusing
-because new contributors see "Experimental" in CDash without understanding
-what it means.
-
-*Two CDash categories desired*: =Canary= (all PR/CI validation builds,
-already present) and =Site= (new, for documentation builds).
+*Existing CDash categories*: =CTest.cmake= accepts =Nightly=, =Continuous=,
+=Canary=, =Experimental= (lines 148–157). =Canary= is already in active use
+by =canary-linux.yml=. =Experimental= is a valid reserved value in
+=CTest.cmake= but is never invoked by any workflow; there is no requirement
+to remove it — it just needs to stay unused so it does not appear in CDash
+as a spurious category.
 
 *CTest.site.cmake approach*: site builds do not use CMake presets or the
-normal configure/build/test pipeline. A lightweight script that calls
-=ctest_start("Site")=, =ctest_build()= (with a custom build command), and
-=ctest_submit()= is sufficient. CDash will record build success/failure and
-any output captured from the Emacs invocation.
+configure/build/test pipeline. A lightweight script calling
+=ctest_start("Site")=, =ctest_build()= (custom command), and =ctest_submit()=
+is sufficient and keeps the site script self-contained. Including
+=CTestConfig.cmake= avoids duplicating the CDash server URL.
+
+*Binary directory*: =ctest_start()= requires a writable binary directory.
+=build/site= (created by =mkdir -p= in the workflow step) works without
+conflicting with any CMake preset's binary directory.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: FA80ED06-408E-4F48-9EC2-D9931164EB06
+:END:
+#+title: Task: Add CDash Site category and clarify build group naming
+#+description: Create a CTest script for site builds submitted under a new Site CDash category; rename Experimental references to Canary throughout.
+#+type: task
+#+level: s1
+#+filetags: :cdash:ci:site:build_groups:improve_cdash_visibility:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two outcomes: (1) site build results (Emacs/org-publish, Doxygen) appear
+as a distinct =Site= category in CDash so build-engineers can see whether
+the docs built; (2) the word =Experimental= is gone from developer-facing
+CI — all local/ad-hoc CTest runs use =Canary= as the default group.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
+| Now          | Analysis complete; design decided.     |
+| Waiting on   | Nothing.                               |
+| Next         | Write CTest.site.cmake; update build-site.yml; audit Experimental. |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- =build-site.yml= submits a CDash entry under the =Site= group after each run.
+- =CTestConfig.cmake= lists =Site= as a recognised group (if needed by CDash).
+- Grepping the repo for =Experimental= in CI/CTest context returns zero hits.
+
+* Plan
+
+** Part A — Site CTest script
+
+1. Create =CTest.site.cmake= (new file, parallel to =CTest.cmake=):
+
+   #+begin_src cmake
+   set(CTEST_PROJECT_NAME "OreStudio")
+   set(CTEST_BUILD_NAME "site-linux")
+   set(CTEST_SITE "github")
+   set(CTEST_SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+   set(CTEST_BINARY_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/build")
+
+   ctest_start("Site")
+
+   set(CTEST_BUILD_COMMAND
+       "emacs --batch -l ./projects/ores.lisp/src/ores-build-site.el")
+   ctest_build()
+
+   ctest_submit()
+   #+end_src
+
+   This is intentionally minimal — no configure or test phases. CDash
+   records the build output (stdout/stderr) and any build warnings/errors.
+
+2. In =.github/workflows/build-site.yml=, add a CTest submit step after
+   the Emacs build step:
+
+   #+begin_src yaml
+   - name: Submit site build to CDash
+     run: |
+       export ORES_BUILD_PROVIDER="github"
+       ctest -VV --script "CTest.site.cmake"
+   #+end_src
+
+** Part B — Remove Experimental references
+
+3. Audit the repo for =Experimental= in CI/CTest context:
+   #+begin_src sh
+   grep -rn "Experimental" .github/ CTest*.cmake CMakeLists.txt
+   #+end_src
+
+   Replace any occurrence with =Canary= in developer-facing documentation
+   and comments. The =Experimental= group name in =CTest.cmake= can remain
+   as a valid (but reserved) value — it should simply not appear in
+   workflow files or developer docs.
+
+* Notes
+
+** Analysis (2026-06-08)
+
+*Site builds (=build-site.yml=)*: currently run Emacs + Doxygen and deploy
+to GitHub Pages, but submit nothing to CDash. The =build-site.yml= does
+not invoke =ctest= at all. No existing =CTest.site.cmake= exists.
+
+*Build groups*: =CTest.cmake= accepts =Nightly=, =Continuous=, =Canary=,
+=Experimental= as valid =build_group= values (lines 148–157). The canary
+workflow already passes =build_group=Canary=. The =Experimental= group is
+declared as valid but never used by any workflow — it is the CTest default
+when a developer runs =ctest -D Experimental= locally. It is confusing
+because new contributors see "Experimental" in CDash without understanding
+what it means.
+
+*Two CDash categories desired*: =Canary= (all PR/CI validation builds,
+already present) and =Site= (new, for documentation builds).
+
+*CTest.site.cmake approach*: site builds do not use CMake presets or the
+normal configure/build/test pipeline. A lightweight script that calls
+=ctest_start("Site")=, =ctest_build()= (with a custom build command), and
+=ctest_submit()= is sufficient. CDash will record build success/failure and
+any output captured from the Emacs invocation.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -155,6 +155,7 @@ LLM-driven workflow frictionless.
 | [[id:3F7752F8-B719-40B4-BA89-09223410999E][Retune CI for tens of merges an hour]] | STARTED | 2026-06-06 | | Path-classified PR jobs behind one pr-gate check; main matrices on staggered 2h/3h/4h schedules with a doc-only skip guard; Claude review replaces Gemini. |
 | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI]] | DONE | 2026-06-08 | 2026-06-08 | Unpin clang-format-18; apply drift to 181 files; restore bot-PR approach. PR #1187. |
 | [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] | BACKLOG | | | Eliminate duplicate-key failures caused by UUID v7 timestamp collision in email generation; one-line fix in account_generator.cpp. |
+| [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] | BACKLOG | | | PR tagging; Site CDash category; drop Experimental from developer-facing CI. |
 
 ** Site
 


### PR DESCRIPTION
## Summary

Story and task scaffolding for three CDash improvements: (1) link canary builds to their PR via CTEST_NOTES_FILES; (2) add a Site CDash category via CTest.site.cmake for documentation builds; (3) clarify that Experimental is reserved for local developer builds, never CI workflows.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve CDash build visibility](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.html) | 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41 |
| Task | [Link canary CDash builds to their PR via Notes](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.html) | 9045AA11-B666-411B-B0CE-C41C3EA6508E |

🤖 Generated with [Claude Code](https://claude.com/claude-code)