### PR TITLE
[data] Fix accumulate_faces.py: age 20-70, 429 exit, N=3 per combination

### DIFF
--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/story.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/story.org
@@ -38,7 +38,7 @@ Move the 60 already-downloaded AI-generated face images from build/tmp/faces/ in
 |------+-------+-------+-----+-------------|
 | [[id:37B73B23-6D75-4B16-B298-E4039DDDD6F5][Scaffold story: Accumulate a tagged face dataset for profile pictures]] | DONE | 2026-06-10 | 2026-06-10 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
 | [[id:E664FF66-C582-4DA8-A779-4940BEF3551E][Create external/facestudio/ dataset structure and move assets]] | DONE | 2026-06-10 | 2026-06-10 | Create the folder, move 60 images from build/tmp/faces/, add accumulation script, write manifest.json and methodology.txt with licence notes. |
-| [[id:5243FDF8-16E0-48D4-AD05-C2D4757A5EFA][Fix accumulate_faces.py: age range, 429 handling, multiple images per combination]] | BACKLOG | | | Fix three bugs in the face accumulation script: filter ages outside 20–70, handle HTTP 429 by stopping cleanly, support N images per combination with indexed filenames, and update output path to external/facestudio/faces/. |
+| [[id:5243FDF8-16E0-48D4-AD05-C2D4757A5EFA][Fix accumulate_faces.py: age range, 429 handling, multiple images per combination]] | DONE | 2026-06-10 | 2026-06-10 | Fix three bugs in the face accumulation script: filter ages outside 20–70, handle HTTP 429 by stopping cleanly, support N images per combination with indexed filenames, and update output path to external/facestudio/faces/. |
 
 * See also
 

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-10
 #+updated: 2026-06-10
-#+environment:
+#+environment: local4
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,11 +26,11 @@ Fix three bugs in accumulate_faces.py: (1) age filter — skip ages below 20 and
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-10                               |
 
 * Acceptance
@@ -43,9 +43,17 @@ Fix three bugs in accumulate_faces.py: (1) age filter — skip ages below 20 and
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Three targeted changes to =external/facestudio/accumulate_faces.py=:
+
+1. Replace =AGES = list(range(0, 81, 5))= with =list(range(20, 71, 5))=.
+2. In =fetch()=: catch =e.code == 429= before the generic =HTTPError= handler;
+   print a clear daily-limit message and =sys.exit(1)=.
+3. Add =COUNT_PER_COMBO = 3=; expand the combo list with an index dimension
+   (=for i in range(1, COUNT_PER_COMBO + 1)=); update =filename()= to include
+   the two-digit index suffix (=_01=, =_02=, …); update =pending= skip-check
+   and progress display accordingly.
+4. Fix =OUT_DIR= to =REPO_ROOT / "external" / "facestudio" / "faces"= (was
+   relative to the old =build/tmp/= location).
 
 * Notes
 
@@ -62,3 +70,13 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+All four fixes applied to =external/facestudio/accumulate_faces.py=:
+
+- =AGES= is now =range(20, 71, 5)= — 11 values, ages 0–15 and 75–80 excluded.
+- HTTP 429 exits with =sys.exit(1)= and a clear "Daily rate limit reached" message.
+- =COUNT_PER_COMBO = 3=; filenames include a two-digit index (=_01=, =_02=, =_03=).
+- =OUT_DIR= points to =REPO_ROOT / "external" / "facestudio" / "faces"=.
+- Skip-on-restart logic preserved and updated for the new filename format.
+- Total pending: 462 images (11 × 2 × 7 × 3) at ~8 days to complete.
+

--- a/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
+++ b/doc/agile/versions/v0/sprint_20/facestudio_face_dataset/task_fix_accumulate_faces_script.org
@@ -8,7 +8,7 @@
 #+filetags: :facestudio_face_dataset:sprint_20:v0:
 #+owner: marco
 #+branch: feature/fix-accumulate-faces-script
