### PR TITLE
[build] Improve CDash visibility: PR notes + site build as a Site group

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -29,6 +29,14 @@ permissions:
   id-token: write
 
 jobs:
+  # Submit the full documentation build (site + Doxygen) to CDash as the Site
+  # group on every push to main — the heavy build the PR link-check defers.
+  # Independent of build/deploy below.
+  cdash:
+    uses: ./.github/workflows/site-cdash.yml
+    with:
+      with_doxygen: true
+
   # Build the site on every push to main and hand it to the deploy job as
   # an artifact. The same build runs on doc-class pull requests via pr.yml,
   # which is where broken id-links are caught before they reach main. It

--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -174,6 +174,8 @@ jobs:
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"
           export ORES_BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
           export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
+          # PR URL for the CDash Notes (empty for non-PR invocations).
+          export ORES_PR_URL="${{ github.event.pull_request.html_url }}"
           export preset=linux-gcc-debug-ninja
           export cmake_args="build_group=Canary,preset=${preset},code_coverage=1"
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,17 +76,11 @@ jobs:
     needs: classify
     # yamllint disable-line rule:line-length
     if: needs.classify.outputs.docs == 'true' || needs.classify.outputs.ci == 'true'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Emacs
-        uses: purcell/setup-emacs@v8.0
-        with:
-          version: 29.1
-      - name: Build site
-        run: |
-          emacs -Q --script projects/ores.lisp/src/ores-build-site.el
+    # Builds the site via CTestSite.cmake and submits it to CDash as the Site
+    # group (link check; no Doxygen on PRs). Fails the gate on broken links.
+    uses: ./.github/workflows/site-cdash.yml
+    with:
+      with_doxygen: false
 
   canary:
     name: canary

--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -1,0 +1,136 @@
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# yamllint disable rule:line-length
+#
+# Reusable: build the documentation site via CTestSite.cmake and submit it to
+# CDash as the "Site" build group. Same script, two configurations (like the
+# continuous/nightly compile builds): with_doxygen=false is the fast PR link
+# check; with_doxygen=true is the full site + Doxygen build for merges to main.
+# The configure step needs the full toolchain (vcpkg/Qt/cmake); the database is
+# not required, so the Postgres setup from the canary build is omitted.
+---
+name: Site CDash
+
+env:
+  VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg-cache,readwrite'
+  SCCACHE_DIR: '${{ github.workspace }}/.sccache'
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      with_doxygen:
+        description: 'Build Doxygen too (full build for main); false = site-only link check'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: site
+    concurrency:
+      group: site-cdash-${{ github.ref }}-${{ inputs.with_doxygen }}
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+    environment: CI
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby \
+            /opt/hostedtoolcache/node /opt/hostedtoolcache/go /usr/share/swift \
+            /usr/lib/jvm /usr/local/share/boost
+          sudo docker image prune --all --force || true
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Restore sccache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-linux-gcc-debug-ninja
+
+      - name: Ccache for gh actions
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          variant: sccache
+          key: linux-gcc-debug-ninja
+          max-size: 2000M
+          save: false
+
+      - name: Install dev packages
+        run: ./build/scripts/install_debian_packages.sh
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.8.3'
+          modules: 'qtcharts'
+          cache: true
+
+      - name: Install Doxygen
+        if: ${{ inputs.with_doxygen }}
+        run: sudo apt-get install -y graphviz doxygen fonts-firacode fonts-freefont-ttf
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@v8.0
+        with:
+          version: 29.1
+
+      - name: Init environment
+        env:
+          ORES_DATABASE_NAME: ores_ci
+          PGPASSWORD: ci-not-used
+        run: |
+          ./projects/ores.compass/compass.sh --no-deps env init -y
+          grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$' \
+            | grep -v 'ORES_IAM_SERVICE_JWT_PRIVATE_KEY' >> $GITHUB_ENV
+
+      - name: get-cmake
+        uses: lukka/get-cmake@v4.3.3
+
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg-cache
+          key: vcpkg-linux-gcc-debug-ninja-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-linux-gcc-debug-ninja-
+
+      - name: run-vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          doNotCache: false
+
+      - name: Run CTest site build
+        run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+          export CTEST_PARALLEL_LEVEL=$(nproc)
+          export ORES_BUILD_PROVIDER="github"
+          export ORES_BUILD_COMMIT="${GITHUB_SHA}"
+          export ORES_BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
+          export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
+          # PR URL for the CDash Notes (empty for non-PR invocations).
+          export ORES_PR_URL="${{ github.event.pull_request.html_url }}"
+          export preset=linux-gcc-debug-ninja
+          if [ "${{ inputs.with_doxygen }}" = "true" ]; then dox=ON; else dox=OFF; fi
+          export cmake_args="build_group=Site,preset=${preset},with_doxygen=${dox}"
+          ctest -VV --preset ${preset} --script "CTestSite.cmake,${cmake_args}"

