### PR TITLE
[compass] Add scoped search (--under/--type); fix capture promote placeholders

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:tooling:llm:sprint_20:v0:
 #+created: 2026-06-06
 #+updated: 2026-06-06
-#+environment: local3
+#+environment: local4
 #+todo: BACKLOG STARTED | DONE ABANDONED
 #+predecessor: A9C8B9F6-C7AE-404D-8EEF-20E5929CB7C0
 
@@ -31,12 +31,12 @@ captures, story search by exact folder name, and a task move command.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                                   |
-| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | All 10 tasks shipped and merged.       |
+| State         | DONE                                   |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                              |
+| Now           | Complete. All 15 tasks shipped.        |
 | Waiting on    | Nothing.                               |
-| Next          | Nothing.                               |
-| Last touched  | 2026-06-06                               |
+| Next          | None.                                  |
+| Last touched  | 2026-06-10                             |
 
 * Acceptance
 
@@ -62,8 +62,8 @@ captures, story search by exact folder name, and a task move command.
 | [[id:B2C9B2C4-3596-4995-95C1-A837DEB09711][compass journal log: newest-first with --limit]] | DONE | 2026-06-06 | 2026-06-06 | journal log prints oldest-first so fresh entries drown at the bottom (and head-clipping shows stale entries). Default to newest-first like git log, add --limit N / -n N to clip, and --chronological to restore oldest-first. |
 | [[id:B18191FB-A6FB-4BA0-9C33-0F33971D4B3C][Boost search ranking by inbound-link count]] | DONE | 2026-06-06 | 2026-06-06 | Apply a link-count boost to compass search: docs linked by more nodes surface higher, stories linked by their tasks float above peripherally-tagged docs. |
 | [[id:BCA13EA7-BB80-4EE6-8347-CC5D4DD098BB][Boost recipe results for 'how do' queries]] | DONE | 2026-06-06 | 2026-06-06 | When a search query starts with 'how do', rank recipe docs first regardless of FTS score — recipes are titled as the question they answer and are almost always the right result. |
