### PR TITLE
[agile] Close story: migrate Claude memories to org system

### DIFF
--- a/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/story.org
+++ b/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/story.org
@@ -32,7 +32,7 @@ stops regenerating those files.
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
 | Now           | All three tasks done.                  |
 | Waiting on    | Nothing.                               |
-| Next          | Merge PR.                              |
+| Next          | Nothing.                               |
 | Last touched  | 2026-06-11                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/task_port_keeper_entries_to_org_memory.org
+++ b/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/task_port_keeper_entries_to_org_memory.org
@@ -8,7 +8,7 @@
 #+filetags: :migrate_claude_memories_to_org_system:sprint_20:v0:
 #+owner: marco
 #+branch: feature/migrate-claude-memories-to-org-system
-#+pr: 1255
+#+pr: 1261
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -57,6 +57,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1261][#1261]] | [agile] Close story: migrate Claude memories to org system |
 | [[https://github.com/OreStudio/OreStudio/pull/1255][#1255]] | [llm] Migrate Claude harness memories to org-based memory system |
 
 * Review


### PR DESCRIPTION
## Summary

Post-merge bookkeeping: update story Next field to Nothing after PR #1255 merged.

## Changes

- Update story Next field from 'Merge PR.' to 'Nothing.'

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Migrate Claude memories to org-based memory system](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/story.html) | D7F3D19C-1E9C-4302-B661-12A28411425E |
| Task | [Port keeper entries to the org memory system](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/migrate_claude_memories_to_org_system/task_port_keeper_entries_to_org_memory.html) | E01D5A91-F3ED-4223-A2ED-E331DD4EF4DB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)