### PR TITLE
[agile] Stamp sprint end date in template and audit

### DIFF
--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/story.org
@@ -56,7 +56,7 @@ whether the team is focused — rather than merely summarising status.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:4F17BC82-00B5-43DE-B618-A87801763479][Health review 1 — sprint 20 housekeeping and status sync]] | DONE | 2026-06-07 | 2026-06-07 | Audit-driven housekeeping: close Open sprint 20 and site navbar stories, fix Commission: currency status drift, run sprint audit and health charts. |
-| [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date (start + 7 days) on sprint backlog]] | BACKLOG | | | Add #+end_date to sprint.org at open time; backfill sprint 20; warn on missing. |
+| [[id:CBD603A3-B05C-495C-9AF5-F919287AA133][Stamp sprint end date (start + 7 days) on sprint backlog]] | STARTED | 2026-06-11 | | Add #+end_date to sprint.org at open time; backfill sprint 20; warn on missing. |
 | [[id:DFC59C81-1D74-45E0-AC73-3FB974B5AA44][Mop up Sprint 20 state drift and stale closeouts]] | DONE | 2026-06-08 | 2026-06-08 | Close merged tasks/stories; block currency; fix sprint/file drift; regenerate the timeline at 20-min granularity. |
 | [[id:E01C8DCB-3864-420E-8A61-D8CD99A3F2D6][Fix dashboard: remove commits chart, fix sprint image display]] | DONE | 2026-06-09 | 2026-06-09 | Remove 'commits per sprint day' from the dashboard, relocate 'tasks done per sprint day' next to the other sprint charts, and fix broken image display when clicking a sprint. |
 | [[id:DEE29002-6007-478D-9665-56C147B5F41B][Health review 2 — sprint 20 mid-sprint analysis]] | DONE | 2026-06-10 | 2026-06-10 | System 2 health review 2 of sprint 20: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict. |

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
@@ -7,12 +7,13 @@
 #+level: s1
 #+filetags: :agile:compass:sprint:template:sprint_health_review:sprint_20:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/stamp-sprint-end-date
 #+pr: 1198
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
 #+updated: 2026-06-08
+#+environment: local2
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -27,7 +28,7 @@ both read this field as the sprint boundary rather than inferring it.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
@@ -28,12 +28,12 @@ both read this field as the sprint boundary rather than inferring it.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3FBD411B-B795-48C5-9EF8-1B76A96B12B5][Sprint health review — System 2 analysis]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Update sprint codegen template; backfill sprint 20. |
-| Last touched | 2026-06-08                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-11                             |
 
 * Acceptance
 
@@ -69,6 +69,12 @@ x-axis runs from sprint day 1 to sprint day 7 using this field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Double file read in sprint audit | compass.py | Fixed | Refactored _sprint_table_states to accept text; single read in cmd_sprint_audit |
+| 2 | False-positive missing_end_date on unreadable file | compass.py | Fixed | sprint_text=None guard suppresses false warning |
 
 * Result
+
+- Sprint doc template (=doc_sprint.org.mustache= and =doc_sprint_org.org=) gains =#+end_date:= frontmatter computed as =start_date + 7 days= via =doc_generate.py=.
+- Sprint 20 backfilled: =#+start_date: 2026-06-06=, =#+end_date: 2026-06-13=.
+- =compass sprint audit= warns when =#+end_date= is absent from the current sprint doc.
+- Review findings addressed: single file read refactor; false-positive guard on unreadable sprint file.

--- a/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
+++ b/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.org
@@ -8,7 +8,7 @@
 #+filetags: :agile:compass:sprint:template:sprint_health_review:sprint_20:v0:
 #+owner: marco
 #+branch: feature/stamp-sprint-end-date
