### PR TITLE
[agile] Start story: Qt help system from the user manual

### DIFF
--- a/doc/agile/product_backlog/next/implement_qt_help_system_integration.org
+++ b/doc/agile/product_backlog/next/implement_qt_help_system_integration.org
@@ -9,15 +9,24 @@
 #+created: 2026-05-28
 #+updated: 2026-05-28
 
-This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the product backlog. *Promoted* (2026-06-08) into the story [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] in Sprint 20.
 
 * What
 
-(One paragraph: the idea.)
+Integrate the org-mode user manual into Qt's native help system: a build
+step compiles the exported manual HTML into a =.qch= collection via
+=qhelpgenerator=, and the application loads it through =QHelpEngine= with a
+contents/index/search sidebar and a =QTextBrowser= content pane. Promoted
+to a story — see that story for the scoped tasks and the
+approach decision (native Qt help over a web view).
 
 * Why
 
-(Motivation, problem being solved, related context.)
+The user manual is the single source of truth for how to drive the app,
+but it lives only on the website. Surfacing it inside the application as
+searchable, offline help means users do not leave the app to find
+guidance, and the help tracks the manual automatically because it is built
+from the same source.
 
 * References
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: FA1DD7D5-DE78-4E97-A9EF-932AD2C46693
+:END:
+#+title: Story: Qt help system from the user manual
+#+description: Reuse the existing website/manual HTML export to drive the Qt desktop app's native help: a build step compiles the manual into a .qch collection via qhelpgenerator, and the application loads it through QHelpEngine with a contents sidebar and a QTextBrowser, opened from the Help menu.
+#+type: story
+#+level: s2
+#+filetags: :qt:help:manual:documentation:build:sprint_20:v0:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Give the Qt desktop application a built-in help system whose content /is/
+the existing user manual — no second source of truth. A build step turns
+the manual's exported HTML into a Qt help collection (=.qch=), and the
+application ships and opens it from the Help menu with a contents tree, a
+keyword index and full-text search, so users get offline, searchable help
+that tracks the manual automatically.
+
+* Status
+
+| Field         | Value                                                        |
+|---------------+--------------------------------------------------------------|
+| State         | STARTED                                                      |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
+| Now           | Scaffolding story and tasks.                                 |
+| Waiting on    | Nothing.                                                     |
+| Next          | Pick up the help-HTML export task.                           |
+| Last touched  | 2026-06-08                                                   |
+
+* Acceptance
+
+- A build target produces =user_manual.qch= (+ collection =.qhc=) from the
+  manual, reusing the org→HTML export rather than a second content source.
+- The exported help HTML is self-contained: relative asset paths, bundled
+  CSS/images, and a plain stylesheet that renders cleanly in QTextBrowser.
+- The Qt app links =Qt6::Help= and has a HelpViewer: contents tree +
+  index + full-text search in a sidebar, content in a QTextBrowser.
+- Help → User Manual opens the viewer (MDI subwindow, like About); the
+  =.qch= is located/packaged with the app and found at runtime.
+- The help system itself is documented in the manual.
+
+* Tasks
+
+| Task                                                                                          | State   | Start      | End | Description                                                          |
+|-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
+| [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | STARTED | 2026-06-08 |     | Story, tasks, sprint wiring, scaffold PR.                           |
+| [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | BACKLOG |            |     | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
+| [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | BACKLOG |            |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
+| [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
+| [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |
+
+* Decisions
+
+- /Native Qt Help over a web view/ :: Chosen the capture's =.qch= +
+  =QHelpEngine= approach over embedding =QWebEngineView=. It adds only the
+  light =Qt6::Help= module (no Chromium), works fully offline, and gives a
+  contents tree, keyword index and full-text search for free. The
+  trade-off — =QTextBrowser= renders only a subset of HTML/CSS — is
+  absorbed by the help-specific export (task 1), which produces a plain,
+  self-contained stylesheet rather than the web theme. External-browser
+  (=QDesktopServices=) was rejected as not in-app; web-engine fidelity was
+  not worth the dependency weight for reference documentation.
+- /Single source of truth/ :: Help content is the manual; the export is a
+  transform, never a copy. Re-running the build refreshes help.
+
+* Out of scope
+
+- Context-sensitive (F1 / "What's This?") help mapping individual windows
+  to manual sections — a natural follow-up once the viewer exists.
+- Authoring new manual content — this story plumbs the existing manual
+  into the app; chapters are written by the manual stories.
+- Online/remote help hosting — the .qch ships with the app, offline.

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -48,7 +48,7 @@ that tracks the manual automatically.
 
 | Task                                                                                          | State   | Start      | End | Description                                                          |
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
-| [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | STARTED | 2026-06-08 |     | Story, tasks, sprint wiring, scaffold PR.                           |
+| [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
 | [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | BACKLOG |            |     | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
 | [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | BACKLOG |            |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
 | [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: B0DAC977-C71E-4795-8CC7-87860F5F8899
+:END:
+#+title: Task: Produce a self-contained manual HTML export suitable for Qt help
+#+description: Initial task for: Qt help system from the user manual
+#+type: task
+#+level: s1
+#+filetags: :qt_help_system:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce a self-contained HTML export of the user manual suitable for a Qt
+help collection: relative asset paths (the site export uses absolute
+=/OreStudio/= URLs that break inside a .qch), bundled CSS and images, and
+a plain stylesheet that renders cleanly in QTextBrowser (no dark web
+theme, web fonts, highlight.js or font-awesome).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- A build step exports the manual chapters to HTML with relative links and
+  the assets they reference copied alongside.
+- A help stylesheet renders acceptably in QTextBrowser (verified by eye in
+  a scratch QTextBrowser load).
+- Output lands in a known directory the .qch generation task consumes.
+- Reuses the existing org→HTML machinery (ores-build-site/manual) rather
+  than a parallel exporter where practical.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 8D8F0CFA-0274-4B33-BF19-4D66E3E6E862
+:END:
+#+title: Task: Generate the .qch help collection via qhelpgenerator
+#+description: Build step that writes a .qhp manifest from the manual chapter ToC and compiles the self-contained HTML into a .qch (and .qhc) collection via qhelpgenerator, wired into a compass/CMake target alongside the manual build.
+#+type: task
+#+level: s1
+#+filetags: :qt_help_system:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_menu_wiring.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_menu_wiring.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: A7BBEC1F-476E-463C-A4C3-82A311AD7C51
+:END:
+#+title: Task: Wire the help viewer into the Help menu
+#+description: Add a User Manual action to the Help menu that opens the HelpViewer in an MDI subwindow, locate/package the .qch with the app, and document the help system in the manual.
+#+type: task
+#+level: s1
+#+filetags: :qt_help_system:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: BCC57354-745C-44FB-9D87-FB1671E400D0
+:END:
+#+title: Task: Add a HelpViewer widget backed by QHelpEngine
+#+description: Link Qt6::Help and add a HelpViewer (QHelpEngine + contents/index sidebar in a QSplitter with a QTextBrowser), loading the bundled .qch.
+#+type: task
+#+level: s1
+#+filetags: :qt_help_system:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 0D5E5423-4B5B-464A-B60D-0A4A7151B1FB
+:END:
+#+title: Task: Scaffold story: Qt help system from the user manual
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :qt_help_system:sprint_20:v0:
+#+owner: marco
+#+branch: feature/qt-help-system
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Promote the long-standing help-system capture into a story with tasks,
+wire it into the sprint, and open the scaffold PR.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
+| Now          | Docs filled; wiring sprint and opening PR. |
+| Waiting on   | Nothing.                               |
+| Next         | Commit, open PR, close before merging.  |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- Story has goal, acceptance, five-task table, decisions and out-of-scope.
+- The next/ capture is retired, pointing at this story.
+- Sprint 20 Stories table has a row; scaffold PR open; this task DONE
+  before it merges.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
@@ -26,11 +26,11 @@ wire it into the sprint, and open the scaffold PR.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Docs filled; wiring sprint and opening PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Commit, open PR, close before merging.  |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -61,3 +61,5 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Story, four implementation tasks, new Qt application epic, capture retired; scaffold PR #1197.

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.org
@@ -8,7 +8,7 @@
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
 #+branch: feature/qt-help-system
-#+pr:
+#+pr: 1197
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -52,7 +52,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1197][#1197]] | [agile] Start story: Qt help system from the user manual |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -79,6 +79,16 @@ script library. Design first, implementation as a follow-up story.
 | [[id:31B8013E-10FF-4FCC-9D1D-D5BAF8D16437][Implement ores-shell provisioning commands]] | DONE | 2026-06-06 | 2026-06-06 | Flag parsing + stop-on-error load; plumbing (bundles, workflow, lei, synthetic, parties, account-parties, reports); provision system/tenant/party porcelain. Scoped by the design story. |
 | [[id:F7AC35C9-ADAE-4330-9640-AD2C7A044A55][Provisioning script library]] | STARTED | 2026-06-06 | | Org-mode script library in ores.shell/scripts/ with emacs tangle CMake target; end-to-end provision_all script; manual chapter. Depends on the commands story. |
 
+*** Epic: Qt application
+
+User-facing improvements to the Qt desktop application beyond entity
+commissioning.
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] | STARTED | 2026-06-08 | | Build the manual into a .qch collection and open it in-app via QHelpEngine; native, offline, searchable help from the existing manual. |
+
 ** Tooling
 
 *** Epic: Compass


### PR DESCRIPTION
## Summary

Promote the help-system capture (next bucket, 2026-05-28) into a Sprint 20 story under a new Qt application epic. The Qt desktop app gains native, offline, searchable help built from the existing user manual: a build step compiles the manual HTML into a .qch collection via qhelpgenerator, and the app opens it through QHelpEngine (contents tree + index + full-text search + QTextBrowser) from the Help menu. Approach decision recorded: native Qt help over QWebEngineView — light dependency, offline, free navigation/search.

## Changes

- Add story with goal, acceptance, five-task table, decisions and out-of-scope.
- Add tasks: help-HTML export, .qch generation, HelpViewer widget, Help-menu wiring.
- Add an Epic: Qt application under Product and wire the story in.
- Retire the next/ capture, pointing it at the story.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Qt help system from the user manual](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/story.html) | FA1DD7D5-DE78-4E97-A9EF-932AD2C46693 |
| Task | [Scaffold story: Qt help system from the user manual](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/task_scaffold_qt_help_system.html) | 0D5E5423-4B5B-464A-B60D-0A4A7151B1FB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)