### PR TITLE
[agile] Sprint bookkeeping: close codegen migration story

### DIFF
--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: D4DA425A-670F-4F1F-88B9-52AC33E9C5DE
+:END:
+#+title: Story: Clean up sprint timeline generation
+#+description: Improve the sprint timeline: skip empty buckets and add a catalogue file linking all generated bucket files.
+#+type: story
+#+level: s2
+#+filetags: :timeline:sprint_health:sprint_20:v0:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The sprint timeline generates one org-mode file per bucket (entry type).
+Two quality problems today:
+
+1. *Empty buckets generate files.* An empty =captures.org= or =decisions.org= is
+   noise — it adds a file to the directory tree that readers open expecting content.
+2. *No catalogue file.* The sprint backlog has no single place to see which
+   bucket files exist and navigate to them. Each bucket file is an island.
+
+This story fixes both: suppress empty bucket files on generation, and introduce
+a =sprint_timeline.org= catalogue that the sprint backlog links to and that
+in turn links to every non-empty bucket file.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Working tasks. |
+| Waiting on    | Nothing.                               |
+| Next          | Implement task 1 (skip empty buckets). |
+| Last touched  | 2026-06-11                               |
+
+* Acceptance
+
+- Running the timeline generator with an empty bucket does not produce an org file
+  for that bucket.
+- A =sprint_timeline.org= catalogue file exists in each sprint's =timeline/= directory
+  and lists every non-empty bucket with a link to its file.
+- The sprint backlog (=sprint.org= or equivalent) links to =sprint_timeline.org=.
+- Existing non-empty bucket files are unaffected.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:D4684195-3045-4428-899E-4FD416C092A9][Skip generating org files for empty timeline buckets]] | BACKLOG | | | When a timeline bucket has no entries, do not write the bucket org file. |
+| [[id:0B62CA68-B0AE-4E49-B4F2-126376AD125E][Add sprint_timeline.org catalogue linked from sprint backlog]] | BACKLOG | | | Generate a sprint_timeline.org catalogue indexing all non-empty bucket files; link it from the sprint backlog. |
+
+* Decisions
+
+* Out of scope
+
+- Retroactively deleting already-generated empty bucket files from the repo — that
+  can be a separate cleanup pass.
+- Changing the content or structure of individual bucket files.

