### PR TITLE
[agile] Sprint health misc fixes

### DIFF
--- a/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_existing_file.org
+++ b/doc/agile/versions/v0/sprint_20/compass_quality_of_life/task_capture_pr_existing_file.org
@@ -26,12 +26,12 @@ compass capture --pr never leaves a dangling branch; if the capture file already
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:EE8D63CB-D468-4D91-A1D8-CDE5A70D3B38][Compass quality of life]] |
-| Now          | Not yet started.                       |
+| Now          | Abandoned — parent story closed DONE.  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-10                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-11                             |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -8,6 +8,7 @@
 #+filetags: :agile:review:sprint_20:v0:
 #+created: 2026-06-07
 #+updated: 2026-06-07
+#+environment: local2
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -59,7 +60,7 @@ whether the team is focused — rather than merely summarising status.
 | [[id:DFC59C81-1D74-45E0-AC73-3FB974B5AA44][Mop up Sprint 20 state drift and stale closeouts]] | DONE | 2026-06-08 | 2026-06-08 | Close merged tasks/stories; block currency; fix sprint/file drift; regenerate the timeline at 20-min granularity. |
 | [[id:E01C8DCB-3864-420E-8A61-D8CD99A3F2D6][Fix dashboard: remove commits chart, fix sprint image display]] | DONE | 2026-06-09 | 2026-06-09 | Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint. |
 | [[id:DEE29002-6007-478D-9665-56C147B5F41B][Health review 2 — sprint 20 mid-sprint analysis]] | DONE | 2026-06-10 | 2026-06-10 | System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict. |
-| [[id:F140AFCC-5398-4960-8D60-1E7A9A308FF0][Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date]] | BACKLOG | | | Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days. |
+| [[id:F140AFCC-5398-4960-8D60-1E7A9A308FF0][Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date]] | STARTED | 2026-06-11 | | Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -60,7 +60,7 @@ whether the team is focused — rather than merely summarising status.
 | [[id:DFC59C81-1D74-45E0-AC73-3FB974B5AA44][Mop up Sprint 20 state drift and stale closeouts]] | DONE | 2026-06-08 | 2026-06-08 | Close merged tasks/stories; block currency; fix sprint/file drift; regenerate the timeline at 20-min granularity. |
 | [[id:E01C8DCB-3864-420E-8A61-D8CD99A3F2D6][Fix dashboard: remove commits chart, fix sprint image display]] | DONE | 2026-06-09 | 2026-06-09 | Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint. |
 | [[id:DEE29002-6007-478D-9665-56C147B5F41B][Health review 2 — sprint 20 mid-sprint analysis]] | DONE | 2026-06-10 | 2026-06-10 | System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict. |
-| [[id:F140AFCC-5398-4960-8D60-1E7A9A308FF0][Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date]] | STARTED | 2026-06-11 | | Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days. |
+| [[id:F140AFCC-5398-4960-8D60-1E7A9A308FF0][Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date]] | DONE | 2026-06-11 | 2026-06-11 | Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -35,9 +35,9 @@ backlog.
 |--------------+----------------------------------------|
 | State        | STARTED                                |
 | Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
-| Now          | Not yet started.                       |
+| Now          | PR #1250 open, addressing review.      |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Merge PR.                              |
 | Last touched | 2026-06-11                             |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_health_review:sprint_20:v0:
 #+owner: marco
 #+branch: feature/sprint-health-misc-fixes
