### PR TITLE
[cmake,ci] ORES_VCPKG_ENABLED switch + linux-doc-only preset

### DIFF
--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -19,14 +19,10 @@
 # CDash as the "Site" build group. Same script, two configurations (like the
 # continuous/nightly compile builds): with_doxygen=false is the fast PR link
 # check; with_doxygen=true is the full site + Doxygen build for merges to main.
-# The configure step needs the full toolchain (vcpkg/Qt/cmake); the database is
-# not required, so the Postgres setup from the canary build is omitted.
+# Uses the linux-doc-only cmake preset (ORES_VCPKG_ENABLED=OFF) — vcpkg,
+# sccache, and Qt are not required for an emacs-based site build.
 ---
 name: Site CDash
-
-env:
-  VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg-cache,readwrite'
-  SCCACHE_DIR: '${{ github.workspace }}/.sccache'
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:
@@ -62,30 +58,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Restore sccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: sccache-linux-gcc-debug-ninja
-
-      - name: Ccache for gh actions
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          variant: sccache
-          key: linux-gcc-debug-ninja
-          max-size: 2000M
-          save: false
-
-      - name: Install dev packages
-        run: ./build/scripts/install_debian_packages.sh
-
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.8.3'
-          modules: 'qtcharts'
-          cache: true
-
       - name: Install Doxygen
         if: ${{ inputs.with_doxygen }}
         run: sudo apt-get install -y graphviz doxygen fonts-firacode fonts-freefont-ttf
@@ -107,19 +79,6 @@ jobs:
       - name: get-cmake
         uses: lukka/get-cmake@v4.3.3
 
-      - name: Cache vcpkg binary packages
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/vcpkg-cache
-          key: vcpkg-linux-gcc-debug-ninja-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-linux-gcc-debug-ninja-
-
-      - name: run-vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          doNotCache: false
-
       - name: Run CTest site build
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
@@ -130,7 +89,7 @@ jobs:
           export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
           # PR URL for the CDash Notes (empty for non-PR invocations).
           export ORES_PR_URL="${{ github.event.pull_request.html_url }}"
-          export preset=linux-gcc-debug-ninja
+          export preset=linux-doc-only
           if [ "${{ inputs.with_doxygen }}" = "true" ]; then dox=ON; else dox=OFF; fi
           export cmake_args="build_group=Site,preset=${preset},with_doxygen=${dox}"
           ctest -VV --preset ${preset} --script "CTestSite.cmake,${cmake_args}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,24 @@ cmake_minimum_required(VERSION 3.28 FATAL_ERROR)
 #
 # vcpkg
 #
