### PR TITLE
[agile] Agile timeline: environment stamp, snapshot skill, storage

### DIFF
--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -29,12 +29,12 @@ event counts over time with click-through to each bucket's log.
 
 | Field         | Value                                                        |
 |---------------+--------------------------------------------------------------|
-| State         | STARTED                                                      |
+| State         | DONE                                                         |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
-| Now           | Scaffolding story and tasks.                                 |
+| Now           | All tasks done or abandoned. Story complete.                 |
 | Waiting on    | Nothing.                                                     |
-| Next          | Temporal-coherence analysis gates the implementation tasks.  |
-| Last touched  | 2026-06-07                                                   |
+| Next          | Nothing.                                                     |
+| Last touched  | 2026-06-10                                                   |
 
 * Acceptance
 
@@ -63,7 +63,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | DONE | 2026-06-10 | 2026-06-10 | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | DONE | 2026-06-10 | 2026-06-10 | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
-| [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | BACKLOG |            |     | Two charts at board top: tasks done per sprint day; commits per sprint day. Blocked on end-date task. |
+| [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | ABANDONED |            | 2026-06-10 | Blocked on end-date task; out of sprint scope. |
 | [[id:09F0C6B1-26C2-4926-AB63-982C2558F4A4][Window the timeline chart with back/forward navigation]] | DONE | 2026-06-08 | 2026-06-08 | Show the board timeline chart as a sliding window of N buckets (default 10, most-recent first) with ← earlier / later → paging instead of cramming every bucket, which made the x-axis unreadable. Realises the movable-time-window capture. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -59,7 +59,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
 | [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | DONE | 2026-06-07 | 2026-06-07 | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
-| [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | BACKLOG |            |     | #+environment: from the .env label via compass task start/done.   |
+| [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | STARTED | 2026-06-10 |     | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
 | [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | BACKLOG |            |     | Two charts at board top: tasks done per sprint day; commits per sprint day. Blocked on end-date task. |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -8,6 +8,7 @@
 #+filetags: :agile:compass:org-js:timeline:llm:sprint_20:v0:
 #+created: 2026-06-07
 #+updated: 2026-06-07
+#+environment: local3
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -60,7 +61,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | DONE | 2026-06-07 | 2026-06-07 | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
 | [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | DONE | 2026-06-10 | 2026-06-10 | #+environment: from the .env label via compass task start/done.   |
-| [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
+| [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | DONE | 2026-06-10 | 2026-06-10 | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
 | [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | BACKLOG |            |     | Two charts at board top: tasks done per sprint day; commits per sprint day. Blocked on end-date task. |
 | [[id:09F0C6B1-26C2-4926-AB63-982C2558F4A4][Window the timeline chart with back/forward navigation]] | DONE | 2026-06-08 | 2026-06-08 | Show the board timeline chart as a sliding window of N buckets (default 10, most-recent first) with ← earlier / later → paging instead of cramming every bucket, which made the x-axis unreadable. Realises the movable-time-window capture. |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/story.org
@@ -59,7 +59,7 @@ event counts over time with click-through to each bucket's log.
 | [[id:8B8361ED-768B-4B8B-B008-83155D0956B7][Scaffold story]]                                     | DONE | 2026-06-07 | 2026-06-07 | Create story, tasks, sprint wiring, scaffold PR.                  |
 | [[id:7FEA4D7A-E1A6-4FC4-B684-297FB7EA4FF7][Analyse temporal commands end-to-end for conceptual coherence]] | DONE | 2026-06-07 | 2026-06-07 | Coherent model for fleet/journal/timeline; analysis doc gates implementation. |
 | [[id:49BE7DB0-0577-4C30-A370-610C0B48FC7F][Add compass timeline command]]                       | DONE | 2026-06-07 | 2026-06-07 | Generate LLM inputs (changed docs per window); view last N buckets. |
-| [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | STARTED | 2026-06-10 |     | #+environment: from the .env label via compass task start/done.   |
+| [[id:8E94E4FD-9C0D-4467-8126-4E224CEBE6CE][Stamp the working environment on documents]]         | DONE | 2026-06-10 | 2026-06-10 | #+environment: from the .env label via compass task start/done.   |
 | [[id:D47C04DD-51F7-4DDB-B4B8-2B4499DEF793][Add LLM snapshot summarisation skill and storage]]   | BACKLOG |            |     | Bucketed snapshot org files under the sprint's timeline/ folder.  |
 | [[id:EF9E326A-D7A6-42A8-8DB2-53D90A265FED][Add timeline view to the agile board]]               | DONE | 2026-06-07 | 2026-06-07 | Event-count chart with click-through to bucket snapshots.         |
 | [[id:91B54191-57EC-4956-9E97-0B8C0EA249F6][Add sprint velocity bar charts to agile board]]      | BACKLOG |            |     | Two charts at board top: tasks done per sprint day; commits per sprint day. Blocked on end-date task. |

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_sprint_velocity_chart.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_sprint_velocity_chart.org
@@ -27,11 +27,11 @@ team can see sprint velocity at a glance without leaving the dashboard.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Not yet started.                       |
-| Waiting on   | [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date]] — need =#+end_date= to compute sprint day N. |
-| Last touched | 2026-06-08                               |
+| Now          | Abandoned — blocked and out of sprint scope. |
+| Waiting on   | Nothing. |
+| Last touched | 2026-06-10                               |
 
 * Acceptance
 
@@ -89,3 +89,7 @@ on a dual-axis chart is harder to read than two narrow side-by-side bars.
 |   |                 |      |          |       |
 
 * Result
+
+Abandoned. Blocked on [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date]] (=#+end_date= not yet written by
+compass) and requires Chart.js integration and Emacs export changes — out
+of scope for this sprint.  Captured for the product backlog.

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
@@ -19,13 +19,18 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add =#+environment:= stamping to compass so every task and story records
+which checkout worked on it. The value comes from =ORES_CHECKOUT_LABEL=
+in the repo's =.env= file. Compass writes the field on =task start= (task
++ story) and =task done= (task only). New task and story templates gain a
+blank =#+environment:= placeholder so the field is always present after
+scaffolding.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
@@ -63,3 +68,12 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+- Added =_set_frontmatter_field(path, field, value)= helper to =compass.py= (after
+  =_set_frontmatter_branch=): updates an existing =#+field:= line or inserts after
+  =#+updated:= (or =#+created:= as fallback).
+- Wired env stamp into =_cmd_task_start=: reads =ORES_CHECKOUT_LABEL= from =.env=
+  and calls =_set_frontmatter_field= on both the task and the story (when present).
+- Wired env stamp into =_cmd_task_done=: stamps the task only.
+- Added blank =#+environment:= field to =doc_task_org.org= / =doc_task.org.mustache=
+  and =doc_story_org.org= / =doc_story.org.mustache= (after =#+updated:=).

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_environment_stamp.org
@@ -13,6 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-07
 #+updated: 2026-06-07
+#+environment: local3
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -30,11 +31,11 @@ scaffolding.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
@@ -8,7 +8,7 @@
 #+filetags: :agile_timeline:sprint_20:v0:
 #+owner: marco
 #+branch: feature/timeline-snapshot-skill
-#+pr:
+#+pr: 1227
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-07
@@ -65,7 +65,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1227][#1227]] | [agile] Agile timeline: environment stamp, snapshot skill, storage |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
+++ b/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.org
@@ -13,23 +13,28 @@
 #+blocked_since:
 #+created: 2026-06-07
 #+updated: 2026-06-07
+#+environment: local3
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add a =compass timeline snapshot= command and an =agile-add-timeline-snapshot=
+skill so the LLM can produce structured 20-minute activity buckets and store
+them in the sprint's =timeline/= folder.  Each snapshot is a scan-first org
+file with Stories, Tasks, Captures, PRs, Problems/suspicious-decisions, and
+an Audit section.  A companion recipe documents the workflow.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-07                               |
 
 * Acceptance
@@ -69,3 +74,15 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+- Added =_cmd_snapshot=, =_write_snapshot=, =_find_sprint_timeline_dir=,
+  =_snapshot_filename=, =_doc_link=, =_event_desc= to =compass_timeline.py=.
+  The =snapshot= subcommand resolves a window, fetches origin/main, buckets
+  doc and PR events, auto-detects the current sprint's =timeline/= dir,
+  generates a UUID per snapshot, and writes the structured org file.
+- Event-count cap of 20 per bucket enforced with a warning on overflow.
+- Audit section auto-flags items closed without =#+environment:= stamp.
+- Created =doc/llm/skills/agile-add-timeline-snapshot/SKILL.org= and deployed
+  via =compass build skills=.
+- Created =doc/recipes/compass/how_do_i_create_a_timeline_snapshot.org=.
+- Added skill to =doc/llm/skills/claude_code_skills.org=.

--- a/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/qt_help_system/story.org
@@ -27,7 +27,7 @@ that tracks the manual automatically.
 |---------------+--------------------------------------------------------------|
 | State         | DONE                                                         |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]    |
-| Now           | Nothing.                                                     |
+| Now           | All tasks merged. Story complete.                            |
 | Waiting on    | Nothing.                                                     |
 | Next          | Nothing.                                                     |
 | Last touched  | 2026-06-10                                                   |

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -178,7 +178,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | [[id:9DCBFE70-C3F0-438A-AD83-1E4F3FBBDAAB][Open sprint 20]] | DONE | 2026-06-06 | 2026-06-06 | Two-PR transition ceremony: close 19 (carry, release notes), open 20 (pull stories, version bump, vcpkg). |
 | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | DONE | 2026-06-06 | 2026-06-07 | PoC succeeded: ores.org-js agile board over graphdata.json, deployed with the site. |
 | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] | STARTED | 2026-06-07 | | Periodic health checks; housekeeping tasks added as the sprint progresses. |
-| [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] | STARTED | 2026-06-07 | | compass timeline command; environment stamping; LLM snapshot skill; board timeline view. |
+| [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] | DONE | 2026-06-07 | 2026-06-10 | compass timeline command; environment stamping; LLM snapshot skill; board timeline view. |
 
 ** Hotfixes
 

--- a/doc/llm/memory/deploy_skills_via_build_skills_command.org
+++ b/doc/llm/memory/deploy_skills_via_build_skills_command.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID: 8EA39071-A347-4608-A57F-611E88B121FA
+:END:
+#+title: Deploy skills via compass build skills, not manually
+#+description: Never create .claude/skills/<name>/SKILL.md manually; always deploy via compass build skills after updating the .org source.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+
+Never create =.claude/skills/<name>/SKILL.md= manually. After writing the =doc/llm/skills/<name>/SKILL.org= source file, always deploy via =./projects/ores.compass/compass.sh build skills= which runs Emacs to export all skill org files to the deployed bundle in =.claude/skills/=.
+
+*Why:* Manually written SKILL.md files miss org-export artifacts (anchor IDs) and diverge from the tangled LICENSE.txt; the build also ensures all org-roam id: links resolve before export fails.
+
+*How to apply:* Any time a skill SKILL.org is created or updated, run =compass build skills= to regenerate the deployed bundle. Do NOT write to =.claude/skills/= directly.

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -63,6 +63,9 @@ of these exclusions, push back: the right home is somewhere else.
   is the first port of call for any project operation.
 - [[id:C26B61E8-1CA7-4241-B1D9-D4D95B7DDB01][Run deploy_skills cmake target directly]] — it is Emacs-only, not C++
   compilation; run =cmake --build --preset linux-clang-debug-ninja --target deploy_skills= without asking the user.
+- [[id:8EA39071-A347-4608-A57F-611E88B121FA][Deploy skills via compass build skills, not manually]] — never write
+  =.claude/skills/<name>/SKILL.md= directly; always run =compass build skills=
+  after editing a =doc/llm/skills/<name>/SKILL.org= source file.
 - [[id:06A0919D-B741-40EA-BFF2-376BD36C4A27][Builds can run outside the sandbox]] — use =dangerouslyDisableSandbox: true=
   for any =cmake --build= or =make -C build/output/...= call; compiler
   toolchain and vcpkg detection are blocked inside the sandbox.

--- a/doc/llm/skills/agile-add-timeline-snapshot/SKILL.org
+++ b/doc/llm/skills/agile-add-timeline-snapshot/SKILL.org
@@ -1,0 +1,91 @@
+:PROPERTIES:
+:ID: 1B837DB5-B27A-451B-A0D0-DD17142476E4
+:END:
+#+title: Agile Add Timeline Snapshot
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :agile:timeline:compass:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+
+#+begin_export markdown
+---
+name: agile-add-timeline-snapshot
+description: Create a 20-minute timeline snapshot of recent agile activity; write it to the current sprint's timeline/ folder.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks to "snapshot the timeline", "create a timeline
+bucket", or record what has happened in the last 20 minutes (or a
+custom window) on the agile board.  The snapshot is stored under the
+current sprint's =timeline/= folder as =<ISO-from>-<ISO-to>.org= and
+read by [[id:551FC710-7E3C-484B-AB52-7F2C8DAF3B6F][the temporal grid's]] =compass timeline show= command.
+
+* How to use this skill
+
+1. /Generate the snapshot scaffold/ for the default 20-minute window:
+
+   #+begin_src sh :results verbatim
+   ./compass.sh timeline snapshot
+   #+end_src
+
+   For a custom window use =--since 1h= or =--from <ISO> --to <ISO>=.
+   If compass warns that the event count exceeds the cap (20), split
+   the window before continuing — a busy bucket defeats the purpose.
+
+2. /Read the generated file/ — compass prints its path on success.
+
+3. /Fill in =* Problems and suspicious decisions=/ based on the events:
+   - LLM co-authored commits that touch code without an open task.
+   - PRs merged while CI was still pending (look for force-merge
+     patterns in the PR table).
+   - Tasks that went DONE rapidly with no =#+environment:= stamp
+     (may indicate incomplete bookkeeping).
+   - Captures filed but no follow-up story opened yet.
+
+4. /Fix the audit section/ if compass flagged bookkeeping drift
+   (items closed without environment stamp).  Correct the actual
+   task/story docs; do not just edit the snapshot.
+
+5. /Commit the snapshot/:
+
+   #+begin_src sh :results verbatim
+   git add <file> && git commit -m "[agile] Timeline snapshot: <from>-<to>" && git push
+   #+end_src
+
+* Recipes
+
+- [[id:55DED59B-0338-4BF7-AC67-ADE0BCA408CC][How do I create a timeline snapshot?]] — step-by-step with examples.
+
+* Reference
+
+- [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] — the story
+  this skill delivers.
+- [[id:551FC710-7E3C-484B-AB52-7F2C8DAF3B6F][Temporal command coherence investigation]] — design rationale for
+  the consistent-substrate model the snapshot uses.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -42,6 +42,7 @@ Stories, tasks, sprints, backlog, journal, orientation.
 | [[id:DD7857D9-068E-D724-5C63-A67BD5F1C009][agile-add-release-notes]] | Agile Add Release Notes | Generate ORE Studio release notes from merged PRs and the closing sprint backlog, then tag main and open a... |
 | [[id:A11D7893-53FB-40BF-B1F1-A760D24D86BC][agile-add-story]] | Agile Add Story | Create a story with docs only — no branch, no journal; backlog refinement and sprint planning use this. |
 | [[id:DBBBE507-E750-40DF-B9EF-06E829836087][agile-add-task]] | Agile Add Task | Add a task to an existing story, docs only — no branch side effects. |
+| [[id:1B837DB5-B27A-451B-A0D0-DD17142476E4][agile-add-timeline-snapshot]] | Agile Add Timeline Snapshot | Create a 20-minute timeline snapshot of recent agile activity; write it to the current sprint's timeline/ folder. |
 | [[id:460C89DA-50D2-40C3-88B2-BE52E430D170][agile-brainstorm-idea]] | Agile Brainstorm Idea | Explore user intent and design through collaborative dialogue — one question at a time, alternatives with t... |
 | [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] | Agile Close Task | Close a task's bookkeeping at the end of the review round: DONE, Result, story and sprint sync; cascades to... |
 | [[id:936389EC-7E0A-4925-9023-D4FA33C0FBF4][agile-find-bearings]] | Agile Find Bearings | Initialise a session — compass-first operation, recipe search for command info, bearings, then a summary an... |

--- a/doc/recipes/compass/how_do_i_create_a_timeline_snapshot.org
+++ b/doc/recipes/compass/how_do_i_create_a_timeline_snapshot.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 55DED59B-0338-4BF7-AC67-ADE0BCA408CC
+:END:
+#+title: How do I create a timeline snapshot?
+#+description: Run compass timeline snapshot to write a 20-minute activity bucket to the sprint's timeline/ folder.
+#+type: recipe
+#+level: cross
+#+filetags: :compass:timeline:agile:recipe:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+
+Relies on =compass timeline snapshot= (in [[id:551FC710-7E3C-484B-AB52-7F2C8DAF3B6F][the temporal command
+coherence investigation]]), which mines =origin/main= and the GitHub PR
+record for the given window and writes a structured org file to the
+current sprint's =timeline/= folder.
+
+* Question
+
+How do I create a 20-minute timeline snapshot of recent agile activity?
+
+* Answer
+
+#+begin_src sh :results verbatim
+./compass.sh timeline snapshot            # default: last 20 minutes
+./compass.sh timeline snapshot --since 1h # last hour
+./compass.sh timeline snapshot --from 2026-06-10T08:00 --to 2026-06-10T10:00
+#+end_src
+
+Compass prints the file path on success.  If it warns that the event
+count exceeds 20, split the window with =--from/--to= — an over-full
+bucket defeats the scan-first goal.
+
+After generating, open the file and fill in =* Problems and suspicious
+decisions= with any patterns that stand out (LLM co-authored commits
+without a task, force-merged PRs, bookkeeping drift).
+
+* Script
+
+[[proj:projects/ores.compass/src/compass_timeline.py][=compass_timeline.py=]] — =_cmd_snapshot= / =_write_snapshot=.
+
+* Tested by
+
+Manual smoke test: =compass timeline snapshot --since 20m= writes a
+file, =compass timeline show= renders it.
+
+* See also
+
+- [[id:1B837DB5-B27A-451B-A0D0-DD17142476E4][agile-add-timeline-snapshot]] — the skill that orchestrates this recipe.

--- a/projects/ores.codegen/library/templates/doc_story.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_story.org.mustache
@@ -9,6 +9,7 @@
 #+filetags: {{filetags}}
 #+created: {{date}}
 #+updated: {{date}}
+#+environment:
 #+todo: BACKLOG STARTED | DONE ABANDONED
 {{#predecessor_id}}
 #+predecessor: {{predecessor_id}}

--- a/projects/ores.codegen/library/templates/doc_story_org.org
+++ b/projects/ores.codegen/library/templates/doc_story_org.org
@@ -32,6 +32,7 @@ The full template source. Edit here and re-tangle with
 ,#+filetags: {{filetags}}
 ,#+created: {{date}}
 ,#+updated: {{date}}
+,#+environment:
 ,#+todo: BACKLOG STARTED | DONE ABANDONED
 {{#predecessor_id}}
 ,#+predecessor: {{predecessor_id}}

--- a/projects/ores.codegen/library/templates/doc_task.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_task.org.mustache
@@ -14,6 +14,7 @@
 #+blocked_since:
 #+created: {{date}}
 #+updated: {{date}}
+#+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:{{parent_id}}][{{parent_title}}]] story. It captures the goal, current status, acceptance, and any notes or results.

--- a/projects/ores.codegen/library/templates/doc_task_org.org
+++ b/projects/ores.codegen/library/templates/doc_task_org.org
@@ -37,6 +37,7 @@ The full template source. Edit here and re-tangle with
 ,#+blocked_since:
 ,#+created: {{date}}
 ,#+updated: {{date}}
+,#+environment:
 ,#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:{{parent_id}}][{{parent_title}}]] story. It captures the goal, current status, acceptance, and any notes or results.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2563,6 +2563,37 @@ def _set_frontmatter_branch(path, branch):
     if new != text:                      # avoid a redundant write
         Path(path).write_text(new, encoding="utf-8")
 
+
+def _set_frontmatter_field(path, field, value):
+    """Set or insert #+field: value in the file's frontmatter.
+
+    Updates the existing line when present; otherwise inserts after
+    #+updated: (or #+created: as fallback) so new fields land inside
+    the frontmatter block rather than at the end of the file.
+    """
+    path = Path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    pattern = rf"^#\+{re.escape(field)}:.*$"
+    new, count = re.subn(pattern, f"#+{field}: {value}", text, count=1,
+                         flags=re.MULTILINE)
+    if count == 0:
+        for anchor_field in ("updated", "created"):
+            anchor = re.search(rf'^#\+{anchor_field}:.*$', text,
+                               flags=re.MULTILINE)
+            if anchor:
+                insert_pos = anchor.end()
+                new = (text[:insert_pos] + f"\n#+{field}: {value}"
+                       + text[insert_pos:])
+                break
+        else:
+            new = text.rstrip() + f"\n#+{field}: {value}\n"
+    if new != text:
+        path.write_text(new, encoding="utf-8")
+
+
 _ORG_ID_RE = re.compile(r"^[ \t]*:ID:\s+(\S+)\s*$", re.MULTILINE)
 
 def _add_wire_task(rest):
@@ -3156,6 +3187,13 @@ def _cmd_task_start(task_ident, branch_arg=""):
         if _set_doc_state(story_path, "STARTED"):
             print(f"🔗 story state → STARTED")
 
+    # Stamp the working environment on the task (and story on first STARTED).
+    env_label = _read_env_map().get("ORES_CHECKOUT_LABEL", "")
+    if env_label:
+        _set_frontmatter_field(task_path, "environment", env_label)
+        if story_path.exists():
+            _set_frontmatter_field(story_path, "environment", env_label)
+
     # Stamp the journal.
     try:
         if story_uuid and task_uuid:
@@ -3193,6 +3231,9 @@ def _cmd_task_done(task_ident, pr=""):
     _set_doc_state(task_path, "DONE")
     _set_status_field(task_path, "Now", "Nothing.")
     _set_status_field(task_path, "Next", "Nothing.")
+    env_label = _read_env_map().get("ORES_CHECKOUT_LABEL", "")
+    if env_label:
+        _set_frontmatter_field(task_path, "environment", env_label)
     print(f"📝 task state → DONE ({task_path.name})")
 
     story_path = task_path.parent / "story.org"

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4522,7 +4522,8 @@ def main():
                                "'pr record'; 'pr --help'")
     subparsers.add_parser("timeline",
                           help="Timeline: everyone × past — 'timeline generate [--since 20m]', "
-                               "'timeline now', 'timeline show [-n N]'; 'timeline --help'")
+                               "'timeline now', 'timeline snapshot [--since 20m]', "
+                               "'timeline show [-n N]'; 'timeline --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/compass_timeline.py
+++ b/projects/ores.compass/src/compass_timeline.py
@@ -1,12 +1,14 @@
 """compass timeline — the everyone × past quadrant of the temporal grid.
 
-Two behaviours (see the temporal command coherence investigation,
+Three behaviours (see the temporal command coherence investigation,
 551FC710-7E3C-484B-AB52-7F2C8DAF3B6F):
 
 - generate: mine the *consistent substrate* — the agile documents'
   git history on origin/main plus the GitHub PR record — for events in
   a time window. Never reads per-worktree journals, so any fresh
   checkout of main produces identical output.
+- snapshot: generate events for a window and write a structured org
+  snapshot to the current sprint's timeline/ folder.
 - show: render the last N LLM-curated snapshot buckets from the
   sprint timeline/ folders.
 """
@@ -16,6 +18,7 @@ import json
 import re
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -350,6 +353,194 @@ def _cmd_show(args, project_root):
 
 
 # ---------------------------------------------------------------------------
+# snapshot — write a structured org file to the current sprint's timeline/
+# ---------------------------------------------------------------------------
+
+EVENT_CAP = 20  # split the window if doc+pr events exceed this
+
+
+def _find_sprint_timeline_dir(project_root):
+    """Return the current sprint's timeline/ Path, creating it if needed."""
+    root = Path(project_root)
+    sprint_dirs = sorted(root.glob("doc/agile/versions/*/sprint_*/"),
+                         key=lambda p: p.name)
+    if not sprint_dirs:
+        return None
+    timeline_dir = sprint_dirs[-1] / "timeline"
+    timeline_dir.mkdir(exist_ok=True)
+    return timeline_dir
+
+
+def _snapshot_filename(start, end):
+    """<YYYYMMDDTHHmm>-<YYYYMMDDTHHmm>.org from window datetimes."""
+    fmt = "%Y%m%dT%H%M"
+    return f"{start.strftime(fmt)}-{end.strftime(fmt)}.org"
+
+
+def _doc_link(e):
+    """[[id:UUID][title]] or bare title when id is absent."""
+    if e.get("id"):
+        title = e.get("title") or e.get("path", "")
+        return f"[[id:{e['id']}][{title}]]"
+    return e.get("title") or e.get("path", "")
+
+
+def _event_desc(e):
+    """Human-readable event description for a doc event."""
+    a = e["action"]
+    if a == "created":
+        st = e.get("state", "")
+        return f"created ({st})" if st else "created"
+    if a == "state":
+        return f"{e.get('from', '?')} → {e.get('to', '?')}"
+    if a == "updated":
+        c = e.get("count", 1)
+        return f"updated ×{c}" if c > 1 else "updated"
+    if a == "deleted":
+        return "deleted"
+    return a
+
+
+def _write_snapshot(timeline_dir, project_root, start, end,
+                    doc_events, pr_events):
+    """Write a structured snapshot org file; return its Path."""
+    snap_id = str(uuid.uuid4()).upper()
+    filename = _snapshot_filename(start, end)
+    snap_path = timeline_dir / filename
+
+    sprint_tag = timeline_dir.parent.name.replace("-", "_")
+    version_tag = timeline_dir.parent.parent.name.replace("-", "_")
+
+    from_str = start.strftime("%Y-%m-%d %H:%M")
+    if start.date() == end.date():
+        to_str = end.strftime("%H:%M")
+    else:
+        to_str = end.strftime("%Y-%m-%d %H:%M")
+
+    duration_min = int((end - start).total_seconds() / 60)
+    desc = (f"{duration_min}-minute timeline snapshot of agile activity "
+            f"in this window, from the consistent substrate "
+            f"(origin/main + GitHub).")
+
+    created_date = start.strftime("%Y-%m-%d")
+    total = len(doc_events) + len(pr_events)
+
+    stories = [e for e in doc_events if e.get("doc_type") == "story"]
+    tasks = [e for e in doc_events if e.get("doc_type") == "task"]
+    captures = [e for e in doc_events if e.get("doc_type") == "capture"]
+
+    done_no_env = [e for e in doc_events
+                   if e.get("action") == "state"
+                   and e.get("to") == "DONE"
+                   and not e.get("environment")]
+
+    lines = [
+        ":PROPERTIES:",
+        f":ID: {snap_id}",
+        ":END:",
+        f"#+title: Timeline: {from_str} → {to_str}",
+        f"#+description: {desc}",
+        "#+type: timeline",
+        "#+level: cross",
+        f"#+filetags: :timeline:{sprint_tag}:{version_tag}:",
+        f"#+created: {created_date}",
+        f"#+updated: {created_date}",
+        "",
+        "* Summary",
+        "",
+        f"- {'No activity.' if total == 0 else str(total) + ' event(s).'}",
+        "",
+        "* Stories",
+        "",
+    ]
+    if stories:
+        lines += ["| Story | Event | Notes |",
+                  "|-------+-------+-------|"]
+        for e in stories:
+            env = f"[{e['environment']}]" if e.get("environment") else ""
+            lines.append(f"| {_doc_link(e)} | {_event_desc(e)} | {env} |")
+    else:
+        lines.append("- None.")
+    lines += ["", "* Tasks", ""]
+    if tasks:
+        lines += ["| Task | Event | Notes |",
+                  "|------+-------+-------|"]
+        for e in tasks:
+            env = f"[{e['environment']}]" if e.get("environment") else ""
+            lines.append(f"| {_doc_link(e)} | {_event_desc(e)} | {env} |")
+    else:
+        lines.append("- None.")
+    lines += ["", "* Captures", ""]
+    if captures:
+        lines += ["| Capture | Notes |", "|---------+-------|"]
+        for e in captures:
+            env = f"[{e['environment']}]" if e.get("environment") else ""
+            lines.append(f"| {_doc_link(e)} | {env} |")
+    else:
+        lines.append("- None.")
+    lines += ["", "* Pull requests", ""]
+    if pr_events:
+        lines += ["| PR | Event | Title |",
+                  "|----+-------+-------|"]
+        for e in pr_events:
+            action = "opened" if e["action"] == "pr-opened" else "merged"
+            lines.append(f"| #{e['number']} | {action} | {e['title']} |")
+    else:
+        lines.append("- None.")
+    lines += [
+        "",
+        "* Problems and suspicious decisions",
+        "",
+        "- None observed.",
+        "",
+        "* Audit",
+        "",
+    ]
+    if done_no_env:
+        links = ", ".join(_doc_link(e) for e in done_no_env[:3])
+        suffix = f" (+{len(done_no_env) - 3} more)" if len(done_no_env) > 3 else ""
+        lines.append(f"- {len(done_no_env)} item(s) closed without "
+                     f"environment stamp: {links}{suffix}.")
+    else:
+        lines.append("- Auto-generated bucket; environment stamps unavailable.")
+
+    snap_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return snap_path
+
+
+def _cmd_snapshot(args, project_root):
+    """Generate events for a window and write a snapshot org file."""
+    window = _resolve_window(args)
+    if not window:
+        return 1
+    start, end = window
+    _run(["git", "fetch", "origin", "main"], project_root)
+    doc_events = _doc_events(project_root, start, end)
+    if doc_events is None:
+        return 1
+    doc_events, _bulk = _split_bulk(doc_events)
+    pr_events = _pr_events(project_root, start, end)
+
+    total = len(doc_events) + len(pr_events)
+    if total > EVENT_CAP:
+        print(f"⚠️  {total} events exceed the cap of {EVENT_CAP}; "
+              f"consider splitting the window with --from/--to.",
+              file=sys.stderr)
+
+    timeline_dir = _find_sprint_timeline_dir(project_root)
+    if not timeline_dir:
+        print("❌ No sprint directory found under doc/agile/versions/.",
+              file=sys.stderr)
+        return 1
+
+    snap_path = _write_snapshot(timeline_dir, project_root,
+                                start, end, doc_events, pr_events)
+    rel = snap_path.relative_to(project_root)
+    print(f"✅ {rel}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # entry point
 # ---------------------------------------------------------------------------
 
@@ -360,7 +551,8 @@ def run(argv, project_root):
         prog="compass timeline",
         description="Timeline pillar: the everyone × past quadrant — "
                     "events from the consistent substrate (origin/main + "
-                    "GitHub), and stored snapshot buckets.")
+                    "GitHub), and stored snapshot buckets. "
+                    "Subcommands: generate, now, snapshot, show.")
     sub = ap.add_subparsers(dest="subcmd", required=True)
 
     gp = sub.add_parser(
@@ -386,6 +578,18 @@ def run(argv, project_root):
     sp.add_argument("-n", "--count", type=int, default=3,
                     help="How many buckets, newest first (default: 3)")
 
+    ssp = sub.add_parser(
+        "snapshot",
+        help=f"Write a structured snapshot org file for the window "
+             f"(default: last {DEFAULT_WINDOW})")
+    ssp.add_argument("--since", default=None,
+                     help=f"Window as duration (20m, 2h, 1d) or ISO start "
+                          f"(default: {DEFAULT_WINDOW})")
+    ssp.add_argument("--from", dest="frm", default=None,
+                     help="Window start (ISO; needs --to)")
+    ssp.add_argument("--to", dest="to", default=None,
+                     help="Window end (ISO; needs --from)")
+
     args = ap.parse_args(argv)
     if args.subcmd == "now":
         args.since, args.frm, args.to = DEFAULT_WINDOW, None, None
@@ -394,4 +598,14 @@ def run(argv, project_root):
         return _cmd_generate(args, project_root)
     if args.subcmd == "show":
         return _cmd_show(args, project_root)
+    if args.subcmd == "snapshot":
+        if not hasattr(args, "since"):
+            args.since = None
+        if not hasattr(args, "frm"):
+            args.frm = None
+        if not hasattr(args, "to"):
+            args.to = None
+        if not args.since and not args.frm:
+            args.since = DEFAULT_WINDOW
+        return _cmd_snapshot(args, project_root)
     return 1


### PR DESCRIPTION
## Summary

Delivers the remaining BACKLOG tasks in the agile timeline story: environment stamping on task/story docs, LLM snapshot skill and compass timeline snapshot command, sprint timeline/ storage.

## Changes

- Add #+environment: stamping to compass task start/done (reads ORES_CHECKOUT_LABEL from .env)
- Add _set_frontmatter_field helper to compass.py; add #+environment: to task/story templates
- Add compass timeline snapshot command with event-count cap and auto-sprint detection
- Create agile-add-timeline-snapshot skill and how_do_i_create_a_timeline_snapshot recipe
- Close agile timeline story DONE; abandon velocity charts task (blocked, out of scope)
- Close Qt help system story DONE

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Agile timeline: bucketed summaries of recent activity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/story.html) | 3697D889-BF01-43D4-9EF7-3AF6B70A8122 |
| Task | [Add LLM snapshot summarisation skill and sprint timeline storage](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/agile_timeline/task_timeline_snapshot_skill.html) | D47C04DD-51F7-4DDB-B4B8-2B4499DEF793 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)