### PR TITLE
[compass] Add compass heading command

### DIFF
--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -146,7 +146,7 @@ LLM-driven workflow frictionless.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] | STARTED | 2026-06-06 | | Second QoL round, 10 tasks: SSH_AUTH_SOCK from .env, dashboard services bug, Claude settings auto-authorisation, actionable search, journal log newest-first, capture --commit, search by folder name, task move, recipe how-do boost, inbound-link boost. |
-| [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] | STARTED | 2026-06-08 | | New =compass heading= command: ranked next-work-item suggestions from the journals, fleet, sprint state, and backlog buckets; optional keyword steering. |
+| [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-10 | New =compass heading= command: ranked next-work-item suggestions from the journals, fleet, sprint state, and backlog buckets; optional keyword steering. |
 
 ** Infrastructure
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
@@ -32,12 +32,12 @@ It completes the navigation arc alongside the existing commands:
 
 | Field         | Value                                                |
 |---------------+------------------------------------------------------|
-| State         | STARTED                                              |
+| State         | DONE                                                 |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                                            |
-| Now           | Story scaffolded; designing the heading command.     |
+| Now           | Nothing.                                             |
 | Waiting on    | Nothing.                                             |
-| Next          | Analyse and design the suggester, then implement.    |
-| Last touched  | 2026-06-08                                           |
+| Next          | Nothing.                                             |
+| Last touched  | 2026-06-10                                           |
 
 * Acceptance
 
@@ -62,7 +62,7 @@ It completes the navigation arc alongside the existing commands:
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:5857B626-1579-4581-844F-B6AF80E66780][Scaffold story: Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-08 | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
-| [[id:85F8CFFB-225B-4BC5-A277-1EE5AB4621A1][Analyse and design the next-work-item suggester]] | BACKLOG | | | Design =compass heading=: the signal sources (journals, fleet, sprint state, backlogs), the priority/scoring model, keyword steering, output format, and which command pillar it belongs to. |
+| [[id:85F8CFFB-225B-4BC5-A277-1EE5AB4621A1][Analyse and design the next-work-item suggester]] | DONE | 2026-06-10 | 2026-06-10 | Design =compass heading=: the signal sources (journals, fleet, sprint state, backlogs), the priority/scoring model, keyword steering, output format, and which command pillar it belongs to. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_design_suggest_next_work_item.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_design_suggest_next_work_item.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :suggest_next_work_item:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/design-suggest-next-work-item
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -19,17 +19,19 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Implement =compass heading=: a ranked next-work-item suggester that synthesises
+sprint state, fleet activity, and product-backlog captures into a prioritised list
+with scores, rationales, and action commands.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-08                               |
 
 * Acceptance
@@ -57,3 +59,18 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Implemented =compass heading= as =cmd_heading= in =compass.py=, wired into =main()=
+and registered in the argparse help. Signal sources and scoring:
+
+- Score 100: BLOCKED tasks (hardest constraint first)
+- Score 90: ready-to-close stories (all tasks DONE, story still STARTED)
+- Score 80: next BACKLOG task in an already-STARTED story
+- Score 65: STARTED task not currently in the fleet
+- Score 50: STARTED task already active in the fleet (de-prioritised to avoid collision)
+- Score 40/20: captures in =next= / =inbox= backlog buckets
+
+Optional positional keywords multiply each item's score (up to 2×) based on
+substring matches in title, description, and directory name. =compass heading compass=
+biases toward compass work. Duplicate UUIDs are filtered so each item appears once.
+=-f json= emits a structured array suitable for LLM consumption; =-n N= caps the list.

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_design_suggest_next_work_item.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_design_suggest_next_work_item.org
@@ -8,7 +8,7 @@
 #+filetags: :suggest_next_work_item:sprint_20:v0:
 #+owner: marco
 #+branch: feature/design-suggest-next-work-item
-#+pr:
+#+pr: 1229
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -50,7 +50,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1229][#1229]] | [compass] Add compass heading command |
 
 * Review
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4090,6 +4090,195 @@ def cmd_bearings(argv):
     return 0
 
 
+# --- Heading: next-work-item suggester ---
+
+def _heading_keyword_boost(text, keywords):
+    """Return a multiplier in [1.0, 2.0] based on keyword matches in text."""
+    if not keywords:
+        return 1.0
+    text_lower = text.lower()
+    hits = sum(1 for kw in keywords if kw.lower() in text_lower)
+    return min(2.0, 1.0 + 0.5 * hits)
+
+
+def cmd_heading(argv):
+    """compass heading — suggest the next logical work item to pick up."""
+    ap = argparse.ArgumentParser(
+        prog="compass heading",
+        description="Recommend the next work item to pick up, ranked by priority. "
+                    "Synthesises sprint state, journal activity, fleet, and backlog.")
+    ap.add_argument("keywords", nargs="*",
+                    help="Bias ranking toward items matching these keywords "
+                         "(matched against title, description, tags).")
+    ap.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty",
+                    help="Output format (default: pretty).")
+    ap.add_argument("-n", "--count", type=int, default=10,
+                    help="Maximum number of suggestions (default: 10).")
+    args = ap.parse_args(argv)
+
+    docs = doc_index.load_all()
+    _, current_sprint = current_version_sprint(docs)
+    if current_sprint is None:
+        print("❌  No current sprint found.")
+        return 1
+
+    sprint_dir = PROJECT_ROOT / _parent_dir(current_sprint.rel_path)
+
+    # Fleet: collect branches currently active across all worktrees so we can
+    # deprioritise items that are already being worked.
+    active_branches = set()
+    for wt_path, wt_branch in list_worktrees():
+        if wt_branch:
+            active_branches.add(wt_branch)
+
+    suggestions = []  # list of dicts: score, kind, title, rationale, action
+
+    # ── Pass 1: sprint story/task signals ────────────────────────────────────
+    for story_file in sorted(sprint_dir.glob("*/story.org")):
+        story_title, story_state, story_uuid = _read_story_state(story_file)
+        story_dir = story_file.parent
+
+        if story_state == "DONE":
+            continue
+
+        tasks = sorted(story_dir.glob("task_*.org"))
+        if not tasks:
+            continue
+
+        task_states = []
+        for tf in tasks:
+            t_title, t_state, t_uuid, t_branch, t_pr = _read_task_detail(tf)
+            task_states.append((tf, t_title, t_state, t_uuid, t_branch))
+
+        done_count  = sum(1 for _, _, s, _, _ in task_states if s == "DONE")
+        total_count = len(task_states)
+
+        # Ready-to-close: all tasks DONE but story still STARTED/BACKLOG.
+        if done_count == total_count and story_state in ("STARTED", "BACKLOG"):
+            search_text = f"{story_title} {story_dir.name}"
+            boost = _heading_keyword_boost(search_text, args.keywords)
+            suggestions.append({
+                "score": int(90 * boost),
+                "kind": "close",
+                "title": story_title,
+                "rationale": f"All {total_count} tasks DONE — story needs closing",
+                "action": f"compass task done <last-task-slug>  # story: {story_dir.name}",
+                "uuid": story_uuid,
+            })
+            continue
+
+        for tf, t_title, t_state, t_uuid, t_branch in task_states:
+            search_text = f"{story_title} {t_title} {story_dir.name}"
+
+            if t_state == "BLOCKED":
+                boost = _heading_keyword_boost(search_text, args.keywords)
+                suggestions.append({
+                    "score": int(100 * boost),
+                    "kind": "blocked",
+                    "title": t_title,
+                    "rationale": f"BLOCKED in story \"{story_title}\" — needs unblocking",
+                    "action": f"compass show {t_uuid}" if t_uuid else f"# {tf.name}",
+                    "uuid": t_uuid,
+                })
+
+            elif t_state == "STARTED":
+                in_fleet = t_branch and t_branch in active_branches
+                boost = _heading_keyword_boost(search_text, args.keywords)
+                base = 50 if in_fleet else 65
+                suggestions.append({
+                    "score": int(base * boost),
+                    "kind": "in-flight",
+                    "title": t_title,
+                    "rationale": (
+                        f"In flight in story \"{story_title}\""
+                        + (" (active in fleet)" if in_fleet else " — may need attention")
+                    ),
+                    "action": f"compass show {t_uuid}" if t_uuid else f"# {tf.name}",
+                    "uuid": t_uuid,
+                })
+
+            elif t_state == "BACKLOG" and story_state == "STARTED":
+                # Next unstarted task in an already-started story.
+                boost = _heading_keyword_boost(search_text, args.keywords)
+                slug = tf.stem.replace("task_", "")
+                suggestions.append({
+                    "score": int(80 * boost),
+                    "kind": "next-task",
+                    "title": t_title,
+                    "rationale": f"Next task in active story \"{story_title}\"",
+                    "action": f"compass task start {slug}",
+                    "uuid": t_uuid,
+                })
+                break  # only the first BACKLOG task per story matters
+
+    # ── Pass 2: product-backlog signals ─────────────────────────────────────
+    for bucket, base_score in [("next", 40), ("inbox", 20)]:
+        bucket_dir = PROJECT_ROOT / "doc" / "agile" / "product_backlog" / bucket
+        if not bucket_dir.exists():
+            continue
+        for cap_file in sorted(bucket_dir.rglob("*.org")):
+            try:
+                text = cap_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            tm = _TITLE_RE2.search(text)
+            im = _ORG_ID_RE.search(text)
+            dm = re.search(r"^#\+description:\s*(.+)$", text, re.MULTILINE | re.IGNORECASE)
+            cap_title = _strip_type_prefix(tm.group(1)) if tm else cap_file.stem
+            cap_uuid  = im.group(1) if im else None
+            cap_desc  = dm.group(1).strip() if dm else ""
+            search_text = f"{cap_title} {cap_desc}"
+            boost = _heading_keyword_boost(search_text, args.keywords)
+            suggestions.append({
+                "score": int(base_score * boost),
+                "kind": bucket,
+                "title": cap_title,
+                "rationale": f"Capture in {bucket} backlog",
+                "action": f"compass show {cap_uuid}" if cap_uuid else f"# {cap_file.name}",
+                "uuid": cap_uuid,
+            })
+
+    # ── Sort, deduplicate by uuid, limit ────────────────────────────────────
+    seen_uuids = set()
+    ranked = []
+    for s in sorted(suggestions, key=lambda x: -x["score"]):
+        uid = s.get("uuid")
+        if uid and uid in seen_uuids:
+            continue
+        if uid:
+            seen_uuids.add(uid)
+        ranked.append(s)
+        if len(ranked) >= args.count:
+            break
+
+    if args.format == "json":
+        import json
+        print(json.dumps(ranked, indent=2))
+        return 0
+
+    print("🧭 ores.compass — heading\n")
+    if not ranked:
+        print("  Nothing to suggest — sprint is clean and backlog is empty.")
+        return 0
+
+    KIND_ICON = {
+        "blocked":   "🔴",
+        "close":     "✅",
+        "next-task": "▶",
+        "in-flight": "🔵",
+        "next":      "📋",
+        "inbox":     "📥",
+    }
+    for i, s in enumerate(ranked, 1):
+        icon = KIND_ICON.get(s["kind"], "•")
+        print(f"  {i:>2}. [{s['score']:>3}]  {icon}  {s['title']}")
+        print(f"        {s['rationale']}")
+        print(f"        {_ycmd(s['action'])}")
+        print()
+
+    return 0
+
+
 # --- Build pillar ---
 
 # Friendly target aliases: compass-level names → cmake target names.