-# Always include common overlays
-set(ORES_OVERLAYS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/overlays")
-set(VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/common")
+set(ORES_VCPKG_ENABLED ON CACHE BOOL
+    "Enable vcpkg package manager. Set OFF for doc-only builds (deploy_site, \
+deploy_skills, etc.) to skip the dependency install step entirely.")
 
-# Add Linux-specific overlays
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-    list(APPEND VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/linux")
+if(ORES_VCPKG_ENABLED)
+    # Always include common overlays
+    set(ORES_OVERLAYS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/overlays")
+    set(VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/common")
+
+    # Add Linux-specific overlays
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+        list(APPEND VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/linux")
+    endif()
+
+    set(CMAKE_TOOLCHAIN_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        CACHE STRING "Vcpkg toolchain file")
 endif()
-
-set(CMAKE_TOOLCHAIN_FILE
-    ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
-    CACHE STRING "Vcpkg toolchain file")
 
 # Log CMake version. Useful for debugging CMake problems.
 message(STATUS "CMake Version: ${CMAKE_VERSION}")
@@ -134,6 +140,120 @@ set(ORES_TEST_ENV_CMD ${CMAKE_COMMAND} -E env ${ORES_TEST_ENV} --)
 # c++ standard.
 #
 message(STATUS "Targeting C++ standard: ${CMAKE_CXX_STANDARD}")
+
+#
+# PlantUML
+#
+find_program(PLANTUML_PROGRAM plantuml)
+if (PLANTUML_PROGRAM)
+    message(STATUS "Found PlantUML: ${PLANTUML_PROGRAM}")
+    set(WITH_PLANTUML "on")
+    set(PLANTUML_ENVIRONMENT PLANTUML_LIMIT_SIZE=131072)
+else()
+    message(STATUS "PlantUML not found.")
+endif()
+
+#
+# Emacs related targets
+#
+# Defined here (before C++ dependency discovery) so that doc-only builds
+# (ORES_VCPKG_ENABLED=OFF) can reach deploy_site, deploy_skills, etc. without
+# configuring the full C++ toolchain.
+#
+set(ORES_SITE_DIRECTORY "build/output/site")
+add_custom_target(deploy_site
+    COMMENT "Deploying ORE Studio Website to ${ORES_SITE_DIRECTORY}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(org_roam_db_sync
+    COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_MANUAL_PDF "doc/manual/user_guide/user_manual.pdf")
+add_custom_target(deploy_manual
+    COMMENT "Building ORE Studio User Manual PDF to ${ORES_MANUAL_PDF}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_HELP_DIRECTORY "build/output/help")
+add_custom_target(deploy_help
+    COMMENT "Exporting self-contained manual HTML for Qt help to ${ORES_HELP_DIRECTORY}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_HELP_QCH_SOURCE
+    "${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help/user_manual.qch")
+add_custom_target(deploy_help_qch
+    COMMENT "Recompiling user_manual.qch and updating source tree" VERBATIM
+    COMMAND python3 build/scripts/generate_help_qch.py
+        --output-dir ${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_dependencies(deploy_help_qch deploy_help)
+
+add_custom_target(tangle_clang_format
+    COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(tangle_codegen_templates
+    COMMENT "Tangling codegen mustache templates from literate facet docs in projects/ores.codegen/library/templates/" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-codegen-templates.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(tangle_shell_scripts
+    COMMENT "Generating the ores-shell script library from recipes in doc/recipes/shell/ into projects/ores.shell/scripts/library/" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-recipe-scripts.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_SKILLS_DIRECTORY ".claude/skills")
+add_custom_target(deploy_skills
+    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM
+    COMMAND echo "Removing skills directory" && rm -rf ${ORES_SKILLS_DIRECTORY}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-skills.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_CLAUDE_SETTINGS_FILE ".claude/settings.json")
+add_custom_target(deploy_settings
+    COMMENT "Deploying ORE Studio Claude Code Settings to ${ORES_CLAUDE_SETTINGS_FILE}" VERBATIM
+    COMMAND echo "Removing settings file" && rm -f ${ORES_CLAUDE_SETTINGS_FILE}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-settings.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_TASKS_DIRECTORY "build/output/plan")
+add_custom_target(deploy_plan
+    COMMENT "Deploying ORE Studio Plan to ${ORES_TASKS_DIRECTORY}" VERBATIM
+    COMMAND echo "Removing site directory" && rm -rf ${ORES_TASKS_DIRECTORY}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-plan.el
+    COMMAND mkdir -p ${ORES_TASKS_DIRECTORY}
+    COMMAND mv doc/agile/v0/version_zero.tjp ${ORES_TASKS_DIRECTORY}
+    COMMAND cd ${ORES_TASKS_DIRECTORY}
+    COMMAND tj3 version_zero.tjp
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(sprint_charts
+    COMMENT "Generating sprint health charts (requires gnuplot)" VERBATIM
+    COMMAND ${CMAKE_SOURCE_DIR}/projects/ores.compass/compass.sh sprint charts --sprint ${SPRINT}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+set(SPRINT 18 CACHE STRING "Sprint number for sprint_charts target")
+
+add_custom_target(make_all_diagrams)
+add_custom_target(mad)
+add_dependencies(mad make_all_diagrams)
+
+add_custom_target(deploy_org
+    COMMENT "Deploying all ORE Studio org-mode artefacts" VERBATIM)
+add_dependencies(deploy_org deploy_site deploy_skills deploy_settings make_all_diagrams)
+add_custom_target(dorg)
+add_dependencies(dorg deploy_org)
+
+# Doc-only mode: all documentation targets are now defined; skip the C++
+# build configuration entirely (no find_package, no add_subdirectory).
+if(NOT ORES_VCPKG_ENABLED)
+    message(STATUS "ORES_VCPKG_ENABLED=OFF: skipping C++ build configuration.")
+    return()
+endif()
 
 #
 # Setup CCache
@@ -328,102 +448,6 @@ else()
 endif()
 
 #
-# PlantUML
-#
-find_program(PLANTUML_PROGRAM plantuml)
-if (PLANTUML_PROGRAM)
-    message(STATUS "Found PlantUML: ${PLANTUML_PROGRAM}")
-    set(WITH_PLANTUML "on")
-    set(PLANTUML_ENVIRONMENT PLANTUML_LIMIT_SIZE=131072)
-else()
-    message(STATUS "PlantUML not found.")
-endif()
-
-#
-# Emacs related targets
-#
-set(ORES_SITE_DIRECTORY "build/output/site")
-add_custom_target(deploy_site
-    COMMENT "Deploying ORE Studio Website to ${ORES_SITE_DIRECTORY}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(org_roam_db_sync
-    COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_MANUAL_PDF "doc/manual/user_guide/user_manual.pdf")
-add_custom_target(deploy_manual
-    COMMENT "Building ORE Studio User Manual PDF to ${ORES_MANUAL_PDF}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_HELP_DIRECTORY "build/output/help")
-add_custom_target(deploy_help
-    COMMENT "Exporting self-contained manual HTML for Qt help to ${ORES_HELP_DIRECTORY}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-# Compile the help HTML into a Qt help collection (.qch) via
-# qhelpgenerator. Depends on deploy_help so building this target runs the
-# HTML export first.
-set(ORES_HELP_QCH_SOURCE
-    "${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help/user_manual.qch")
-add_custom_target(deploy_help_qch
-    COMMENT "Recompiling user_manual.qch and updating source tree" VERBATIM
-    COMMAND python3 build/scripts/generate_help_qch.py
-        --output-dir ${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_dependencies(deploy_help_qch deploy_help)
-
-add_custom_target(tangle_clang_format
-    COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(tangle_codegen_templates
-    COMMENT "Tangling codegen mustache templates from literate facet docs in projects/ores.codegen/library/templates/" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-codegen-templates.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(tangle_shell_scripts
-    COMMENT "Generating the ores-shell script library from recipes in doc/recipes/shell/ into projects/ores.shell/scripts/library/" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-recipe-scripts.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_SKILLS_DIRECTORY ".claude/skills")
-add_custom_target(deploy_skills
-    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM
-    COMMAND echo "Removing skills directory" && rm -rf ${ORES_SKILLS_DIRECTORY}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-skills.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_CLAUDE_SETTINGS_FILE ".claude/settings.json")
-add_custom_target(deploy_settings
-    COMMENT "Deploying ORE Studio Claude Code Settings to ${ORES_CLAUDE_SETTINGS_FILE}" VERBATIM
-    COMMAND echo "Removing settings file" && rm -f ${ORES_CLAUDE_SETTINGS_FILE}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-settings.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_TASKS_DIRECTORY "build/output/plan")
-add_custom_target(deploy_plan
-    COMMENT "Deploying ORE Studio Plan to ${ORES_TASKS_DIRECTORY}" VERBATIM
-    COMMAND echo "Removing site directory" && rm -rf ${ORES_TASKS_DIRECTORY}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-plan.el
-    COMMAND mkdir -p ${ORES_TASKS_DIRECTORY}
-    COMMAND mv doc/agile/v0/version_zero.tjp ${ORES_TASKS_DIRECTORY}
-    COMMAND cd ${ORES_TASKS_DIRECTORY}
-    COMMAND tj3 version_zero.tjp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(sprint_charts
-    COMMENT "Generating sprint health charts (requires gnuplot)" VERBATIM
-    COMMAND ${CMAKE_SOURCE_DIR}/projects/ores.compass/compass.sh sprint charts --sprint ${SPRINT}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-set(SPRINT 18 CACHE STRING "Sprint number for sprint_charts target")
-
-#
 # Java args for PlantUML
 #
 set(ORES_PLANTUML_JAR "/usr/share/plantuml/plantuml.jar")
@@ -431,21 +455,11 @@ set(ORES_JAVA_ARGS "-Djava.awt.headless=true")
 list(APPEND ORES_JAVA_ARGS "-DPLANTUML_LIMIT_SIZE=131072")
 
 #
-# aggregate targets and their aliases
+# C++ test runner aggregates
 #
 add_custom_target(run_all_tests)
 add_custom_target(rat)
 add_dependencies(rat run_all_tests)
-
-add_custom_target(make_all_diagrams)
-add_custom_target(mad)
-add_dependencies(mad make_all_diagrams)
-
-add_custom_target(deploy_org
-    COMMENT "Deploying all ORE Studio org-mode artefacts" VERBATIM)
-add_dependencies(deploy_org deploy_site deploy_skills deploy_settings make_all_diagrams)
-add_custom_target(dorg)
-add_dependencies(dorg deploy_org)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/build)
 add_subdirectory(${CMAKE_SOURCE_DIR}/assets)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,883 +1,938 @@
 {
-    "version": 8,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 28,
-        "patch": 0
+  "version": 8,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 28,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-configuration",
+      "description": "Base class for common configuration options.",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/output/${presetName}",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_CXX_STANDARD": "23",
+        "CMAKE_CXX_STANDARD_REQUIRED": true,
+        "CMAKE_CXX_EXTENSIONS": false,
+        "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": "BOTH",
+        "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": "ON",
+        "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": "ON",
+        "CMAKE_PREFIX_PATH": "",
+        "VCPKG_INSTALL_OPTIONS": "--clean-after-build",
+        "X_VCPKG_APPLOCAL_DEPS_INSTALL": false
+      },
+      "warnings": {
+        "uninitialized": true,
+        "dev": false,
+        "deprecated": true,
+        "systemVars": true
+      },
+      "errors": {
+        "dev": false
+      },
+      "architecture": {
+        "value": "unknown",
+        "strategy": "external"
+      }
     },
-    "configurePresets": [
-        {
-            "name": "base-configuration",
-            "description": "Base class for common configuration options.",
-            "hidden": true,
-            "binaryDir": "${sourceDir}/build/output/${presetName}",
-            "cacheVariables": {
-                "CMAKE_POSITION_INDEPENDENT_CODE": true,
-                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "CMAKE_CXX_STANDARD": "23",
-                "CMAKE_CXX_STANDARD_REQUIRED": true,
-                "CMAKE_CXX_EXTENSIONS": false,
-                "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": "BOTH",
-                "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": "ON",
-                "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": "ON",
-                "CMAKE_PREFIX_PATH": "",
-                "VCPKG_INSTALL_OPTIONS": "--clean-after-build",
-                "X_VCPKG_APPLOCAL_DEPS_INSTALL": false
-            },
-            "warnings": {
-                "uninitialized": true,
-                "dev": false,
-                "deprecated": true,
-                "systemVars": true
-            },
-            "errors": {
-                "dev": false
-            },
-            "architecture": {
-                "value": "unknown",
-                "strategy": "external"
-            }
-        },
-        {
-            "name": "debug-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            },
-            "description": "Setup CMake debug build."
-        },
-        {
-            "name": "release-with-debug-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
-            "description": "Setup CMake release with debug symbols build."
-        },
-        {
-            "name": "release-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            },
-            "description": "Setup CMake release build."
-        },
-        {
-            "name": "clang",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang++"
-            },
-            "description": "Setup the Clang C++ compiler."
-        },
-        {
-            "name": "gcc",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "g++"
-            },
-            "description": "Setup the GCC C++ compiler."
-        },
-        {
-            "name": "msvc-cl",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "cl"
-            },
-            "description": "Setup the MSVC C++ compiler."
-        },
-        {
-            "name": "msvc-clang-cl",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang-cl"
-            },
-            "description": "Setup the Clang MSVC C++ compiler."
-        },
-        {
-            "name": "ninja",
-            "hidden": true,
-            "generator": "Ninja",
-            "description": "Build using the Ninja build tool."
-        },
-        {
-            "name": "make",
-            "hidden": true,
-            "generator": "Unix Makefiles",
-            "cacheVariables": {
-                "CMAKE_COLOR_DIAGNOSTICS": "OFF",
-                "CMAKE_COLOR_MAKEFILE": "OFF"
-            },
-            "description": "Build using Unix Make."
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "displayName": "Linux Clang Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Linux Clang using Ninja."
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "displayName": "Linux Clang Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for Linux Clang using Make."
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "displayName": "Linux Clang Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Linux Clang using Ninja."
-        },
-        {
-            "name": "linux-clang-release-make",
-            "displayName": "Linux Clang Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for Linux Clang using Make."
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "displayName": "Linux GCC Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Linux GCC using Ninja."
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "displayName": "Linux GCC Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for Linux GCC using Make."
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "displayName": "Linux GCC Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Linux GCC using Ninja."
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "displayName": "Linux GCC Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for Linux GCC using Make."
-        },
-        {
-            "name": "windows-arch-x64",
-            "hidden": true,
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "toolset": {
-                "value": "host=x64",
-                "strategy": "external"
-            },
-            "description": "Base configuration for Windows 64-bit"
-        },
-        {
-            "name": "windows-msvc",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "windows-arch-x64",
-                "msvc-cl"
-            ],
-            "cacheVariables": {
-                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the MSVC C++ compiler for Windows."
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-clang-cl",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "msvc-clang-cl",
-                "windows-arch-x64"
-            ],
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the Clang MSVC C++ compiler for Windows."
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc-clang-cl",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows Clang MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc-clang-cl",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows Clang MSVC using Ninja."
-        },
-        {
-            "name": "windows-clang",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "clang",
-                "windows-arch-x64"
-            ],
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the Clang C++ compiler for Windows."
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-clang",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows Clang using Ninja."
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-clang",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "displayName": "Mac OSX Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for MacOSX Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "displayName": "Mac OSX Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for MacOSX Clang using Make."
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "displayName": "Mac OSX Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for MacOSX Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-release-make",
-            "displayName": "Mac OSX Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for MacOSX Clang using Make."
+    {
+      "name": "debug-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "description": "Setup CMake debug build."
+    },
+    {
+      "name": "release-with-debug-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "description": "Setup CMake release with debug symbols build."
+    },
+    {
+      "name": "release-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "description": "Setup CMake release build."
+    },
+    {
+      "name": "clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "description": "Setup the Clang C++ compiler."
+    },
+    {
+      "name": "gcc",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "description": "Setup the GCC C++ compiler."
+    },
+    {
+      "name": "msvc-cl",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl"
+      },
+      "description": "Setup the MSVC C++ compiler."
+    },
+    {
+      "name": "msvc-clang-cl",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang-cl"
+      },
+      "description": "Setup the Clang MSVC C++ compiler."
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja",
+      "description": "Build using the Ninja build tool."
+    },
+    {
+      "name": "make",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "CMAKE_COLOR_DIAGNOSTICS": "OFF",
+        "CMAKE_COLOR_MAKEFILE": "OFF"
+      },
+      "description": "Build using Unix Make."
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "displayName": "Linux Clang Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Linux Clang using Ninja."
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "displayName": "Linux Clang Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for Linux Clang using Make."
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "displayName": "Linux Clang Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Linux Clang using Ninja."
+    },
+    {
+      "name": "linux-clang-release-make",
+      "displayName": "Linux Clang Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for Linux Clang using Make."
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "displayName": "Linux GCC Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Linux GCC using Ninja."
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "displayName": "Linux GCC Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for Linux GCC using Make."
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "displayName": "Linux GCC Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Linux GCC using Ninja."
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "displayName": "Linux GCC Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for Linux GCC using Make."
+    },
+    {
+      "name": "linux-doc-only",
+      "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
+      "description": "Configures without vcpkg; use for deploy_site, deploy_skills, deploy_settings and similar doc-only targets.",
+      "inherits": [
+        "base-configuration"
+      ],
+      "cacheVariables": {
+        "ORES_VCPKG_ENABLED": "OFF"
+      }
+    },
+    {
+      "name": "windows-arch-x64",
+      "hidden": true,
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "description": "Base configuration for Windows 64-bit"
+    },
+    {
+      "name": "windows-msvc",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "windows-arch-x64",
+        "msvc-cl"
+      ],
+      "cacheVariables": {
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "buildPresets": [
-        {
-            "name": "base-build",
-            "hidden": true,
-            "description": "Base build preset inherited by all build presets."
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "configurePreset": "windows-msvc-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "configurePreset": "windows-msvc-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "configurePreset": "windows-msvc-clang-cl-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "configurePreset": "windows-msvc-clang-cl-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "configurePreset": "windows-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "configurePreset": "windows-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "configurePreset": "linux-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "configurePreset": "linux-clang-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "configurePreset": "linux-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "configurePreset": "linux-clang-release-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "configurePreset": "linux-gcc-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "configurePreset": "linux-gcc-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "configurePreset": "linux-gcc-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "configurePreset": "linux-gcc-release-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "configurePreset": "macos-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "configurePreset": "macos-clang-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "configurePreset": "macos-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-release-make",
-            "configurePreset": "macos-clang-release-make",
-            "inherits": ["base-build"]
+      },
+      "description": "Setup the MSVC C++ compiler for Windows."
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-clang-cl",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "msvc-clang-cl",
+        "windows-arch-x64"
+      ],
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "testPresets": [
-        {
-            "name": "test-default",
-            "hidden": true,
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "noTestsAction": "error",
-                "stopOnFailure": false
-            }
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "configurePreset": "windows-msvc-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "configurePreset": "windows-msvc-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "configurePreset": "windows-msvc-clang-cl-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "configurePreset": "windows-msvc-clang-cl-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "configurePreset": "windows-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "configurePreset": "windows-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "configurePreset": "linux-gcc-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "configurePreset": "linux-gcc-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "configurePreset": "linux-gcc-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "configurePreset": "linux-gcc-debug-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "configurePreset": "linux-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "configurePreset": "linux-clang-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "configurePreset": "linux-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "configurePreset": "linux-clang-debug-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "configurePreset": "macos-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-release-make",
-            "configurePreset": "macos-clang-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "configurePreset": "macos-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "configurePreset": "macos-clang-debug-make",
-            "inherits": [
-                "test-default"
-            ]
+      },
+      "description": "Setup the Clang MSVC C++ compiler for Windows."
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc-clang-cl",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows Clang MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc-clang-cl",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows Clang MSVC using Ninja."
+    },
+    {
+      "name": "windows-clang",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "clang",
+        "windows-arch-x64"
+      ],
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "packagePresets": [
+      },
+      "description": "Setup the Clang C++ compiler for Windows."
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-clang",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows Clang using Ninja."
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-clang",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "displayName": "Mac OSX Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for MacOSX Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "displayName": "Mac OSX Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for MacOSX Clang using Make."
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "displayName": "Mac OSX Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for MacOSX Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-release-make",
+      "displayName": "Mac OSX Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for MacOSX Clang using Make."
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base-build",
+      "hidden": true,
+      "description": "Base build preset inherited by all build presets."
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "configurePreset": "windows-msvc-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "configurePreset": "windows-msvc-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "configurePreset": "windows-msvc-clang-cl-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "configurePreset": "windows-msvc-clang-cl-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "configurePreset": "windows-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "configurePreset": "windows-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "configurePreset": "linux-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "configurePreset": "linux-clang-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "configurePreset": "linux-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "configurePreset": "linux-clang-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "configurePreset": "linux-gcc-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "configurePreset": "linux-gcc-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "configurePreset": "linux-gcc-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "configurePreset": "linux-gcc-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-doc-only",
+      "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
+      "configurePreset": "linux-doc-only",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "configurePreset": "macos-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "configurePreset": "macos-clang-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "configurePreset": "macos-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-release-make",
+      "configurePreset": "macos-clang-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test-default",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false
+      }
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "configurePreset": "windows-msvc-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "configurePreset": "windows-msvc-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "configurePreset": "windows-msvc-clang-cl-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "configurePreset": "windows-msvc-clang-cl-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "configurePreset": "windows-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "configurePreset": "windows-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "configurePreset": "linux-gcc-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "configurePreset": "linux-gcc-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "configurePreset": "linux-gcc-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "configurePreset": "linux-gcc-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "configurePreset": "linux-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "configurePreset": "linux-clang-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "configurePreset": "linux-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "configurePreset": "linux-clang-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "configurePreset": "macos-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-release-make",
+      "configurePreset": "macos-clang-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "configurePreset": "macos-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "configurePreset": "macos-clang-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "linux-gcc-release-ninja",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-gcc-release-ninja",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-gcc-release-make",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-clang-release-ninja",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-clang-release-make",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-debug-ninja",
+      "steps": [
         {
-            "name": "linux-gcc-release-ninja",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-gcc-release-ninja",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "configure",
+          "name": "linux-clang-debug-ninja"
         },
         {
-            "name": "linux-gcc-release-make",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-gcc-release-make",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "build",
+          "name": "linux-clang-debug-ninja"
         },
         {
-            "name": "linux-clang-release-ninja",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-clang-release-ninja",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-clang-release-make",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "test",
+          "name": "linux-clang-debug-ninja"
         }
-    ],
-    "workflowPresets": [
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-debug-make",
+      "steps": [
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-debug-ninja"
-                }
-            ]
+          "type": "configure",
+          "name": "linux-clang-debug-make"
         },
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-debug-make"
-                }
-            ]
+          "type": "build",
+          "name": "linux-clang-debug-make"
         },
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-release-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-debug-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-debug-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-release-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-debug-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-debug-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-release-make"
-                }
-            ]
+          "type": "test",
+          "name": "linux-clang-debug-make"
         }
-    ]
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-clang-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-clang-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-clang-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-clang-release-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-clang-release-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-clang-release-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-debug-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-debug-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-debug-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-debug-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-debug-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-debug-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-debug-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-debug-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-release-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-release-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-release-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-debug-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-debug-ninja"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-debug-ninja"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-debug-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-debug-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-debug-make"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-debug-make"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-debug-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-release-make"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-release-make"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-release-make"
+        }
+      ]
+    }
+  ]
 }