--- a/CTest.cmake
+++ b/CTest.cmake
@@ -356,6 +356,22 @@ if(WITH_COVERAGE AND configure_result EQUAL 0 AND build_result EQUAL 0)
 endif()
 
 #
+# Step: attach Notes
+#
+# When building a pull request, write the PR URL (and commit) to a notes
+# file so the CDash build entry links straight back to the PR. The build
+# name is unchanged. Must be set before ctest_submit so the Notes part is
+# included.
+if(NOT "$ENV{ORES_PR_URL}" STREQUAL "")
+    set(notes_file "${CTEST_BINARY_DIRECTORY}/cdash_notes.txt")
+    file(WRITE "${notes_file}"
+        "Pull request: $ENV{ORES_PR_URL}\n"
+        "Commit: $ENV{ORES_BUILD_COMMIT}\n")
+    set(CTEST_NOTES_FILES "${notes_file}")
+    message(STATUS "CDash notes: PR $ENV{ORES_PR_URL}")
+endif()
+
+#
 # Step: submit build results
 #
 # Always attempt to submit results to CDash, even if there were failures.

--- a/CTestSite.cmake
+++ b/CTestSite.cmake
@@ -85,6 +85,16 @@ set(retry_delay 300)
 set(retry_count 10)
 set(had_failures OFF)
 
+# Keep Emacs package bootstrap noise out of the CDash dashboard. The cold
+# install (see ores-site-packages.el) is pre-warmed out of band below, but
+# belt-and-suspenders: never let anything under ./.packages — third-party
+# byte-compile warnings or the benign seq activation message — be counted as a
+# build error/warning against our build.
+set(CTEST_CUSTOM_WARNING_EXCEPTION ${CTEST_CUSTOM_WARNING_EXCEPTION}
+    "\\.packages/" "package--load-files-for-activation")
+set(CTEST_CUSTOM_ERROR_EXCEPTION ${CTEST_CUSTOM_ERROR_EXCEPTION}
+    "\\.packages/" "package--load-files-for-activation")
+
 ctest_start(${build_group})
 
 # Version-only update (detached-HEAD PR checkouts return non-zero harmlessly).
@@ -98,6 +108,25 @@ ctest_configure(OPTIONS "--preset ${preset}" RETURN_VALUE configure_result)
 if(NOT configure_result EQUAL 0)
     message(WARNING "Failed to configure")
     set(had_failures ON)
+endif()
+
+# Pre-warm the Emacs package cache OUT OF BAND, before the monitored build.
+# On a cold CI checkout package-install byte-compiles dozens of third-party
+# files; running it here via execute_process keeps that output in the plain CI
+# step log instead of the CTest-scraped deploy_site build. When the cache is
+# already warm (developer machines) this is a quick no-op.
+if(configure_result EQUAL 0)
+    message(STATUS "Pre-warming Emacs package cache (out of band)")
+    execute_process(
+        COMMAND emacs -Q --batch
+            -l projects/ores.lisp/src/ores-site-packages.el
+            --eval "(ores-site-ensure-packages)"
+        WORKING_DIRECTORY "${CTEST_SOURCE_DIRECTORY}"
+        RESULT_VARIABLE prewarm_result)
+    if(NOT prewarm_result EQUAL 0)
+        message(WARNING "Package pre-warm failed with error code: ${prewarm_result}")
+        set(had_failures ON)
+    endif()
 endif()
 
 # Build the org-publish site target. ores-build-site.el fails on a broken

