### PR TITLE
[build] Use Continuous CDash group for site builds; record revision

### DIFF
--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -132,5 +132,5 @@ jobs:
           export ORES_PR_URL="${{ github.event.pull_request.html_url }}"
           export preset=linux-gcc-debug-ninja
           if [ "${{ inputs.with_doxygen }}" = "true" ]; then dox=ON; else dox=OFF; fi
-          export cmake_args="build_group=Site,preset=${preset},with_doxygen=${dox}"
+          export cmake_args="build_group=Continuous,preset=${preset},with_doxygen=${dox}"
           ctest -VV --preset ${preset} --script "CTestSite.cmake,${cmake_args}"

--- a/CTestSite.cmake
+++ b/CTestSite.cmake
@@ -41,7 +41,11 @@ if(NOT DEFINED preset)
     message(FATAL_ERROR "Parameter preset not defined.")
 endif()
 if(NOT DEFINED build_group)
-    set(build_group "Site")
+    # CTest only recognises Nightly/Continuous/Experimental as model names;
+    # any other string silently falls back to Experimental.  Site builds fire
+    # on every merge to main, so Continuous is the correct semantic here and
+    # gives a distinct CDash section separate from the Experimental canary builds.
+    set(build_group "Continuous")
 endif()
 message(STATUS "CDash build group: ${build_group}")
 
@@ -97,10 +101,18 @@ set(CTEST_CUSTOM_ERROR_EXCEPTION ${CTEST_CUSTOM_ERROR_EXCEPTION}
 
 ctest_start(${build_group})
 
-# Version-only update (detached-HEAD PR checkouts return non-zero harmlessly).
-find_package(Git)
-set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
-set(CTEST_UPDATE_VERSION_ONLY ON)
+# Record the current commit as the build revision for CDash.  GitHub Actions
+# checks out a detached HEAD with a shallow clone, so ctest_update's normal
+# "count new commits" produces 0 and CDash shows a blank Revision column.
+# Overriding CTEST_UPDATE_COMMAND with a script that emits the SHA makes CDash
+# display the commit hash in the Revision column without trying to update the tree.
+if(DEFINED ENV{ORES_BUILD_COMMIT} AND NOT "$ENV{ORES_BUILD_COMMIT}" STREQUAL "")
+    set(CTEST_UPDATE_COMMAND "${CMAKE_COMMAND}" -E echo "$ENV{ORES_BUILD_COMMIT}")
+else()
+    find_package(Git)
+    set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
+    set(CTEST_UPDATE_VERSION_ONLY ON)
+endif()
 ctest_update(RETURN_VALUE update_result)
 
 # Configure (reuses the preset; cheap on an already-configured tree).

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: AA30D7A7-16F8-47CC-814E-7382E830F064
+:END:
+#+title: Task: Use Continuous group and record revision in CDash site builds
+#+description: Task for: Improve CDash build visibility
+#+type: task
+#+level: s1
+#+filetags: :improve_cdash_visibility:sprint_20:v0:
+#+owner: marco
+#+branch: feature/cdash-correct-group-and-revision
+#+pr: 1218
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-09                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1218][#1218]] | [build] Use Continuous CDash group for site builds; record revision |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

Site builds were landing in the Experimental CDash group (same as canary) because CTest only recognises Nightly/Continuous/Experimental as valid model names — 'Site' silently fell back to Experimental. This switches the model to Continuous and records the commit SHA as the CDash revision (GitHub's shallow checkout caused the Revision column to be blank).

## Changes

- CTestSite.cmake: use Continuous as CDash model so site builds get a distinct section from Experimental canary builds
- CTestSite.cmake: override CTEST_UPDATE_COMMAND to emit SHA from ORES_BUILD_COMMIT so CDash Revision column is not blank
- site-cdash.yml: pass build_group=Continuous

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve CDash build visibility](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.html) | 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41 |
| Task | [Use Continuous group and record revision in CDash site builds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.html) | AA30D7A7-16F8-47CC-814E-7382E830F064 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)