### PR TITLE
[agile] Add dashboard fix and health review 2 tasks to sprint 20

### DIFF
--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -57,6 +57,8 @@ whether the team is focused — rather than merely summarising status.
 | [[id:4F17BC82-00B5-43DE-B618-A87801763479][Health review 1 — sprint 20 housekeeping and status sync]] | DONE | 2026-06-07 | 2026-06-07 | Audit-driven housekeeping: close Open sprint 20 and site navbar stories, fix Commission: currency status drift, run sprint audit and health charts. |
 | [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date (start + 7 days) on sprint backlog]] | BACKLOG | | | Add #+end_date to sprint.org at open time; backfill sprint 20; warn on missing. |
 | [[id:DFC59C81-1D74-45E0-AC73-3FB974B5AA44][Mop up Sprint 20 state drift and stale closeouts]] | DONE | 2026-06-08 | 2026-06-08 | Close merged tasks/stories; block currency; fix sprint/file drift; regenerate the timeline at 20-min granularity. |
+| [[id:E01C8DCB-3864-420E-8A61-D8CD99A3F2D6][Fix dashboard: remove commits chart, fix sprint image display]] | BACKLOG | | | Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint. |
+| [[id:DEE29002-6007-478D-9665-56C147B5F41B][Health review 2 — sprint 20 mid-sprint analysis]] | BACKLOG | | | System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_fix_dashboard_sprint_charts.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_fix_dashboard_sprint_charts.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: E01C8DCB-3864-420E-8A61-D8CD99A3F2D6
+:END:
+#+title: Task: Fix dashboard: remove commits chart, fix sprint image display
+#+description: Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint.
+#+type: task
+#+level: s1
+#+filetags: :dashboard:agile:charts:sprint_20:v0:sprint_health_review:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Three targeted fixes to the agile board dashboard sprint view:
+
+1. Remove the "commits per sprint day" chart — it is noisy and not
+   actionable; the PR cycle-time and churn charts already cover
+   velocity.
+2. Move "tasks done per sprint day" next to the other sprint health
+   charts so all chart widgets sit together.
+3. Fix broken image display when clicking a sprint card — chart PNGs
+   are not rendering in the sprint detail view.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Locate the dashboard sprint-view code and make the three changes.  |
+| Last touched | 2026-06-09                             |
+
+* Acceptance
+
+- "Commits per sprint day" widget is removed from the dashboard.
+- "Tasks done per sprint day" is positioned adjacent to the other sprint
+  health charts (PR cycle time, line churn, stories done).
+- Clicking a sprint card on the dashboard correctly renders all chart
+  images without broken-image placeholders.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_health_review_2_mid_sprint_analysis.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_health_review_2_mid_sprint_analysis.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: DEE29002-6007-478D-9665-56C147B5F41B
+:END:
+#+title: Task: Health review 2 — sprint 20 mid-sprint analysis
+#+description: System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict.
+#+type: task
+#+level: s1
+#+filetags: :agile:review:health:sprint_20:v0:sprint_health_review:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Run the second System 2 health review of sprint 20 following the
+[[id:30FE3C0F-ECCB-46AD-AC1F-75C6CE05F0E7][Run a sprint health review]] runbook: generate the four sprint health
+charts, analyse the six dimensions (goal alignment, load, PR velocity,
+story/task balance, focus signal, overall verdict), write the full
+findings into =* Result=, add a summary row to =sprint.org=, and
+perform shape-completeness fixes on DONE tasks.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Run the runbook.                       |
+| Last touched | 2026-06-09                             |
+
+* Acceptance
+
+- Four chart PNGs (=prs_commits.png=, =line_churn.png=, =pr_cycle.png=,
+  =stories_done.png=) generated and committed under
+  =doc/agile/versions/v0/sprint_20/=.
+- =* Result= contains all six review sub-sections.
+- =sprint.org= =* Health Review= table has a new summary row linking to
+  this task.
+- Every DONE task in sprint 20 has =#+branch:=, =#+pr:=, and a
+  populated =* PRs= table; =Waiting on= / =Next= cleared.
+
+* Plan
+
+Follow [[id:30FE3C0F-ECCB-46AD-AC1F-75C6CE05F0E7][Run a sprint health review]] runbook steps 1–14.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

- **Task E01C8DCB**: Fix dashboard — remove "commits per sprint day", move "tasks done per sprint day" next to other charts, fix broken image display on sprint click
- **Task DEE29002**: Health review 2 — sprint 20 mid-sprint analysis (follows the run-sprint-health-review runbook)

Both wired into the sprint 20 health review story (3FBD411B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)