### PR TITLE
[qt] Generate the .qch help collection via qhelpgenerator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,15 @@ add_custom_target(deploy_help
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+# Compile the help HTML into a Qt help collection (.qch) via
+# qhelpgenerator. Depends on deploy_help so building this target runs the
+# HTML export first.
+add_custom_target(deploy_help_qch
+    COMMENT "Compiling ${ORES_HELP_DIRECTORY}/user_manual.qch via qhelpgenerator" VERBATIM
+    COMMAND python3 build/scripts/generate_help_qch.py
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_dependencies(deploy_help_qch deploy_help)
+
 add_custom_target(tangle_clang_format
     COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1

--- a/build/scripts/generate_help_qch.py
+++ b/build/scripts/generate_help_qch.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Compile the help HTML export into a Qt help collection (.qch).
+
+Reads the self-contained manual produced by ores-build-help.el
+(build/output/help/user_manual.html + images/), derives a Qt Help
+Project (.qhp) — contents tree and keyword index from the HTML's
+table of contents — bundles every file, and runs qhelpgenerator to
+produce user_manual.qch.
+
+The .qch is the input the in-app QHelpEngine viewer loads. Run after
+deploy_help; wired as the deploy_help_qch CMake target.
+
+Usage: python3 build/scripts/generate_help_qch.py
+(paths are derived from this script's location).
+"""
+import html
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+HELP_DIR = REPO_ROOT / "build" / "output" / "help"
+HTML_FILE = HELP_DIR / "user_manual.html"
+QHP_FILE = HELP_DIR / "user_manual.qhp"
+QCH_FILE = HELP_DIR / "user_manual.qch"
+
+NAMESPACE = "org.orestudio.usermanual"
+VIRTUAL_FOLDER = "manual"
+
+# A table-of-contents entry: section number → depth, anchor, title.
+TOC_RE = re.compile(
+    r'<a href="#(?P<anchor>[^"]+)">(?P<num>[0-9.]+)\.\s+(?P<title>[^<]*)</a>')
+
+
+def find_qhelpgenerator():
+    """Locate qhelpgenerator across PATH and the usual Qt install dirs."""
+    for name in ("qhelpgenerator", "qhelpgenerator-qt6"):
+        found = shutil.which(name)
+        if found:
+            return found
+    for base in ("/usr/lib/qt6/libexec", "/usr/lib/qt6/bin",
+                 "/usr/lib/x86_64-linux-gnu/qt6/libexec"):
+        cand = Path(base) / "qhelpgenerator"
+        if cand.exists():
+            return str(cand)
+    return None
+
+
+def parse_toc(text):
+    """Return [(depth, anchor, title)] from the manual's contents list.
+
+    Depth comes from the section number (1 → 0, 1.1 → 1, …) so the
+    nesting is reconstructed without parsing the HTML list structure.
+    """
+    toc = []
+    # Restrict to the TOC block so body links are not mistaken for entries.
+    m = re.search(r'id="text-table-of-contents".*?</ul>\s*</div>',
+                  text, re.S)
+    block = m.group(0) if m else text
+    for entry in TOC_RE.finditer(block):
+        depth = entry.group("num").count(".")
+        title = html.unescape(entry.group("title").strip())
+        toc.append((depth, entry.group("anchor"), title))
+    return toc
+
+
+def build_toc_xml(toc):
+    """Nest the flat TOC into Qt Help <section> elements."""
+    lines = []
+    stack = []  # open depths
+    indent = "        "
+    for depth, anchor, title in toc:
+        while stack and stack[-1] >= depth:
+            lines.append(indent + "  " * len(stack) + "</section>")
+            stack.pop()
+        ref = f"user_manual.html#{anchor}"
+        attrs = f'title="{html.escape(title)}" ref="{html.escape(ref)}"'
+        # Open (children may follow); close lazily when depth recedes.
+        lines.append(indent + "  " * (len(stack) + 1) + f"<section {attrs}>")
+        stack.append(depth)
+    while stack:
+        lines.append(indent + "  " * len(stack) + "</section>")
+        stack.pop()
+    return "\n".join(lines)
+
+
+def build_keywords_xml(toc):
+    """Index every section title as a keyword for the help index."""
+    seen = set()
+    out = []
+    for _depth, anchor, title in toc:
+        if title in seen:
+            continue
+        seen.add(title)
+        ref = f"user_manual.html#{anchor}"
+        out.append(
+            f'        <keyword name="{html.escape(title)}" '
+            f'ref="{html.escape(ref)}"/>')
+    return "\n".join(out)
+
+
+def build_files_xml():
+    """List the HTML and every bundled image."""
+    files = ["user_manual.html"]
+    images = HELP_DIR / "images"
+    if images.is_dir():
+        files += sorted(f"images/{p.name}" for p in images.iterdir())
+    return "\n".join(f"        <file>{html.escape(f)}</file>" for f in files)
+
+
+def main():
+    if not HTML_FILE.exists():
+        sys.exit(f"error: {HTML_FILE} not found — run deploy_help first.")
+    gen = find_qhelpgenerator()
+    if not gen:
+        sys.exit("error: qhelpgenerator not found (install qt6-tools-dev-tools "
+                 "or add it to PATH).")
+
+    toc = parse_toc(HTML_FILE.read_text(encoding="utf-8"))
+    if not toc:
+        sys.exit("error: no table-of-contents entries parsed from the HTML.")
+
+    qhp = f"""<?xml version="1.0" encoding="UTF-8"?>
+<QtHelpProject version="1.0">
+    <namespace>{NAMESPACE}</namespace>
+    <virtualFolder>{VIRTUAL_FOLDER}</virtualFolder>
+    <filterSection>
+        <toc>
+{build_toc_xml(toc)}
+        </toc>
+        <keywords>
+{build_keywords_xml(toc)}
+        </keywords>
+        <files>
+{build_files_xml()}
+        </files>
+    </filterSection>
+</QtHelpProject>
+"""
+    QHP_FILE.write_text(qhp, encoding="utf-8")
+    print(f"wrote {QHP_FILE.relative_to(REPO_ROOT)} "
+          f"({len(toc)} sections)")
+
+    result = subprocess.run(
+        [gen, str(QHP_FILE), "-o", str(QCH_FILE)],
+        cwd=HELP_DIR, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        sys.exit(f"error: qhelpgenerator failed (exit {result.returncode}).")
+    print(result.stdout.strip())
+    print(f"wrote {QCH_FILE.relative_to(REPO_ROOT)} "
+          f"({QCH_FILE.stat().st_size // 1024} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/build/scripts/generate_help_qch.py
+++ b/build/scripts/generate_help_qch.py
@@ -41,8 +41,14 @@ def find_qhelpgenerator():
         found = shutil.which(name)
         if found:
             return found
+    # PATH (above) covers Homebrew/macOS when `brew install qt` is used and
+    # most Linux distros. These fallbacks cover Debian/Ubuntu (x86_64 and
+    # aarch64) and macOS Homebrew when qt is keg-only and not on PATH.
     for base in ("/usr/lib/qt6/libexec", "/usr/lib/qt6/bin",
-                 "/usr/lib/x86_64-linux-gnu/qt6/libexec"):
+                 "/usr/lib/x86_64-linux-gnu/qt6/libexec",
+                 "/usr/lib/aarch64-linux-gnu/qt6/libexec",
+                 "/opt/homebrew/opt/qt/libexec",
+                 "/usr/local/opt/qt/libexec"):
         cand = Path(base) / "qhelpgenerator"
         if cand.exists():
             return str(cand)
@@ -57,9 +63,14 @@ def parse_toc(text):
     """
     toc = []
     # Restrict to the TOC block so body links are not mistaken for entries.
-    m = re.search(r'id="text-table-of-contents".*?</ul>\s*</div>',
-                  text, re.S)
-    block = m.group(0) if m else text
+    # The org TOC div contains only nested <ul>s (no inner <div>), so it
+    # ends at the first </div> after its id attribute.
+    start = text.find('id="text-table-of-contents"')
+    if start != -1:
+        end = text.find("</div>", start)
+        block = text[start:end] if end != -1 else text[start:]
+    else:
+        block = text
     for entry in TOC_RE.finditer(block):
         depth = entry.group("num").count(".")
         title = html.unescape(entry.group("title").strip())
@@ -116,7 +127,8 @@ def main():
         sys.exit(f"error: {HTML_FILE} not found — run deploy_help first.")
     gen = find_qhelpgenerator()
     if not gen:
-        sys.exit("error: qhelpgenerator not found (install qt6-tools-dev-tools "
+        sys.exit("error: qhelpgenerator not found (Debian/Ubuntu: "
+                 "install qt6-tools-dev-tools; macOS: brew install qt; "
                  "or add it to PATH).")
 
     toc = parse_toc(HTML_FILE.read_text(encoding="utf-8"))
@@ -148,10 +160,13 @@ def main():
         [gen, str(QHP_FILE), "-o", str(QCH_FILE)],
         cwd=HELP_DIR, capture_output=True, text=True)
     if result.returncode != 0:
-        sys.stdout.write(result.stdout)
-        sys.stderr.write(result.stderr)
+        if result.stdout.strip():
+            print(result.stdout.strip())
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
         sys.exit(f"error: qhelpgenerator failed (exit {result.returncode}).")
-    print(result.stdout.strip())
+    if result.stdout.strip():
+        print(result.stdout.strip())
     print(f"wrote {QCH_FILE.relative_to(REPO_ROOT)} "
           f"({QCH_FILE.stat().st_size // 1024} KB)")
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -50,7 +50,7 @@ that tracks the manual automatically.
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
 | [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | DONE | 2026-06-08 | 2026-06-08 | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
-| [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | BACKLOG |            |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
+| [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | STARTED | 2026-06-08 |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
 | [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -50,7 +50,7 @@ that tracks the manual automatically.
 |-----------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------|
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
 | [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | DONE | 2026-06-08 | 2026-06-08 | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
-| [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | STARTED | 2026-06-08 |     | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
+| [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | DONE | 2026-06-08 | 2026-06-08 | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
 | [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
@@ -65,7 +65,10 @@ Qt help collection:
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Non-greedy TOC regex may truncate | generate_help_qch.py | Accepted | Bound block by id attr → next </div>. |
+| 1 | qhelpgenerator paths Linux x86_64 only | generate_help_qch.py | Accepted | Added aarch64 + macOS Homebrew paths and hint. |
+| 1 | Blank line on silent success | generate_help_qch.py | Accepted | Guard empty stdout. |
+| 1 | Error stderr newline safety | generate_help_qch.py | Accepted | Use print() on error path. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
@@ -8,7 +8,7 @@
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
 #+branch: feature/qt-help-generate-qch
-#+pr:
+#+pr: 1203
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -59,7 +59,7 @@ Qt help collection:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1203][#1203]] | [qt] Generate the .qch help collection via qhelpgenerator |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Implemented and verified; opening the PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR, close task; HelpViewer widget follows. |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/qt-help-generate-qch
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Not yet started.                       |
+| Now          | Implemented and verified; opening the PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR, close task; HelpViewer widget follows. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -38,9 +38,20 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+=build/scripts/generate_help_qch.py= turns the help HTML export into a
+Qt help collection:
+
+- Parse the contents list of =build/output/help/user_manual.html=; the
+  section number (1, 1.1, 1.1.1) gives the nesting depth, the anchor and
+  title give the =<section ref="user_manual.html#anchor">= entries.
+- Emit a =.qhp= (Qt Help Project): namespace
+  =org.orestudio.usermanual=, virtual folder =manual=, a nested =<toc>=,
+  a =<keywords>= index of every section title, and a =<files>= list of
+  the HTML plus every bundled image.
+- Locate =qhelpgenerator= (PATH, then the Qt libexec dirs) and compile
+  the =.qhp= to =user_manual.qch=.
+- New =deploy_help_qch= CMake target depends on =deploy_help= so one
+  build runs the HTML export then the .qch compile.
 
 * Notes
 
@@ -57,3 +68,11 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+=generate_help_qch.py= + the =deploy_help_qch= target (chained after
+=deploy_help=) produce =build/output/help/user_manual.qch= (4.4 MB) from
+the help HTML. Derives a 143-section contents tree and a keyword index
+from the manual's TOC, bundles the HTML and all 90 images. Verified the
+compiled .qch (a SQLite db): 92 files registered, 127 index keywords,
+contents table populated, namespace =org.orestudio.usermanual= — exactly
+what the in-app QHelpEngine viewer will load next.


### PR DESCRIPTION
## Summary

Second task of the Qt help story. Adds build/scripts/generate_help_qch.py and a deploy_help_qch CMake target that compile the help HTML export into a Qt help collection (user_manual.qch) — the artifact the in-app QHelpEngine viewer will load. The script derives a 143-section contents tree and a keyword index from the manual's table of contents, bundles the HTML and all 90 images into a .qhp, and runs qhelpgenerator. deploy_help_qch depends on deploy_help so a single build runs the export then the compile.

## Changes

- Add build/scripts/generate_help_qch.py: parse TOC for nested sections, emit .qhp (toc + keyword index + files), locate qhelpgenerator, compile to .qch.
- Add deploy_help_qch CMake target depending on deploy_help.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Qt help system from the user manual](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/story.html) | FA1DD7D5-DE78-4E97-A9EF-932AD2C46693 |
| Task | [Generate the .qch help collection via qhelpgenerator](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_generate_qch.html) | 8D8F0CFA-0274-4B33-BF19-4D66E3E6E862 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)