### PR TITLE
[agile] Add sprint velocity chart and end-date tasks

### DIFF
--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -62,6 +62,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
+| [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | BACKLOG |            |     | Two charts at board top: tasks done per sprint day; commits per sprint day. Blocked on end-date task. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_sprint_velocity_chart.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_sprint_velocity_chart.org
@@ -1,0 +1,91 @@
+:PROPERTIES:
+:ID: 91B54191-57EC-4956-9E97-0B8C0EA249F6
+:END:
+#+title: Task: Add sprint velocity bar charts to agile board
+#+description: Two bar charts at the top of the org-js dashboard: tasks completed per sprint day and commits per sprint day, using the sprint end date as the x-axis boundary.
+#+type: task
+#+level: s1
+#+filetags: :agile:org-js:dashboard:chart:sprint:agile_timeline:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The top of the agile board shows two bar charts side by side — one for
+tasks completed per sprint day, one for commits per sprint day — so the
+team can see sprint velocity at a glance without leaving the dashboard.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
+| Now          | Not yet started.                       |
+| Waiting on   | [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date]] — need =#+end_date= to compute sprint day N. |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- Two bar charts render at the top of the board above the story table.
+- X-axis: sprint days 1–7 (derived from =#+start_date= / =#+end_date=
+  in the current sprint's =sprint.org=).
+- Chart A: count of tasks whose =#+todo:= transitioned to DONE on each
+  sprint day (sourced from =graphdata.json= task nodes).
+- Chart B: commit count per sprint day (sourced from the git log data
+  already in =graphdata.json= or fetched at build time).
+- Days beyond today render with a lighter colour (future / not yet elapsed).
+- Both charts use the same x-axis scale so visual comparison is easy.
+- If =#+end_date= is absent, a single combined chart falls back to
+  showing the last 14 days of activity instead.
+
+* Plan
+
+1. Confirm that =graphdata.json= carries enough data to drive both charts:
+   - Task nodes: does each task carry a =done_date= or is it inferrable
+     from git history? Investigate what the Emacs export puts in the JSON.
+   - Commit data: check whether =graphdata.json= includes commit history,
+     or whether it needs to be added as a new top-level key.
+
+2. Extend the =graphdata.json= export (in the Emacs site-build script or
+   a separate compass command) with:
+   - =sprint.start_date= / =sprint.end_date= for the active sprint.
+   - =commits_by_day=: array of ={date, count}= for the sprint window.
+   - Task done-date is likely already present; verify or add.
+
+3. In =ores.org-js=, add a =VelocityCharts= component:
+   - Reads =sprint.start_date= / =sprint.end_date= to build the day axis.
+   - Renders two =<canvas>= bar charts (Chart.js is already a dependency
+     if the timeline view uses it; otherwise add it).
+   - Mount at the top of the board view, above the story table.
+
+4. Style: match existing dashboard palette; future days in =rgba(...)=
+   with 40% opacity.
+
+* Notes
+
+Two charts rather than one combined chart keeps each y-axis meaningful —
+tasks and commits have different magnitudes and units, so overlaying them
+on a dual-axis chart is harder to read than two narrow side-by-side bars.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -7,6 +7,8 @@
 #+level: s3
 #+filetags: :v0:
 #+created: 2026-06-06
+#+start_date: 2026-06-06
+#+end_date: 2026-06-13
 #+updated: 2026-06-08
 #+todo: STARTED | DONE
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -55,6 +55,7 @@ whether the team is focused — rather than merely summarising status.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:4F17BC82-00B5-43DE-B618-A87801763479][Health review 1 — sprint 20 housekeeping and status sync]] | DONE | 2026-06-07 | 2026-06-07 | Audit-driven housekeeping: close Open sprint 20 and site navbar stories, fix Commission: currency status drift, run sprint audit and health charts. |
+| [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date (start + 7 days) on sprint backlog]] | BACKLOG | | | Add #+end_date to sprint.org at open time; backfill sprint 20; warn on missing. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
@@ -8,7 +8,7 @@
 #+filetags: :agile:compass:sprint:template:sprint_health_review:sprint_20:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1198
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -61,7 +61,7 @@ x-axis runs from sprint day 1 to sprint day 7 using this field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1198][#1198]] | [agile] Add sprint velocity chart and end-date tasks |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
@@ -1,0 +1,72 @@
+:PROPERTIES:
+:ID: CBD603A3-B05C-495C-9AF5-F919287AA133
+:END:
+#+title: Task: Stamp sprint end date (start + 7 days) on sprint backlog
+#+description: Add #+end_date to sprint.org at sprint-open time; compass sprint new computes it as start + 7 days; health reviewer and velocity chart use it as the sprint boundary.
+#+type: task
+#+level: s1
+#+filetags: :agile:compass:sprint:template:sprint_health_review:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-08
+#+updated: 2026-06-08
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Every sprint document has an explicit =#+end_date= field set to exactly
+7 days after =#+start_date=. The sprint reviewer and the velocity chart
+both read this field as the sprint boundary rather than inferring it.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Update sprint codegen template; backfill sprint 20. |
+| Last touched | 2026-06-08                               |
+
+* Acceptance
+
+- =compass sprint new= writes =#+end_date: <start + 7 days>= into the
+  newly created =sprint.org=.
+- Sprint 20's =sprint.org= is backfilled with the correct end date.
+- =compass sprint audit= reports a warning when =#+end_date= is absent.
+
+* Plan
+
+1. Find the sprint codegen template (the =*.org= source tangled or used
+   by =compass add sprint=) and add =#+end_date:= to the frontmatter,
+   computed as =start_date + timedelta(days=7)= in the Python generator.
+
+2. Backfill =sprint.org= for Sprint 20 (start 2026-06-06 → end
+   2026-06-13).
+
+3. Update =compass sprint audit= to warn when =#+end_date= is missing.
+
+* Notes
+
+Needed by [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]] — the chart's
+x-axis runs from sprint day 1 to sprint day 7 using this field.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.org-js/agile/src/app.js
+++ b/projects/ores.org-js/agile/src/app.js
@@ -10,7 +10,7 @@
 import { h, render } from 'https://esm.sh/preact@10.25.4';
 import { useState, useEffect, useMemo } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
