### PR TITLE
[iam,tests] Fix flaky IAM repository tests

### DIFF
--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/story.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/story.org
@@ -22,12 +22,12 @@ a retry loop or test ordering workaround.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Investigation complete; ready to implement. |
-| Waiting on    | Nothing.                               |
-| Next          | Fix email suffix and verify no recurrence. |
-| Last touched  | 2026-06-08                               |
+| Now           | Nothing.                             |
+| Waiting on    | Nothing.                             |
+| Next          | Nothing.                             |
+| Last touched  | 2026-06-10                           |
 
 * Acceptance
 
@@ -39,7 +39,7 @@ a retry loop or test ordering workaround.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:F94637CA-06CE-4A61-BEEC-9A090649C3FC][Fix email-suffix collision]] | BACKLOG | | | Use full-UUID random tail as email suffix; one-line change to account_generator.cpp. |
+| [[id:F94637CA-06CE-4A61-BEEC-9A090649C3FC][Fix email-suffix collision]] | DONE | 2026-06-10 | 2026-06-10 | Use full-UUID random tail as email suffix; one-line change to account_generator.cpp. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :iam:tests:flaky:generation:infrastructure:fix_flaky_iam_tests:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-email-generation
 #+pr: 1195
 #+blocked_on:
 #+blocked_since:
@@ -27,11 +27,11 @@ parallel CI workers.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] |
-| Now          | Investigation complete; fix is clear.  |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Apply fix, build, run tests locally.   |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -105,3 +105,8 @@ astronomically unlikely with 48 bits of independent randomness per suffix.
 |   |                 |      |          |       |
 
 * Result
+
+Changed =id_str.substr(0, 8)= to =id_str.substr(24)= in =account_generator.cpp=.
+The suffix now draws from bytes 10–15 of the UUID v7 — 48 bits of =mt19937_64= random
+state, independent of the millisecond timestamp in bytes 0–5. Parallel CI workers seeded
+from separate =std::random_device= instances will not collide.

--- a/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
+++ b/doc/agile/versions/v0/sprint_20/fix_flaky_iam_tests/task_fix_email_generation.org
@@ -8,7 +8,7 @@
 #+filetags: :iam:tests:flaky:generation:infrastructure:fix_flaky_iam_tests:sprint_20:v0:
 #+owner: marco
 #+branch: feature/fix-email-generation
-#+pr: 1195
+#+pr: 1224
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -96,7 +96,7 @@ astronomically unlikely with 48 bits of independent randomness per suffix.
 
 | PR | Title |
 |----+-------|