-#+pr:
+#+pr: 1243
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-10
@@ -61,7 +61,7 @@ Three targeted changes to =external/facestudio/accumulate_faces.py=:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1243][#1243]] | [data] Fix accumulate_faces.py: age 20-70, 429 exit, N=3 per combination |
 
 * Review
 

--- a/external/facestudio/accumulate_faces.py
+++ b/external/facestudio/accumulate_faces.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
 """
-Accumulate a tagged face dataset from facestud.io.
+Accumulate a tagged face dataset from facestudio.app.
 
-Iterates over the full cross-product of gender × age × ethnicity in a
-randomised order, sleeping 10 minutes between requests so the script
-can run in the background for several days without hammering the API.
+Iterates over the full cross-product of gender × age × ethnicity × index in a
+randomised order, sleeping 10 minutes between requests so the script can run in
+the background for several days without hammering the API.
 Skips combinations already on disk — safe to kill and restart.
 
-Output directory: assets/faces/  (relative to repo root; create before first run)
-File naming:      <gender>_age<NN>_<ethnicity>.jpeg
-                  e.g.  female_age34_south_asian.jpeg
+Output directory: external/facestudio/faces/  (relative to repo root)
+File naming:      <gender>_age<NN>_<ethnicity>_<NN>.jpeg
+                  e.g.  female_age25_south_asian_01.jpeg
 """
 
 import itertools
-import os
 import random
 import sys
 import time
@@ -35,25 +34,27 @@ ETHNICITIES = [
     "southeast_asian",
     "latin_american",
 ]
-# Age step: every 5 years gives good coverage without 81 × 2 × 7 = 1134 images
-# (that would take ~8 days).  Every 5 years → 17 steps × 2 × 7 = 238 images
-# → ~1.6 days.  Change to range(0, 81) for the full set.
-AGES        = list(range(0, 81, 5))
+# Ages 20–70 in 5-year steps. Under-20 are not plausible account holders in a
+# trading system; over-70 adds diminishing value.
+AGES        = list(range(20, 71, 5))
+
+# Number of images per (gender, age, ethnicity) combination.
+# 11 ages × 2 genders × 7 ethnicities × 3 = 462 total images; at 60/day ≈ 8 days.
+COUNT_PER_COMBO = 3
 
 BASE_URL    = "https://facestud.io/v1/generate"
 FORMAT      = "jpeg"
-SLEEP_SECS  = 10 * 60   # 10 minutes between requests
+SLEEP_SECS  = 10 * 60   # 10 minutes between requests (~60 req/day)
 
-# Output directory — relative to this script's location (build/tmp/),
-# two levels up lands at the repo root.
+# Output directory — external/facestudio/faces/ relative to repo root.
 SCRIPT_DIR  = Path(__file__).parent
 REPO_ROOT   = SCRIPT_DIR.parent.parent
-OUT_DIR     = SCRIPT_DIR / "faces"
+OUT_DIR     = REPO_ROOT / "external" / "facestudio" / "faces"
 
 # ---------------------------------------------------------------------------
 
-def filename(gender: str, age: int, ethnicity: str) -> str:
-    return f"{gender}_age{age:02d}_{ethnicity}.{FORMAT}"
+def filename(gender: str, age: int, ethnicity: str, index: int) -> str:
+    return f"{gender}_age{age:02d}_{ethnicity}_{index:02d}.{FORMAT}"
 
 
 def fetch(gender: str, age: int, ethnicity: str, dest: Path) -> bool:
@@ -72,6 +73,10 @@ def fetch(gender: str, age: int, ethnicity: str, dest: Path) -> bool:
         dest.write_bytes(data)
         return True
     except urllib.error.HTTPError as e:
+        if e.code == 429:
+            print(f"\n  Daily rate limit reached (HTTP 429). Stopping cleanly.")
+            print(f"  Progress saved — rerun tomorrow to continue.")
+            sys.exit(1)
         print(f"  HTTP {e.code}: {e.reason}")
         return False
     except Exception as e:
@@ -82,19 +87,25 @@ def fetch(gender: str, age: int, ethnicity: str, dest: Path) -> bool:
 def main() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    combos = list(itertools.product(GENDERS, AGES, ETHNICITIES))
+    combos = [
+        (g, a, e, i)
+        for g, a, e in itertools.product(GENDERS, AGES, ETHNICITIES)
+        for i in range(1, COUNT_PER_COMBO + 1)
+    ]
     random.shuffle(combos)   # randomise so early runs get good variety
 
     total   = len(combos)
-    pending = [(g, a, e) for g, a, e in combos
-               if not (OUT_DIR / filename(g, a, e)).exists()]
+    pending = [
+        (g, a, e, i) for g, a, e, i in combos
+        if not (OUT_DIR / filename(g, a, e, i)).exists()
+    ]
 
     print(f"Face dataset accumulator")
     print(f"  Output : {OUT_DIR}")
-    print(f"  Total  : {total} combinations")
+    print(f"  Total  : {total} images ({COUNT_PER_COMBO} per combination)")
     print(f"  Done   : {total - len(pending)} already on disk")
     print(f"  Pending: {len(pending)}")
-    print(f"  Sleep  : {SLEEP_SECS // 60} min between requests")
+    print(f"  Sleep  : {SLEEP_SECS // 60} min between requests (~60/day limit)")
     print(f"  ETA    : ~{len(pending) * SLEEP_SECS / 3600:.1f} hours")
     print()
 
@@ -102,8 +113,8 @@ def main() -> None:
         print("All combinations already downloaded.")
         return
 
-    for i, (gender, age, ethnicity) in enumerate(pending, 1):
-        fname = filename(gender, age, ethnicity)
+    for i, (gender, age, ethnicity, idx) in enumerate(pending, 1):
+        fname = filename(gender, age, ethnicity, idx)
         dest  = OUT_DIR / fname
         if dest.exists():
             continue  # another process may have written it


### PR DESCRIPTION
## Summary

- Age range tightened to 20–70 (was 0–80); removes implausible account-holder ages
- HTTP 429 now exits cleanly with a "Daily rate limit reached" message instead of continuing to fail
- `COUNT_PER_COMBO = 3`; combos include an index dimension; filenames use two-digit suffix (`_01`, `_02`, `_03`)
- `OUT_DIR` fixed to `REPO_ROOT / "external" / "facestudio" / "faces"` (was relative to the old `build/tmp/` location)
- Skip-on-restart logic updated for new filename format; safe to kill and restart

Task: 5243FDF8 — Fix accumulate_faces.py: age range, 429 handling, multiple images per combination

## Test plan

- [ ] Script runs without error: `python3 external/facestudio/accumulate_faces.py`
- [ ] `AGES` is `[20, 25, ..., 70]` (11 values)
- [ ] Existing files in `external/facestudio/faces/` are skipped on restart
- [ ] `--dry-run` shows 462 pending images (11 × 2 × 7 × 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)