--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_add_sprint_timeline_catalogue.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_add_sprint_timeline_catalogue.org
@@ -1,0 +1,88 @@
+:PROPERTIES:
+:ID: 0B62CA68-B0AE-4E49-B4F2-126376AD125E
+:END:
+#+title: Task: Add sprint_timeline.org catalogue linked from sprint backlog
+#+description: Generate a sprint_timeline.org catalogue indexing all non-empty bucket files; link it from the sprint backlog.
+#+type: task
+#+level: s1
+#+filetags: :timeline:sprint_health:sprint_20:v0:clean_up_sprint_timeline:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The sprint's =timeline/= directory holds up to 100+ snapshot org files with no
+single index.  Readers have to browse filenames (opaque =YYYYMMDDTHHmm= stamps)
+to find a window of interest.  The sprint backlog (=sprint.org=) has no link into
+the timeline at all.
+
+Introduce a =sprint_timeline.org= catalogue file that:
+
+1. Lives in the same =timeline/= directory as the snapshots.
+2. Is generated (or re-generated in place) by a new =compass timeline catalogue=
+   subcommand that scans existing =timeline/*.org= snapshot files, reads their
+   =#+title:= lines, and builds an org table with one row per snapshot.
+3. Has a stable UUID so it can be linked from =sprint.org= via org-roam.
+4. The sprint backlog (=sprint.org=) gains a =* Timeline= section (or a link in
+   =* See also=) pointing at the catalogue.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next          | Begin implementation.                  |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- =compass timeline catalogue= writes =timeline/sprint_timeline.org= (creating or
+  overwriting it).
+- The catalogue lists every non-empty snapshot file in the directory as a row in an
+  org table: =| [[id:UUID][title]] | path |= (or similar).
+- The file has a stable UUID (stored in =:PROPERTIES: :ID:=) so it can be linked.
+- =sprint.org= links to the catalogue (=[[id:UUID][Sprint timeline]]=).
+- Re-running the command after new snapshots are added updates the table correctly.
+
+* Plan
+
+1. Add =_cmd_catalogue= to =compass_timeline.py=:
+   - Find the current sprint's =timeline/= directory.
+   - Check for an existing =sprint_timeline.org=; if found, read its UUID from the
+     =:ID:= property.  If not found, generate a fresh UUID.
+   - Glob =timeline/*.org= (excluding =sprint_timeline.org= itself), read each
+     file's =#+title:= and =:ID:= lines.
+   - Write =sprint_timeline.org= with frontmatter + a table row per snapshot.
+
+2. Register the new subcommand in the =sub= parser in =run()=.
+
+3. After the command is implemented: run it for the current sprint, wire the
+   resulting file's UUID into =sprint.org=.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
@@ -1,0 +1,78 @@
+:PROPERTIES:
+:ID: D4684195-3045-4428-899E-4FD416C092A9
+:END:
+#+title: Task: Skip generating org files for empty timeline buckets
+#+description: When a timeline bucket has no entries, do not write the bucket org file.
+#+type: task
+#+level: s1
+#+filetags: :timeline:sprint_health:sprint_20:v0:clean_up_sprint_timeline:
+#+owner: marco
+#+branch: feature/skip-empty-timeline-buckets
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The =compass timeline snapshot= command currently writes a snapshot org file even when
+the time window has zero agile events (no doc changes, no PRs).  These empty files
+clutter the =timeline/= directory and add noise when readers browse it.
+
+Fix =_cmd_snapshot= in =compass_timeline.py= so that a window with no events produces
+no file — and prints an explanatory message to stdout instead.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next          | Begin implementation.                  |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- Running =compass timeline snapshot= over a window with no events does not write a
+  file to =timeline/=.
+- A clear message (e.g. "no events in window — snapshot skipped") is printed.
+- Running over a window with events behaves exactly as today.
+- The existing 129 non-empty snapshot files in =doc/agile/versions/v0/sprint_20/timeline/=
+  are unaffected (no regeneration required).
+
+* Plan
+
+In =projects/ores.compass/src/compass_timeline.py=, =_cmd_snapshot=, around line 524:
+
+#+begin_example
+total = len(doc_events) + len(pr_events)
+# Add guard here:
+if total == 0:
+    print("(no events in window — snapshot skipped)")
+    return 0
+#+end_example
+
+No changes to =_write_snapshot= needed — it simply never gets called.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/codegen_org_model_migration/story.org
+++ b/doc/agile/versions/v0/sprint_20/codegen_org_model_migration/story.org
@@ -59,9 +59,9 @@ against an inadequate model format and migrating later.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED |
+| State         | DONE    |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                              |
-| Now           | Nothing. All tasks DONE or ABANDONED. |
+| Now           | Nothing. Closed. |
 | Waiting on    | Nothing.                               |
 | Next          | Nothing. |
 | Last touched  | 2026-06-11 |

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -179,6 +179,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | [[id:B6D4D06E-6699-476E-89ED-4623DC3DF62A][Agile dashboard PoC: JavaScript UI over org-mode data]] | DONE | 2026-06-06 | 2026-06-07 | PoC succeeded: ores.org-js agile board over graphdata.json, deployed with the site. |
 | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] | STARTED | 2026-06-07 | | Periodic health checks; housekeeping tasks added as the sprint progresses. |
 | [[id:3697D889-BF01-43D4-9EF7-3AF6B70A8122][Agile timeline: bucketed summaries of recent activity]] | DONE | 2026-06-07 | 2026-06-10 | compass timeline command; environment stamping; LLM snapshot skill; board timeline view. |
+| [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] | STARTED | 2026-06-11 | | Skip empty buckets; add sprint_timeline.org catalogue. |
 
 ** Hotfixes
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -125,7 +125,7 @@ the safety and CI guardrails so generated code stays trustworthy. Carried from s
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] | STARTED | 2026-06-06 | | Carried at 28/32: templates group contract, component manifest, SQL array fields, cross-link entity/component schema remain. |
+| [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] | DONE | 2026-06-06 | 2026-06-11 | All 32 tasks completed or abandoned; meta-model improved and schema reference authored. |
 | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BLOCKED | | | Carried: audit/resolve template-production drift; 13 open tasks; was blocked on the org migration tail. |
 | [[id:1C659EB3-5227-46B6-8B5C-68E9F98C10D1][Decommission legacy codegen bash scripts]] | BACKLOG | | | Replace direct bash invocations of ores.codegen with compass or the Python codegen; remove the scripts. |
 | [[id:73D7AFB0-F1D0-48D4-86CB-27E17798B674][Codegen CI zero-diff invariant]] | BACKLOG | | | CI job regenerating all registered components, failing on any diff vs HEAD. |

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -59,6 +59,7 @@ whether the team is focused — rather than merely summarising status.
 | [[id:DFC59C81-1D74-45E0-AC73-3FB974B5AA44][Mop up Sprint 20 state drift and stale closeouts]] | DONE | 2026-06-08 | 2026-06-08 | Close merged tasks/stories; block currency; fix sprint/file drift; regenerate the timeline at 20-min granularity. |
 | [[id:E01C8DCB-3864-420E-8A61-D8CD99A3F2D6][Fix dashboard: remove commits chart, fix sprint image display]] | DONE | 2026-06-09 | 2026-06-09 | Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint. |
 | [[id:DEE29002-6007-478D-9665-56C147B5F41B][Health review 2 — sprint 20 mid-sprint analysis]] | DONE | 2026-06-10 | 2026-06-10 | System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict. |
+| [[id:F140AFCC-5398-4960-8D60-1E7A9A308FF0][Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date]] | BACKLOG | | | Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: F140AFCC-5398-4960-8D60-1E7A9A308FF0
+:END:
+#+title: Task: Sprint health misc fixes: timeline order, abandoned tasks, QoL story state, sprint end date
+#+description: Fix four small issues found during sprint health work: reorder timeline charts, show abandoned tasks in red on done-story progress bars, resolve BACKLOG task under DONE Compass QoL story, and auto-fill sprint end date as start + 7 days.
+#+type: task
+#+level: s1
+#+filetags: :sprint_health_review:sprint_20:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix four small issues surfaced during sprint health work: (1) reorder
+the timeline charts so "Tasks done per sprint day" sits next to
+"Velocity — stories done per sprint"; (2) on done-story progress bars,
+show abandoned tasks in red rather than counting them as done; (3)
+resolve the state mismatch where a task in the Compass quality-of-life
+story is still =BACKLOG= even though the story is =DONE=; (4) auto-fill
+the sprint end date as start + 7 days when it is missing from the sprint
+backlog.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-11                             |
+
+* Acceptance
+
+- [ ] Timeline: "Tasks done per sprint day" chart appears immediately next to "Velocity — stories done per sprint" in the rendered sprint health view.
+- [ ] Done-story progress bar: tasks closed as =ABANDONED= render as a red segment; only =DONE= tasks count toward the green progress fill (e.g. 7 done + 1 abandoned → 7 green + 1 red, not 7/8 done).
+- [ ] Compass quality-of-life story: the =BACKLOG= task is either closed as =ABANDONED= (if superseded) or moved to =DONE= / resolved to match the story's =DONE= state; no dangling open task remains under a closed story.
+- [ ] Sprint backlog: when the end date field is blank, it is populated with start date + 7 days as an estimate.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_sprint_health_misc_fixes.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :sprint_health_review:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/sprint-health-misc-fixes
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/investigations/msvc_c1202_rfl_complexity.org
+++ b/doc/investigations/msvc_c1202_rfl_complexity.org
@@ -354,3 +354,4 @@ field counts against the safety threshold would prevent future surprises.
 
 - [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] — current sprint 19 story.
 - [[id:FBE68713-40C1-4B1D-A228-1C55AB4ABC34][MSVC C1202 constexpr depth fixes]] — sprint 17 story; trade decomposition.
+- [[id:7E3A9C2F-B405-4D81-A63E-F18D205B47C9][MSVC C1202 Workaround Cleanup]] — plan for removing the workarounds once rfl is upgraded or replaced.


### PR DESCRIPTION
## Summary

Agile bookkeeping for sprint 20 — closes the completed codegen migration story, links a loose-end investigation document, and scaffolds the new timeline cleanup story.

## Changes

- Mark story D85E2B30 (Codegen unified model — org-mode migration) DONE in story.org and sprint.org
- Add org-roam link from MSVC C1202 investigation to the cleanup plan doc (7E3A9C2F)
- Scaffold story D4DA425A (Clean up sprint timeline generation) with two tasks:
  - D4684195: Skip generating org files for empty timeline buckets
  - 0B62CA68: Add sprint_timeline.org catalogue linked from sprint backlog
- Also carries two earlier commits: sprint_health_misc_fixes task scaffolding

## Traceability

| Story | D85E2B30-8C64-46DF-819D-B50D2E70B73C |
| Story | D4DA425A-670F-4F1F-88B9-52AC33E9C5DE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)