### PR TITLE
[llm] Add agile-find-heading skill wrapping compass heading

### DIFF
--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:agile:tooling:backlog:llm:sprint_20:v0:
 #+created: 2026-06-08
 #+updated: 2026-06-08
-#+environment: remote
+#+environment: local2
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -33,7 +33,7 @@ It completes the navigation arc alongside the existing commands:
 
 | Field         | Value                                                |
 |---------------+------------------------------------------------------|
-| State         | DONE                                                    |
+| State         | STARTED                                                    |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                                            |
 | Now           | All tasks merged. Story complete.                    |
 | Waiting on    | Nothing.                                             |
@@ -65,6 +65,7 @@ It completes the navigation arc alongside the existing commands:
 | [[id:5857B626-1579-4581-844F-B6AF80E66780][Scaffold story: Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-08 | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
 | [[id:85F8CFFB-225B-4BC5-A277-1EE5AB4621A1][Analyse and design the next-work-item suggester]] | DONE | 2026-06-10 | 2026-06-10 | Design =compass heading=: the signal sources (journals, fleet, sprint state, backlogs), the priority/scoring model, keyword steering, output format, and which command pillar it belongs to. |
 | [[id:05401E9F-3F6B-4731-A62F-20FA7B798B09][Write recipe for compass heading]] | DONE | 2026-06-10 | 2026-06-10 | Write a recipe documenting how to use compass heading: scoring model, keyword steering, JSON output, and placement in the recipe index. |
+| [[id:5F7B9EDB-EE92-499E-B1A3-7C9A9AE173E0][Add agile-find-heading skill wrapping compass heading]] | STARTED | 2026-06-11 | | Create a Claude Code skill that runs compass heading, summarises the ranked suggestions, and recommends the next action — a session-start companion to agile-find-bearings. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :compass:agile:tooling:backlog:llm:sprint_20:v0:
 #+created: 2026-06-08
-#+updated: 2026-06-08
+#+updated: 2026-06-11
 #+environment: local2
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
@@ -33,12 +33,12 @@ It completes the navigation arc alongside the existing commands:
 
 | Field         | Value                                                |
 |---------------+------------------------------------------------------|
-| State         | STARTED                                                    |
+| State         | DONE                                                 |
 | Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                                            |
-| Now           | All tasks merged. Story complete.                    |
+| Now           | Nothing.                                             |
 | Waiting on    | Nothing.                                             |
 | Next          | Nothing.                                             |
-| Last touched  | 2026-06-10                                           |
+| Last touched  | 2026-06-11                                           |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.org
@@ -65,7 +65,7 @@ It completes the navigation arc alongside the existing commands:
 | [[id:5857B626-1579-4581-844F-B6AF80E66780][Scaffold story: Suggest the next work item to pick up]] | DONE | 2026-06-08 | 2026-06-08 | Story scaffolding: documents, sprint wiring, and the scaffold PR. |
 | [[id:85F8CFFB-225B-4BC5-A277-1EE5AB4621A1][Analyse and design the next-work-item suggester]] | DONE | 2026-06-10 | 2026-06-10 | Design =compass heading=: the signal sources (journals, fleet, sprint state, backlogs), the priority/scoring model, keyword steering, output format, and which command pillar it belongs to. |
 | [[id:05401E9F-3F6B-4731-A62F-20FA7B798B09][Write recipe for compass heading]] | DONE | 2026-06-10 | 2026-06-10 | Write a recipe documenting how to use compass heading: scoring model, keyword steering, JSON output, and placement in the recipe index. |
-| [[id:5F7B9EDB-EE92-499E-B1A3-7C9A9AE173E0][Add agile-find-heading skill wrapping compass heading]] | STARTED | 2026-06-11 | | Create a Claude Code skill that runs compass heading, summarises the ranked suggestions, and recommends the next action — a session-start companion to agile-find-bearings. |
+| [[id:5F7B9EDB-EE92-499E-B1A3-7C9A9AE173E0][Add agile-find-heading skill wrapping compass heading]] | DONE | 2026-06-11 | 2026-06-11 | Create a Claude Code skill that runs compass heading, summarises the ranked suggestions, and recommends the next action — a session-start companion to agile-find-bearings. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
@@ -55,7 +55,8 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Story state still STARTED; #+updated stale on story/s1_agent/catalogue | story.org, s1_agent.org, claude_code_skills.org | Fixed | a31a046f |
+| 2 | Keyword steering not mentioned in skill steps | SKILL.org | Fixed | Added hint to step 1 in a31a046f |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
@@ -8,7 +8,7 @@
 #+filetags: :suggest_next_work_item:sprint_20:v0:
 #+owner: marco
 #+branch: feature/add-agile-find-heading-skill
-#+pr:
+#+pr: 1263
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1263][#1263]] | [llm] Add agile-find-heading skill wrapping compass heading |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 5F7B9EDB-EE92-499E-B1A3-7C9A9AE173E0
+:END:
+#+title: Task: Add agile-find-heading skill wrapping compass heading
+#+description: Create a Claude Code skill that runs compass heading, summarises the ranked suggestions, and recommends the next action — a session-start companion to agile-find-bearings.
+#+type: task
+#+level: s1
+#+filetags: :suggest_next_work_item:sprint_20:v0:
+#+owner: marco
+#+branch: feature/add-agile-find-heading-skill
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local2
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Provide a Claude Code skill (agile-find-heading) that runs compass heading, presents the ranked work-item suggestions to the user, and recommends the top action — mirroring the pattern established by agile-find-bearings for compass bearings.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- agile-find-heading skill exists and is deployed; invoking it runs compass heading and surfaces the top suggestion with a short rationale; skill follows the same structure as agile-find-bearings.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
+++ b/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.org
@@ -26,12 +26,12 @@ Provide a Claude Code skill (agile-find-heading) that runs compass heading, pres
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                                  |
 | Parent story | [[id:1863389D-A909-4265-8C03-5C93109C180D][Suggest the next work item to pick up]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-11                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-11                             |
 
 * Acceptance
 
@@ -58,3 +58,8 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+- =doc/llm/skills/agile-find-heading/SKILL.org= scaffolded and filled: two-step skill (run =compass heading=, report back top suggestion).
+- Skill cross-referenced from =doc/functions/s1_agent.org= alongside =agile-find-bearings=.
+- Added to the skills catalogue (=claude_code_skills.org=) under the agile area.
+- Bundle rebuilt and deployed; =agile-find-heading= live in the current session.

--- a/doc/functions/s1_agent.org
+++ b/doc/functions/s1_agent.org
@@ -56,6 +56,10 @@ Before acting, load:
 
 The Claude Code [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skills]] you invoke per situation:
 
+- [[id:936389EC-7E0A-4925-9023-D4FA33C0FBF4][agile-find-bearings]] — at session start: orient yourself (branch,
+  story, task, PR state, environment health).
+- [[id:117A7CC5-67B7-4B51-BD6D-41E0A00B5A3D][agile-find-heading]] — when the user asks what to work on next:
+  run =compass heading= and surface the top suggestion.
 - the work lifecycle (=agile-start-task= → =agile-close-task=) — the default: take one story / task,
   implement it incrementally with tests and commits, submit for
   review.

--- a/doc/functions/s1_agent.org
+++ b/doc/functions/s1_agent.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :function:s1:agent:operations:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-11
 
 You are an *S1 Agent* — the operational unit at [[id:DBFD530B-4B56-48D1-9F03-3A0D0DA16552][System 1]]. You take a
 single [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]], implement it within its size budget, and merge a PR.

--- a/doc/llm/skills/agile-find-heading/SKILL.org
+++ b/doc/llm/skills/agile-find-heading/SKILL.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 117A7CC5-67B7-4B51-BD6D-41E0A00B5A3D
+:END:
+#+title: Agile Find Heading
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :compass:agile:orientation:heading:llm:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+
+#+begin_export markdown
+---
+name: agile-find-heading
+description: Find the next work item — run compass heading, surface the ranked suggestions, and recommend the top action.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks "what should I work on next?", "what's the next
+task?", or any variant of finding the next logical work item to pick
+up.  Complements [[id:936389EC-7E0A-4925-9023-D4FA33C0FBF4][agile-find-bearings]] (where am I?) — this skill
+answers "what next?".
+
+* How to use this skill
+
+1. /Run compass heading/:
+
+   #+begin_src sh :results verbatim
+   ./compass.sh heading
+   #+end_src
+
+2. /Report back/: summarise the top suggestion — its score, the
+   one-line rationale, and the action to take.  If the top item is
+   BLOCKED, say so and suggest unblocking it or picking the next
+   non-blocked item.
+
+* Recipes
+
+- [[id:D0522FBB-A1B7-42B0-BE60-B07A2878AADB][How do I get a ranked next-work-item suggestion?]]
+
+* Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the compass tool's component model.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/agile-find-heading/SKILL.org
+++ b/doc/llm/skills/agile-find-heading/SKILL.org
@@ -33,6 +33,9 @@ answers "what next?".
    ./compass.sh heading
    #+end_src
 
+   Pass optional keywords to bias ranking toward matching items (e.g.
+   =./compass.sh heading compass= to surface compass-related work).
+
 2. /Report back/: summarise the top suggestion — its score, the
    one-line rationale, and the action to take.  If the top item is
    BLOCKED, say so and suggest unblocking it or picking the next

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :skills:claude_code:catalogue:index:knowledge:
 #+created: 2024-06-15
-#+updated: 2026-06-04
+#+updated: 2026-06-11
 
 Every Claude Code [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skill]] used with ORE Studio lives at
 =doc/llm/skills/<slug>/SKILL.org= and is listed below, grouped by area. Skills are

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -46,6 +46,7 @@ Stories, tasks, sprints, backlog, journal, orientation.
 | [[id:460C89DA-50D2-40C3-88B2-BE52E430D170][agile-brainstorm-idea]] | Agile Brainstorm Idea | Explore user intent and design through collaborative dialogue — one question at a time, alternatives with t... |
 | [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] | Agile Close Task | Close a task's bookkeeping at the end of the review round: DONE, Result, story and sprint sync; cascades to... |
 | [[id:936389EC-7E0A-4925-9023-D4FA33C0FBF4][agile-find-bearings]] | Agile Find Bearings | Initialise a session — compass-first operation, recipe search for command info, bearings, then a summary an... |