-| [[id:53CE8498-7469-4063-863D-EEC4F901571E][Add scoped search to compass]] | BACKLOG | | | compass search cannot be restricted to a repo path or doc type; backlog-only full-text search currently requires raw grep. |
-| [[id:1BD08842-A987-4FD0-AFFC-FA73FEEC7077][compass capture promote copies the capture's What section in…]] | BACKLOG | | | compass capture promote copies the capture's What section into the task Goal verbatim, including the '(One paragraph: the idea.)' template placeholder when the capture body was never filled in, and appends an all-placeholder 'Promoted from capture' section. Promote should detect placeholder What/Why/References/See-also content (the literal template strings), fall back to the capture description for the goal, and omit empty placeholder subsections from the promoted body. |
+| [[id:53CE8498-7469-4063-863D-EEC4F901571E][Add scoped search to compass]] | DONE | 2026-06-10 | 2026-06-10 | compass search cannot be restricted to a repo path or doc type; backlog-only full-text search currently requires raw grep. |
+| [[id:1BD08842-A987-4FD0-AFFC-FA73FEEC7077][compass capture promote copies the capture's What section in…]] | DONE | 2026-06-10 | 2026-06-10 | compass capture promote copies the capture's What section into the task Goal verbatim, including the '(One paragraph: the idea.)' template placeholder when the capture body was never filled in, and appends an all-placeholder 'Promoted from capture' section. Promote should detect placeholder What/Why/References/See-also content (the literal template strings), fall back to the capture description for the goal, and omit empty placeholder subsections from the promoted body. |
 | [[id:9A548F0C-659A-4DE9-A44D-97DA0365309F][Gate the PR review round on unaddressed comments]] | DONE | 2026-06-07 | 2026-06-07 | pr-address-review and its runbook synced/rebased before checking whether a round existed, churning CI and force-pushing for nothing. |
 | [[id:2D674256-EF41-47AD-9D64-E767E9625DE0][Add compass story tasks: list tasks under a story directly]] | DONE | 2026-06-10 | 2026-06-10 | compass story <id> (or --tasks flag) should enumerate all tasks in a story with their state, branch, and PR — without requiring the caller to navigate outgoing links from compass show. |
 | [[id:1C0EF2C8-E952-4807-92EF-A217C8DFF49A][Wire cross-reference tables in story new / task new]] | DONE | 2026-06-10 | 2026-06-10 | compass story new and task new scaffold the story/task docs but leave their cross-references unwired and their Goal/Acceptance as placeholders. Observed: the new task is not added to the story's * Tasks table; story new does not add the new story to the sprint's * Stories table (the tool prints both as manual 'next steps'); and neither accepts --goal/--acceptance, so docs are born without content. Make scaffolding wire the story<->task and sprint<->story table rows automatically, and accept --goal/--acceptance (matching the documented expectation that scaffolding wires the tables and is born with content). |

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_promote_placeholder_goal.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_promote_placeholder_goal.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_quality_of_life:sprint_20:v0:
 #+owner: marco
 #+branch: feature/capture-promote-placeholder-goal
-#+pr:
+#+pr: 1234
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -73,7 +73,7 @@ Modified =projects/ores.compass/src/compass.py=:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1234][#1234]] | [compass] Add scoped search (--under/--type); fix capture promote placeholders |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_promote_placeholder_goal.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_promote_placeholder_goal.org
@@ -7,12 +7,13 @@
 #+level: s1
 #+filetags: :compass_quality_of_life:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/capture-promote-placeholder-goal
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
 #+updated: 2026-06-06
+#+environment: local4
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -34,22 +35,37 @@ goal — hand-fixed in the same commit.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
-| Now          | Not yet started.                       |
+| State        | DONE                                   |
+| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]]                |
+| Now          | Complete.                              |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-06                               |
+| Next         | None.                                  |
+| Last touched | 2026-06-10                             |
 
 * Acceptance
 
--
+- Promoting an unfilled capture (placeholder What/Why/References/See-also)
+  uses the capture description as the goal — not the literal placeholder string.
+- The "Promoted from capture" section is omitted entirely when all subsections
+  are placeholders.
+- Filled captures continue to work as before.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Modified =projects/ores.compass/src/compass.py=:
+
+1. Added =_CAPTURE_PLACEHOLDER_BODIES= set and =_is_capture_placeholder(text)=
+   helper — recognises the literal template strings used in unfilled captures.
+
+2. Added =_filter_capture_body(body)= — splits the capture body on top-level
+   headings (=* What=, =* Why=, =* References=, =* See also=) and drops any
+   section whose content is a known placeholder or empty. Returns empty string
+   when all sections are placeholders, which causes the caller to skip the
+   "Promoted from capture" block entirely.
+
+3. In =_cmd_capture_promote=: replaced the bare What-section extraction with
+   a placeholder-aware version; replaced =_capture_body= with
+   =_filter_capture_body(_capture_body(...))= before writing the appended section.
 
 * Notes
 
@@ -66,6 +82,10 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Promoting an unfilled capture now uses the =#+description= as the goal
+instead of the placeholder text. The "Promoted from capture" section is
+suppressed entirely when the capture body contains only template filler.
 
 * Promoted from capture
 

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_scoped_search.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_scoped_search.org
@@ -7,12 +7,13 @@
 #+level: s1
 #+filetags: :compass:search:tooling:compass_quality_of_life:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/scoped-search
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
 #+updated: 2026-06-06
+#+environment: local4
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -25,12 +26,12 @@ Hunting for product-backlog captures exposed three search gaps: compass search h
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
-| Now          | Not yet started.                       |
+| State        | DONE                                   |
+| Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]]                |
+| Now          | Complete.                              |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-06                               |
+| Next         | None.                                  |
+| Last touched | 2026-06-10                             |
 
 * Acceptance
 
@@ -40,9 +41,26 @@ Hunting for product-backlog captures exposed three search gaps: compass search h
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Modified =projects/ores.compass/src/compass.py= and
+=doc/recipes/compass/how_do_i_search_docs_with_compass.org=:
+
+1. Added =--under PATH= (append) and =--type DOCTYPE= arguments to the
+   =search= subparser.
+
+2. Increased the over-fetch cap from =limit*10= (max 200) to =limit*50=
+   (max 1000) when either filter is active, so post-filter clipping still
+   yields =--limit= hits from a large doc corpus.
+
+3. Applied =--under= as a post-filter using both
+   =Path.relative_to(PROJECT_ROOT)= and a path-component suffix check
+   (needed because the FTS index stores absolute paths that may use a
+   different mount prefix than the current shell).
+
+4. Applied =--type= as a post-filter: load the doc_index, collect UUIDs
+   whose =doctype= matches, and keep only those results.
+
+5. Updated the search recipe with three worked examples showing the
+   backlog-only idiom.
 
 * Notes
 
@@ -59,3 +77,10 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+All acceptance criteria met:
+
+- =compass search --under doc/agile/product_backlog --type capture 'ores-shell'=
+  returns only product-backlog captures matching the query.
+- =--under= is repeatable; =--type= accepts any doctype string.
+- The search recipe documents the backlog-only idiom with three examples.

--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_scoped_search.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_scoped_search.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:search:tooling:compass_quality_of_life:sprint_20:v0:
 #+owner: marco
 #+branch: feature/scoped-search