-| [[https://github.com/OreStudio/OreStudio/pull/1195][#1195]] | [iam,tests] Fix flaky IAM repository tests |
+| [[https://github.com/OreStudio/OreStudio/pull/1224][#1224]] | [iam,tests] Fix flaky IAM repository tests |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -25,12 +25,12 @@ that tracks the manual automatically.
 
 | Field         | Value                                                        |
 |---------------+--------------------------------------------------------------|
-| State         | STARTED                                                      |
+| State         | DONE                                                         |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
-| Now           | Scaffolding story and tasks.                                 |
+| Now           | Nothing.                                                     |
 | Waiting on    | Nothing.                                                     |
-| Next          | Pick up the help-HTML export task.                           |
-| Last touched  | 2026-06-08                                                   |
+| Next          | Nothing.                                                     |
+| Last touched  | 2026-06-10                                                   |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -89,7 +89,7 @@ commissioning.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] | STARTED | 2026-06-08 | | Build the manual into a .qch collection and open it in-app via QHelpEngine; native, offline, searchable help from the existing manual. |
+| [[id:FA1DD7D5-DE78-4E97-A9EF-932AD2C46693][Qt help system from the user manual]] | DONE | 2026-06-08 | 2026-06-10 | Build the manual into a .qch collection and open it in-app via QHelpEngine; native, offline, searchable help from the existing manual. |
 
 ** Tooling
 
@@ -156,7 +156,7 @@ LLM-driven workflow frictionless.
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. Slipped in sprints 18 and 19. |
 | [[id:3F7752F8-B719-40B4-BA89-09223410999E][Retune CI for tens of merges an hour]] | DONE | 2026-06-06 | 2026-06-08 | Path-classified PR jobs behind one pr-gate check; main matrices on staggered 2h/3h/4h schedules with a doc-only skip guard; Claude review replaces Gemini. |
 | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI]] | DONE | 2026-06-08 | 2026-06-08 | Unpin clang-format-18; apply drift to 181 files; restore bot-PR approach. PR #1187. |
-| [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] | BACKLOG | | | Eliminate duplicate-key failures caused by UUID v7 timestamp collision in email generation; one-line fix in account_generator.cpp. |
+| [[id:C1BBE8C8-2FBD-4AA2-83B0-4E57112B8505][Fix flaky IAM repository tests]] | DONE | 2026-06-10 | 2026-06-10 | Eliminate duplicate-key failures caused by UUID v7 timestamp collision in email generation; one-line fix in account_generator.cpp. |
 | [[id:545DCC1B-D3D0-4E4E-92BA-C4F2F50FEB41][Improve CDash build visibility]] | DONE | 2026-06-08 | 2026-06-09 | PR tagging; Site CDash category; drop Experimental from developer-facing CI. |
 
 ** Site

--- a/projects/ores.iam/api/src/generators/account_generator.cpp
+++ b/projects/ores.iam/api/src/generators/account_generator.cpp
@@ -42,7 +42,7 @@ domain::account generate_synthetic_account(utility::generation::generation_conte
     // Use a UUID-based suffix to prevent duplicate key violations when many
     // accounts are written within the same test tenant in a single test run.
     const auto id_str = boost::uuids::to_string(r.id);
-    const auto suffix = id_str.substr(0, 8);
+    const auto suffix = id_str.substr(24); // random tail — 12 hex chars from bytes 10-15
 
     auto first = std::string(faker::person::firstName());
     auto last = std::string(faker::person::lastName());

--- a/projects/ores.iam/api/src/generators/account_generator.cpp
+++ b/projects/ores.iam/api/src/generators/account_generator.cpp
@@ -42,7 +42,7 @@ domain::account generate_synthetic_account(utility::generation::generation_conte
     // Use a UUID-based suffix to prevent duplicate key violations when many
     // accounts are written within the same test tenant in a single test run.
     const auto id_str = boost::uuids::to_string(r.id);
-    const auto suffix = id_str.substr(24); // random tail — 12 hex chars from bytes 10-15
+    const auto suffix = id_str.substr(24);
 
     auto first = std::string(faker::person::firstName());
     auto last = std::string(faker::person::lastName());


### PR DESCRIPTION
## Summary

- Change `account_generator.cpp` email suffix from `id_str.substr(0, 8)` (timestamp prefix, same across parallel workers in the same millisecond) to `id_str.substr(24)` (random tail, 48 bits of independent `mt19937_64` state)
- Closes the Qt help system from the user manual story bookkeeping (all tasks DONE, sprint row updated)

## Root cause

UUID v7 places the millisecond timestamp in bytes 0–5. The old `substr(0, 8)` took the first 8 hex chars — bytes 0–3, the upper 32 bits of the timestamp — which are identical for every UUID generated within the same millisecond. CI canary runs with `CTEST_PARALLEL_LEVEL=$(nproc)`, so parallel test processes collided on `accounts_email_uniq_idx`.

## Fix

`substr(24)` takes the last 12 hex chars (bytes 10–15), drawn entirely from the `mt19937_64` engine state seeded by `std::random_device`. Collisions require 48-bit random state agreement across independent processes — astronomically unlikely.

## Test plan

- [ ] CI canary (`linux-gcc-debug-ninja`) passes the full IAM test suite with maximum parallelism
- [ ] No new unique-constraint failures in IAM tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)