-#+pr:
+#+pr: 1250
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -59,7 +59,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1250][#1250]] | [agile] Sprint health misc fixes |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -33,11 +33,11 @@ backlog.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                                |
+| State        | DONE                                |
 | Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
-| Now          | PR #1250 open, addressing review.      |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Merge PR.                              |
+| Next         | Nothing. |
 | Last touched | 2026-06-11                             |
 
 * Acceptance
@@ -68,3 +68,9 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+- Dashboard panels reordered: "Tasks done per sprint day" now appears directly after "Velocity — stories done per sprint".
+- Progress bar split into green (DONE) and red (ABANDONED) float-left segments; label reads "N done · M abandoned" when abandonments exist.
+- =task_capture_pr_existing_file= in the Compass quality-of-life story marked ABANDONED; parent story was already DONE.
+- Sprint template =End (expected)= row now renders ={{end_date}}= (start + 7 days) via a new variable in =doc_generate.py=; both =doc_sprint.org.mustache= and =doc_sprint_org.org= updated.
+- Pre-existing template drift fixed: =doc_facet= and =doc_facet_group= mustache files synced to =facet_catalogue.org= id-links, unblocking the drift CI check.

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-11
 #+updated: 2026-06-11
-#+environment:
+#+environment: local2
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -33,7 +33,7 @@ backlog.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | STARTED                                |
 | Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/projects/ores.codegen/library/templates/doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_sprint.org.mustache
@@ -25,7 +25,7 @@ This page documents a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] (*{{ti
 | Parent version | [[id:{{parent_id}}][{{parent_title}}]] |
 | Previous       | {{previous}}                           |
 | Start          | {{date}}                               |
-| End (expected) |                                        |
+| End (expected) | {{end_date}}                           |
 | Now            | Sprint in flight.                      |
 | Waiting on     | Nothing.                               |
 | Next           | Pick the first story.                  |

--- a/projects/ores.codegen/library/templates/doc_sprint_org.org
+++ b/projects/ores.codegen/library/templates/doc_sprint_org.org
@@ -48,7 +48,7 @@ This page documents a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] (*{{ti
 | Parent version | [[id:{{parent_id}}][{{parent_title}}]] |
 | Previous       | {{previous}}                           |
 | Start          | {{date}}                               |
-| End (expected) |                                        |
+| End (expected) | {{end_date}}                           |
 | Now            | Sprint in flight.                      |
 | Waiting on     | Nothing.                               |
 | Next           | Pick the first story.                  |

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -24,7 +24,7 @@ document is expected to follow.
 import argparse
 import sys
 import uuid
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pystache
@@ -599,6 +599,7 @@ def main(argv=None):
         "dataset_version": dataset_version,
         "dataset_type": dataset_type,
         "source_methodology": source_methodology,
+        "end_date": (date.today() + timedelta(days=7)).isoformat(),
     }
 
     template_path = TEMPLATE_DIR / TYPE_TO_TEMPLATE[args.type]

--- a/projects/ores.org-js/agile/src/app.js
+++ b/projects/ores.org-js/agile/src/app.js
@@ -65,11 +65,17 @@ function OrgText({ text, onNav }) {
 function Progress({ tasks }) {
   if (!tasks.length) return null;
   const done = tasks.filter(t => t.state === 'DONE').length;
-  const pct = Math.round(100 * done / tasks.length);
+  const abandoned = tasks.filter(t => t.state === 'ABANDONED').length;
+  const donePct = Math.round(100 * done / tasks.length);
+  const abandonedPct = Math.round(100 * abandoned / tasks.length);
+  const label = abandoned
+    ? `${done} done · ${abandoned} abandoned`
+    : `${done}/${tasks.length}`;
   return html`
-    <div class="progress" title="${done}/${tasks.length} tasks done">
-      <div class="progress-bar" style="width:${pct}%"></div>
-      <span class="progress-label">${done}/${tasks.length}</span>
+    <div class="progress" title="${label}">
+      <div class="progress-done" style="width:${donePct}%"></div>
+      <div class="progress-abandoned" style="width:${abandonedPct}%"></div>
+      <span class="progress-label">${label}</span>
     </div>`;
 }
 
@@ -109,8 +115,8 @@ function Panels({ model, vel }) {
     <div class="panels">
       <${LineChart} points=${bu} title="Tasks completed (burn-up)" />
       <${BarChart} data=${vel.slice(-8)} title="Velocity — stories done per sprint" />
-      <${BarChart} data=${status} title="Tasks by state" />
       ${vd && html`<${BarChart} data=${vd.taskData} title="Tasks done per sprint day" />`}
+      <${BarChart} data=${status} title="Tasks by state" />
     </div>`;
 }
 

--- a/projects/ores.org-js/agile/style.css
+++ b/projects/ores.org-js/agile/style.css
@@ -208,7 +208,7 @@ html, body {
     overflow: hidden;
 }
 .progress-done     { height: 100%; background: var(--state-done);     opacity: 0.55; float: left; }
-.progress-abandoned{ height: 100%; background: var(--state-abandoned); opacity: 0.55; float: left; }
+.progress-abandoned { height: 100%; background: var(--state-abandoned); opacity: 0.55; float: left; }
 .progress-label {
     position: absolute;
     top: 0; right: 0.35rem;

--- a/projects/ores.org-js/agile/style.css
+++ b/projects/ores.org-js/agile/style.css
@@ -207,7 +207,8 @@ html, body {
     margin-top: 0.5rem;
     overflow: hidden;
 }
-.progress-bar { height: 100%; background: var(--state-done); opacity: 0.55; }
+.progress-done     { height: 100%; background: var(--state-done);     opacity: 0.55; float: left; }
+.progress-abandoned{ height: 100%; background: var(--state-abandoned); opacity: 0.55; float: left; }
 .progress-label {
     position: absolute;
     top: 0; right: 0.35rem;


### PR DESCRIPTION
## Summary

Four small improvements surfaced during sprint health review: reorder timeline charts, show abandoned tasks in red on progress bars, resolve a BACKLOG task under a DONE story, and auto-fill sprint end date as start + 7 days.

## Changes

- Dashboard: move 'Tasks done per sprint day' chart next to 'Velocity — stories done per sprint' in the Panels layout
- Dashboard: split story progress bar into green (DONE) + red (ABANDONED) segments; label shows 'N done · M abandoned' when abandonments exist
- Compass QoL: mark task_capture_pr_existing_file ABANDONED — parent story is DONE and task was never picked up within it
- Sprint template: auto-fill End (expected) as start + 7 days via new {{end_date}} variable in doc_generate.py and both template sources

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint health review — System 2 analysis](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/story.html) | 3FBD411B-B795-48C5-9EF8-1B76A96B12B5 |
| Task | [Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.html) | F140AFCC-5398-4960-8D60-1E7A9A308FF0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)