### PR TITLE
[hotfix] Fix setenv/unsetenv build failure on Windows

### DIFF
--- a/projects/ores.shell/tests/app_script_runner_tests.cpp
+++ b/projects/ores.shell/tests/app_script_runner_tests.cpp
@@ -30,6 +30,19 @@ namespace {
 const std::string_view test_suite("ores.shell.tests");
 const std::string tags("[app]");
 
+// setenv/unsetenv are POSIX-only; Windows uses _putenv_s/_putenv.
+#ifdef _WIN32
+void set_env(const char* name, const char* value) { _putenv_s(name, value); }
+void unset_env(const char* name) {
+    std::string s(name);
+    s += '='; // "NAME=" with no value removes the variable on Windows.
+    _putenv(s.c_str());
+}
+#else
+void set_env(const char* name, const char* value) { ::setenv(name, value, 1); }
+void unset_env(const char* name) { ::unsetenv(name); }
+#endif
+
 }
 
 using ores::shell::app::command_feedback;
@@ -149,7 +162,7 @@ TEST_CASE("run_script_expands_environment_variables", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::setenv("ORES_TEST_RUNNER_URL", "nats://host:42222", 1);
+    set_env("ORES_TEST_RUNNER_URL", "nats://host:42222");
 
     std::istringstream in("connect $ORES_TEST_RUNNER_URL\n"
                           "braced ${ORES_TEST_RUNNER_URL}\n"
@@ -159,7 +172,7 @@ TEST_CASE("run_script_expands_environment_variables", tags) {
     auto r = run_script(in, [&](const std::string& c) { fed.push_back(c); },
                         out, false);
 
-    ::unsetenv("ORES_TEST_RUNNER_URL");
+    unset_env("ORES_TEST_RUNNER_URL");
 
     CHECK_FALSE(r.aborted);
     CHECK(r.executed == 3);
@@ -174,7 +187,7 @@ TEST_CASE("run_script_aborts_on_undefined_environment_variable", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::unsetenv("ORES_TEST_RUNNER_MISSING");
+    unset_env("ORES_TEST_RUNNER_MISSING");
 
     std::istringstream in("good\n"
                           "connect $ORES_TEST_RUNNER_MISSING\n"
@@ -195,7 +208,7 @@ TEST_CASE("run_script_continue_on_error_skips_undefined_variable_line", tags) {
     auto lg(make_logger(test_suite));
     command_feedback::reset();
 
-    ::unsetenv("ORES_TEST_RUNNER_MISSING");
+    unset_env("ORES_TEST_RUNNER_MISSING");
 
     std::istringstream in("good\n"
                           "connect $ORES_TEST_RUNNER_MISSING\n"


### PR DESCRIPTION
## Summary

- `setenv` and `unsetenv` are POSIX-only — not available in the Windows UCRT used by the clang-cl canary build
- Adds `set_env`/`unset_env` helpers in the anonymous namespace that dispatch to `_putenv_s`/`_putenv` on `_WIN32` and the POSIX calls on Linux/macOS
- Replaces all four call sites in `app_script_runner_tests.cpp`

## Test plan

- [ ] Canary (`windows-clang-debug-ninja`) passes — no more `no member named 'setenv'` errors
- [ ] Linux (`linux-gcc-debug-ninja`) continues to pass — POSIX path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)