### PR TITLE
[agile] Scaffold story: Accumulate tagged face dataset for profile pictures

### DIFF
--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/story.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/story.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 9246285C-5ACC-43F8-8F9C-ED086273F51D
+:END:
+#+title: Story: Accumulate a tagged face dataset for profile pictures
+#+description: Build the external/facestudio/ seed catalog: move the 60 downloaded AI faces, add manifest/methodology metadata, document the FaceStudio licence, fix the accumulation script (age filter 20–70, 429 handling, multiple images per combination, correct output path), and wire into the seeder.
+#+type: story
+#+level: s2
+#+filetags: :dataset:seeder:iam:ui:sprint_20:v0:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment: local4
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Move the 60 already-downloaded AI-generated face images from build/tmp/faces/ into a properly structured external/facestudio/ dataset directory following the external/flags/ pattern, document the FaceStudio licence (permissive for internal use), and fix the accumulation script so it filters ages outside 20–70, handles HTTP 429 gracefully, supports multiple images per combination, and writes to the canonical external/facestudio/faces/ location.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-10                               |
+
+* Acceptance
+
+- external/facestudio/faces/ holds the downloaded images. manifest.json and methodology.txt follow the external/flags/ pattern. Methodology documents the 60-req/day limit and licence. Script filters ages less than 20 and greater than 70. Script generates N images per combination with indexed filenames. Script handles HTTP 429 by stopping cleanly. Script skips already-downloaded files on restart. Script output path is external/facestudio/faces/.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:37B73B23-6D75-4B16-B298-E4039DDDD6F5][Scaffold story: Accumulate a tagged face dataset for profile pictures]] | DONE | 2026-06-10 | 2026-06-10 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:E664FF66-C582-4DA8-A779-4940BEF3551E][Create external/facestudio/ dataset structure and move assets]] | BACKLOG | | | Create the folder, move 60 images from build/tmp/faces/, add accumulation script, write manifest.json and methodology.txt with licence notes. |
+| [[id:5243FDF8-16E0-48D4-AD05-C2D4757A5EFA][Fix accumulate_faces.py: age range, 429 handling, multiple images per combination]] | BACKLOG | | | Fix three bugs in the face accumulation script: filter ages outside 20–70, handle HTTP 429 by stopping cleanly, support N images per combination with indexed filenames, and update output path to external/facestudio/faces/. |
+
+* See also
+
+- [[id:42EB2329-CD49-430D-A78A-49D2D14987BD][Accumulate a tagged face dataset for profile pictures]] — source capture in the inbox.
+- [[id:2D640A42-ECCE-4A76-80D1-169430E7D219][Users should be able to add picture to profile]] — UI consumer of this catalog.
+
+* Decisions
+
+- Use N=3 images per combination as the default — gives variety without multiplying the pending count 3× (238 → 714 total at 60/day ≈ 12 days).
+- Age range 20–70 inclusive: under-20 are not plausible account holders in a trading system; over-70 adds diminishing value.
+- FaceStudio licence (checked 2026-06-10): permissive for internal use. No attribution required. Competitive reuse prohibited (Clause 8) — irrelevant here.
+
+* Out of scope
+
+- Wiring the catalog into the seeder (separate story).
+- Automated regeneration / nightly accumulation job.

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 5243FDF8-16E0-48D4-AD05-C2D4757A5EFA
+:END:
+#+title: Task: Fix accumulate_faces.py: age range, 429 handling, multiple images per combination
+#+description: Fix three bugs in the face accumulation script: filter ages outside 20–70, handle HTTP 429 by stopping cleanly, support N images per combination with indexed filenames, and update output path to external/facestudio/faces/.
+#+type: task
+#+level: s1
+#+filetags: :facestudio_face_dataset:sprint_20:v0:
+#+owner: marco
+#+branch: feature/fix-accumulate-faces-script
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix three bugs in accumulate_faces.py: (1) age filter — skip ages below 20 and above 70; (2) HTTP 429 handling — print a clear daily-limit message and exit cleanly instead of continuing to fail; (3) multiple images per combination — add N parameter (default 3) with filenames indexed as female_age25_african_01.jpeg. Output path must point to external/facestudio/faces/. Restart file-skipping must be preserved.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-10                               |
+
+* Acceptance
+
+- Script AGES excludes values below 20 and above 70.
+- On HTTP 429 script prints a rate-limit message and exits cleanly.
+- Script generates N images per combination with two-digit indexed filenames.
+- Output path is external/facestudio/faces/ relative to repo root.
+- Restart skips files already present on disk.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_implement_facestudio_face_dataset.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_implement_facestudio_face_dataset.org
@@ -1,0 +1,79 @@
+:PROPERTIES:
+:ID: E664FF66-C582-4DA8-A779-4940BEF3551E
+:END:
+#+title: Task: Create external/facestudio/ dataset structure and move assets
+#+description: Create the external/facestudio/ folder following the external/flags/ pattern; move the 60 downloaded face images from build/tmp/faces/; add the accumulation script; write manifest.json and methodology.txt documenting the FaceStudio licence and 60-req/day rate limit.
+#+type: task
+#+level: s1
+#+filetags: :facestudio_face_dataset:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create the =external/facestudio/= dataset directory following the
+=external/flags/= pattern. Move the 60 already-downloaded AI-generated
+face images from =build/tmp/faces/= into =external/facestudio/faces/=.
+Copy the accumulation script (=build/tmp/accumulate_faces.py=) into
+=external/facestudio/=. Write =manifest.json= and =methodology.txt=
+documenting the source, file-naming convention, FaceStudio licence
+(permissive for internal use — no attribution required, competitive
+reuse only restriction), and the 60-request-per-day rate limit.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-10                             |
+
+* Acceptance
+
+- =external/facestudio/faces/= contains the 60 images moved from =build/tmp/faces/=.
+- =external/facestudio/accumulate_faces.py= is present (even if still buggy — fixes are a separate task).
+- =manifest.json= follows the =external/flags/manifest.json= schema: name, description, downloaded_at, sources (with licence), datasets.
+- =methodology.txt= describes the generation steps, FaceStudio licence summary, rate-limit note (60 req/day), and file-naming convention (=<gender>_age<NN>_<ethnicity>[_<NN>].jpeg=).
+
+* Plan
+
+1. =mkdir -p external/facestudio/faces/=
+2. =mv build/tmp/faces/*.jpeg external/facestudio/faces/=
+3. =cp build/tmp/accumulate_faces.py external/facestudio/=
+4. Write =external/facestudio/manifest.json= (source: facestudio.app, licence: permissive).
+5. Write =external/facestudio/methodology.txt= (generation steps, licence notes, rate-limit, naming scheme).
+6. Commit and raise PR.
+
+* Notes
+
+Licence check (2026-06-10, https://facestudio.app/terms):
+- Clause 5: generated images may be used by Face Studio for R&D. No explicit restriction on storing images in a repository.
+- Clause 8: prohibits building a competing face-generation product. Internal seeder use is not competitive — this is permitted.
+- No attribution requirement.
+- Rate limit: 60 requests/day (observed empirically; not specified in terms).
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_scaffold_facestudio_face_dataset.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_scaffold_facestudio_face_dataset.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 37B73B23-6D75-4B16-B298-E4039DDDD6F5
+:END:
+#+title: Task: Scaffold story: Accumulate a tagged face dataset for profile pictures
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :facestudio_face_dataset:sprint_20:v0:
+#+owner: marco
+#+branch: feature/facestudio-face-dataset
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment: local4
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-10                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Promoted capture [[id:42EB2329-CD49-430D-A78A-49D2D14987BD][42EB2329]] to story [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][9246285C]] in Sprint 20.
+Created two implementation tasks: dataset structure (E664FF66) and script
+fixes (5243FDF8). Licence confirmed permissive for internal use; decisions
+recorded in story (N=3 per combination, age 20–70).

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_scaffold_facestudio_face_dataset.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_scaffold_facestudio_face_dataset.org
@@ -8,7 +8,7 @@
 #+filetags: :facestudio_face_dataset:sprint_20:v0:
 #+owner: marco
 #+branch: feature/facestudio-face-dataset
-#+pr:
+#+pr: 1239
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-10
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1239][#1239]] | [agile] Scaffold story: Accumulate tagged face dataset for profile pictures |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -187,6 +187,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 |-------+-------+-------+-----+-------------|
 | [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] | DONE | 2026-06-07 | 2026-06-07 | New command_args/command_feedback/script_runner symbols lack ORES_SHELL_EXPORT; Windows test exe cannot link against the DLL. |
 | [[id:E9CC8354-318C-4B08-B307-25910F536F2E][Hotfix: shell bundles gcc build]] | DONE | 2026-06-06 | 2026-06-06 | linux-gcc-debug-ninja red: four shell command files built std::string from std::vector<std::byte> iterators; converted to ores::nats::as_string_view. PR [[https://github.com/OreStudio/OreStudio/pull/1133][#1133]]. |
+| [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] | BACKLOG | | | Build the external/facestudio/ seed catalog: move the 60 downloaded AI faces, add manifest/methodology metadata, document the FaceStudio licence, fix the accumulation script (age filter 20–70, 429 handling, multiple images per combination, correct output path), and wire into the seeder. |
 
 * Achievements
 


### PR DESCRIPTION
## Summary

Promotes capture 42EB2329 to story 9246285C in Sprint 20. No C++ or production code — agile docs only.

- Story: `doc/agile/versions/v0/sprint_20/facestudio_face_dataset/story.org`
- Task 1 (E664FF66): Create `external/facestudio/` dataset structure, move 60 images from `build/tmp/faces/`, write `manifest.json` and `methodology.txt`
- Task 2 (5243FDF8): Fix `accumulate_faces.py` — age range 20–70, HTTP 429 graceful exit, N images per combination with indexed filenames, correct output path

**Licence check (https://facestudio.app/terms, 2026-06-10):** permissive for internal use — no attribution required; Clause 8 prohibits competitive reuse only, which does not apply to an internal seeder dataset. Documented in story `* Decisions`.

**Scope decisions recorded in story:**
- N=3 images per combination default (238 combinations × 3 = 714 total; at 60/day ≈ 12 days)
- Age range 20–70 inclusive (children and very elderly excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)