### PR TITLE
[compass] Add recipe for compass heading

### DIFF
--- a/doc/agile/product_backlog/inbox/migrate_claude_memories_to_org_system.org
+++ b/doc/agile/product_backlog/inbox/migrate_claude_memories_to_org_system.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: D7F3D19C-1E9C-4302-B661-12A28411425E
+:END:
+#+title: Migrate Claude memories to org-based memory system
+#+description: Extract memories from the Claude harness memory system (/home/marco/.claude/projects) into the project org-based memory system, delete the harness memories, and configure Claude to use only the org system.
+#+type: capture
+#+level: cross
+#+filetags: :compass:agile:memory:tooling:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Claude Code's harness auto-memory system writes files under
+=/home/marco/.claude/projects/<project-hash>/memory/= (=MEMORY.md= index +
+individual =*.md= files). We currently have entries there (feedback,
+user, project, reference memories) that duplicate or contradict the
+project's org-based memory system in =doc/llm/memories/= (or equivalent
+org path). The task is to:
+
+1. Audit the files under =/home/marco/.claude/projects/.../memory/=.
+2. For each entry: decide whether it is already captured in the org
+   system, needs to be ported, or can be discarded.
+3. Port any keepers to the org-based memory system using the compass
+   memory primitive.
+4. Delete the harness memory files (=MEMORY.md= + all =*.md= companions)
+   so Claude stops reading them.
+5. Update =CLAUDE.md= (or the LLM instructions doc) to explicitly
+   prohibit Claude from writing to or reading from any memory system
+   outside the project org tree.
+6. Remove the auto-memory instructions from Claude's active config
+   (=.claude/settings.json= / =doc/llm/claude_code_settings.org=) if they
+   exist, so the harness stops regenerating the files.
+
+* Why
+
+The two memory systems can diverge: harness memories written during one
+session may contradict the org system, or record stale information that
+survives long after it is wrong. The org system is version-controlled,
+reviewable, and lives with the codebase; the harness system is a
+hidden artefact outside the repo. Having a single, canonical memory
+location avoids confusion and ensures Claude's context is always
+consistent with the current project state.
+
+* References
+
+- Harness memory dir: =/home/marco/.claude/projects/-mnt-development-Development-OreStudio-OreStudio-remote/memory/=
+- Current harness entries: =MEMORY.md=, =feedback_use_codegen_for_v2_docs.md=,
+  =feedback_plan_location.md=, =project_org_js_naming.md=
+- LLM instructions doc: =doc/llm/llm_instructions.org= (or =CLAUDE.md=)
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
@@ -8,6 +8,7 @@
 #+filetags: :compass:agile:tooling:backlog:llm:sprint_20:v0:
 #+created: 2026-06-08
 #+updated: 2026-06-08
+#+environment: remote
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -32,9 +33,9 @@ It completes the navigation arc alongside the existing commands:
 
 | Field         | Value                                                |
 |---------------+------------------------------------------------------|
-| State         | DONE                                                 |
+| State         | DONE                                                    |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                                            |
-| Now           | Nothing.                                             |
+| Now           | All tasks merged. Story complete.                    |
 | Waiting on    | Nothing.                                             |
 | Next          | Nothing.                                             |
 | Last touched  | 2026-06-10                                           |