--- a/CTestSite.cmake
+++ b/CTestSite.cmake
@@ -1,0 +1,151 @@
+# -*- mode: cmake; cmake-tab-width: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Submit the documentation site build (org-publish + Doxygen via the
+# deploy_site target) to CDash as its own build group, so build engineers can
+# see at a glance whether the documentation built. A broken org id-link fails
+# ores-build-site.el, which fails the build step here and is reported to CDash.
+#
+# Usage:
+#   ctest -VV --script "CTestSite.cmake,preset=<preset>,build_group=Site"
+# Set ORES_CDASH_NOSUBMIT=1 in the environment to skip the CDash submission
+# (used when testing the script locally).
+#
+cmake_minimum_required(VERSION 3.29 FATAL_ERROR)
+
+# Transform "script,var1=value1,var2=value2" args into CMake variables.
+if(DEFINED CTEST_SCRIPT_ARG)
+    string(REPLACE "," ";" script_args "${CTEST_SCRIPT_ARG}")
+    foreach(current_var ${script_args})
+        if ("${current_var}" MATCHES "^([^=]+)=(.+)$")
+            set("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}")
+        endif()
+    endforeach()
+endif()
+
+if(NOT DEFINED preset)
+    message(FATAL_ERROR "Parameter preset not defined.")
+endif()
+if(NOT DEFINED build_group)
+    set(build_group "Site")
+endif()
+message(STATUS "CDash build group: ${build_group}")
+
+# with_doxygen controls which targets the build runs:
+#   OFF (default) — org-publish site only; the fast link-checking build for PRs.
+#   ON            — site + Doxygen; the full build, reserved for merges to main.
+if(NOT DEFINED with_doxygen)
+    set(with_doxygen OFF)
+endif()
+message(STATUS "Build Doxygen: ${with_doxygen}")
+
+# Build name: distinguish the documentation build from the compile builds.
+set(CTEST_BUILD_NAME "${preset}-site")
+message(STATUS "CDash build name: ${CTEST_BUILD_NAME}")
+
+# Derive the generator from the preset's build-tool segment (…-<tool>).
+string(TOLOWER "${preset}" preset_lower)
+string(REPLACE "-" ";" preset_list ${preset_lower})
+list(GET preset_list 3 build_tool)
+if(build_tool STREQUAL "ninja")
+    set(CTEST_CMAKE_GENERATOR "Ninja")
+elseif(build_tool STREQUAL "make")
+    set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+else()
+    message(FATAL_ERROR "Unsupported build tool: ${build_tool}")
+endif()
+
+if(DEFINED ENV{ORES_BUILD_PROVIDER})
+    set(CTEST_SITE $ENV{ORES_BUILD_PROVIDER})
+else()
+    site_name(APP_SITE)
+    set(CTEST_SITE "${APP_SITE}")
+endif()
+
+set(CTEST_SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build/output/${preset}")
+message(STATUS "Source directory: ${CTEST_SOURCE_DIRECTORY}")
+message(STATUS "Binary directory: ${CTEST_BINARY_DIRECTORY}")
+
+set(retry_delay 300)
+set(retry_count 10)
+set(had_failures OFF)
+
+ctest_start(${build_group})
+
+# Version-only update (detached-HEAD PR checkouts return non-zero harmlessly).
+find_package(Git)
+set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
+set(CTEST_UPDATE_VERSION_ONLY ON)
+ctest_update(RETURN_VALUE update_result)
+
+# Configure (reuses the preset; cheap on an already-configured tree).
+ctest_configure(OPTIONS "--preset ${preset}" RETURN_VALUE configure_result)
+if(NOT configure_result EQUAL 0)
+    message(WARNING "Failed to configure")
+    set(had_failures ON)
+endif()
+
+# Build the org-publish site target. ores-build-site.el fails on a broken
+# org id-link, so a bad link fails this step and is reported to CDash.
+set(build_result 0)
+if(configure_result EQUAL 0)
+    set(CTEST_BUILD_TARGET "deploy_site")
+    ctest_build(RETURN_VALUE build_result)
+    if(NOT build_result EQUAL 0)
+        message(WARNING "Site build failed with error code: ${build_result}")
+        set(had_failures ON)
+    endif()
+endif()
+
+# Doxygen only for the full build (with_doxygen=ON, merges to main). It is not
+# a CMake target, so run it directly; a failure fails the Site build on CDash.
+if(with_doxygen AND configure_result EQUAL 0 AND build_result EQUAL 0)
+    message(STATUS "Running Doxygen")
+    execute_process(
+        COMMAND doxygen build/doxygen/Doxyfile
+        WORKING_DIRECTORY "${CTEST_SOURCE_DIRECTORY}"
+        RESULT_VARIABLE doxygen_result)
+    if(NOT doxygen_result EQUAL 0)
+        message(WARNING "Doxygen failed with error code: ${doxygen_result}")
+        set(had_failures ON)
+    endif()
+endif()
+
+# Attach the PR URL as Notes on pull-request builds (build name unchanged).
+if(NOT "$ENV{ORES_PR_URL}" STREQUAL "")
+    set(notes_file "${CTEST_BINARY_DIRECTORY}/cdash_site_notes.txt")
+    file(WRITE "${notes_file}"
+        "Pull request: $ENV{ORES_PR_URL}\n"
+        "Commit: $ENV{ORES_BUILD_COMMIT}\n")
+    set(CTEST_NOTES_FILES "${notes_file}")
+endif()
+
+# Submit to CDash (skipped for local testing via ORES_CDASH_NOSUBMIT=1).
+if("$ENV{ORES_CDASH_NOSUBMIT}" STREQUAL "1")
+    message(STATUS "ORES_CDASH_NOSUBMIT=1 — skipping CDash submission.")
+else()
+    ctest_submit(RETRY_COUNT ${retry_count} RETRY_DELAY ${retry_delay}
+        RETURN_VALUE submit_result)
+    if(submit_result)
+        message(WARNING "CDash submission failed (exit code: ${submit_result}).")
+    endif()
+endif()
+
+if(had_failures)
+    message(FATAL_ERROR "Site build completed with failures. Results submitted to CDash.")
+endif()

--- a/doc/agile/product_backlog/inbox/profile_picture_face_dataset.org
+++ b/doc/agile/product_backlog/inbox/profile_picture_face_dataset.org
@@ -1,0 +1,40 @@
+:PROPERTIES:
+:ID: 42EB2329-CD49-430D-A78A-49D2D14987BD
+:END:
+#+title: Accumulate a tagged face dataset for profile pictures
+#+description: Build a seed catalog of generated face images (via facestudio.app), tagged by attributes, accumulated over time within API throttling limits, for use as account profile pictures.
+#+type: capture
+#+level: cross
+#+filetags: :dataset:seeder:iam:ui:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Build a seed catalog of generated face images for account profile pictures.
+Generate the faces via [[https://facestudio.app/api-access][facestudio.app]], tag each by attributes (e.g. age
+band, gender presentation, ethnicity, expression) so the seeder can pick a
+plausible face per synthetic account, and accumulate the catalog *over time*
+within the API's throttling limits rather than in one batch. Stored as a
+=ores.seeder= dataset so account provisioning can attach a picture to each
+profile. The eventual consumers are the IAM account seeder and the Qt/Wt
+profile UI.
+
+* Why
+
+Synthetic accounts currently have no profile pictures, so the UI and demos
+look bare. A pre-accumulated, attribute-tagged catalog lets us assign
+realistic pictures deterministically at seed time without hitting the
+generation API live (and within its rate limits).
+
+* References
+
+- https://facestudio.app/api-access — the face generation API.
+- =projects/ores.seeder/datasets/= — where the catalog would live.
+
+* See also
+
+- [[id:8C53F763-1DB4-4287-AB72-7471E1A7DE29][Add a sample set of gravatars for profiles]] — related; gravatar fallback.
+- [[id:2D640A42-ECCE-4A76-80D1-169430E7D219][Users should be able to add picture to profile]] — the UI side this feeds.

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -24,12 +24,12 @@ exists. The build names are unchanged.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Investigation complete; ready to implement. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Task A (PR Notes) then Task B (Site category). |
-| Last touched  | 2026-06-08                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-09                               |
 
 * Acceptance
 
@@ -42,8 +42,8 @@ exists. The build names are unchanged.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | STARTED | 2026-06-09 | | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
-| [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category for doc builds]] | BACKLOG | | | CTest.site.cmake script; update build-site.yml to submit; Canary already exists. |
+| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | DONE | 2026-06-09 | 2026-06-09 | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
+| [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category for doc builds]] | DONE | | 2026-06-09 | CTest.site.cmake script; update build-site.yml to submit; Canary already exists. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -24,7 +24,7 @@ exists. The build names are unchanged.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | Investigation complete; ready to implement. |
 | Waiting on    | Nothing.                               |
