### PR TITLE
[agile] Close CDash group/revision task (not pursued)

### DIFF
--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -44,6 +44,7 @@ exists. The build names are unchanged.
 |------+-------+-------+-----+-------------|
 | [[id:9045AA11-B666-411B-B0CE-C41C3EA6508E][Link canary CDash builds to their PR via Notes]] | DONE | 2026-06-09 | 2026-06-09 | Write PR URL to CTEST_NOTES_FILES in CTest.cmake; thread pr_number through canary-linux.yml. |
 | [[id:FA80ED06-408E-4F48-9EC2-D9931164EB06][Add CDash Site category for doc builds]] | DONE | | 2026-06-09 | CTest.site.cmake script; update build-site.yml to submit; Canary already exists. |
+| [[id:AA30D7A7-16F8-47CC-814E-7382E830F064][Use Continuous group and record revision in CDash site builds]] | DONE | 2026-06-09 | 2026-06-09 | Investigated CTest model names and CDash group; PR #1218 closed — Experimental + -site suffix is sufficient. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :cdash:ci:infrastructure:tooling:sprint_20:v0:
 #+created: 2026-06-08
-#+updated: 2026-06-08
+#+updated: 2026-06-09
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
@@ -58,7 +58,7 @@ n/a — investigation closed before a formal plan was written; see =* Result=.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | #+pr: 1219 → 1218; Goal placeholder; Acceptance bare dash; Plan boilerplate; missing :cdash:ci: filetags; story.org #+updated: stale | task+story | Accept | Fixed in a72e6a6 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
@@ -8,7 +8,7 @@
 #+filetags: :improve_cdash_visibility:sprint_20:v0:
 #+owner: marco
 #+branch: feature/cdash-correct-group-and-revision
-#+pr: 1218
+#+pr: 1219
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-09
@@ -48,6 +48,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1219][#1219]] | [agile] Close CDash group/revision task (not pursued) |
 | [[https://github.com/OreStudio/OreStudio/pull/1218][#1218]] | [build] Use Continuous CDash group for site builds; record revision |
 
 * Review

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: AA30D7A7-16F8-47CC-814E-7382E830F064
+:END:
+#+title: Task: Use Continuous group and record revision in CDash site builds
+#+description: Task for: Improve CDash build visibility
+#+type: task
+#+level: s1
+#+filetags: :improve_cdash_visibility:sprint_20:v0:
+#+owner: marco
+#+branch: feature/cdash-correct-group-and-revision
+#+pr: 1218
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-09
+#+updated: 2026-06-09
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-09                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1218][#1218]] | [build] Use Continuous CDash group for site builds; record revision |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Not pursued. CTest only supports Nightly/Continuous/Experimental as model names
+(custom names fall back to Experimental), and a literal =Site= CDash group would
+require admin access on my.cdash.org. The =CTEST_UPDATE_COMMAND= override to
+emit a SHA caused CDash to show a red revision column. Closed PR #1218 without
+merging. Existing state is acceptable: site builds land in Experimental with the
+=-site= build-name suffix providing visual distinction from canary builds, and
+the version-only Git update already records correct revisions on completed builds.

--- a/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
+++ b/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.org
@@ -5,10 +5,10 @@
 #+description: Task for: Improve CDash build visibility
 #+type: task
 #+level: s1
-#+filetags: :improve_cdash_visibility:sprint_20:v0:
+#+filetags: :cdash:ci:improve_cdash_visibility:sprint_20:v0:
 #+owner: marco
 #+branch: feature/cdash-correct-group-and-revision
-#+pr: 1219
+#+pr: 1218
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-09
@@ -19,7 +19,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Investigate using CTest's =Continuous= model so site builds appear in a
+dedicated CDash group separate from the =Experimental= canary builds, and
+override =CTEST_UPDATE_COMMAND= to record the Git SHA in the CDash Revision
+column (GitHub's shallow checkout causes the default version-only update to
+report 0 new commits).
 
 * Status
 
@@ -34,13 +38,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+n/a — task not pursued; investigation concluded the approach was not feasible
+without CDash admin access.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+n/a — investigation closed before a formal plan was written; see =* Result=.
 
 * Notes
 


### PR DESCRIPTION
## Summary

Close the task that investigated using a Continuous CDash group and fixing the revision column. Both changes in PR #1218 were counterproductive — CTest custom model names fall back to Experimental, and the CTEST_UPDATE_COMMAND override caused a red revision. Closed #1218 without merging. Adds the task result and wires the task row into the story.

## Changes

- Add task_cdash_correct_group_and_revision.org with DONE state and investigation result
- Wire the task row into improve_cdash_visibility/story.org Tasks table

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve CDash build visibility](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/story.html) | 545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41 |
| Task | [Use Continuous group and record revision in CDash site builds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/improve_cdash_visibility/task_cdash_correct_group_and_revision.html) | AA30D7A7-16F8-47CC-814E-7382E830F064 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)