### PR TITLE
[compass] Add --pr option to compass capture

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
@@ -8,6 +8,7 @@
 #+filetags: :compass:tooling:llm:sprint_20:v0:
 #+created: 2026-06-06
 #+updated: 2026-06-06
+#+environment: local3
 #+todo: BACKLOG STARTED | DONE ABANDONED
 #+predecessor: A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0
 
@@ -66,6 +67,7 @@ captures, story search by exact folder name, and a task move command.
 | [[id:9A548F0C-659A-4DE9-A44D-97DA0365309F][Gate the PR review round on unaddressed comments]] | DONE | 2026-06-07 | 2026-06-07 | pr-address-review and its runbook synced/rebased before checking whether a round existed, churning CI and force-pushing for nothing. |
 | [[id:2D674256-EF41-47AD-9D64-E767E9625DE0][Add compass story tasks: list tasks under a story directly]] | DONE | 2026-06-10 | 2026-06-10 | compass story <id> (or --tasks flag) should enumerate all tasks in a story with their state, branch, and PR — without requiring the caller to navigate outgoing links from compass show. |
 | [[id:1C0EF2C8-E952-4807-92EF-A217C8DFF49A][Wire cross-reference tables in story new / task new]] | DONE | 2026-06-10 | 2026-06-10 | compass story new and task new scaffold the story/task docs but leave their cross-references unwired and their Goal/Acceptance as placeholders. Observed: the new task is not added to the story's * Tasks table; story new does not add the new story to the sprint's * Stories table (the tool prints both as manual 'next steps'); and neither accepts --goal/--acceptance, so docs are born without content. Make scaffolding wire the story<->task and sprint<->story table rows automatically, and accept --goal/--acceptance (matching the documented expectation that scaffolding wires the tables and is born with content). |
+| [[id:681D882D-5A34-45D4-86F3-880206EACF95][Add --pr option to compass capture to branch, commit, and open PR]] | DONE | 2026-06-10 | 2026-06-10 | compass capture --commit commits the capture on the current branch but cannot push or create a PR because there is no task doc and branch protection blocks direct main commits. Add --pr that creates a capture/<slug> branch off origin/main, commits the capture and regenerated indexes, pushes the branch, and opens a PR via gh pr create — no task doc required. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_create.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_create.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_quality_of_life:sprint_20:v0:
 #+owner: marco
 #+branch: feature/capture-pr-create