--- a/doc/agile/product_backlog/inbox/skip-vcpkg-for-doc-builds.org
+++ b/doc/agile/product_backlog/inbox/skip-vcpkg-for-doc-builds.org
@@ -6,6 +6,7 @@
 #+type: capture
 #+level: cross
 #+filetags: :cmake:ci:sprint_20:v0:
+#+branch: feature/vcpkg-off-for-doc-builds
 #+created: 2026-06-12
 #+updated: 2026-06-12
 

--- a/doc/agile/product_backlog/inbox/skip-vcpkg-for-doc-builds.org
+++ b/doc/agile/product_backlog/inbox/skip-vcpkg-for-doc-builds.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 56E13507-50C4-4A7A-956A-FE66968B017E
+:END:
+#+title: Skip vcpkg for doc-only cmake builds
+#+description: ORES_VCPKG_ENABLED cmake switch + linux-doc-only preset; site CI no longer needs sccache, Qt, or vcpkg.
+#+type: capture
+#+level: cross
+#+filetags: :cmake:ci:sprint_20:v0:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-


### PR DESCRIPTION
## Summary

Adds `ORES_VCPKG_ENABLED` (default `ON`) as a cmake cache variable that disables vcpkg entirely for doc-only builds. The emacs targets (`deploy_site`, `deploy_skills`, `deploy_settings`, etc.) are moved before C++ dependency discovery so a doc-only configure exits cleanly via `return()` without running any `find_package` calls. A new `linux-doc-only` preset flips the switch; `cmake --preset linux-doc-only` configures in ~0.1s with no package installation. The site CI workflow switches to this preset, removing the sccache, Qt, and vcpkg setup steps it never actually needed.

