### PR TITLE
[ores.platform,ores.shell] Add unset_value; fix POSIX env calls in tests

### DIFF
--- a/projects/ores.platform/include/ores.platform/environment/environment.hpp
+++ b/projects/ores.platform/include/ores.platform/environment/environment.hpp
@@ -74,6 +74,13 @@ public:
      * @param value Value to set.
      */
     static void set_value(const std::string& name, const std::string& value);
+
+    /**
+     * @brief Removes an environment variable.
+     *
+     * @param name Name of the environment variable to remove.
+     */
+    static void unset_value(const std::string& name);
 };
 
 }

--- a/projects/ores.platform/src/environment/environment.cpp
+++ b/projects/ores.platform/src/environment/environment.cpp
@@ -66,4 +66,12 @@ void environment::set_value(const std::string& name, const std::string& value) {
 #endif
 }
 
+void environment::unset_value(const std::string& name) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), "");
+#else
+    unsetenv(name.c_str());
+#endif
+}
+
 }

--- a/projects/ores.shell/tests/app_script_runner_tests.cpp
+++ b/projects/ores.shell/tests/app_script_runner_tests.cpp
@@ -18,10 +18,10 @@
  *
  */
 #include "ores.logging/make_logger.hpp"
+#include "ores.platform/environment/environment.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/script_runner.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <cstdlib>
 #include <sstream>
 #include <vector>
 
@@ -149,7 +149,8 @@ TEST_CASE("run_script_expands_environment_variables", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::setenv("ORES_TEST_RUNNER_URL", "nats://host:42222", 1);
+    namespace pe = ores::platform::environment;
+    pe::environment::set_value("ORES_TEST_RUNNER_URL", "nats://host:42222");
 
     std::istringstream in("connect $ORES_TEST_RUNNER_URL\n"
                           "braced ${ORES_TEST_RUNNER_URL}\n"
@@ -159,7 +160,7 @@ TEST_CASE("run_script_expands_environment_variables", tags) {
     auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
                         out, false);
 
-    ::unsetenv("ORES_TEST_RUNNER_URL");
+    pe::environment::unset_value("ORES_TEST_RUNNER_URL");
 
     CHECK_FALSE(r.aborted);
     CHECK(r.executed == 3);
@@ -174,7 +175,7 @@ TEST_CASE("run_script_aborts_on_undefined_environment_variable", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::unsetenv("ORES_TEST_RUNNER_MISSING");
+    ores::platform::environment::environment::unset_value("ORES_TEST_RUNNER_MISSING");
 
     std::istringstream in("good\n"
                           "connect $ORES_TEST_RUNNER_MISSING\n"
@@ -195,7 +196,7 @@ TEST_CASE("run_script_continue_on_error_skips_undefined_variable_line", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::unsetenv("ORES_TEST_RUNNER_MISSING");
+    ores::platform::environment::environment::unset_value("ORES_TEST_RUNNER_MISSING");
 
     std::istringstream in("good\n"
                           "connect $ORES_TEST_RUNNER_MISSING\n"


### PR DESCRIPTION
## Summary

- Add `environment::unset_value` to `ores.platform` (`_putenv_s(name, "")` on Windows, `unsetenv` on POSIX)
- Replace `::setenv`/`::unsetenv` in `app_script_runner_tests.cpp` with the platform wrappers — fixes MSVC build failure (`C2039: 'setenv' is not a member of global namespace`)

## Test plan

- [ ] Windows CI build passes
- [ ] Linux build and tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)