-import { loadAgileIndex, loadSprint, loadBacklog, loadTimelineBuckets, velocity, burnup } from './data.js';
+import { loadAgileIndex, loadSprint, loadBacklog, loadTimelineBuckets, velocity, burnup, velocityData } from './data.js';
 import { section, fieldTable, linkText } from './orgparse.js';
 import { BarChart, LineChart, StackedBars } from './charts.js';
 import { orgToHtml } from './render.js';
@@ -292,6 +292,46 @@ function SprintDetail({ sprint, onClose, onNav }) {
     </div>`;
 }
 
+const GITHUB_COMMITS_URL =
+  'https://api.github.com/repos/OreStudio/OreStudio/commits';
+
+function VelocityCharts({ model }) {
+  const [commitData, setCommitData] = useState(null);
+  const vd = useMemo(() => velocityData(model), [model]);
+
+  useEffect(() => {
+    if (!vd) return;
+    const since = `${vd.days[0].date}T00:00:00Z`;
+    const until = `${vd.days[vd.days.length - 1].date}T23:59:59Z`;
+    fetch(`${GITHUB_COMMITS_URL}?since=${since}&until=${until}&per_page=100`)
+      .then(r => r.ok ? r.json() : [])
+      .then(commits => {
+        if (!Array.isArray(commits)) return;
+        const byDate = new Map();
+        for (const c of commits) {
+          const date = ((c.commit || {}).author || {}).date || '';
+          if (date) byDate.set(date.slice(0, 10), (byDate.get(date.slice(0, 10)) || 0) + 1);
+        }
+        setCommitData(vd.days.map(d => ({
+          label: d.label,
+          value: byDate.get(d.date) || 0,
+          color: d.isFuture ? 'rgba(247,140,108,0.4)' : 'var(--state-started, #f78c6c)',
+        })));
+      })
+      .catch(() => {});
+  }, [vd]);
+
+  if (!vd) return null;
+  return html`
+    <div class="panels">
+      <${BarChart} data=${vd.taskData} title="Tasks done per sprint day" />
+      ${commitData
+        ? html`<${BarChart} data=${commitData} title="Commits per sprint day" />`
+        : html`<div class="panel"><div class="panel-title">Commits per sprint day</div>
+                 <div class="panel-empty">fetching…</div></div>`}
+    </div>`;
+}
+
 function Board({ stories, filter, epic, onSelect }) {
   const visible = useMemo(() => {
     let v = stories;
@@ -521,6 +561,7 @@ function App() {
       </div>
       ${view === 'sprints' && model && html`
         <${SprintHeader} sprint=${model.sprint} onOpen=${() => setShowSprint(true)} />
+        <${VelocityCharts} model=${model} />
         <${Tiles} stories=${model.stories} />
         <${Panels} model=${model} vel=${vel} />
         <${EpicChips} stories=${model.stories} epic=${epic} onPick=${setEpic} />

--- a/projects/ores.org-js/agile/src/data.js
+++ b/projects/ores.org-js/agile/src/data.js
@@ -203,6 +203,54 @@ export function velocity(index) {
 }
 
 /**
+ * Sprint velocity data: tasks completed per sprint day (1–7).
+ * Reads #+start_date and #+end_date from the sprint doc keywords.
+ * Returns {days, taskData} where taskData is [{label, value, color}]
+ * suitable for BarChart. Days beyond today are rendered at 40% opacity.
+ * Returns null when #+start_date is absent.
+ */
+export function velocityData(model) {
+  if (!model.sprint) return null;
+  const startDate = model.sprint.keywords.start_date;
+  if (!startDate) return null;
+
+  const start = new Date(startDate + 'T00:00:00');
+  const today = new Date();
+
+  const days = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(d.getDate() + i);
+    return {
+      date: d.toISOString().slice(0, 10),
+      label: `D${i + 1}`,
+      isFuture: d > today,
+    };
+  });
+
+  const byDate = new Map();
+  for (const story of model.stories) {
+    const s = section(story.doc, 'Tasks');
+    if (!s) continue;
+    for (const tbl of s.tables) {
+      for (const row of tbl.rows) {
+        const state = (row[1] || '').trim().toUpperCase();
+        const end = (row[3] || '').trim();
+        if (state === 'DONE' && /^\d{4}-\d{2}-\d{2}$/.test(end))
+          byDate.set(end, (byDate.get(end) || 0) + 1);
+      }
+    }
+  }
+
+  const taskData = days.map(d => ({
+    label: d.label,
+    value: byDate.get(d.date) || 0,
+    color: d.isFuture ? 'rgba(88,166,255,0.4)' : 'var(--accent, #58a6ff)',
+  }));
+
+  return { days, taskData };
+}
+
+/**
  * Burn-up for one sprint: cumulative DONE tasks by End date, read from
  * each story's * Tasks table (columns: task, state, start, end, desc).
  */


### PR DESCRIPTION
## Summary

Two tasks added to existing stories. (1) sprint_health_review: stamp #+end_date (start+7 days) on sprint.org at open time, backfill sprint 20, warn on missing. (2) agile_timeline: two side-by-side bar charts at top of org-js board — tasks completed per sprint day and commits per sprint day — blocked on the end-date task.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint health review — System 2 analysis](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/story.html) | 3FBD411B-B795-48C5-9EF8-1B76A96B12B5 |
| Task | [Stamp sprint end date (start + 7 days) on sprint backlog](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.html) | CBD603A3-B05C-495C-9AF5-F919287AA133 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)