### PR TITLE
[qt] Add HelpViewer widget backed by QHelpEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ target_link_libraries(ores.openssl_cleanup INTERFACE OpenSSL::Crypto)
 
 # Qt
 set(QT_NO_PRIVATE_MODULE_WARNING ON)
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Concurrent Network Svg Charts)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Concurrent Network Svg Charts Help)
 
 # Reflect CPP
 find_package(pugixml CONFIG REQUIRED)

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -51,7 +51,7 @@ that tracks the manual automatically.
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
 | [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | DONE | 2026-06-08 | 2026-06-08 | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
 | [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | DONE | 2026-06-08 | 2026-06-08 | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
-| [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | STARTED | 2026-06-08 |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
+| [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | DONE | 2026-06-08 | 2026-06-09 | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -51,7 +51,7 @@ that tracks the manual automatically.
 | [[id:0D5E5423-4B5B-464A-B60D-0A4A7151B1FB][Scaffold story]]                                | DONE | 2026-06-08 | 2026-06-08 | Story, tasks, sprint wiring, scaffold PR.                           |
 | [[id:B0DAC977-C71E-4795-8CC7-87860F5F8899][Produce a self-contained manual HTML export for Qt help]]   | DONE | 2026-06-08 | 2026-06-08 | Help-friendly export: relative assets, bundled CSS/images, plain stylesheet. |
 | [[id:8D8F0CFA-0274-4B33-BF19-4D66E3E6E862][Generate the .qch help collection via qhelpgenerator]]      | DONE | 2026-06-08 | 2026-06-08 | .qhp manifest from the chapter ToC; compile to .qch/.qhc; build target. |
-| [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | BACKLOG |            |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
+| [[id:BCC57354-745C-44FB-9D87-FB1671E400D0][Add a HelpViewer widget backed by QHelpEngine]]             | STARTED | 2026-06-08 |     | Link Qt6::Help; QHelpEngine + contents/index/search sidebar + QTextBrowser. |
 | [[id:A7BBEC1F-476E-463C-A4C3-82A311AD7C51][Wire the help viewer into the Help menu]]                   | BACKLOG |            |     | User Manual action → MDI subwindow; package/locate the .qch; document it. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
@@ -67,7 +67,13 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | available_ set despite registration failure | HelpViewer.cpp | Accepted | Gated on namespace registered; not-available label otherwise. |
+| 1 | Second setupData() return unchecked | HelpViewer.cpp | Accepted | Now the single checked call. |
+| 1 | Hardcoded namespace in home URL | HelpViewer.cpp | Accepted | Derived from registered namespace + constants. |
+| 1 | reindexDocumentation unconditional | HelpViewer.cpp | Accepted | Only on fresh collection / newly registered. |
+| 1 | Splitter absolute pixel sizes | HelpViewer.cpp | Accepted | Dropped; rely on 1:3 stretch (DPI-safe). |
+| 1 | AppDataLocation should be CacheLocation | HelpViewer.cpp | Accepted | .qhc is a regenerable index → CacheLocation. |
+| 1 | Comment the 8-level walk-up | HelpViewer.cpp | Accepted | Added rationale. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
@@ -8,7 +8,7 @@
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
 #+branch: feature/qt-help-viewer-widget
-#+pr:
+#+pr: 1206
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -61,7 +61,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1206][#1206]] | [qt] Add HelpViewer widget backed by QHelpEngine |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Implemented and compiles; opening the PR. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR, close task; Help-menu wiring follows. |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :qt_help_system:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/qt-help-viewer-widget
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] |
-| Now          | Not yet started.                       |
+| Now          | Implemented and compiles; opening the PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR, close task; Help-menu wiring follows. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -38,9 +38,22 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+=HelpViewer= (QWidget, like AboutDialog) backed by =QHelpEngine=:
+
+- Link =Qt6::Help= (added to the root find_package and the app lib).
+- =locateHelpCollection()= finds =user_manual.qch=: =ORES_HELP_QCH= env
+  override, then executable-relative install layouts, then the in-tree
+  =build/output/help= (walk up from the exe) — packaging is finalised in
+  the menu-wiring task.
+- The engine's writable collection (=.qhc=) lives in the app cache
+  (=AppDataLocation=) so a read-only install of the =.qch= still works;
+  register the =.qch= namespace if not already present.
+- Sidebar =QTabWidget=: Contents (=contentWidget=), Index (=indexWidget=,
+  =documentActivated= — the non-deprecated Qt 6.10 signal), and Search
+  (=QLineEdit= over =searchEngine= + =resultWidget=). A =HelpBrowser=
+  (QTextBrowser subclass) overrides =loadResource= to serve =qthelp://=
+  URLs from the engine; a =QSplitter= holds sidebar + browser; opens on
+  the manual home page.
 
 * Notes
 
@@ -57,3 +70,11 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+=HelpViewer= widget added (=HelpViewer.hpp/.cpp=) and compiling against
+=Qt6::Help= (verified: =ores.qt.lib= builds clean under
+linux-clang-debug-make). Loads =user_manual.qch= via =QHelpEngine= with a
+Contents/Index/Search sidebar and a =qthelp://=-resolving =QTextBrowser=,
+graceful when the collection is absent. The by-eye QTextBrowser render and
+live navigation happen once the Help menu opens it (next task); the widget
+is structurally complete and links the help module.

--- a/projects/ores.qt/application/include/ores.qt/HelpViewer.hpp
+++ b/projects/ores.qt/application/include/ores.qt/HelpViewer.hpp
@@ -1,0 +1,88 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2024-2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_HELP_VIEWER_HPP
+#define ORES_QT_HELP_VIEWER_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include <QString>
+#include <QWidget>
+#include <optional>
+
+class QHelpEngine;
+class QLineEdit;
+
+namespace ores::qt {
+
+/**
+ * @brief In-application user-manual viewer backed by the Qt help system.
+ *
+ * Loads the user_manual.qch help collection (built from the org-mode user
+ * manual via deploy_help_qch) through a QHelpEngine and presents it with a
+ * sidebar — contents tree, keyword index and full-text search — alongside a
+ * content pane. Designed to be embedded in an MDI subwindow like AboutDialog.
+ *
+ * The content pane is a QTextBrowser subclass that resolves qthelp:// URLs
+ * against the QHelpEngine, so links, images and cross-references inside the
+ * collection render without touching the filesystem or the network.
+ */
+class HelpViewer final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name = "ores.qt.help_viewer";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit HelpViewer(QWidget* parent = nullptr);
+    ~HelpViewer() override;
+
+    /**
+     * @brief Locate the user_manual.qch shipped with the application.
+     *
+     * Searches, in order: an explicit ORES_HELP_QCH environment override,
+     * locations relative to the running executable (install layouts), and
+     * the in-tree build output (build/output/help). Returns std::nullopt
+     * when no collection can be found.
+     */
+    [[nodiscard]] static std::optional<QString> locateHelpCollection();
+
+    /// True when a help collection was found and registered.
+    [[nodiscard]] bool isAvailable() const;
+
+private:
+    /// Build the sidebar (contents / index / search) and content pane.
+    void buildUi();
+    /// Run the current full-text search query.
+    void runSearch();
+
+    QHelpEngine* engine_{nullptr};
+    QLineEdit* searchField_{nullptr};
+    bool available_{false};
+};
+
+}
+
+#endif

--- a/projects/ores.qt/application/include/ores.qt/HelpViewer.hpp
+++ b/projects/ores.qt/application/include/ores.qt/HelpViewer.hpp
@@ -74,12 +74,14 @@ public:
 
 private:
     /// Build the sidebar (contents / index / search) and content pane.
-    void buildUi();
+    /// @param reindex rebuild the full-text search index (new collection).
+    void buildUi(bool reindex);
     /// Run the current full-text search query.
     void runSearch();
 
     QHelpEngine* engine_{nullptr};
     QLineEdit* searchField_{nullptr};
+    QString namespace_;
     bool available_{false};
 };
 

--- a/projects/ores.qt/application/src/CMakeLists.txt
+++ b/projects/ores.qt/application/src/CMakeLists.txt
@@ -81,7 +81,8 @@ target_link_libraries(${lib_target_name}
         ores.controller.api.lib
         ores.security.lib
         ores.qt.workflow.lib
-        Qt6::Charts)
+        Qt6::Charts
+        Qt6::Help)
 # Note: ores.nats, ores.eventing.api, ores.iam.api, ores.compute.api, ores.utility,
 # ores.platform, and Qt6 core modules come transitively from ores.qt.api.lib (PUBLIC)
 # Note: Boost::process comes transitively through ores.telemetry.core.lib (PUBLIC)

--- a/projects/ores.qt/application/src/HelpViewer.cpp
+++ b/projects/ores.qt/application/src/HelpViewer.cpp
@@ -46,6 +46,8 @@ using namespace ores::logging;
 namespace {
 
 constexpr auto qch_name = "user_manual.qch";
+constexpr auto virtual_folder = "manual";
+constexpr auto home_page = "user_manual.html";
 
 /*
  * A QTextBrowser cannot fetch qthelp:// URLs on its own; loadResource is
@@ -90,7 +92,8 @@ std::optional<QString> HelpViewer::locateHelpCollection() {
     }
 
     // 3. In-tree build output (deploy_help_qch), found by walking up from
-    //    the executable to a directory that holds build/output/help.
+    //    the executable to a directory that holds build/output/help. Eight
+    //    levels is ample for any realistic build-tree depth.
     QDir dir(appDir);
     for (int i = 0; i < 8; ++i) {
         const QString candidate =
@@ -117,32 +120,53 @@ HelpViewer::HelpViewer(QWidget* parent) : QWidget(parent) {
         return;
     }
 
-    // The collection (.qhc) is the engine's writable index; keep it in the
-    // app cache so a read-only install location for the .qch still works.
+    // The collection (.qhc) is a derived, regenerable index over the .qch,
+    // so it lives in the OS cache, not app data. Keeping it writable also
+    // lets a read-only install location for the .qch work.
     const QString cacheDir =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     QDir().mkpath(cacheDir);
     const QString collection = QDir(cacheDir).filePath("user_manual.qhc");
+    const bool freshCollection = !QFileInfo::exists(collection);
+
+    const QString ns = QHelpEngineCore::namespaceName(*qch);
+    if (ns.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Help collection has no namespace; viewer unavailable.";
+        auto* layout = new QVBoxLayout(this);
+        layout->addWidget(new QLabel(
+            tr("The user manual help collection could not be loaded."), this));
+        return;
+    }
 
     engine_ = new QHelpEngine(collection, this);
+    bool newlyRegistered = false;
+    if (!engine_->registeredDocumentations().contains(ns)) {
+        if (engine_->registerDocumentation(*qch))
+            newlyRegistered = true;
+        else
+            BOOST_LOG_SEV(lg(), warn) << "Failed to register help: "
+                                      << engine_->error().toStdString();
+    }
     if (!engine_->setupData()) {
         BOOST_LOG_SEV(lg(), warn)
             << "Help engine setup failed: " << engine_->error().toStdString();
     }
 
-    // Register the .qch into the collection if it is not already present.
-    const QString ns = QHelpEngineCore::namespaceName(*qch);
-    if (!ns.isEmpty()
-        && !engine_->registeredDocumentations().contains(ns)) {
-        if (!engine_->registerDocumentation(*qch)) {
-            BOOST_LOG_SEV(lg(), warn) << "Failed to register help: "
-                                      << engine_->error().toStdString();
-        }
+    available_ = engine_->registeredDocumentations().contains(ns);
+    if (!available_) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Help namespace not registered; viewer unavailable.";
+        auto* layout = new QVBoxLayout(this);
+        layout->addWidget(new QLabel(
+            tr("The user manual help collection could not be loaded."), this));
+        return;
     }
-    engine_->setupData();
 
-    available_ = true;
-    buildUi();
+    namespace_ = ns;
+    // Re-index full-text search only when the collection is new or a
+    // document was just registered; subsequent opens reuse the index.
+    buildUi(freshCollection || newlyRegistered);
     BOOST_LOG_SEV(lg(), info)
         << "Help viewer ready from " << qch->toStdString();
 }
@@ -151,7 +175,7 @@ HelpViewer::~HelpViewer() = default;
 
 bool HelpViewer::isAvailable() const { return available_; }
 
-void HelpViewer::buildUi() {
+void HelpViewer::buildUi(bool reindex) {
     auto* browser = new HelpBrowser(engine_, this);
 
     // Sidebar: Contents, Index, Search tabs.
@@ -185,19 +209,23 @@ void HelpViewer::buildUi() {
             this, &HelpViewer::runSearch);
     connect(results, &QHelpSearchResultWidget::requestShowLink,
             browser, [browser](const QUrl& url) { browser->setSource(url); });
-    search->reindexDocumentation();
+    if (reindex)
+        search->reindexDocumentation();
 
     // Land on the manual's home page so the content pane is never blank.
-    const QString home =
-        QString("qthelp://org.orestudio.usermanual/manual/user_manual.html");
+    // The namespace comes from the registered collection, not a literal, so
+    // a namespace change cannot silently blank the pane.
+    const QString home = QString("qthelp://%1/%2/%3")
+                             .arg(namespace_, virtual_folder, home_page);
     browser->setSource(QUrl(home));
 
+    // No absolute setSizes: the 1:3 stretch ratio scales correctly on
+    // high-DPI displays where fixed pixel sizes would look cramped.
     auto* splitter = new QSplitter(Qt::Horizontal, this);
     splitter->addWidget(tabs);
     splitter->addWidget(browser);
     splitter->setStretchFactor(0, 1);
     splitter->setStretchFactor(1, 3);
-    splitter->setSizes({240, 720});
 
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/projects/ores.qt/application/src/HelpViewer.cpp
+++ b/projects/ores.qt/application/src/HelpViewer.cpp
@@ -1,0 +1,215 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2024-2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/HelpViewer.hpp"
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QHelpContentWidget>
+#include <QHelpEngine>
+#include <QHelpEngineCore>
+#include <QHelpIndexWidget>
+#include <QHelpLink>
+#include <QHelpSearchEngine>
+#include <QHelpSearchResultWidget>
+#include <QLabel>
+#include <QLineEdit>
+#include <QSplitter>
+#include <QStandardPaths>
+#include <QTabWidget>
+#include <QTextBrowser>
+#include <QUrl>
+#include <QVBoxLayout>
+#include <QWidget>
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+
+constexpr auto qch_name = "user_manual.qch";
+
+/*
+ * A QTextBrowser cannot fetch qthelp:// URLs on its own; loadResource is
+ * overridden to read file data out of the QHelpEngine, so links, images
+ * and cross-references inside the collection resolve in-process.
+ */
+class HelpBrowser final : public QTextBrowser {
+public:
+    HelpBrowser(QHelpEngine* engine, QWidget* parent)
+        : QTextBrowser(parent), engine_(engine) {
+        setOpenExternalLinks(false);
+    }
+
+    QVariant loadResource(int type, const QUrl& url) override {
+        if (url.scheme() == "qthelp")
+            return engine_->fileData(url);
+        return QTextBrowser::loadResource(type, url);
+    }
+
+private:
+    QHelpEngine* engine_;
+};
+
+}
+
+std::optional<QString> HelpViewer::locateHelpCollection() {
+    // 1. Explicit override for developers and packagers.
+    const auto env = qEnvironmentVariable("ORES_HELP_QCH");
+    if (!env.isEmpty() && QFileInfo::exists(env))
+        return env;
+
+    // 2. Locations relative to the running executable (install layouts).
+    const QString appDir = QCoreApplication::applicationDirPath();
+    const QStringList relative{
+        QString("%1/%2").arg(appDir, qch_name),
+        QString("%1/help/%2").arg(appDir, qch_name),
+        QString("%1/../share/orestudio/help/%2").arg(appDir, qch_name),
+    };
+    for (const auto& path : relative) {
+        if (QFileInfo::exists(path))
+            return QDir::cleanPath(path);
+    }
+
+    // 3. In-tree build output (deploy_help_qch), found by walking up from
+    //    the executable to a directory that holds build/output/help.
+    QDir dir(appDir);
+    for (int i = 0; i < 8; ++i) {
+        const QString candidate =
+            dir.filePath(QString("build/output/help/%1").arg(qch_name));
+        if (QFileInfo::exists(candidate))
+            return QDir::cleanPath(candidate);
+        if (!dir.cdUp())
+            break;
+    }
+    return std::nullopt;
+}
+
+HelpViewer::HelpViewer(QWidget* parent) : QWidget(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Creating help viewer.";
+
+    const auto qch = locateHelpCollection();
+    if (!qch) {
+        BOOST_LOG_SEV(lg(), warn) << "No help collection (" << qch_name
+                                  << ") found; help viewer unavailable.";
+        auto* layout = new QVBoxLayout(this);
+        layout->addWidget(new QLabel(
+            tr("The user manual help collection could not be found.\n"
+               "Build it with the deploy_help_qch target."), this));
+        return;
+    }
+
+    // The collection (.qhc) is the engine's writable index; keep it in the
+    // app cache so a read-only install location for the .qch still works.
+    const QString cacheDir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir().mkpath(cacheDir);
+    const QString collection = QDir(cacheDir).filePath("user_manual.qhc");
+
+    engine_ = new QHelpEngine(collection, this);
+    if (!engine_->setupData()) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Help engine setup failed: " << engine_->error().toStdString();
+    }
+
+    // Register the .qch into the collection if it is not already present.
+    const QString ns = QHelpEngineCore::namespaceName(*qch);
+    if (!ns.isEmpty()
+        && !engine_->registeredDocumentations().contains(ns)) {
+        if (!engine_->registerDocumentation(*qch)) {
+            BOOST_LOG_SEV(lg(), warn) << "Failed to register help: "
+                                      << engine_->error().toStdString();
+        }
+    }
+    engine_->setupData();
+
+    available_ = true;
+    buildUi();
+    BOOST_LOG_SEV(lg(), info)
+        << "Help viewer ready from " << qch->toStdString();
+}
+
+HelpViewer::~HelpViewer() = default;
+
+bool HelpViewer::isAvailable() const { return available_; }
+
+void HelpViewer::buildUi() {
+    auto* browser = new HelpBrowser(engine_, this);
+
+    // Sidebar: Contents, Index, Search tabs.
+    auto* tabs = new QTabWidget(this);
+
+    auto* contents = engine_->contentWidget();
+    tabs->addTab(contents, tr("Contents"));
+    connect(contents, &QHelpContentWidget::linkActivated,
+            browser, [browser](const QUrl& url) { browser->setSource(url); });
+
+    auto* index = engine_->indexWidget();
+    tabs->addTab(index, tr("Index"));
+    connect(index, &QHelpIndexWidget::documentActivated, browser,
+            [browser](const QHelpLink& doc, const QString&) {
+                browser->setSource(doc.url);
+            });
+
+    // Search tab: a query field over the full-text search engine, with the
+    // result widget below.
+    auto* searchTab = new QWidget(this);
+    auto* searchLayout = new QVBoxLayout(searchTab);
+    searchField_ = new QLineEdit(searchTab);
+    searchField_->setPlaceholderText(tr("Search the manual…"));
+    auto* search = engine_->searchEngine();
+    auto* results = search->resultWidget();
+    searchLayout->addWidget(searchField_);
+    searchLayout->addWidget(results, 1);
+    tabs->addTab(searchTab, tr("Search"));
+
+    connect(searchField_, &QLineEdit::returnPressed,
+            this, &HelpViewer::runSearch);
+    connect(results, &QHelpSearchResultWidget::requestShowLink,
+            browser, [browser](const QUrl& url) { browser->setSource(url); });
+    search->reindexDocumentation();
+
+    // Land on the manual's home page so the content pane is never blank.
+    const QString home =
+        QString("qthelp://org.orestudio.usermanual/manual/user_manual.html");
+    browser->setSource(QUrl(home));
+
+    auto* splitter = new QSplitter(Qt::Horizontal, this);
+    splitter->addWidget(tabs);
+    splitter->addWidget(browser);
+    splitter->setStretchFactor(0, 1);
+    splitter->setStretchFactor(1, 3);
+    splitter->setSizes({240, 720});
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(splitter);
+}
+
+void HelpViewer::runSearch() {
+    if (!engine_ || !searchField_)
+        return;
+    const QString q = searchField_->text().trimmed();
+    if (!q.isEmpty())
+        engine_->searchEngine()->search(q);
+}
+
+}


