### PR TITLE
[qt] Help-friendly manual HTML export for Qt help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,12 @@ add_custom_target(deploy_manual
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+set(ORES_HELP_DIRECTORY "build/output/help")
+add_custom_target(deploy_help
+    COMMENT "Exporting self-contained manual HTML for Qt help to ${ORES_HELP_DIRECTORY}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 add_custom_target(tangle_clang_format
     COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -49,7 +49,7 @@ that tracks the manual automatically.
 | Task                                                                                          | State   | Start      | End | Description                                                          |
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
-| [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | STARTED | 2026-06-08 |     | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
+| [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | DONE | 2026-06-08 | 2026-06-08 | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
 | [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | BACKLOG |            |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
 | [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -49,7 +49,7 @@ that tracks the manual automatically.
 | Task                                                                                          | State   | Start      | End | Description                                                          |
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
-| [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | BACKLOG |            |     | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
+| [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | STARTED | 2026-06-08 |     | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
 | [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | BACKLOG |            |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
 | [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
@@ -8,7 +8,7 @@
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
 #+branch: feature/qt-help-export-html
-#+pr:
+#+pr: 1199
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -69,7 +69,7 @@ site export:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1199][#1199]] | [qt] Help-friendly manual HTML export for Qt help |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/qt-help-export-html
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -29,11 +29,11 @@ theme, web fonts, highlight.js or font-awesome).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Not yet started.                       |
+| Now          | Implemented and verified; opening the PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR, close task; .qch generation follows. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -48,9 +48,20 @@ theme, web fonts, highlight.js or font-awesome).
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+New =ores-build-help.el= exports the single-file =user_manual.org= (which
+#+includes every chapter) to one self-contained HTML, distinct from the
+site export:
+
+- Override the shared =proj:= link's HTML branch so images become relative
+  =images/BASENAME= (the site export uses absolute =/OreStudio/= URLs that
+  break inside a .qch) and collect each referenced image for copying.
+- Plain inline stylesheet only — QTextBrowser supports a subset of CSS
+  2.1, so no custom properties, flexbox, web fonts, highlight.js or
+  font-awesome; =org-html-htmlize-output-type nil= for plain code.
+- Resolve =id:= locations across the repo so cross-document links do not
+  abort the export (they point outside the manual; not live in help).
+- Output =build/output/help/user_manual.html= + =images/=; new CMake
+  target =deploy_help= mirrors =deploy_manual=.
 
 * Notes
 
@@ -67,3 +78,12 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+=ores-build-help.el= + the =deploy_help= CMake target produce
+=build/output/help/user_manual.html= (200 KB, single self-contained file)
+with all 90 referenced images copied to =images/= and linked relatively.
+Verified self-contained: zero external =<link>=/=<script>= resource tags
+(the only =<script>= is org's inert TOC fold helper), no absolute
+=/OreStudio/= asset URLs, no web-theme assets. QTextBrowser-by-eye check
+deferred to the HelpViewer task, which loads this HTML — the stylesheet is
+restricted to QTextBrowser-supported CSS by construction.

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.org
@@ -29,11 +29,11 @@ theme, web fonts, highlight.js or font-awesome).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Implemented and verified; opening the PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR, close task; .qch generation follows. |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance

--- a/projects/ores.lisp/src/ores-build-help.el
+++ b/projects/ores.lisp/src/ores-build-help.el
@@ -1,0 +1,160 @@
+;;; ores-build-help.el --- Export the user manual as Qt-help HTML. -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2026 Marco Craveiro
+;;
+;; Author: Marco Craveiro <marco.craveiro@gmail.com>
+;; Maintainer: Marco Craveiro <marco.craveiro@gmail.com>
+;; URL: https://github.com/OreStudio/OreStudio
+;;
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program. If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; Exports the single-file user manual (doc/manual/user_guide/user_manual.org,
+;; which #+includes every chapter) to ONE self-contained HTML file suitable
+;; for compilation into a Qt help collection (.qch) by qhelpgenerator.
+;;
+;; Unlike the site export, the output is help-friendly:
+;;   - assets are RELATIVE (images/NAME.png) and copied alongside the HTML,
+;;     not absolute /OreStudio/ URLs that break inside a .qch;
+;;   - a plain stylesheet renders in QTextBrowser, which supports only a
+;;     subset of HTML/CSS — no dark web theme, web fonts, highlight.js, or
+;;     font-awesome;
+;;   - no site preamble/nav.
+;;
+;; Output: build/output/help/user_manual.html + build/output/help/images/.
+;;
+;;; Code:
+(require 'org)
+(require 'org-id)
+(require 'ox-html)
+
+(setq debug-on-error nil)
+(setq debug-on-quit nil)
+
+(defvar ores/help-root
+  (if (or load-file-name buffer-file-name)
+      (expand-file-name "../../../"
+                        (file-name-directory (or load-file-name buffer-file-name)))
+    default-directory)
+  "Repository root, captured when this script is loaded.")
+
+(defvar ores/help-output-dir
+  (expand-file-name "build/output/help/" ores/help-root)
+  "Directory the help HTML and its assets are written to.")
+
+(defvar ores/help-manual
+  (expand-file-name "doc/manual/user_guide/user_manual.org" ores/help-root)
+  "The single-file manual to export.")
+
+;; Load the shared proj: link type, then override its HTML export below so
+;; images become relative and are collected for copying.
+(load-file (expand-file-name
+            "ores-link-types.el"
+            (file-name-directory (or load-file-name buffer-file-name))))
+
+(defvar ores/help-images nil
+  "Alist of (REPO-RELATIVE-PATH . BASENAME) for images to copy.")
+
+(defun ores/help--proj-export (path desc backend _info)
+  "Export a proj: link for the Qt-help HTML build.
+Images under the repo become relative images/BASENAME and are
+recorded for copying; everything else falls back to a GitHub URL."
+  (when (org-export-derived-backend-p backend 'html)
+    (if (ores/proj--image-p path)
+        (let ((base (file-name-nondirectory path)))
+          (cl-pushnew (cons path base) ores/help-images :test #'equal)
+          (format "<img src=\"images/%s\" alt=\"%s\"/>"
+                  base
+                  (or (and (stringp desc) (> (length desc) 0) desc) base)))
+      (let ((url (ores/proj--github-url path)))
+        (format "<a href=\"%s\">%s</a>" url (or desc url))))))
+
+(org-link-set-parameters "proj" :export #'ores/help--proj-export)
+
+;; Plain stylesheet: QTextBrowser supports a subset of CSS 2.1, so keep to
+;; basic selectors — no custom properties, flexbox, or box-shadow.
+(defvar ores/help-style "<style>
+body { font-family: sans-serif; color: #222222; line-height: 1.5;
+       margin: 1em 2em; max-width: 50em; }
+h1, h2, h3, h4, h5 { color: #1a3a5a; font-weight: bold; }
+h1 { font-size: 1.7em; }
+h2 { font-size: 1.4em; border-bottom: 1px solid #cccccc; }
+a { color: #1560b0; text-decoration: none; }
+table { border-collapse: collapse; margin: 1em 0; }
+th, td { border: 1px solid #aaaaaa; padding: 4px 9px; text-align: left; }
+th { background-color: #eef2f6; }
+pre { background-color: #f4f4f4; border: 1px solid #dddddd; padding: 8px;
+      white-space: pre-wrap; }
+code { background-color: #f4f4f4; }
+blockquote { border-left: 3px solid #cccccc; margin-left: 0;
+             padding-left: 1em; color: #555555; }
+img { max-width: 100%; }
+.figure { margin: 1em 0; }
+.figure p { margin: 0; }
+</style>")
+
+(defun ores/build-help ()
+  "Export the manual to self-contained Qt-help HTML."
+  ;; Resolve id: links across the whole repo so export does not abort on
+  ;; cross-document references (they point outside the manual; that is fine
+  ;; for help — they just will not be live).
+  (setq org-id-locations-file
+        (expand-file-name "./.org-id-locations-file" ores/help-root))
+  (org-id-update-id-locations
+   (directory-files-recursively ores/help-root "\\.org$"))
+
+  (make-directory (expand-file-name "images" ores/help-output-dir) t)
+
+  ;; Plain, deterministic HTML for QTextBrowser.
+  (let ((org-html-head ores/help-style)
+        (org-html-head-include-default-style nil)
+        (org-html-head-include-scripts nil)
+        (org-html-htmlize-output-type nil)   ; no syntax-highlight spans
+        (org-html-validation-link nil)
+        (org-html-preamble nil)
+        (org-html-postamble nil)
+        (org-export-with-sub-superscripts nil)
+        (org-export-use-babel nil)
+        (org-export-with-toc t)
+        (org-export-with-section-numbers t)
+        (default-directory (file-name-directory ores/help-manual))
+        (out (expand-file-name "user_manual.html" ores/help-output-dir)))
+    (setq ores/help-images nil)
+    (with-current-buffer (find-file-noselect ores/help-manual)
+      (org-export-to-file 'html out))
+    ;; Copy every referenced image next to the HTML.
+    (let ((copied 0) (missing 0))
+      (dolist (pair ores/help-images)
+        (let ((src (expand-file-name (car pair) ores/help-root))
+              (dst (expand-file-name (concat "images/" (cdr pair))
+                                     ores/help-output-dir)))
+          (if (file-readable-p src)
+              (progn (copy-file src dst t) (setq copied (1+ copied)))
+            (message "Warning: help image missing: %s" src)
+            (setq missing (1+ missing)))))
+      (message "ores-build-help: wrote %s (%d images copied, %d missing)"
+               out copied missing))))
+
+(condition-case err
+    (progn
+      (ores/build-help)
+      (message "Help build succeeded.")
+      (kill-emacs 0))
+  (error
+   (message "Help build failed: %s" (error-message-string err))
+   (kill-emacs 1)))
+
+(provide 'ores-build-help)
+;;; ores-build-help.el ends here


### PR DESCRIPTION
## Summary

First implementation task of the Qt help system story. Adds ores-build-help.el and a deploy_help CMake target that export the single-file user manual to one self-contained HTML suitable for compilation into a .qch by qhelpgenerator. Unlike the site export it is help-friendly: relative image paths (the site uses absolute /OreStudio/ URLs that break inside a .qch) with all 90 referenced images copied alongside, and a plain stylesheet restricted to the CSS subset QTextBrowser renders. Verified self-contained: no external resource tags, no absolute asset URLs.

## Changes

- Add projects/ores.lisp/src/ores-build-help.el: override proj: to relative images, collect+copy them, plain QTextBrowser stylesheet, repo-wide id resolution so cross-doc links do not abort export.
- Add deploy_help CMake target mirroring deploy_manual.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Qt help system from the user manual](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/story.html) | FA1DD7D5-DE78-4E97-A9EF-932AD2C46693 |
| Task | [Produce a self-contained manual HTML export suitable for Qt help](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_export_html.html) | B0DAC977-C71E-4795-8CC7-87860F5F8899 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)