@@ -42,7 +42,7 @@ exists. The build names are unchanged.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | BACKLOG | | | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
+| [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | STARTED | 2026-06-09 | | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
 | [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category for doc builds]] | BACKLOG | | | CTest.site.cmake script; update build-site.yml to submit; Canary already exists. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :cdash:ci:canary:github_actions:improve_cdash_visibility:sprint_20:v0:
 #+owner: marco
-#+branch:
-#+pr: 1196
+#+branch: feature/improve-cdash-visibility
+#+pr: 1210
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -27,7 +27,7 @@ name itself is unchanged.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
 | Now          | Analysis complete; approach decided.   |
 | Waiting on   | Nothing.                               |
@@ -107,6 +107,7 @@ pattern: =ORES_GITHUB_PR_URL= follows it exactly.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1210][#1210]] | [build] Improve CDash visibility: PR notes + site build as a Site group |
 | [[https://github.com/OreStudio/OreStudio/pull/1196][#1196]] | [ci] Improve CDash build visibility |
 
 * Review

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.org
@@ -27,11 +27,11 @@ name itself is unchanged.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
-| Now          | Analysis complete; approach decided.   |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Update CTest.cmake and canary-linux.yml; thread PR number through pr.yml. |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -117,3 +117,7 @@ pattern: =ORES_GITHUB_PR_URL= follows it exactly.
 |   |                 |      |          |       |
 
 * Result
+
+PR URL written to =CTEST_NOTES_FILES= in =CTest.cmake= via an =ORES_PR_URL=
+environment variable threaded through =canary-linux.yml=. Canary builds on
+CDash now show a clickable Notes link back to the originating pull request.

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
@@ -8,7 +8,7 @@
 #+filetags: :cdash:ci:site:build_groups:improve_cdash_visibility:sprint_20:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1210
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -116,7 +116,7 @@ conflicting with any CMake preset's binary directory.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1210][#1210]] | [build] Improve CDash visibility: PR notes + site build as a Site group |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_site_and_categories.org
@@ -27,11 +27,11 @@ build-engineers can see at a glance whether the documentation built.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
-| Now          | Analysis complete; design decided.     |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Write CTest.site.cmake; update build-site.yml. |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -125,3 +125,10 @@ conflicting with any CMake preset's binary directory.
 |   |                 |      |          |       |
 
 * Result
+
+=CTestSite.cmake= drives the documentation build via =ctest_build= against the
+=deploy_site= target and submits to CDash as the =Site= build group. The
+=site-cdash.yml= reusable workflow wires it into both =pr.yml= (link-check,
+no Doxygen) and =build-site.yml= (full build with Doxygen on merge to main).
+Package bootstrap extracted to =ores-site-packages.el= and pre-warmed out of
+band so byte-compile noise never reaches CDash.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -214,6 +214,7 @@ health review (promote to a story, move to =next=, or discard).
 |---------+------+-------------|
 | [[id:13BBAE0C-8EA9-4266-85D1-77F7F603B71B][Split the user manual into Qt and Wt manuals]] | =documentation= =manual= =wt= =qt= | Split the single manual into separate Qt and Wt manuals (near-identical), sharing identical content via codegen. |
 | [[id:8DA74BFC-F213-4A02-A872-91A7D6C8D4F7][Standardise timeline bucket generation as a compass writer]] | =agile= =timeline= =compass= =tooling= | Build the bucket writer (canonical format) under the snapshot-skill task; replaces ad-hoc generation. |
+| [[id:42EB2329-CD49-430D-A78A-49D2D14987BD][Accumulate a tagged face dataset for profile pictures]] | =dataset= =seeder= =iam= =ui= | Build a seed catalog of attribute-tagged faces (via facestudio.app), accumulated over time within API throttling, for account profile pictures. |
 * Health Review
 
 (Run =agile-review-sprint= to generate this section.)

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -157,7 +157,7 @@ LLM-driven workflow frictionless.
 | [[id:3F7752F8-B719-40B4-BA89-09223410999E][Retune CI for tens of merges an hour]] | DONE | 2026-06-06 | 2026-06-08 | Path-classified PR jobs behind one pr-gate check; main matrices on staggered 2h/3h/4h schedules with a doc-only skip guard; Claude review replaces Gemini. |
 | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI]] | DONE | 2026-06-08 | 2026-06-08 | Unpin clang-format-18; apply drift to 181 files; restore bot-PR approach. PR #1187. |
 | [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] | BACKLOG | | | Eliminate duplicate-key failures caused by UUID v7 timestamp collision in email generation; one-line fix in account_generator.cpp. |
-| [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] | BACKLOG | | | PR tagging; Site CDash category; drop Experimental from developer-facing CI. |
+| [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] | DONE | 2026-06-08 | 2026-06-09 | PR tagging; Site CDash category; drop Experimental from developer-facing CI. |
 
 ** Site
 

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -38,48 +38,19 @@
 ;; Optionally, also suppress debug-on-quit and debug-on-signal if needed
 (setq debug-on-quit nil)
 
-(load-file (expand-file-name
-            "ores-link-types.el"
-            (file-name-directory (or load-file-name buffer-file-name))))
+(let ((src-dir (file-name-directory (or load-file-name buffer-file-name))))
+  (load-file (expand-file-name "ores-link-types.el" src-dir))
+  ;; Package bootstrap lives in its own file so CI can pre-warm the cache
+  ;; out of band (see CTestSite.cmake): a cold install byte-compiles dozens
+  ;; of files, and that output must not be scraped into the CDash build.
+  (load-file (expand-file-name "ores-site-packages.el" src-dir)))
 
 (setq org-id-locations-file (expand-file-name "./.org-id-locations-file"))
 (org-id-update-id-locations (directory-files-recursively "." "\\.org$"))
-(setq package-user-dir (expand-file-name "./.packages"))
-(setq package-archives '(("gnu" . "https://elpa.gnu.org/packages/")
-                         ("nongnu" . "https://elpa.nongnu.org/nongnu/")
-                         ("melpa" . "https://melpa.org/packages/")))
 