### PR DESCRIPTION
## Summary

Third task of the Qt help story. Links Qt6::Help and adds the HelpViewer widget (like AboutDialog) that loads the user_manual.qch collection through QHelpEngine and presents a Contents/Index/full-text-Search sidebar next to a content pane. A QTextBrowser subclass resolves qthelp:// URLs via the engine so links and images render without filesystem or network access. The .qch is located via an ORES_HELP_QCH override, executable-relative install layouts, or the in-tree build output (deploy_help_qch); the engine's writable collection lives in the app cache so a read-only install of the .qch works. Compiles clean against Qt6::Help (ores.qt.lib verified).

## Changes

- Add Qt6::Help to the root find_package and the app lib link.
- Add HelpViewer.hpp/.cpp: QHelpEngine + Contents/Index/Search sidebar + qthelp://-resolving QTextBrowser; graceful when the collection is missing.
- Use the non-deprecated documentActivated signal for the index widget (Qt 6.10).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Qt help system from the user manual](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/story.html) | FA1DD7D5-DE78-4E97-A9EF-932AD2C46693 |
| Task | [Add a HelpViewer widget backed by QHelpEngine](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/qt_help_system/task_qt_help_viewer_widget.html) | BCC57354-745C-44FB-9D87-FB1671E400D0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)