@@ -4348,6 +4537,8 @@ def main():
         sys.exit(cmd_pr(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ("bearings", "orient"):
         sys.exit(cmd_bearings(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "heading":
+        sys.exit(cmd_heading(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ALL_BUCKETS:
         sys.exit(cmd_backlog(sys.argv[1], sys.argv[2:]))
 
@@ -4486,6 +4677,9 @@ def main():
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",
                           help="Alias for bearings")
+    subparsers.add_parser("heading",
+                          help="Suggest the next work item: ranked by priority from sprint state, "
+                               "fleet, and backlog; optional keywords bias the ranking")
     subparsers.add_parser("inbox",     help="List captures in the product backlog inbox/")
     subparsers.add_parser("next",      help="List captures in the product backlog next/")
     subparsers.add_parser("deferred",  help="List captures in the product backlog deferred/")

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4166,7 +4166,7 @@ def cmd_heading(argv):
                 "kind": "close",
                 "title": story_title,
                 "rationale": f"All {total_count} tasks DONE — story needs closing",
-                "action": f"compass task done <last-task-slug>  # story: {story_dir.name}",
+                "action": f"# Set State → DONE in {story_dir.name}/story.org",
                 "uuid": story_uuid,
             })
             continue

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4109,12 +4109,16 @@ def cmd_heading(argv):
                     "Synthesises sprint state, journal activity, fleet, and backlog.")
     ap.add_argument("keywords", nargs="*",
                     help="Bias ranking toward items matching these keywords "
-                         "(matched against title, description, tags).")
+                         "(matched against title, description, and directory name).")
     ap.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty",
                     help="Output format (default: pretty).")
     ap.add_argument("-n", "--count", type=int, default=10,
                     help="Maximum number of suggestions (default: 10).")
     args = ap.parse_args(argv)
