### PR TITLE
[site] Add Edit on GitHub button to every site page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -146,6 +146,11 @@ body {
     vertical-align: middle;
 }
 
+.edit-on-github i {
+    font-size: 1.05rem;
+    vertical-align: middle;
+}
+
 #content {
     max-width: var(--max-width);
     width: 100%;

--- a/doc/agile/versions/v0/sprint_20/edit_on_github_button/story.org
+++ b/doc/agile/versions/v0/sprint_20/edit_on_github_button/story.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 708C460F-06AE-426E-B0D6-390C51C3E51E
+:END:
+#+title: Story: Add Edit on GitHub button to every site page
+#+description: Each published HTML page gets an Edit button linking to its GitHub edit URL, so readers can fix minor issues immediately.
+#+type: story
+#+level: s2
+#+filetags: :site:ux:sprint_20:v0:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+When reading a published site page, it is common to spot a minor typo or
+wording issue that you could fix in seconds — but there is no fast path from
+the rendered page to the source org file.  This story adds an *Edit on GitHub*
+button to every published HTML page.  Clicking it takes the reader directly to
+the GitHub web editor for the corresponding source =.org= file, e.g.:
+
+: https://github.com/OreStudio/OreStudio/edit/main/doc/knowledge/masd/masd.org
+
+The reader needs only a GitHub account; no local checkout required.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Implementing in ores-build-site.el.    |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-11                               |
+
+* Acceptance
+
+- Every org-sourced HTML page shows an "Edit on GitHub" button in the preamble area.
+- The button URL is =https://github.com/OreStudio/OreStudio/edit/main/<rel-path>.org=
+  where =<rel-path>= is the source =.org= file path relative to the repo root.
+- The button is styled consistently with the site theme (small, subtle, top-right of nav).
+- Web apps (graph, agile board) injected via =ores-inject-site-nav= are not affected
+  (they have no corresponding org source).
+- The site builds cleanly with the new feature in place.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:F1B4BAE1-CF11-45FE-82B5-A4F2D3D1A6D1][Add Edit on GitHub button to every site page]] | STARTED | 2026-06-11 | | Inject a per-page Edit button into the site HTML that links to the corresponding GitHub edit URL for the source org file. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/edit_on_github_button/story.org
+++ b/doc/agile/versions/v0/sprint_20/edit_on_github_button/story.org
@@ -29,9 +29,9 @@ The reader needs only a GitHub account; no local checkout required.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                   |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
-| Now           | Implementing in ores-build-site.el.    |
+| Now           | Closed. Edit button delivered.         |
 | Waiting on    | Nothing.                               |
 | Next          | Nothing.                               |
 | Last touched  | 2026-06-11                               |
@@ -50,7 +50,7 @@ The reader needs only a GitHub account; no local checkout required.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:F1B4BAE1-CF11-45FE-82B5-A4F2D3D1A6D1][Add Edit on GitHub button to every site page]] | STARTED | 2026-06-11 | | Inject a per-page Edit button into the site HTML that links to the corresponding GitHub edit URL for the source org file. |
+| [[id:F1B4BAE1-CF11-45FE-82B5-A4F2D3D1A6D1][Add Edit on GitHub button to every site page]] | DONE | 2026-06-11 | 2026-06-11 | Inject a per-page Edit button into the site HTML that links to the corresponding GitHub edit URL for the source org file. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
+++ b/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: F1B4BAE1-CF11-45FE-82B5-A4F2D3D1A6D1
+:END:
+#+title: Task: Add Edit on GitHub button to every site page
+#+description: Inject a per-page Edit button into the site HTML that links to the corresponding GitHub edit URL for the source org file.
+#+type: task
+#+level: s1
+#+filetags: :site:ux:sprint_20:v0:edit_on_github_button:
+#+owner: marco
+#+branch: feature/add-edit-on-github-button
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a per-page "Edit on GitHub" button to every org-sourced page in the site.
+The button must link to the exact GitHub web-editor URL for the source =.org=
+file, derived at publish time from the absolute path of the input file.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] |
+| Now          | Implementing in ores-build-site.el.    |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- =ores/site-preamble= function in =ores-build-site.el= derives the relative
+  =.org= path from =:input-file= in the export plist.
+- The preamble HTML returned includes both the existing nav and an edit button.
+- =:html-preamble= in =site:pages= is set to =#'ores/site-preamble=.
+- Web app preamble injection (=ores-inject-site-nav=) uses the static string
+  and is unaffected.
+- An =.edit-on-github= CSS class styles the button in =assets/style.css=.
+
+* Plan
+
+1. In =projects/ores.lisp/src/ores-build-site.el=:
+   - Capture repo root at load time:
+     =(defvar ores/repo-root (expand-file-name "./"))=
+   - Define =(defun ores/site-preamble (info) ...)=:
+     - =input-file= ← =(plist-get info :input-file)=
+     - =rel-path= ← strip =ores/repo-root= prefix, keep the =.org= extension
+     - =edit-url= ← =https://github.com/OreStudio/OreStudio/edit/main/<rel-path>=
+     - Return =site-html-preamble= concatenated with an edit button =<a>= tag
+   - Change =:html-preamble ,site-html-preamble= → =:html-preamble #'ores/site-preamble=
+
+2. In =assets/style.css=: add =.edit-on-github= button rules (small, top-right
+   of nav bar, Font Awesome pencil icon).
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
+++ b/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
@@ -8,7 +8,7 @@
 #+filetags: :site:ux:sprint_20:v0:edit_on_github_button:
 #+owner: marco
 #+branch: feature/add-edit-on-github-button