@@ -63,6 +64,7 @@ It completes the navigation arc alongside the existing commands:
 |------+-------+-------+-----+-------------|
 | [[id:5857B626-1579-4581-844F-B6AF80E66780][Scaffold story: Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-08 | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
 | [[id:85F8CFFB-225B-4BC5-A277-1EE5AB4621A1][Analyse and design the next-work-item suggester]] | DONE | 2026-06-10 | 2026-06-10 | Design =compass heading=: the signal sources (journals, fleet, sprint state, backlogs), the priority/scoring model, keyword steering, output format, and which command pillar it belongs to. |
+| [[id:05401E9F-3F6B-4731-A62F-20FA7B798B09][Write recipe for compass heading]] | DONE | 2026-06-10 | 2026-06-10 | Write a recipe documenting how to use compass heading: scoring model, keyword steering, JSON output, and placement in the recipe index. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
@@ -54,13 +54,16 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1242][#1242]] | [compass] Add recipe for compass heading |
 
 * Review
 
 | # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+|---+-------------------------------------------------------------------+---------------------------------------+----------+-------|
+| 1 | default -n says 5, code has 10                                    | recipe:68                             | Fixed    | 490643240 |
+| 2 | JSON fields id/type should be uuid/kind                           | recipe:82–84                          | Fixed    | 490643240 |
+| 3 | _read_captures does not exist; reads inline from bucket dirs      | recipe:87–91                          | Fixed    | 490643240 |
+| 4 | Task Goal and Acceptance have unfilled template text              | task doc                              | Fixed    | 490643240 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 05401E9F-3F6B-4731-A62F-20FA7B798B09
+:END:
+#+title: Task: Write recipe for compass heading
+#+description: Write a recipe documenting how to use compass heading: scoring model, keyword steering, JSON output, and placement in the recipe index.
+#+type: task
+#+level: s1
+#+filetags: :suggest_next_work_item:sprint_20:v0:
+#+owner: marco
+#+branch: feature/write-recipe-compass-heading
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+#+environment: remote
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-10                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Wrote =doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org=
+covering: the scoring model (BLOCKED=100 down to inbox=20), keyword
+steering (up to 2× boost, BLOCKED excluded), =-n= cap, =-f json= output,
+and =See also= links to =where=, =fleet=, and =task new=. Wired into the
+=* Orient= section of =doc/recipes/compass/compass.org=.

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_write_recipe_compass_heading.org
@@ -20,7 +20,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Write =doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org=
+covering the =compass heading= command: scoring model, keyword steering,
+=-n= cap, =-f json= output, and =See also= links. Wire it into the
+=* Orient= section of =doc/recipes/compass/compass.org=.
 
 * Status
 
@@ -35,7 +38,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Acceptance
 
--
+- Recipe file created at =doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org=.
+- Scoring table, keyword steering, =-n= cap, and =-f json= field names match the implementation.
+- Entry wired into =* Orient= section of =doc/recipes/compass/compass.org=.
 
 * Plan
 

--- a/doc/recipes/compass/compass.org
+++ b/doc/recipes/compass/compass.org
@@ -24,6 +24,9 @@ pillars that fold in the standalone scripts, starting with Provision.
   PR per git worktree (=fleet=).
 - [[id:A7D3C1E5-9F2B-4A8D-B6E4-3C7F1D9A2E5B][How do I get a sprint or story status?]] — all stories or tasks grouped
   by state (=sprint status= / =story status=).
+- [[id:D0522FBB-A1B7-42B0-BE60-B07A2878AADB][How do I get a ranked next-work-item suggestion?]] — prioritised list of
+  what to pick up next, scored from sprint state, fleet, and backlog
+  (=heading=).
 
 * Search and indexing
 

--- a/doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org
+++ b/doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org
@@ -65,7 +65,7 @@ boost. Keyword boost only applies to non-BLOCKED items.
 
 ** Limit output
 
-=-n N= caps the list to the top N suggestions (default: 5):
+=-n N= caps the list to the top N suggestions (default: 10):
 
 #+begin_src sh :results verbatim
 ./projects/ores.compass/compass.sh heading -n 3
@@ -79,16 +79,17 @@ boost. Keyword boost only applies to non-BLOCKED items.
 ./projects/ores.compass/compass.sh heading -f json
 #+end_src
 
-Each entry carries =score=, =rationale=, =action=, =id=, =title=, and
-=type= fields.
+Each entry carries =score=, =kind=, =title=, =rationale=, =action=, and
+=uuid= fields.
 
 * Script
 
 =projects/ores.compass/compass.sh heading= → =src/compass.py=
 (=cmd_heading=), which reads sprint story/task state via
 =_read_story_state= and =_read_task_detail=, fleet activity via
-=list_worktrees=, and product-backlog captures via =_read_captures=.
-Optional keyword boost is applied by =_heading_keyword_boost=.
+=list_worktrees=, and product-backlog captures by iterating the =next/=
+and =inbox/= bucket dirs directly. Optional keyword boost is applied by
+=_heading_keyword_boost=.
 
 * Tested by
 

--- a/doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org
+++ b/doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org
@@ -1,0 +1,104 @@
+:PROPERTIES:
+:ID: D0522FBB-A1B7-42B0-BE60-B07A2878AADB
+:END:
+#+title: How do I get a ranked next-work-item suggestion?
+#+description: Use compass heading to get a prioritised list of candidate next work items, scored from sprint state, fleet activity, and backlog captures.
+#+type: recipe
+#+level: cross
+#+filetags: :compass:agile:heading:orientation:recipe:bearings:
+#+created: 2026-06-10
+#+updated: 2026-06-10
+
+The /Orient/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]]. It synthesises sprint state,
+fleet activity, and product-backlog captures into a ranked suggestion
+list — the decision-support step between =bearings= (where am I?) and
+=goto= / =task start= (set off).
+
+* Question
+
+I have multiple things I could work on. Which story or task should I
+pick up next, and why?
+
+* Answer
+
+Run =compass heading=:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh heading
+#+end_src
+
+It prints a ranked list of candidate next work items, each with a
+priority score, a one-line "why now" rationale, and the action to take.
+
+** Scoring model
+
+Items are scored in descending priority:
+
+| Score | Signal                                                                 |
+|-------+------------------------------------------------------------------------|
+|   100 | BLOCKED task — hardest constraint; must be unblocked before anything else |
+|    90 | Ready-to-close story — all tasks DONE but story still STARTED          |
+|    80 | Next BACKLOG task in an already-STARTED story                          |
+|    65 | STARTED task not currently active in the fleet                         |
+|    50 | STARTED task already active in the fleet (de-prioritised, avoid collision) |
+|    40 | Capture in the =next= product-backlog bucket                           |
+|    20 | Capture in the =inbox= product-backlog bucket                          |
+
+** Keyword steering
+
+Pass optional keywords to bias the ranking toward matching items.
+Keywords are matched against item title, description, and directory
+name. Each match multiplies the score up to 2×:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh heading compass
+#+end_src
+
+Multiple keywords combine — the more matches, the higher the boost:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh heading compass recipe
+#+end_src
+
+Note: BLOCKED items always score exactly 100 regardless of keyword
+boost. Keyword boost only applies to non-BLOCKED items.
+
+** Limit output
+
+=-n N= caps the list to the top N suggestions (default: 5):
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh heading -n 3
+#+end_src
+
+** JSON output for LLM / tooling consumption
+
+=-f json= emits a structured array suitable for LLM tool use:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh heading -f json
+#+end_src
+
+Each entry carries =score=, =rationale=, =action=, =id=, =title=, and
+=type= fields.
+
+* Script
+
+=projects/ores.compass/compass.sh heading= → =src/compass.py=
+(=cmd_heading=), which reads sprint story/task state via
+=_read_story_state= and =_read_task_detail=, fleet activity via
+=list_worktrees=, and product-backlog captures via =_read_captures=.
+Optional keyword boost is applied by =_heading_keyword_boost=.
+
+* Tested by
+
+Manual smoke test. Read-only over the working tree and fleet.
+
+* See also
+
+- [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]] — =where= / =status=: current version,
+  sprint, and in-flight stories/tasks (the "before" step).
+- [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — =story new= / =task new=:
+  act on a suggestion from =heading= (the "after" step).
+- [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][How do I see what every worktree is doing?]] — =fleet=: see what the
+  other worktrees are already working on (feeds the 50 vs 65 signal).


### PR DESCRIPTION
## Summary

- Adds `doc/recipes/compass/how_do_i_get_a_ranked_next_work_item_suggestion.org`: full recipe for `compass heading` covering scoring model, keyword steering, `-n` cap, `-f json` output, and See also links
- Wires the recipe into the Orient section of `doc/recipes/compass/compass.org`
- Closes the `write_recipe_compass_heading` task and marks the `suggest_next_work_item` story DONE

## Test plan

- [ ] `compass heading` prints a ranked list with correct scores and rationales
- [ ] `compass heading compass` boosts compass-related items
- [ ] `compass heading -f json` emits valid JSON
- [ ] `compass heading -n 2` caps to 2 results
- [ ] Recipe renders correctly in org-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)