+
+    if args.count < 1:
+        print("❌  --count must be a positive integer.")
+        return 1
 
     docs = doc_index.load_all()
     _, current_sprint = current_version_sprint(docs)
@@ -4171,9 +4175,10 @@ def cmd_heading(argv):
             search_text = f"{story_title} {t_title} {story_dir.name}"
 
             if t_state == "BLOCKED":
-                boost = _heading_keyword_boost(search_text, args.keywords)
+                # BLOCKED tasks always score 100 regardless of keywords — they
+                # require immediate attention irrespective of topic focus.
                 suggestions.append({
-                    "score": int(100 * boost),
+                    "score": 100,
                     "kind": "blocked",
                     "title": t_title,
                     "rationale": f"BLOCKED in story \"{story_title}\" — needs unblocking",
@@ -4252,7 +4257,6 @@ def cmd_heading(argv):
             break
 
     if args.format == "json":
-        import json
         print(json.dumps(ranked, indent=2))
         return 0
 


### PR DESCRIPTION
## Summary

- New `compass heading` command: ranked next-work-item suggestions synthesised from sprint state, fleet activity, and product-backlog captures
- Closes the "Suggest the next work item to pick up" story

## How it works

Signal sources and scoring:

| Score | Kind | Signal |
|-------|------|--------|
| 100 | `blocked` | BLOCKED task in current sprint |
| 90 | `close` | Story where all tasks DONE but state still STARTED |
| 80 | `next-task` | First BACKLOG task in an already-STARTED story |
| 65 | `in-flight` | STARTED task not currently active in the fleet |
| 50 | `in-flight` | STARTED task already active in the fleet (de-prioritised) |
| 40 | `next` | Capture in the product-backlog `next/` bucket |
| 20 | `inbox` | Capture in the product-backlog `inbox/` bucket |

Optional positional keywords multiply each item's score (up to 2×) by substring matching against title, description, and directory name. `compass heading compass` biases toward compass work.

`-f json` emits a structured array for LLM consumption; `-n N` caps the list.

Completes the navigation arc: `bearings` (where am I?) → `heading` (where do I go next?)

## Test plan

- [ ] `compass heading` prints a ranked list
- [ ] `compass heading <keyword>` boosts matching items
- [ ] `compass heading -f json` emits valid JSON
- [ ] `compass heading -n 3` limits to 3 items
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)