### PR TITLE
[timeline] Skip snapshot write for empty windows

### DIFF
--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/story.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/story.org
@@ -51,7 +51,7 @@ in turn links to every non-empty bucket file.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:D4684195-3045-4428-899E-4FD416C092A9][Skip generating org files for empty timeline buckets]] | BACKLOG | | | When a timeline bucket has no entries, do not write the bucket org file. |
+| [[id:D4684195-3045-4428-899E-4FD416C092A9][Skip generating org files for empty timeline buckets]] | DONE | 2026-06-11 | 2026-06-11 | When a timeline bucket has no entries, do not write the bucket org file. |
 | [[id:0B62CA68-B0AE-4E49-B4F2-126376AD125E][Add sprint_timeline.org catalogue linked from sprint backlog]] | BACKLOG | | | Generate a sprint_timeline.org catalogue indexing all non-empty bucket files; link it from the sprint backlog. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
@@ -31,11 +31,11 @@ no file — and prints an explanatory message to stdout instead.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:D4DA425A-670F-4F1F-88B9-52AC33E9C5DE][Clean up sprint timeline generation]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next          | Begin implementation.                  |
+| Next          | Nothing. |
 | Last touched | 2026-06-11                               |
 
 * Acceptance
@@ -76,3 +76,9 @@ No changes to =_write_snapshot= needed — it simply never gets called.
 |   |                 |      |          |       |
 
 * Result
+
+Added a three-line guard in =_cmd_snapshot= (=compass_timeline.py= around line 524):
+when =total == 0= after collecting both doc and PR events, print
+=(no events in window — snapshot skipped)= and return 0 without calling
+=_find_sprint_timeline_dir= or =_write_snapshot=.
+The EVENT_CAP overflow check is unchanged and fires only when total > 0.

--- a/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
+++ b/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.org
@@ -8,7 +8,7 @@
 #+filetags: :timeline:sprint_health:sprint_20:v0:clean_up_sprint_timeline:
 #+owner: marco
 #+branch: feature/skip-empty-timeline-buckets
-#+pr:
+#+pr: 1253
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -67,7 +67,7 @@ No changes to =_write_snapshot= needed — it simply never gets called.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1253][#1253]] | [timeline] Skip snapshot write for empty windows |
 
 * Review
 

--- a/projects/ores.compass/src/compass_timeline.py
+++ b/projects/ores.compass/src/compass_timeline.py
@@ -522,6 +522,9 @@ def _cmd_snapshot(args, project_root):
     pr_events = _pr_events(project_root, start, end)
 
     total = len(doc_events) + len(pr_events)
+    if total == 0:
+        print("(no events in window — snapshot skipped)")
+        return 0
     if total > EVENT_CAP:
         print(f"⚠️  {total} events exceed the cap of {EVENT_CAP}; "
               f"consider splitting the window with --from/--to.",


### PR DESCRIPTION
## Summary

Guard in _cmd_snapshot: if total events == 0 after collection, print a notice and skip writing the file. Avoids empty bucket files in timeline/.

## Changes

- _cmd_snapshot: return early with message when total doc+pr events == 0

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Clean up sprint timeline generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/story.html) | D4DA425A-670F-4F1F-88B9-52AC33E9C5DE |
| Task | [Skip generating org files for empty timeline buckets](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/clean_up_sprint_timeline/task_skip_empty_timeline_buckets.html) | D4684195-3045-4428-899E-4FD416C092A9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)