-#+pr:
+#+pr: 1234
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -68,7 +68,7 @@ Modified =projects/ores.compass/src/compass.py= and
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1234][#1234]] | [compass] Add scoped search (--under/--type); fix capture promote placeholders |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -145,7 +145,7 @@ LLM-driven workflow frictionless.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] | STARTED | 2026-06-06 | | Second QoL round, 10 tasks: SSH_AUTH_SOCK from .env, dashboard services bug, Claude settings auto-authorisation, actionable search, journal log newest-first, capture --commit, search by folder name, task move, recipe how-do boost, inbound-link boost. |
+| [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] | DONE | 2026-06-06 | 2026-06-10 | Second QoL round, 15 tasks: SSH_AUTH_SOCK from .env, dashboard services bug, Claude settings auto-authorisation, actionable search, journal log newest-first, capture --commit, search by folder name, task move, recipe how-do boost, inbound-link boost, PR review gate, cross-reference wiring, story tasks subcommand, scoped search, capture promote fix. |
 | [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-10 | New =compass heading= command: ranked next-work-item suggestions from the journals, fleet, sprint state, and backlog buckets; optional keyword steering. |
 
 ** Infrastructure

--- a/doc/recipes/compass/how_do_i_search_docs_with_compass.org
+++ b/doc/recipes/compass/how_do_i_search_docs_with_compass.org
@@ -63,6 +63,24 @@ description, tags, content and outline path; results are deduplicated
    ./projects/ores.compass/compass.sh search "nats" -f json
    #+end_src
 
+6. /Scope by path/ with =--under <path>= (repeatable). Restricts
+   results to docs below the given directory. Combine with =--type= to
+   narrow further:
+
+   #+begin_src sh :results verbatim
+   # Full-text search across the product backlog captures only
+   ./projects/ores.compass/compass.sh search "ores shell" \
+     --under doc/agile/product_backlog --type capture
+
+   # Backlog search for a feature idea (no grep needed)
+   ./projects/ores.compass/compass.sh search "typesense" \
+     --under doc/agile/product_backlog/inbox
+
+   # All sprint-20 tasks mentioning codegen
+   ./projects/ores.compass/compass.sh search "codegen" \
+     --under doc/agile/versions/v0/sprint_20 --type task -l 10
+   #+end_src
+
 The query supports FTS5 syntax (quoted phrases, =AND=/=OR=, =*=
 prefixes); a bare multi-word query is tokenised (punctuation safe)
 and OR'd with prefix matching.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -466,10 +466,13 @@ def cmd_search(args):
     # Over-fetch, then dedup: the index can carry the same node twice —
     # once under a relative and once under an absolute file_path — and a
     # doc can match on several chunks. One result per roam_id, best rank
-    # first, clipped to --limit.
+    # first, clipped to --limit.  Fetch more when --under/--type filters
+    # are active so post-filter clipping still yields --limit hits.
+    _has_filter = bool(args.under or args.doctype)
+    _fetch_cap  = min(args.limit * 50, 1000) if _has_filter else min(args.limit * 10, 200)
     try:
         rows.extend(compass_conn.execute(
-            sql, (fts_query, min(args.limit * 10, 200))).fetchall())
+            sql, (fts_query, _fetch_cap)).fetchall())
     except sqlite3.OperationalError as e:
         print(f"Search syntax error: {e}")
         return
@@ -550,6 +553,36 @@ def cmd_search(args):
         story_hits = [r for r in in_folder if r['file_path'].endswith("/story.org")]
         task_hits  = [r for r in in_folder if not r['file_path'].endswith("/story.org")]
         results = (story_hits + task_hits + out_folder)[:args.limit]
+
+    # Apply --under path-prefix filter.
+    # FTS stores absolute paths that may use a different mount prefix than
+    # PROJECT_ROOT, so we match the normalized relative fragment as a
+    # path-component suffix of whatever absolute path is stored.
+    if args.under:
+        def _under_any(file_path, prefixes):
+            try:
+                rel = str(Path(file_path).relative_to(PROJECT_ROOT))
+                for p in prefixes:
+                    p = p.strip("/")
+                    if rel.startswith(p + "/") or rel == p:
+                        return True
+            except ValueError:
+                pass
+            for p in prefixes:
+                p = p.strip("/")
+                if ("/" + p + "/") in file_path or file_path.endswith("/" + p):
+                    return True
+            return False
+        results = [r for r in results if _under_any(r['file_path'], args.under)]
+
+    # Apply --type doctype filter.
+    if args.doctype:
+        _all_docs = doc_index.load_all()
+        _type_ids = {d.id.upper() for d in _all_docs.values()
+                     if d.doctype == args.doctype}
+        results = [r for r in results if r['roam_id'] in _type_ids]
+
+    results = results[:args.limit]
 
     if not results:
         print("No results found.")