-#+pr: 1198
+#+pr: 1259
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-08
@@ -62,6 +62,7 @@ x-axis runs from sprint day 1 to sprint day 7 using this field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1259][#1259]] | [agile] Stamp sprint end date in template and audit |
 | [[https://github.com/OreStudio/OreStudio/pull/1198][#1198]] | [agile] Add sprint velocity chart and end-date tasks |
 
 * Review

--- a/projects/ores.codegen/library/templates/doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_sprint.org.mustache
@@ -8,6 +8,8 @@
 #+level: s3
 #+filetags: {{filetags}}
 #+created: {{date}}
+#+start_date: {{date}}
+#+end_date: {{end_date}}
 #+updated: {{date}}
 #+todo: STARTED | DONE
 

--- a/projects/ores.codegen/library/templates/doc_sprint_org.org
+++ b/projects/ores.codegen/library/templates/doc_sprint_org.org
@@ -31,6 +31,8 @@ The full template source. Edit here and re-tangle with
 ,#+level: s3
 ,#+filetags: {{filetags}}
 ,#+created: {{date}}
+,#+start_date: {{date}}
+,#+end_date: {{end_date}}
 ,#+updated: {{date}}
 ,#+todo: STARTED | DONE
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1716,13 +1716,9 @@ def _audit_pr_states(numbers):
             KeyError, ValueError):
         return {}
 
-def _sprint_table_states(sprint_file):
+def _sprint_table_states(text):
     """Map story uuid (upper) -> state recorded in the sprint page's tables."""
     states = {}
-    try:
-        text = Path(sprint_file).read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return states
     row_re = re.compile(
         r"^\|\s*\[\[id:([A-Fa-f0-9-]+)\]\[.*?\]\]\s*\|\s*([A-Z]+)\s*\|",
         re.MULTILINE)
@@ -1738,14 +1734,15 @@ def cmd_sprint_audit(args):
         return 1
     sprint_dir = Path(PROJECT_ROOT) / _parent_dir(current_sprint.rel_path)
     sprint_file = Path(PROJECT_ROOT) / current_sprint.rel_path
-    table_states = _sprint_table_states(sprint_file)
 
-    # Check sprint doc for missing #+end_date keyword.
     try:
         sprint_text = sprint_file.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        sprint_text = ""
-    missing_end_date = not re.search(r"(?m)^#\+end_date:\s*\S", sprint_text)
+        sprint_text = None
+
+    table_states = _sprint_table_states(sprint_text or "")
+    missing_end_date = sprint_text is not None and not re.search(
+        r"(?m)^#\+end_date:\s*\S", sprint_text)
 
     # Gather stories, tasks and every referenced PR number.
     pr_re = re.compile(r"pull/(\d+)")

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1740,6 +1740,13 @@ def cmd_sprint_audit(args):
     sprint_file = Path(PROJECT_ROOT) / current_sprint.rel_path
     table_states = _sprint_table_states(sprint_file)
 
+    # Check sprint doc for missing #+end_date keyword.
+    try:
+        sprint_text = sprint_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        sprint_text = ""
+    missing_end_date = not re.search(r"(?m)^#\+end_date:\s*\S", sprint_text)
+
     # Gather stories, tasks and every referenced PR number.
     pr_re = re.compile(r"pull/(\d+)")
     now_re = re.compile(r"(?m)^\| Now\s+\|([^|]*)\|")
@@ -1801,7 +1808,7 @@ def cmd_sprint_audit(args):
             mismatch.append((s, table))
 
     total = (len(zombie) + len(closeable) + len(merged_open) + len(mismatch)
-             + len(stale_now))
+             + len(stale_now) + (1 if missing_end_date else 0))
 
     if args.format == "json":
         findings = (
@@ -1823,7 +1830,10 @@ def cmd_sprint_audit(args):
                for s, table in mismatch]
             + [{"check": "closed-doc-now-not-nothing", "kind": kind,
                 "title": title, "uuid": uuid, "state": state, "now": now}
-               for kind, title, uuid, state, now in stale_now])
+               for kind, title, uuid, state, now in stale_now]
+            + ([{"check": "sprint-missing-end-date",
+                 "sprint": current_sprint.title}]
+               if missing_end_date else []))
         print(json.dumps({"sprint": current_sprint.title,
                           "findings": findings}, indent=2))
         return 0
@@ -1880,6 +1890,11 @@ def cmd_sprint_audit(args):
             print(f"  • {title}  ({kind}, {state}) Now: "
                   f"{_C_YELLOW}{now}{_C_RESET}")
             _hint(uuid, 4)
+
+    if missing_end_date:
+        _section("📅", "Sprint doc missing #+end_date")
+        print(f"  • {current_sprint.title} has no #+end_date keyword.")
+        print(f"    Set it to #+start_date + 7 days in {sprint_file.relative_to(Path(PROJECT_ROOT))}")
 
     print(f"\n  {total} finding(s).")
     return 0


### PR DESCRIPTION
## Summary

Every new sprint doc now carries #+start_date and #+end_date keywords from scaffolding. compass sprint audit warns when the end date is missing. Sprint 20 was already backfilled.

## Changes

- doc_sprint.org.mustache + doc_sprint_org.org: add #+start_date and #+end_date to sprint frontmatter, computed as creation date + 7 days
- compass sprint audit: new warning section when #+end_date is absent from the current sprint doc (human output + JSON format)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint health review — System 2 analysis](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/story.html) | 3FBD411B-B795-48C5-9EF8-1B76A96B12B5 |
| Task | [Stamp sprint end date (start + 7 days) on sprint backlog](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint_health_review/task_stamp_sprint_end_date.html) | CBD603A3-B05C-495C-9AF5-F919287AA133 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)