-#+pr:
+#+pr: 1258
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -66,7 +66,7 @@ file, derived at publish time from the absolute path of the input file.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1258][#1258]] | [site] Add Edit on GitHub button to every site page |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
+++ b/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.org
@@ -28,11 +28,11 @@ file, derived at publish time from the absolute path of the input file.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] |
-| Now          | Implementing in ores-build-site.el.    |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing.                               |
+| Next         | Nothing. |
 | Last touched | 2026-06-11                               |
 
 * Acceptance
@@ -75,3 +75,11 @@ file, derived at publish time from the absolute path of the input file.
 |   |                 |      |          |       |
 
 * Result
+
+Added =ores/repo-root= and =ores/site-preamble= to =ores-build-site.el=.
+The preamble function reads =:input-file= from the export plist, strips
+the repo-root prefix to get the relative =.org= path, and injects an
+=<a class='edit-on-github'>= anchor into the nav bar before =</nav>=.
+The =site:pages= project now uses =#'ores/site-preamble= instead of
+the static string.  A matching =.edit-on-github i= rule in =assets/style.css=
+sizes the Font Awesome pencil icon.  Web apps are unaffected.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -169,7 +169,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-09 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Plus a refinement: merge Agile into Developer, reorder for new users. |
-| [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] | STARTED | 2026-06-11 | | Per-page Edit button in the site preamble linking to the GitHub web editor for the source org file. |
+| [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] | DONE | 2026-06-11 | 2026-06-11 | Per-page Edit button in the site preamble linking to the GitHub web editor for the source org file. |
 
 ** Agile
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -169,6 +169,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-09 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Plus a refinement: merge Agile into Developer, reorder for new users. |
+| [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] | STARTED | 2026-06-11 | | Per-page Edit button in the site preamble linking to the GitHub web editor for the source org file. |
 
 ** Agile
 

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -153,6 +153,27 @@
   </nav>
 </header>")
 
+(defvar ores/repo-root (expand-file-name "./"))
+
+(defun ores/site-preamble (info)
+  "Return site preamble with a per-page Edit on GitHub button.
+Injects an edit link into the nav using :input-file from INFO."
+  (let* ((input-file (plist-get info :input-file))
+         (rel-path   (when input-file
+                       (file-relative-name input-file ores/repo-root)))
+         (edit-url   (when rel-path
+                       (concat "https://github.com/OreStudio/OreStudio/edit/main/"
+                               rel-path)))
+         (edit-btn   (when edit-url
+                       (format "<a class='edit-on-github' href='%s' \
+title='Edit this page on GitHub' aria-label='Edit this page on GitHub'>\
+<i class='fas fa-pencil-alt'></i></a>"
+                               edit-url))))
+    (if edit-btn
+        (replace-regexp-in-string "</nav>" (concat edit-btn "</nav>")
+                                  site-html-preamble)
+      site-html-preamble)))
+
 ;; Define the publishing project
 (setq org-publish-project-alist
       `(
@@ -162,7 +183,7 @@
          :exclude "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|projects/ores.org-js"
          :publishing-function org-html-publish-to-html
          :publishing-directory "./build/output/site/OreStudio"
-         :html-preamble ,site-html-preamble
+         :html-preamble #'ores/site-preamble
          :with-author nil
          :with-creator t
          :with-toc t


### PR DESCRIPTION
## Summary

Each published HTML page now shows a pencil-icon link in the nav bar that opens the GitHub web editor for the corresponding source .org file.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add Edit on GitHub button to every site page](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/edit_on_github_button/story.html) | 708C460F-06AE-426E-B0D6-390C51C3E51E |
| Task | [Add Edit on GitHub button to every site page](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/edit_on_github_button/task_add_edit_on_github_button.html) | F1B4BAE1-CF11-45FE-82B5-A4F2D3D1A6D1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)