### PR TITLE
[site] Hotfix: bare symbol for ores/site-preamble in project alist

### DIFF
--- a/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/story.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/story.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: 35D01E18-F27B-47F4-B99E-E474CF310F2E
+:END:
+#+title: Story: Hotfix: site navbar missing after edit-on-github change
+#+description: ores/site-preamble function not called by org-publish because #' in backtick alist embeds a literal (function ...) form that functionp does not recognise.
+#+type: story
+#+level: s2
+#+filetags: :sprint_20:v0:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The navbar disappeared because :html-preamble #'ores/site-preamble in the backtick alist inserts the literal form (function ores/site-preamble), which org-html's functionp check rejects. Dropping #' embeds the bare symbol, which functionp recognises correctly.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                   |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Closed. Fix delivered.                 |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-11                               |
+
+* Acceptance
+
+- Published site has nav bar on every page. ores-build-site.el uses :html-preamble ores/site-preamble (no #').
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:E30B7701-788C-4902-9F64-CB0983920AEE][Fix ores/site-preamble not called by org-publish]] | DONE | 2026-06-11 | 2026-06-11 | Remove #' from :html-preamble entry in org-publish-project-alist so the bare symbol is used and functionp recognises it. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/task_fix_site_preamble_symbol.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/task_fix_site_preamble_symbol.org
@@ -8,7 +8,7 @@
 #+filetags: :hotfix_site_navbar_missing:sprint_20:v0:
 #+owner: marco
 #+branch: feature/fix-site-preamble-symbol
-#+pr:
+#+pr: 1265
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-11
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1265][#1265]] | [site] Hotfix: bare symbol for ores/site-preamble in project alist |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/task_fix_site_preamble_symbol.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/task_fix_site_preamble_symbol.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: E30B7701-788C-4902-9F64-CB0983920AEE
+:END:
+#+title: Task: Fix ores/site-preamble not called by org-publish
+#+description: Remove #' from :html-preamble entry in org-publish-project-alist so the bare symbol is used and functionp recognises it.
+#+type: task
+#+level: s1
+#+filetags: :hotfix_site_navbar_missing:sprint_20:v0:
+#+owner: marco
+#+branch: feature/fix-site-preamble-symbol
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-11
+#+updated: 2026-06-11
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:35D01E18-F27B-47F4-B99E-E474CF310F2E][Hotfix: site navbar missing after edit-on-github change]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Change :html-preamble #'ores/site-preamble to :html-preamble ores/site-preamble in ores-build-site.el.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:35D01E18-F27B-47F4-B99E-E474CF310F2E][Hotfix: site navbar missing after edit-on-github change]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-11                               |
+
+* Acceptance
+
+- org-publish calls ores/site-preamble per page; every published HTML page has the nav bar and edit button.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Removed =`#'= from =:html-preamble= in the =site:pages= project entry.  In a backtick
+alist, =#'ores/site-preamble= embeds the literal form =(function ores/site-preamble)=
+which =functionp= does not recognise; the bare symbol =ores/site-preamble= is what
+=functionp= accepts.  One character change in =ores-build-site.el=.

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -190,6 +190,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
+| [[id:35D01E18-F27B-47F4-B99E-E474CF310F2E][Hotfix: site navbar missing after edit-on-github change]] | DONE | 2026-06-11 | 2026-06-11 | =#'= in backtick alist embeds literal =(function ...)= form; =functionp= rejects it; bare symbol fixes it. |
 | [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] | DONE | 2026-06-07 | 2026-06-07 | New command_args/command_feedback/script_runner symbols lack ORES_SHELL_EXPORT; Windows test exe cannot link against the DLL. |
 | [[id:E9CC8354-318C-4B08-B307-25910F536F2E][Hotfix: shell bundles gcc build]] | DONE | 2026-06-06 | 2026-06-06 | linux-gcc-debug-ninja red: four shell command files built std::string from std::vector<std::byte> iterators; converted to ores::nats::as_string_view. PR [[https://github.com/OreStudio/OreStudio/pull/1133][#1133]]. |
 | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] | BACKLOG | | | Build the external/facestudio/ seed catalog: move the 60 downloaded AI faces, add manifest/methodology metadata, document the FaceStudio licence, fix the accumulation script (age filter 20–70, 429 handling, multiple images per combination, correct output path), and wire into the seeder. |

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -185,7 +185,7 @@ title='Edit this page on GitHub' aria-label='Edit this page on GitHub'>\
          :exclude "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|projects/ores.org-js"
          :publishing-function org-html-publish-to-html
          :publishing-directory "./build/output/site/OreStudio"
-         :html-preamble #'ores/site-preamble
+         :html-preamble ores/site-preamble
          :with-author nil
          :with-creator t
          :with-toc t


### PR DESCRIPTION
## Summary

Nav bar disappeared because #' in a backtick alist embeds (function ores/site-preamble) as literal data, which functionp rejects. Bare symbol fixes it.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: site navbar missing after edit-on-github change](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/story.html) | 35D01E18-F27B-47F4-B99E-E474CF310F2E |
| Task | [Fix ores/site-preamble not called by org-publish](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/hotfix_site_navbar_missing/task_fix_site_preamble_symbol.html) | E30B7701-788C-4902-9F64-CB0983920AEE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)