-#+pr:
+#+pr: 1233
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-10
@@ -54,7 +54,7 @@ restores the original branch and any stashed changes.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1233][#1233]] | [compass] Add --pr option to compass capture |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_create.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_create.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 681D882D-5A34-45D4-86F3-880206EACF95
+:END:
+#+title: Task: Add --pr option to compass capture to branch, commit, and open PR
+#+description: compass capture --commit commits the capture on the current branch but cannot push or create a PR because there is no task doc and branch protection blocks direct main commits. Add --pr that creates a capture/<slug> branch off origin/main, commits the capture and regenerated indexes, pushes the branch, and opens a PR via gh pr create — no task doc required.
+#+type: task
+#+level: s1
+#+filetags: :compass_quality_of_life:sprint_20:v0:
+#+owner: marco
+#+branch: feature/capture-pr-create
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment: local3
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+compass capture --pr '<note>' lands the capture, regenerated indexes, and an open PR in one command, with no manual branch creation or gh invocation.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-10                               |
+
+* Acceptance
+
+- compass capture --note '...' --pr creates capture/<slug> branch
+- capture file and regenerated indexes are committed on that branch
+- branch is pushed and a PR opened via gh pr create
+- PR title follows [agile] Capture: <title> convention
+- --commit and --pr flags are composable: --pr implies --commit
+
+* Plan
+
+Added =_capture_pr_flow= to =compass.py= and a =--pr= flag on the =compass capture=
+command. The flow stashes any tracked changes on the current branch, creates a
+=capture/<slug>= branch off =origin/main=, generates the capture file, commits
+capture + regenerated indexes via the existing =_capture_commit= helper, pushes,
+opens a PR via =gh pr create= with =[agile] Capture: <title>= as title, and then
+restores the original branch and any stashed changes.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Implemented. =compass capture --note "..." --pr= now creates a =capture/<slug>=
+branch off =origin/main=, commits the capture and regenerated backlog indexes,
+pushes, and opens a PR — no task doc or manual branch management required. The
+original branch is restored on completion; uncommitted tracked changes are
+stashed and restored. =--pr= subsumes =--commit=.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2222,9 +2222,11 @@ def cmd_capture(argv):
     if not argv or argv[0] in ("-h", "--help"):
         print(
             "usage:\n"
-            "  compass capture --note \"...\" [--slug <slug>] [--commit]\n"
+            "  compass capture --note \"...\" [--slug <slug>] [--commit] [--pr]\n"
             "      Create a capture in doc/agile/product_backlog/inbox/; --commit\n"
-            "      regenerates the indexes and commits capture + indexes only.\n"
+            "      regenerates the indexes and commits capture + indexes only;\n"
+            "      --pr creates a capture/<slug> branch off origin/main, commits,\n"
+            "      pushes, and opens a PR via gh — no task doc required.\n"
             "  compass capture file <slug> next|deferred|discarded\n"
             "      Move an inbox capture to a triaged product backlog bucket.\n"
             "  compass capture promote <slug> --to story|task [--story <id-or-slug>]\n"
@@ -2284,6 +2286,11 @@ def cmd_capture(argv):
                     help="Regenerate the backlog indexes and commit the capture "
                          "plus indexes — and nothing else — with a conventional "
                          "'[agile] Capture: <title>' message.")
+    ap.add_argument("--pr", action="store_true",
+                    help="Create a capture/<slug> branch off origin/main, commit "
+                         "the capture + regenerated indexes on it, push, and open "
+                         "a PR via gh pr create. Implies --commit. After the PR is "
+                         "opened the original branch is restored.")
     ap.add_argument("--co-author", default="Claude <noreply@anthropic.com>",
                     metavar="IDENT",
                     help="Co-Authored-By identity for --commit "
@@ -2301,9 +2308,15 @@ def cmd_capture(argv):
         print(f"  file:  {out_file.relative_to(PROJECT_ROOT)}")
         print(f"  slug:  {slug}")
         print(f"  title: {title}")
-        if args.commit:
+        if args.pr:
+            print(f"  branch: capture/{slug.replace('_', '-')}")
+            print(f"  pr title: [agile] Capture: {title}")
+        elif args.commit:
             print(f"  commit: [agile] Capture: {title}")
         return 0
+
+    if args.pr:
+        return _capture_pr_flow(slug, title, args, inbox_dir, out_file)
 
     gen = _import_generator()
     inbox_dir.mkdir(parents=True, exist_ok=True)
@@ -2372,6 +2385,105 @@ def _capture_commit(out_file, title, note, co_author):
         return p.returncode
     print(f"✅ Capture committed: {subject}")
     return 0
+
+def _capture_pr_flow(slug, title, args, inbox_dir, out_file):
+    """Branch, create capture, commit, push, open PR — no task doc required.
+
+    Stashes any tracked changes on the current branch, creates a fresh
+    capture/<slug> branch off origin/main, generates the capture file and
+    commits it with the regenerated indexes, pushes, and opens a PR via gh.
+    The original branch is restored when done.
+    """
+    # Remember where we are.
+    p = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+    orig_branch = p.stdout.strip()
+
+    # Stash any tracked modifications so the branch switch is clean.
+    stashed = False
+    has_staged   = subprocess.run(["git", "diff", "--cached", "--quiet"],
+                                   cwd=str(PROJECT_ROOT)).returncode != 0
+    has_unstaged = subprocess.run(["git", "diff", "--quiet"],
+                                   cwd=str(PROJECT_ROOT)).returncode != 0
+    if has_staged or has_unstaged:
+        p = subprocess.run(
+            ["git", "stash", "push", "-m", "compass capture --pr: save wip"],
+            cwd=str(PROJECT_ROOT))
+        stashed = (p.returncode == 0)
+
+    def _restore(rc):
+        subprocess.run(["git", "checkout", orig_branch], cwd=str(PROJECT_ROOT))
+        if stashed:
+            pop = subprocess.run(["git", "stash", "pop"], cwd=str(PROJECT_ROOT))
+            if pop.returncode != 0:
+                print("⚠️  Stash pop had conflicts — resolve manually.",
+                      file=sys.stderr)
+        return rc
+
+    branch = "capture/" + slug.replace("_", "-")
+
+    # Fetch and create the capture branch off origin/main.
+    subprocess.run(["git", "fetch", "origin", "main"],
+                   cwd=str(PROJECT_ROOT), capture_output=True)
+    p = subprocess.run(
+        ["git", "checkout", "-b", branch, "origin/main"],
+        capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+    if p.returncode != 0:
+        print(f"❌ Could not create branch '{branch}': {p.stderr.strip()}",
+              file=sys.stderr)
+        return _restore(p.returncode)
+
+    # Create the capture file on this branch.
+    gen = _import_generator()
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        rc = gen.main(["--type", "capture", "--slug", slug,
+                       "--parent-dir", str(inbox_dir.relative_to(PROJECT_ROOT)),
+                       "--title", title, "--description", args.note,
+                       "--tags", args.tags or "capture"])
+    except SystemExit as exc:
+        rc = exc.code
+    if rc not in (None, 0):
+        return _restore(rc or 1)
+    print(f"✅ Product backlog note created: {out_file.relative_to(PROJECT_ROOT)}")
+
+    # Commit capture + regenerated indexes.
+    rc = _capture_commit(out_file, title, args.note, args.co_author)
+    if rc != 0:
+        return _restore(rc)
+
+    # Push the branch.
+    p = subprocess.run(
+        ["git", "push", "-u", "origin", branch],
+        cwd=str(PROJECT_ROOT))
+    if p.returncode != 0:
+        print("❌ Push failed.", file=sys.stderr)
+        return _restore(p.returncode)
+
+    # Open the PR.
+    pr_title = f"[agile] Capture: {title}"
+    if len(pr_title) > 72:
+        pr_title = pr_title[:71].rstrip() + "…"
+    pr_body = (
+        f"## Summary\n\n{args.note.strip()}\n\n"
+        "## Changes\n\n"
+        f"- Add capture `{slug}` to the product backlog inbox.\n"
+        "- Regenerate inbox/next/deferred backlog indexes.\n\n"
+        "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+    )
+    p = subprocess.run(
+        ["gh", "pr", "create", "--title", pr_title, "--body", pr_body],
+        capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+    if p.returncode != 0:
+        print(p.stderr.strip() or "❌ gh pr create failed.", file=sys.stderr)
+        return _restore(p.returncode)
+
+    pr_url = p.stdout.strip().splitlines()[-1] if p.stdout.strip() else "(no URL)"
+    print(f"🔗 PR created: {pr_url}")
+
+    return _restore(0)
+
 
 _PUML_HEADER_TEMPLATE = """\
 ' -*- mode: plantuml; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-


### PR DESCRIPTION
## Summary

Adds a --pr flag to compass capture that creates a capture/<slug> branch off origin/main, commits the capture file and regenerated backlog indexes, pushes, and opens a PR via gh pr create — no task doc required. The command restores the original branch and any stashed changes when done.

## Changes

- Add --pr argument to compass capture argument parser
- Add _capture_pr_flow() to handle branch creation, commit, push, and PR creation
- Update compass capture help text to document --pr

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality of life](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.html) | EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38 |
| Task | [Add --pr option to compass capture to branch, commit, and open PR](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_create.html) | 681D882D-5A34-45D4-86F3-880206EACF95 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)