-;; Initialize the package system
-(package-initialize)
-
-;; Refresh with retries: a transient archive outage otherwise surfaces
-;; later as a baffling "Package 'queue' is unavailable" mid-install
-;; (2026-06-05: GNU ELPA hiccup on CI, swallowed by the old warning).
-(let ((refreshed nil))
-  (dotimes (attempt 3)
-    (unless refreshed
-      (condition-case err
-          (progn (package-refresh-contents)
-                 (setq refreshed t))
-        (error
-         (message "Warning: package refresh attempt %d/3 failed: %s"
-                  (1+ attempt) (error-message-string err))
-         (sleep-for 5)))))
-  (unless refreshed
-    (message "Warning: all refresh attempts failed; using cached contents")))
-
-;; queue (GNU ELPA) is citeproc's dependency; its absence from the
-;; archive contents is the signature of a failed GNU ELPA refresh —
-;; fail here with the real cause rather than mid-install.
-(when (and (not (package-installed-p 'queue))
-           (not (assq 'queue package-archive-contents)))
-  (error "GNU ELPA archive contents unavailable (queue missing) — refresh failed; re-run the build"))
-
-;; Install dependencies; skip what the cache already satisfies so a
-;; failed refresh only matters for genuinely missing packages.
-(dolist (pkg '(htmlize citeproc org-roam))
-  (unless (package-installed-p pkg)
-    (package-install pkg)))
+;; Ensure the site's package dependencies are present. A no-op when the cache
+;; is already warm (the CI pre-warm step, or a developer's local .packages).
+(ores-site-ensure-packages)
 
 ;; Load the publishing system
 (require 'ox-publish)

--- a/projects/ores.lisp/src/ores-site-packages.el
+++ b/projects/ores.lisp/src/ores-site-packages.el
@@ -1,0 +1,92 @@
+;;; ores-site-packages.el --- Ensure Emacs packages for the site build. -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2026 Marco Craveiro
+;;
+;; Author: Marco Craveiro <marco.craveiro@gmail.com>
+;; Maintainer: Marco Craveiro <marco.craveiro@gmail.com>
+;; URL: https://github.com/OreStudio/OreStudio
+;;
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program. If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; Bootstraps the third-party Emacs packages the site build depends on
+;; (htmlize, citeproc, org-roam) into ./.packages.
+;;
+;; Factored out of `ores-build-site.el' so the install — which byte-compiles
+;; dozens of files on a cold checkout, and is pure noise — can run as a
+;; *separate* step in CI (see CTestSite.cmake) rather than inside the
+;; CTest-monitored `deploy_site' build. CTest scrapes the build command's
+;; output into the CDash dashboard; a cold `package-install' otherwise shows up
+;; there as a "compiler error" (the benign seq activation message) plus dozens
+;; of byte-compile warnings, drowning the signal we actually care about (did the
+;; site build and are its links resolvable?). Pre-warming the cache out of band
+;; keeps the monitored build quiet.
+;;
+;; Pre-warm the cache (no CDash monitoring) with:
+;;   emacs -Q --batch -l ores-site-packages.el --eval "(ores-site-ensure-packages)"
+;;
+;;; Code:
+(require 'package)
+(require 'seq)
+
+(setq package-user-dir (expand-file-name "./.packages"))
+(setq package-archives '(("gnu" . "https://elpa.gnu.org/packages/")
+                         ("nongnu" . "https://elpa.nongnu.org/nongnu/")
+                         ("melpa" . "https://melpa.org/packages/")))
+
+(defconst ores-site-packages '(htmlize citeproc org-roam)
+  "Third-party packages required to publish the site.")
+
+(defun ores-site--refresh-with-retries ()
+  "Refresh package archive contents, retrying a transient archive outage.
+A single failed refresh otherwise surfaces later as a baffling \"Package
+\\='queue\\=' is unavailable\" mid-install (2026-06-05: GNU ELPA hiccup on CI,
+swallowed by the old warning)."
+  (let ((refreshed nil))
+    (dotimes (attempt 3)
+      (unless refreshed
+        (condition-case err
+            (progn (package-refresh-contents)
+                   (setq refreshed t))
+          (error
+           (message "Warning: package refresh attempt %d/3 failed: %s"
+                    (1+ attempt) (error-message-string err))
+           (sleep-for 5)))))
+    (unless refreshed
+      (message "Warning: all refresh attempts failed; using cached contents"))))
+
+(defun ores-site-ensure-packages ()
+  "Install the site's package dependencies if they are not already present.
+Beyond `package-initialize' this is a no-op when the cache is already warm, so
+the `deploy_site' build run stays quiet on CDash; the cold install runs once,
+out of band."
+  (package-initialize)
+  (when (seq-some (lambda (pkg) (not (package-installed-p pkg)))
+                  ores-site-packages)
+    (ores-site--refresh-with-retries)
+    ;; queue (GNU ELPA) is citeproc's dependency; its absence from the
+    ;; archive contents is the signature of a failed GNU ELPA refresh —
+    ;; fail here with the real cause rather than mid-install.
+    (when (and (not (package-installed-p 'queue))
+               (not (assq 'queue package-archive-contents)))
+      (error "GNU ELPA archive contents unavailable (queue missing) — refresh failed; re-run the build"))
+    ;; Install dependencies; skip what the cache already satisfies so a
+    ;; failed refresh only matters for genuinely missing packages.
+    (dolist (pkg ores-site-packages)
+      (unless (package-installed-p pkg)
+        (package-install pkg)))))
+
+(provide 'ores-site-packages)
+;;; ores-site-packages.el ends here


### PR DESCRIPTION
## Summary

Make the documentation build visible in CDash and link canary builds to their PR. Canary builds gain a 'Pull request: <url>' note; the site build now runs through a CTest script and submits to CDash as the Site group (PR link-check without Doxygen; full site + Doxygen on merges to main) — the same-script/two-configs pattern used by the continuous/nightly compile builds.

## Changes

- CTest.cmake: write the PR URL (ORES_PR_URL) to a notes file and set CTEST_NOTES_FILES so canary CDash entries link to the PR; canary-linux.yml passes the URL.
- CTestSite.cmake: one script for the doc build, parameterised by build_group (Site) and with_doxygen (OFF=site link-check, ON=site+Doxygen); fails on broken org id-links (verified locally).
- site-cdash.yml: reusable workflow running CTestSite (full configure, no database). Wired from pr.yml's site job (with_doxygen=false) and build-site.yml on main (with_doxygen=true).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve CDash build visibility](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.html) | 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41 |
| Task | [Link canary CDash builds to their PR via Notes](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_pr_tagging.html) | 9045AA11-B666-411B-B0CE-C41C3EA6508E |

🤖 Generated with [Claude Code](https://claude.com/claude-code)