@@ -2075,6 +2108,38 @@ def _capture_body(text):
     return text[m.start():].rstrip() if m else ""
 
 
+_CAPTURE_PLACEHOLDER_BODIES = {
+    "(One paragraph: the idea.)",
+    "(Motivation, problem being solved, related context.)",
+    "-",
+    "",
+}
+
+
+def _is_capture_placeholder(text):
+    return text.strip() in _CAPTURE_PLACEHOLDER_BODIES
+
+
+def _filter_capture_body(body):
+    """Strip sections whose content is only template filler.
+
+    When every subsection is a placeholder (unfilled capture), returns
+    an empty string so the caller omits the 'Promoted from capture' block.
+    """
+    if not body:
+        return body
+    parts = re.split(r"(?=^\* )", body, flags=re.M)
+    kept = []
+    for part in parts:
+        if not part.strip():
+            continue
+        m = re.match(r"^\* [^\n]+\n?(.*)", part, re.S)
+        if m and _is_capture_placeholder(m.group(1)):
+            continue
+        kept.append(part.rstrip())
+    return "\n\n".join(kept)
+
+
 def _cmd_capture_promote(argv):
     """compass capture promote — turn a capture into a story or task.
 
@@ -2114,9 +2179,11 @@ def _cmd_capture_promote(argv):
         print(f"❌ Capture has no :ID:.", file=sys.stderr)
         return 1
 
-    # Goal: the capture's What section when present, else description.
+    # Goal: the capture's What section when present and not a placeholder,
+    # else fall back to the capture description.
     m = re.search(r"^\* What\s*\n(.*?)(?=^\* |\Z)", text, re.M | re.S)
-    goal = (m.group(1).strip() if m else "") or description
+    what_body = m.group(1).strip() if m else ""
+    goal = ("" if _is_capture_placeholder(what_body) else what_body) or description
 
     # Resolve target locations.
     docs = doc_index.load_all()
@@ -2177,7 +2244,9 @@ def _cmd_capture_promote(argv):
     print(f"✅ {args.to} scaffolded with the capture's UUID: {new_rel}")
 
     # Preserve the rest of the capture body, demoted one level.
-    body = _capture_body(text)
+    # Strip placeholder sections first so an unfilled capture doesn't
+    # append an all-placeholder 'Promoted from capture' block.
+    body = _filter_capture_body(_capture_body(text))
     if body:
         demoted = re.sub(r"^(\*+ )", r"*\1", body, flags=re.M)
         with new_path.open("a", encoding="utf-8") as f:
@@ -4808,6 +4877,10 @@ def main():
                               help="Output format: pretty (default), line (UUID path match), or json")
     search_parser.add_argument("-v", "--verbose", action="store_true",
                               help="Verbose pretty output: file path, location, and matched snippet per hit")
+    search_parser.add_argument("--under", action="append", default=[], metavar="PATH",
+                              help="Restrict to docs whose path is below PATH (repeatable)")
+    search_parser.add_argument("--type", dest="doctype", default="",
+                              help="Filter by document type (task, story, capture, recipe, …)")
 
     debug_parser = subparsers.add_parser("debug", help="Debug the index contents")
     debug_parser.add_argument("-f", "--file", type=str, help="Check a specific file (partial match)")


### PR DESCRIPTION
## Summary

Combines tasks 53CE8498 (scoped search) and 1BD08842 (capture promote fix) into one PR.

- **`compass search --under <path>`** (repeatable): restricts FTS hits to docs below the given path prefix. Handles mount-prefix discrepancies between the FTS index and `PROJECT_ROOT` via dual path matching (`relative_to` fallback to path-component substring check). Over-fetch cap raised to `limit*50` (max 1000) when a filter is active so post-filter clipping still yields the requested result count.
- **`compass search --type <doctype>`**: filters results by document type using the doc index.
- **Capture promote placeholder fix**: detects unfilled template placeholder text in `What`/`Why`/`References`/`See also` sections; falls back to `#+description` for the goal when `What` is a placeholder; omits the "Promoted from capture" section entirely when all subsections are placeholders.
- **Search recipe** updated with three worked examples showing the `--under`/`--type` idiom including backlog-only full-text search.
- **Agile close-out**: both task docs set to DONE; Compass QoL story and sprint row marked DONE (all 15 tasks shipped).

## Test plan

- [ ] `compass search --under doc/agile/product_backlog --type capture '<term>'` returns only matching captures under that path
- [ ] `compass search --under doc/agile/versions/v0/sprint_20 --type task '<term>'` scopes to sprint-20 tasks
- [ ] `--under` with a path stored under a different mount prefix still matches
- [ ] Promoting an unfilled capture uses description as goal, no placeholder section appended
- [ ] Promoting a filled capture works as before
- [ ] Search recipe section 6 renders correctly in org-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)