+| [[id:117A7CC5-67B7-4B51-BD6D-41E0A00B5A3D][agile-find-heading]] | Agile Find Heading | Find the next work item — run compass heading, surface the ranked suggestions, and recommend the top action. |
 | [[id:C5EEF144-BB9D-2F44-453B-4B7338D8A457][agile-open-sprint]] | Agile Open Sprint | Open a new ORE Studio sprint. Scaffold the sprint folder via codegen, set its mission, link it from the ver... |
 | [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][agile-plan-sprint]] | Agile Plan Sprint | Run a sprint planning session: read the sprint mission, score next-backlog captures against sprint goals, p... |
 | [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][agile-refine-backlog]] | Agile Refine Backlog | Run a backlog housekeeping session: scan the next/deferred captures, clarify descriptions, cull stale items... |


### PR DESCRIPTION
## Summary

Adds the agile-find-heading Claude Code skill — the 'what next?' companion to agile-find-bearings. Runs compass heading and surfaces the top ranked work-item suggestion with a short rationale.

## Changes

- New skill doc/llm/skills/agile-find-heading/SKILL.org: two-step (run compass heading, report top suggestion)
- Cross-referenced from doc/functions/s1_agent.org alongside agile-find-bearings
- Added to skills catalogue (claude_code_skills.org) under the agile area
- Bundle rebuilt and deployed
- Task 5F7B9EDB closed; story Suggest the next work item to pick up (1863389D) all tasks done

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Suggest the next work item to pick up](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/suggest_next_work_item/story.html) | 1863389D-A909-4265-8C03-5C93109C180D |
| Task | [Add agile-find-heading skill wrapping compass heading](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/suggest_next_work_item/task_add_agile_find_heading_skill.html) | 5F7B9EDB-EE92-499E-B1A3-7C9A9AE173E0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)