## Changes

- **CMakeLists.txt**: guard vcpkg overlay/toolchain setup with `ORES_VCPKG_ENABLED`; move emacs targets (`deploy_site`, `deploy_skills`, `deploy_settings`, `deploy_manual`, etc.) and doc aggregates (`deploy_org`, `make_all_diagrams`) before C++ dependency discovery; add `return()` early exit when `ORES_VCPKG_ENABLED=OFF`
- **CMakePresets.json**: add `linux-doc-only` configure preset (inherits `base-configuration`, sets `ORES_VCPKG_ENABLED=OFF`) and matching build preset
- **site-cdash.yml**: switch from `linux-gcc-debug-ninja` to `linux-doc-only`; remove `Restore sccache`, `Ccache for gh actions`, `Install dev packages`, `Install Qt`, `Cache vcpkg binary packages`, and `run-vcpkg` steps

## Test plan

- [ ] `cmake --preset linux-doc-only` completes in ~0.1s, prints `ORES_VCPKG_ENABLED=OFF: skipping C++ build configuration.`
- [ ] `cmake --build --preset linux-doc-only --target deploy_site` builds the site
- [ ] `cmake --preset linux-clang-debug-make` still finds vcpkg packages normally
- [ ] Site CI (PR + main) passes with the slimmed-down workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)