### PR TITLE
[compass] Fix ORES_SITE_PORT to use env base port range

### DIFF
--- a/build/scripts/serve-site.sh
+++ b/build/scripts/serve-site.sh
@@ -44,7 +44,8 @@ set +a
 source "$PROJECT_DIR/projects/ores.sql/utility/validate_env_version.sh"
 
 # ---------------------------------------------------------------------------
-# Resolve port: --port flag > PORT env var > ORES_SITE_PORT from .env > 8000
+# Resolve port: --port flag > PORT env var > ORES_SITE_PORT from .env > 8000 (last-resort fallback)
+# ORES_SITE_PORT is base_port+4 for compass-managed envs (51004, 52004, …).
 # ---------------------------------------------------------------------------
 _dotenv_port=""
 if [[ -f "$DOTENV" ]]; then

--- a/doc/agile/versions/v0/sprint_20/fix_site_port_range/story.org
+++ b/doc/agile/versions/v0/sprint_20/fix_site_port_range/story.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: D20E794C-DB40-4173-9535-846C614A1F66
+:END:
+#+title: Story: Fix site preview port to env port range
+#+description: Move ORES_SITE_PORT from the ad-hoc 8000+suffix range into each environment's assigned port range (base_port+4).
+#+type: story
+#+level: s2
+#+filetags: :sprint_20:v0:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The site preview port (ORES_SITE_PORT) is currently generated as 8000+suffix (8001, 8002…), putting it outside the environment's designated port range. Each environment should have a fixed site port derived from its base port (51004 for local1, 52004 for local2, etc.) so all service ports are predictable and within range.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                   |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Closed. Single task delivered.         |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-11                               |
+
+* Acceptance
+
+- ORES_SITE_PORT in every env is base_port+4 (51004, 52004, 53004, 54004, 50004 for remote). serve-site.sh reads ORES_SITE_PORT from .env as already implemented. compass env init re-run produces the correct port.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:8D0D9CDF-F772-4783-B582-2610ED36D1BE][Fix ORES_SITE_PORT to use env base port]] | DONE | 2026-06-11 | 2026-06-11 | Change env_init.py to derive ORES_SITE_PORT from base_port+4 instead of 8000+suffix. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
+++ b/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
@@ -55,7 +55,8 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Env version not bumped (stale — bumped in d2929fe before review ran) | env_format_version_log.org | N/A | Already done |
+| 2 | serve-site.sh comment stale — update to note base_port+4 | serve-site.sh | Fixed in d744641 | Cosmetic |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
+++ b/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 8D0D9CDF-F772-4783-B582-2610ED36D1BE
+:END:
+#+title: Task: Fix ORES_SITE_PORT to use env base port
+#+description: Change env_init.py to derive ORES_SITE_PORT from base_port+4 instead of 8000+suffix.
+#+type: task
+#+level: s1
+#+filetags: :fix_site_port_range:sprint_20:v0:
+#+owner: marco
+#+branch: feature/fix-site-port-in-env-init
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D20E794C-DB40-4173-9535-846C614A1F66][Fix site preview port to env port range]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+In env_init.py the site port is currently 8000+suffix. Change it to base_port+4 so local1=51004, local2=52004, local3=53004, local4=54004, remote=50004.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:D20E794C-DB40-4173-9535-846C614A1F66][Fix site preview port to env port range]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- env_init.py computes site_port = base_port + 4. Running compass env init on any env produces ORES_SITE_PORT within the env's port range. serve-site.sh already reads ORES_SITE_PORT so no change needed there.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+One-line change in =env_init.py=: replaced =8000 + int(label_suffix) if label_suffix else 8000=
+with =base_port + 4=.  Port assignments after =compass env init=: local1=51004, local2=52004,
+local3=53004, local4=54004, remote=50004.  =serve-site.sh= already reads =ORES_SITE_PORT=
+so no further changes needed there.

--- a/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
+++ b/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_site_port_range:sprint_20:v0:
 #+owner: marco
 #+branch: feature/fix-site-port-in-env-init
-#+pr:
+#+pr: 1260
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1260][#1260]] | [compass] Fix ORES_SITE_PORT to use env base port range |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -170,6 +170,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 |-------+-------+-------+-----+-------------|
 | [[id:84CB6F89-8847-47B0-B844-3D754BF00276][Replace site navbar with a structured menu]] | DONE | 2026-06-07 | 2026-06-09 | Replace the flat nav bar with a hierarchical dropdown menu; reorganise existing items; expose new pages. Plus a refinement: merge Agile into Developer, reorder for new users. |
 | [[id:708C460F-06AE-426E-B0D6-390C51C3E51E][Add Edit on GitHub button to every site page]] | DONE | 2026-06-11 | 2026-06-11 | Per-page Edit button in the site preamble linking to the GitHub web editor for the source org file. |
+| [[id:D20E794C-DB40-4173-9535-846C614A1F66][Fix site preview port to env port range]] | DONE | 2026-06-11 | 2026-06-11 | Move ORES_SITE_PORT from ad-hoc 8000+suffix to base_port+4 within each env's port range. |
 
 ** Agile
 

--- a/doc/knowledge/architecture/env_format_version_log.org
+++ b/doc/knowledge/architecture/env_format_version_log.org
@@ -35,6 +35,7 @@ The table is machine-parsed: each data row is =| <integer> | <date> |
 | 4 |            | Added ORES_SITE_PORT for the local documentation site server. |
 | 5 |            | Added org-roam knowledge graph integration to site build. |
 | 6 |            | Added ORES_SHELL_NATS_* for ores.shell mTLS auto-connect support. |
+| 7 | 2026-06-11 | ORES_SITE_PORT moved to base_port+4 (local1=51004, local2=52004, etc.) |
 
 * See also
 

--- a/projects/ores.compass/src/env_init.py
+++ b/projects/ores.compass/src/env_init.py
@@ -322,8 +322,7 @@ def run(argv, project_root: Path) -> int:
     else:
         http_port = base_port + 0
         wt_port = base_port + 2
-    # Site preview port: preset-independent — 8000 + numeric suffix, else 8000.
-    site_port = 8000 + int(label_suffix) if label_suffix else 8000
+    site_port = base_port + 4
 
     nats_store_dir = checkout_root / "build" / "nats" / label / "jetstream"
     nats_certs_dir = checkout_root / "build" / "keys" / "nats"


### PR DESCRIPTION
## Summary

ORES_SITE_PORT was 8000+suffix (arbitrary range). Now base_port+4: local1=51004, local2=52004, etc. Re-run compass env init to pick up the change.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix site preview port to env port range](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_site_port_range/story.html) | D20E794C-DB40-4173-9535-846C614A1F66 |
| Task | [Fix ORES_SITE_PORT to use env base port](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/fix_site_port_range/task_fix_site_port_in_env_init.html) | 8D0D9CDF-F772-4783-B582-2610ED36D1BE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)