### PR TITLE
[site] Merge the Agile nav group into Developer

### DIFF
--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
@@ -24,11 +24,11 @@ groups, no page content changed — so future sections can be added cleanly.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                                |
+| State         | DONE                                   |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Menu refinement: merge Agile into Developer. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Implement the Developer/Agile menu merge. |
+| Next          | Nothing.                               |
 | Last touched  | 2026-06-09                               |
 
 * Acceptance
@@ -51,7 +51,7 @@ groups, no page content changed — so future sections can be added cleanly.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:5AF053C0-0017-4ACC-AF44-7343531D0D99][Scaffold story: Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-07 | Create story folder, wire sprint table, fill in all scaffold docs, raise scaffold PR. |
-| [[id:42B291C9-55B2-4B3B-9FFC-DECB2E8AB82A][Design and implement the site navigation menu]] | STARTED | 2026-06-07 | | Replace flat =site-html-preamble= with a dropdown menu; update CSS and graph-page injection. |
+| [[id:42B291C9-55B2-4B3B-9FFC-DECB2E8AB82A][Design and implement the site navigation menu]] | DONE | 2026-06-07 | 2026-06-07 | Replace flat =site-html-preamble= with a dropdown menu; update CSS and graph-page injection. |
 | [[id:DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE][Merge the Agile menu into Developer and reorder for new users]] | DONE | 2026-06-09 | 2026-06-09 | Fold the Agile group into Developer; drop the agile recipes link; rename Overview→Agile, Board→Agile Board; reorder for new users. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
@@ -24,12 +24,12 @@ groups, no page content changed — so future sections can be added cleanly.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                                   |
+| State         | STARTED                                |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Nothing.                               |
+| Now           | Menu refinement: merge Agile into Developer. |
 | Waiting on    | Nothing.                               |
-| Next          | Nothing.                               |
-| Last touched  | 2026-06-07                               |
+| Next          | Implement the Developer/Agile menu merge. |
+| Last touched  | 2026-06-09                               |
 
 * Acceptance
 
@@ -52,6 +52,7 @@ groups, no page content changed — so future sections can be added cleanly.
 |------+-------+-------+-----+-------------|
 | [[id:5AF053C0-0017-4ACC-AF44-7343531D0D99][Scaffold story: Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-07 | Create story folder, wire sprint table, fill in all scaffold docs, raise scaffold PR. |
 | [[id:42B291C9-55B2-4B3B-9FFC-DECB2E8AB82A][Design and implement the site navigation menu]] | STARTED | 2026-06-07 | | Replace flat =site-html-preamble= with a dropdown menu; update CSS and graph-page injection. |
+| [[id:DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE][Merge the Agile menu into Developer and reorder for new users]] | BACKLOG | | | Fold the Agile group into Developer; drop the agile recipes link; rename Overview→Agile, Board→Agile Board; reorder for new users. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.org
@@ -52,7 +52,7 @@ groups, no page content changed — so future sections can be added cleanly.
 |------+-------+-------+-----+-------------|
 | [[id:5AF053C0-0017-4ACC-AF44-7343531D0D99][Scaffold story: Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-07 | Create story folder, wire sprint table, fill in all scaffold docs, raise scaffold PR. |
 | [[id:42B291C9-55B2-4B3B-9FFC-DECB2E8AB82A][Design and implement the site navigation menu]] | STARTED | 2026-06-07 | | Replace flat =site-html-preamble= with a dropdown menu; update CSS and graph-page injection. |
-| [[id:DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE][Merge the Agile menu into Developer and reorder for new users]] | BACKLOG | | | Fold the Agile group into Developer; drop the agile recipes link; rename Overview→Agile, Board→Agile Board; reorder for new users. |
+| [[id:DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE][Merge the Agile menu into Developer and reorder for new users]] | DONE | 2026-06-09 | 2026-06-09 | Fold the Agile group into Developer; drop the agile recipes link; rename Overview→Agile, Board→Agile Board; reorder for new users. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
@@ -49,7 +49,7 @@ Proposed =Developer= order (new-user-first):
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
@@ -89,3 +89,16 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Done in =site-html-preamble= (=projects/ores.lisp/src/ores-build-site.el=).
+The top-level =Agile= nav group is removed and its items folded into
+=Developer=, which now reads, in order: Guide, Recipes, Agile, Agile
+Board, LLMs. =Overview= was relabelled =Agile= (still
+=/doc/agile/agile.html=) and =Board= relabelled =Agile Board= (still
+=/agile/index.html=); the agile =Recipes= link
+(=/doc/recipes/agile/agile.html=) is dropped from the menu (agile
+recipes remain reachable from the Developer → Recipes index).
+
+The nav is a verbatim HTML string injected into every page, so the edit
+is the entire change; =ores-build-site.el= byte-compiles cleanly and no
+other file referenced the removed link or the old labels.

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
@@ -49,11 +49,11 @@ Proposed =Developer= order (new-user-first):
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-09                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
@@ -1,0 +1,91 @@
+:PROPERTIES:
+:ID: DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE
+:END:
+#+title: Task: Merge the Agile menu into Developer and reorder for new users
+#+description: Fold the top-level Agile nav group into the Developer group: remove the Agile recipes link, rename Overview to Agile and Board to Agile Board, and reorder the combined Developer menu with new users in mind.
+#+type: task
+#+level: s1
+#+filetags: :site_menu_navigation:sprint_20:v0:
+#+owner: marco
+#+branch: feature/merge-agile-into-developer-menu
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The site nav (=site-html-preamble= in
+[[proj:projects/ores.lisp/src/ores-build-site.el][=projects/ores.lisp/src/ores-build-site.el=]]) has a separate top-level
+=Agile= group holding /Overview/, /Board/ and /Recipes/. The agile
+material is really part of the contributor experience, so fold it into
+the =Developer= group and tidy the result:
+
+- Remove the top-level =Agile= nav group.
+- Drop the /Agile/ → Recipes link (=/doc/recipes/agile/agile.html=)
+  from the menu entirely — agile recipes are reachable from the
+  Developer /Recipes/ index.
+- Rename /Overview/ → *Agile* (still =/doc/agile/agile.html=) and
+  /Board/ → *Agile Board* (still =/agile/index.html=).
+- Move both into the =Developer= group and re-order the whole group for
+  someone arriving new to the project (onboarding first, niche tooling
+  last).
+
+Proposed =Developer= order (new-user-first):
+
+| # | Label       | Target                          | Rationale                          |
+|---+-------------+---------------------------------+------------------------------------|
+| 1 | Guide       | =/doc/developer.html=           | Where a new contributor starts     |
+| 2 | Recipes     | =/doc/recipes/recipes.html=     | Practical how-tos, next step        |
+| 3 | Agile       | =/doc/agile/agile.html=         | How we work — process overview     |
+| 4 | Agile Board | =/agile/index.html=             | The live board for current work    |
+| 5 | LLMs        | =/doc/llm/llm.html=             | Advanced / AI-assisted workflow    |
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-09                               |
+
+* Acceptance
+
+- The top-level =Agile= nav group no longer exists.
+- The =Developer= group contains, in order: Guide, Recipes, Agile,
+  Agile Board, LLMs.
+- =Agile= points at =/doc/agile/agile.html= (was /Overview/); =Agile
+  Board= points at =/agile/index.html= (was /Board/).
+- The agile /Recipes/ link (=/doc/recipes/agile/agile.html=) is gone
+  from the menu.
+- Site rebuilds (=deploy_site=) and the rendered nav matches the above
+  on every page.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
@@ -84,9 +84,16 @@ plan itself stays — it is the historical record of what we did.)
 
 * Review
 
+** Round 1 (2026-06-09, claude[bot] — approve with nits)
+
+Nav change confirmed correct and complete; the nits were agile-doc
+housekeeping, fixed in this PR.
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | task State/Now stale vs written Result | task_merge_agile_into_developer_menu.org | Accepted | Already DONE via task done |
+| 2 | story Tasks row showed BACKLOG/STARTED | story.org | Accepted | Merge task DONE; stale 42B291C9 row set DONE to match its file |
+| 3 | stale story Now/Next describing done work | story.org | Accepted | Story back to DONE; sprint row updated |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
+++ b/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.org
@@ -8,7 +8,7 @@
 #+filetags: :site_menu_navigation:sprint_20:v0:
 #+owner: marco
 #+branch: feature/merge-agile-into-developer-menu
-#+pr:
+#+pr: 1213
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-09
@@ -80,7 +80,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1213][#1213]] | [site] Merge the Agile nav group into Developer |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -167,7 +167,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-07 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. |
+| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | STARTED | 2026-06-07 | | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Reopened for menu refinement (merge Agile into Developer). |
 
 ** Agile
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -167,7 +167,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | STARTED | 2026-06-07 | | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Reopened for menu refinement (merge Agile into Developer). |
+| [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-09 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Plus a refinement: merge Agile into Developer, reorder for new users. |
 
 ** Agile
 

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -164,15 +164,9 @@
       <ul class='nav-dropdown'>
         <li><a href='/OreStudio/doc/developer.html'>Guide</a></li>
         <li><a href='/OreStudio/doc/recipes/recipes.html'>Recipes</a></li>
+        <li><a href='/OreStudio/doc/agile/agile.html'>Agile</a></li>
+        <li><a href='/OreStudio/agile/index.html'>Agile Board</a></li>
         <li><a href='/OreStudio/doc/llm/llm.html'>LLMs</a></li>
-      </ul>
-    </div>
-    <div class='nav-group'>
-      <span class='nav-group-label' tabindex='0'>Agile</span>
-      <ul class='nav-dropdown'>
-        <li><a href='/OreStudio/doc/agile/agile.html'>Overview</a></li>
-        <li><a href='/OreStudio/agile/index.html'>Board</a></li>
-        <li><a href='/OreStudio/doc/recipes/agile/agile.html'>Recipes</a></li>
       </ul>
     </div>
     <div class='nav-group'>


### PR DESCRIPTION
## Summary

Fold the top-level Agile menu into the Developer group and tidy it: drop the agile recipes link, rename Overview->Agile and Board->Agile Board, and reorder the combined group new-user-first (Guide, Recipes, Agile, Agile Board, LLMs).

## Changes

- Remove the top-level Agile nav group from site-html-preamble in ores-build-site.el
- Developer group order: Guide, Recipes, Agile (was Agile/Overview), Agile Board (was Agile/Board), LLMs
- Drop the agile Recipes link (/doc/recipes/agile/agile.html) from the menu; still reachable via Developer -> Recipes

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Replace site navbar with a structured menu](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/site_menu_navigation/story.html) | 84CB6F89-8847-47B0-B844-3D754BF00276 |
| Task | [Merge the Agile menu into Developer and reorder for new users](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/site_menu_navigation/task_merge_agile_into_developer_menu.html) | DC403A5E-6AE3-4FBE-A6B2-912CE57CE1EE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)