### PR TITLE
[cmake,ci] Skip vcpkg for doc-only cmake builds

### DIFF
--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -19,13 +19,10 @@
 # CDash as the "Site" build group. Same script, two configurations (like the
 # continuous/nightly compile builds): with_doxygen=false is the fast PR link
 # check; with_doxygen=true is the full site + Doxygen build for merges to main.
-# The configure step needs the full toolchain (vcpkg/Qt/cmake); the database is
-# not required, so the Postgres setup from the canary build is omitted.
+# Uses the linux-doc-only cmake preset (ORES_VCPKG_ENABLED=OFF) — vcpkg,
+# sccache, and Qt are not required for an emacs-based site build.
 ---
 name: Site CDash
-
-env:
-  VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg-cache,readwrite'
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:
@@ -94,16 +91,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dev packages
-        run: ./build/scripts/install_debian_packages.sh
-
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.8.3'
-          modules: 'qtcharts'
-          cache: true
-
       - name: Lint filetags
         run: ./projects/ores.compass/compass.sh lint
 
@@ -128,19 +115,6 @@ jobs:
       - name: get-cmake
         uses: lukka/get-cmake@v4.3.3
 
-      - name: Cache vcpkg binary packages
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/vcpkg-cache
-          key: vcpkg-linux-gcc-debug-ninja-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-linux-gcc-debug-ninja-
-
-      - name: run-vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          doNotCache: false
-
       - name: Run CTest site build
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
@@ -151,7 +125,7 @@ jobs:
           export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
           # PR URL for the CDash Notes (empty for non-PR invocations).
           export ORES_PR_URL="${{ github.event.pull_request.html_url }}"
-          export preset=linux-gcc-debug-ninja
+          export preset=linux-doc-only
           if [ "${{ inputs.with_doxygen }}" = "true" ]; then dox=ON; else dox=OFF; fi
           export cmake_args="build_group=Site,preset=${preset},with_doxygen=${dox}"
           ctest -VV --preset ${preset} --script "CTestSite.cmake,${cmake_args}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,24 @@ cmake_minimum_required(VERSION 3.28 FATAL_ERROR)
 #
 # vcpkg
 #
-# Always include common overlays
-set(ORES_OVERLAYS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/overlays")
-set(VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/common")
+set(ORES_VCPKG_ENABLED ON CACHE BOOL
+    "Enable vcpkg package manager. Set OFF for doc-only builds (deploy_site, \
+deploy_skills, etc.) to skip the dependency install step entirely.")
 
-# Add Linux-specific overlays
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-    list(APPEND VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/linux")
+if(ORES_VCPKG_ENABLED)
+    # Always include common overlays
+    set(ORES_OVERLAYS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/overlays")
+    set(VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/common")
+
+    # Add Linux-specific overlays
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+        list(APPEND VCPKG_OVERLAY_PORTS "${ORES_OVERLAYS_DIR}/linux")
+    endif()
+
+    set(CMAKE_TOOLCHAIN_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        CACHE STRING "Vcpkg toolchain file")
 endif()
-
-set(CMAKE_TOOLCHAIN_FILE
-    ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
-    CACHE STRING "Vcpkg toolchain file")
 
 # Log CMake version. Useful for debugging CMake problems.
 message(STATUS "CMake Version: ${CMAKE_VERSION}")
@@ -134,6 +140,120 @@ set(ORES_TEST_ENV_CMD ${CMAKE_COMMAND} -E env ${ORES_TEST_ENV} --)
 # c++ standard.
 #
 message(STATUS "Targeting C++ standard: ${CMAKE_CXX_STANDARD}")
+
+#
+# PlantUML
+#
+find_program(PLANTUML_PROGRAM plantuml)
+if (PLANTUML_PROGRAM)
+    message(STATUS "Found PlantUML: ${PLANTUML_PROGRAM}")
+    set(WITH_PLANTUML "on")
+    set(PLANTUML_ENVIRONMENT PLANTUML_LIMIT_SIZE=131072)
+else()
+    message(STATUS "PlantUML not found.")
+endif()
+
+#
+# Emacs related targets
+#
+# Defined here (before C++ dependency discovery) so that doc-only builds
+# (ORES_VCPKG_ENABLED=OFF) can reach deploy_site, deploy_skills, etc. without
+# configuring the full C++ toolchain.
+#
+set(ORES_SITE_DIRECTORY "build/output/site")
+add_custom_target(deploy_site
+    COMMENT "Deploying ORE Studio Website to ${ORES_SITE_DIRECTORY}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(org_roam_db_sync
+    COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_MANUAL_PDF "doc/manual/user_guide/user_manual.pdf")
+add_custom_target(deploy_manual
+    COMMENT "Building ORE Studio User Manual PDF to ${ORES_MANUAL_PDF}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_HELP_DIRECTORY "build/output/help")
+add_custom_target(deploy_help
+    COMMENT "Exporting self-contained manual HTML for Qt help to ${ORES_HELP_DIRECTORY}" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_HELP_QCH_SOURCE
+    "${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help/user_manual.qch")
+add_custom_target(deploy_help_qch
+    COMMENT "Recompiling user_manual.qch and updating source tree" VERBATIM
+    COMMAND python3 build/scripts/generate_help_qch.py
+        --output-dir ${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_dependencies(deploy_help_qch deploy_help)
+
+add_custom_target(tangle_clang_format
+    COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(tangle_codegen_templates
+    COMMENT "Tangling codegen mustache templates from literate facet docs in projects/ores.codegen/library/templates/" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-codegen-templates.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(tangle_shell_scripts
+    COMMENT "Generating the ores-shell script library from recipes in doc/recipes/shell/ into projects/ores.shell/scripts/library/" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-recipe-scripts.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_SKILLS_DIRECTORY ".claude/skills")
+add_custom_target(deploy_skills
+    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM
+    COMMAND echo "Removing skills directory" && rm -rf ${ORES_SKILLS_DIRECTORY}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-skills.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_CLAUDE_SETTINGS_FILE ".claude/settings.json")
+add_custom_target(deploy_settings
+    COMMENT "Deploying ORE Studio Claude Code Settings to ${ORES_CLAUDE_SETTINGS_FILE}" VERBATIM
+    COMMAND echo "Removing settings file" && rm -f ${ORES_CLAUDE_SETTINGS_FILE}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-settings.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(ORES_TASKS_DIRECTORY "build/output/plan")
+add_custom_target(deploy_plan
+    COMMENT "Deploying ORE Studio Plan to ${ORES_TASKS_DIRECTORY}" VERBATIM
+    COMMAND echo "Removing site directory" && rm -rf ${ORES_TASKS_DIRECTORY}
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-plan.el
+    COMMAND mkdir -p ${ORES_TASKS_DIRECTORY}
+    COMMAND mv doc/agile/v0/version_zero.tjp ${ORES_TASKS_DIRECTORY}
+    COMMAND cd ${ORES_TASKS_DIRECTORY}
+    COMMAND tj3 version_zero.tjp
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(sprint_charts
+    COMMENT "Generating sprint health charts (requires gnuplot)" VERBATIM
+    COMMAND ${CMAKE_SOURCE_DIR}/projects/ores.compass/compass.sh sprint charts --sprint ${SPRINT}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+set(SPRINT 18 CACHE STRING "Sprint number for sprint_charts target")
+
+add_custom_target(make_all_diagrams)
+add_custom_target(mad)
+add_dependencies(mad make_all_diagrams)
+
+add_custom_target(deploy_org
+    COMMENT "Deploying all ORE Studio org-mode artefacts" VERBATIM)
+add_dependencies(deploy_org deploy_site deploy_skills deploy_settings make_all_diagrams)
+add_custom_target(dorg)
+add_dependencies(dorg deploy_org)
+
+# Doc-only mode: all documentation targets are now defined; skip the C++
+# build configuration entirely (no find_package, no add_subdirectory).
+if(NOT ORES_VCPKG_ENABLED)
+    message(STATUS "ORES_VCPKG_ENABLED=OFF: skipping C++ build configuration.")
+    return()
+endif()
 
 #
 # Setup CCache
@@ -328,102 +448,6 @@ else()
 endif()
 
 #
-# PlantUML
-#
-find_program(PLANTUML_PROGRAM plantuml)
-if (PLANTUML_PROGRAM)
-    message(STATUS "Found PlantUML: ${PLANTUML_PROGRAM}")
-    set(WITH_PLANTUML "on")
-    set(PLANTUML_ENVIRONMENT PLANTUML_LIMIT_SIZE=131072)
-else()
-    message(STATUS "PlantUML not found.")
-endif()
-
-#
-# Emacs related targets
-#
-set(ORES_SITE_DIRECTORY "build/output/site")
-add_custom_target(deploy_site
-    COMMENT "Deploying ORE Studio Website to ${ORES_SITE_DIRECTORY}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(org_roam_db_sync
-    COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_MANUAL_PDF "doc/manual/user_guide/user_manual.pdf")
-add_custom_target(deploy_manual
-    COMMENT "Building ORE Studio User Manual PDF to ${ORES_MANUAL_PDF}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_HELP_DIRECTORY "build/output/help")
-add_custom_target(deploy_help
-    COMMENT "Exporting self-contained manual HTML for Qt help to ${ORES_HELP_DIRECTORY}" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-help.el
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-# Compile the help HTML into a Qt help collection (.qch) via
-# qhelpgenerator. Depends on deploy_help so building this target runs the
-# HTML export first.
-set(ORES_HELP_QCH_SOURCE
-    "${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help/user_manual.qch")
-add_custom_target(deploy_help_qch
-    COMMENT "Recompiling user_manual.qch and updating source tree" VERBATIM
-    COMMAND python3 build/scripts/generate_help_qch.py
-        --output-dir ${CMAKE_SOURCE_DIR}/projects/ores.qt/application/resources/help
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_dependencies(deploy_help_qch deploy_help)
-
-add_custom_target(tangle_clang_format
-    COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(tangle_codegen_templates
-    COMMENT "Tangling codegen mustache templates from literate facet docs in projects/ores.codegen/library/templates/" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-codegen-templates.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(tangle_shell_scripts
-    COMMENT "Generating the ores-shell script library from recipes in doc/recipes/shell/ into projects/ores.shell/scripts/library/" VERBATIM
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-recipe-scripts.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_SKILLS_DIRECTORY ".claude/skills")
-add_custom_target(deploy_skills
-    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM
-    COMMAND echo "Removing skills directory" && rm -rf ${ORES_SKILLS_DIRECTORY}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-skills.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_CLAUDE_SETTINGS_FILE ".claude/settings.json")
-add_custom_target(deploy_settings
-    COMMENT "Deploying ORE Studio Claude Code Settings to ${ORES_CLAUDE_SETTINGS_FILE}" VERBATIM
-    COMMAND echo "Removing settings file" && rm -f ${ORES_CLAUDE_SETTINGS_FILE}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-settings.el 2>&1
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-set(ORES_TASKS_DIRECTORY "build/output/plan")
-add_custom_target(deploy_plan
-    COMMENT "Deploying ORE Studio Plan to ${ORES_TASKS_DIRECTORY}" VERBATIM
-    COMMAND echo "Removing site directory" && rm -rf ${ORES_TASKS_DIRECTORY}
-    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-plan.el
-    COMMAND mkdir -p ${ORES_TASKS_DIRECTORY}
-    COMMAND mv doc/agile/v0/version_zero.tjp ${ORES_TASKS_DIRECTORY}
-    COMMAND cd ${ORES_TASKS_DIRECTORY}
-    COMMAND tj3 version_zero.tjp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_custom_target(sprint_charts
-    COMMENT "Generating sprint health charts (requires gnuplot)" VERBATIM
-    COMMAND ${CMAKE_SOURCE_DIR}/projects/ores.compass/compass.sh sprint charts --sprint ${SPRINT}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-set(SPRINT 18 CACHE STRING "Sprint number for sprint_charts target")
-
-#
 # Java args for PlantUML
 #
 set(ORES_PLANTUML_JAR "/usr/share/plantuml/plantuml.jar")
@@ -431,21 +455,11 @@ set(ORES_JAVA_ARGS "-Djava.awt.headless=true")
 list(APPEND ORES_JAVA_ARGS "-DPLANTUML_LIMIT_SIZE=131072")
 
 #
-# aggregate targets and their aliases
+# C++ test runner aggregates
 #
 add_custom_target(run_all_tests)
 add_custom_target(rat)
 add_dependencies(rat run_all_tests)
-
-add_custom_target(make_all_diagrams)
-add_custom_target(mad)
-add_dependencies(mad make_all_diagrams)
-
-add_custom_target(deploy_org
-    COMMENT "Deploying all ORE Studio org-mode artefacts" VERBATIM)
-add_dependencies(deploy_org deploy_site deploy_skills deploy_settings make_all_diagrams)
-add_custom_target(dorg)
-add_dependencies(dorg deploy_org)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/build)
 add_subdirectory(${CMAKE_SOURCE_DIR}/assets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ cmake_minimum_required(VERSION 3.28 FATAL_ERROR)
 #
 set(ORES_VCPKG_ENABLED ON CACHE BOOL
     "Enable vcpkg package manager. Set OFF for doc-only builds (deploy_site, \
-deploy_skills, etc.) to skip the dependency install step entirely.")
+deploy_skills, etc.) to skip the dependency install step entirely. \
+Note: project(LANGUAGES CXX) is unconditional so a C++ compiler is still \
+required at configure time even when vcpkg is disabled.")
 
 if(ORES_VCPKG_ENABLED)
     # Always include common overlays
@@ -209,7 +211,7 @@ add_custom_target(tangle_shell_scripts
 
 set(ORES_SKILLS_DIRECTORY ".claude/skills")
 add_custom_target(deploy_skills
-    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM
+    COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SKILLS_DIRECTORY}" VERBATIM
     COMMAND echo "Removing skills directory" && rm -rf ${ORES_SKILLS_DIRECTORY}
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-skills.el 2>&1
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,883 +1,927 @@
 {
-    "version": 8,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 28,
-        "patch": 0
+  "version": 8,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 28,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-configuration",
+      "description": "Base class for common configuration options.",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/output/${presetName}",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_CXX_STANDARD": "23",
+        "CMAKE_CXX_STANDARD_REQUIRED": true,
+        "CMAKE_CXX_EXTENSIONS": false,
+        "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": "BOTH",
+        "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": "ON",
+        "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": "ON",
+        "CMAKE_PREFIX_PATH": "",
+        "VCPKG_INSTALL_OPTIONS": "--clean-after-build",
+        "X_VCPKG_APPLOCAL_DEPS_INSTALL": false
+      },
+      "warnings": {
+        "uninitialized": true,
+        "dev": false,
+        "deprecated": true,
+        "systemVars": true
+      },
+      "errors": {
+        "dev": false
+      },
+      "architecture": {
+        "value": "unknown",
+        "strategy": "external"
+      }
     },
-    "configurePresets": [
-        {
-            "name": "base-configuration",
-            "description": "Base class for common configuration options.",
-            "hidden": true,
-            "binaryDir": "${sourceDir}/build/output/${presetName}",
-            "cacheVariables": {
-                "CMAKE_POSITION_INDEPENDENT_CODE": true,
-                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "CMAKE_CXX_STANDARD": "23",
-                "CMAKE_CXX_STANDARD_REQUIRED": true,
-                "CMAKE_CXX_EXTENSIONS": false,
-                "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": "BOTH",
-                "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": "ON",
-                "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": "ON",
-                "CMAKE_PREFIX_PATH": "",
-                "VCPKG_INSTALL_OPTIONS": "--clean-after-build",
-                "X_VCPKG_APPLOCAL_DEPS_INSTALL": false
-            },
-            "warnings": {
-                "uninitialized": true,
-                "dev": false,
-                "deprecated": true,
-                "systemVars": true
-            },
-            "errors": {
-                "dev": false
-            },
-            "architecture": {
-                "value": "unknown",
-                "strategy": "external"
-            }
-        },
-        {
-            "name": "debug-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            },
-            "description": "Setup CMake debug build."
-        },
-        {
-            "name": "release-with-debug-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
-            "description": "Setup CMake release with debug symbols build."
-        },
-        {
-            "name": "release-build",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            },
-            "description": "Setup CMake release build."
-        },
-        {
-            "name": "clang",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang++"
-            },
-            "description": "Setup the Clang C++ compiler."
-        },
-        {
-            "name": "gcc",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "g++"
-            },
-            "description": "Setup the GCC C++ compiler."
-        },
-        {
-            "name": "msvc-cl",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "cl"
-            },
-            "description": "Setup the MSVC C++ compiler."
-        },
-        {
-            "name": "msvc-clang-cl",
-            "hidden": true,
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang-cl"
-            },
-            "description": "Setup the Clang MSVC C++ compiler."
-        },
-        {
-            "name": "ninja",
-            "hidden": true,
-            "generator": "Ninja",
-            "description": "Build using the Ninja build tool."
-        },
-        {
-            "name": "make",
-            "hidden": true,
-            "generator": "Unix Makefiles",
-            "cacheVariables": {
-                "CMAKE_COLOR_DIAGNOSTICS": "OFF",
-                "CMAKE_COLOR_MAKEFILE": "OFF"
-            },
-            "description": "Build using Unix Make."
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "displayName": "Linux Clang Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Linux Clang using Ninja."
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "displayName": "Linux Clang Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for Linux Clang using Make."
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "displayName": "Linux Clang Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Linux Clang using Ninja."
-        },
-        {
-            "name": "linux-clang-release-make",
-            "displayName": "Linux Clang Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "clang",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for Linux Clang using Make."
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "displayName": "Linux GCC Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Linux GCC using Ninja."
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "displayName": "Linux GCC Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for Linux GCC using Make."
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "displayName": "Linux GCC Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Linux GCC using Ninja."
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "displayName": "Linux GCC Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "gcc",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for Linux GCC using Make."
-        },
-        {
-            "name": "windows-arch-x64",
-            "hidden": true,
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "toolset": {
-                "value": "host=x64",
-                "strategy": "external"
-            },
-            "description": "Base configuration for Windows 64-bit"
-        },
-        {
-            "name": "windows-msvc",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "windows-arch-x64",
-                "msvc-cl"
-            ],
-            "cacheVariables": {
-                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the MSVC C++ compiler for Windows."
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-clang-cl",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "msvc-clang-cl",
-                "windows-arch-x64"
-            ],
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the Clang MSVC C++ compiler for Windows."
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc-clang-cl",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows Clang MSVC using Ninja."
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-msvc-clang-cl",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows Clang MSVC using Ninja."
-        },
-        {
-            "name": "windows-clang",
-            "displayName": "Windows x64",
-            "hidden": true,
-            "inherits": [
-                "clang",
-                "windows-arch-x64"
-            ],
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [
-                        "Windows"
-                    ]
-                }
-            },
-            "description": "Setup the Clang C++ compiler for Windows."
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "displayName": "Windows x64 Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-clang",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for Windows Clang using Ninja."
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "displayName": "Windows x64 Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "windows-clang",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for Windows Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "displayName": "Mac OSX Debug (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "debug-build",
-                "ninja"
-            ],
-            "description": "OreStudio debug build for MacOSX Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "displayName": "Mac OSX Debug (Make)",
-            "inherits": [
-                "base-configuration",
-                "debug-build",
-                "make"
-            ],
-            "description": "OreStudio debug build for MacOSX Clang using Make."
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "displayName": "Mac OSX Release (Ninja)",
-            "inherits": [
-                "base-configuration",
-                "release-build",
-                "ninja"
-            ],
-            "description": "OreStudio release build for MacOSX Clang using Ninja."
-        },
-        {
-            "name": "macos-clang-release-make",
-            "displayName": "Mac OSX Release (Make)",
-            "inherits": [
-                "base-configuration",
-                "release-build",
-                "make"
-            ],
-            "description": "OreStudio release build for MacOSX Clang using Make."
+    {
+      "name": "debug-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "description": "Setup CMake debug build."
+    },
+    {
+      "name": "release-with-debug-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "description": "Setup CMake release with debug symbols build."
+    },
+    {
+      "name": "release-build",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "description": "Setup CMake release build."
+    },
+    {
+      "name": "clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "description": "Setup the Clang C++ compiler."
+    },
+    {
+      "name": "gcc",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "description": "Setup the GCC C++ compiler."
+    },
+    {
+      "name": "msvc-cl",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl"
+      },
+      "description": "Setup the MSVC C++ compiler."
+    },
+    {
+      "name": "msvc-clang-cl",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang-cl"
+      },
+      "description": "Setup the Clang MSVC C++ compiler."
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja",
+      "description": "Build using the Ninja build tool."
+    },
+    {
+      "name": "make",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "CMAKE_COLOR_DIAGNOSTICS": "OFF",
+        "CMAKE_COLOR_MAKEFILE": "OFF"
+      },
+      "description": "Build using Unix Make."
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "displayName": "Linux Clang Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Linux Clang using Ninja."
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "displayName": "Linux Clang Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for Linux Clang using Make."
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "displayName": "Linux Clang Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Linux Clang using Ninja."
+    },
+    {
+      "name": "linux-clang-release-make",
+      "displayName": "Linux Clang Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "clang",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for Linux Clang using Make."
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "displayName": "Linux GCC Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Linux GCC using Ninja."
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "displayName": "Linux GCC Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for Linux GCC using Make."
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "displayName": "Linux GCC Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Linux GCC using Ninja."
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "displayName": "Linux GCC Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "gcc",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for Linux GCC using Make."
+    },
+    {
+      "name": "windows-arch-x64",
+      "hidden": true,
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "description": "Base configuration for Windows 64-bit"
+    },
+    {
+      "name": "windows-msvc",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "windows-arch-x64",
+        "msvc-cl"
+      ],
+      "cacheVariables": {
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "buildPresets": [
-        {
-            "name": "base-build",
-            "hidden": true,
-            "description": "Base build preset inherited by all build presets."
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "configurePreset": "windows-msvc-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "configurePreset": "windows-msvc-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "configurePreset": "windows-msvc-clang-cl-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "configurePreset": "windows-msvc-clang-cl-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "configurePreset": "windows-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "configurePreset": "windows-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "configurePreset": "linux-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "configurePreset": "linux-clang-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "configurePreset": "linux-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "configurePreset": "linux-clang-release-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "configurePreset": "linux-gcc-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "configurePreset": "linux-gcc-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "configurePreset": "linux-gcc-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "configurePreset": "linux-gcc-release-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "configurePreset": "macos-clang-debug-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "configurePreset": "macos-clang-debug-make",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "configurePreset": "macos-clang-release-ninja",
-            "inherits": ["base-build"]
-        },
-        {
-            "name": "macos-clang-release-make",
-            "configurePreset": "macos-clang-release-make",
-            "inherits": ["base-build"]
+      },
+      "description": "Setup the MSVC C++ compiler for Windows."
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-clang-cl",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "msvc-clang-cl",
+        "windows-arch-x64"
+      ],
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "testPresets": [
-        {
-            "name": "test-default",
-            "hidden": true,
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "noTestsAction": "error",
-                "stopOnFailure": false
-            }
-        },
-        {
-            "name": "windows-msvc-release-ninja",
-            "configurePreset": "windows-msvc-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-debug-ninja",
-            "configurePreset": "windows-msvc-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-clang-cl-release-ninja",
-            "configurePreset": "windows-msvc-clang-cl-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-msvc-clang-cl-debug-ninja",
-            "configurePreset": "windows-msvc-clang-cl-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-clang-release-ninja",
-            "configurePreset": "windows-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "windows-clang-debug-ninja",
-            "configurePreset": "windows-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-release-ninja",
-            "configurePreset": "linux-gcc-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-release-make",
-            "configurePreset": "linux-gcc-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-debug-ninja",
-            "configurePreset": "linux-gcc-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-gcc-debug-make",
-            "configurePreset": "linux-gcc-debug-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-release-ninja",
-            "configurePreset": "linux-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "configurePreset": "linux-clang-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-debug-ninja",
-            "configurePreset": "linux-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "linux-clang-debug-make",
-            "configurePreset": "linux-clang-debug-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-release-ninja",
-            "configurePreset": "macos-clang-release-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-release-make",
-            "configurePreset": "macos-clang-release-make",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-debug-ninja",
-            "configurePreset": "macos-clang-debug-ninja",
-            "inherits": [
-                "test-default"
-            ]
-        },
-        {
-            "name": "macos-clang-debug-make",
-            "configurePreset": "macos-clang-debug-make",
-            "inherits": [
-                "test-default"
-            ]
+      },
+      "description": "Setup the Clang MSVC C++ compiler for Windows."
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc-clang-cl",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows Clang MSVC using Ninja."
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-msvc-clang-cl",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows Clang MSVC using Ninja."
+    },
+    {
+      "name": "windows-clang",
+      "displayName": "Windows x64",
+      "hidden": true,
+      "inherits": [
+        "clang",
+        "windows-arch-x64"
+      ],
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
         }
-    ],
-    "packagePresets": [
+      },
+      "description": "Setup the Clang C++ compiler for Windows."
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "displayName": "Windows x64 Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-clang",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for Windows Clang using Ninja."
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "displayName": "Windows x64 Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "windows-clang",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for Windows Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "displayName": "Mac OSX Debug (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "debug-build",
+        "ninja"
+      ],
+      "description": "OreStudio debug build for MacOSX Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "displayName": "Mac OSX Debug (Make)",
+      "inherits": [
+        "base-configuration",
+        "debug-build",
+        "make"
+      ],
+      "description": "OreStudio debug build for MacOSX Clang using Make."
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "displayName": "Mac OSX Release (Ninja)",
+      "inherits": [
+        "base-configuration",
+        "release-build",
+        "ninja"
+      ],
+      "description": "OreStudio release build for MacOSX Clang using Ninja."
+    },
+    {
+      "name": "macos-clang-release-make",
+      "displayName": "Mac OSX Release (Make)",
+      "inherits": [
+        "base-configuration",
+        "release-build",
+        "make"
+      ],
+      "description": "OreStudio release build for MacOSX Clang using Make."
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base-build",
+      "hidden": true,
+      "description": "Base build preset inherited by all build presets."
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "configurePreset": "windows-msvc-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "configurePreset": "windows-msvc-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "configurePreset": "windows-msvc-clang-cl-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "configurePreset": "windows-msvc-clang-cl-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "configurePreset": "windows-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "configurePreset": "windows-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "configurePreset": "linux-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "configurePreset": "linux-clang-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "configurePreset": "linux-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "configurePreset": "linux-clang-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "configurePreset": "linux-gcc-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "configurePreset": "linux-gcc-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "configurePreset": "linux-gcc-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "configurePreset": "linux-gcc-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "configurePreset": "macos-clang-debug-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "configurePreset": "macos-clang-debug-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "configurePreset": "macos-clang-release-ninja",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "macos-clang-release-make",
+      "configurePreset": "macos-clang-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test-default",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false
+      }
+    },
+    {
+      "name": "windows-msvc-release-ninja",
+      "configurePreset": "windows-msvc-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-debug-ninja",
+      "configurePreset": "windows-msvc-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-release-ninja",
+      "configurePreset": "windows-msvc-clang-cl-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-msvc-clang-cl-debug-ninja",
+      "configurePreset": "windows-msvc-clang-cl-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-clang-release-ninja",
+      "configurePreset": "windows-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "windows-clang-debug-ninja",
+      "configurePreset": "windows-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-ninja",
+      "configurePreset": "linux-gcc-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "configurePreset": "linux-gcc-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-ninja",
+      "configurePreset": "linux-gcc-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-gcc-debug-make",
+      "configurePreset": "linux-gcc-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "configurePreset": "linux-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "configurePreset": "linux-clang-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-ninja",
+      "configurePreset": "linux-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-clang-debug-make",
+      "configurePreset": "linux-clang-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "linux-doc-only",
+      "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
+      "configurePreset": "linux-doc-only",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-release-ninja",
+      "configurePreset": "macos-clang-release-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-release-make",
+      "configurePreset": "macos-clang-release-make",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-ninja",
+      "configurePreset": "macos-clang-debug-ninja",
+      "inherits": [
+        "test-default"
+      ]
+    },
+    {
+      "name": "macos-clang-debug-make",
+      "configurePreset": "macos-clang-debug-make",
+      "inherits": [
+        "test-default"
+      ]
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "linux-gcc-release-ninja",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-gcc-release-ninja",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-gcc-release-make",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-gcc-release-make",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-clang-release-ninja",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-clang-release-ninja",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "linux-clang-release-make",
+      "packageName": "OreStudio",
+      "packageVersion": "0.0.2",
+      "displayName": "Distribute Release",
+      "configurePreset": "linux-clang-release-make",
+      "generators": [
+        "DEB"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-debug-ninja",
+      "steps": [
         {
-            "name": "linux-gcc-release-ninja",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-gcc-release-ninja",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "configure",
+          "name": "linux-clang-debug-ninja"
         },
         {
-            "name": "linux-gcc-release-make",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-gcc-release-make",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "build",
+          "name": "linux-clang-debug-ninja"
         },
         {
-            "name": "linux-clang-release-ninja",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-clang-release-ninja",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
-        },
-        {
-            "name": "linux-clang-release-make",
-            "packageName": "OreStudio",
-            "packageVersion": "0.0.2",
-            "displayName": "Distribute Release",
-            "configurePreset": "linux-clang-release-make",
-            "generators": [
-                "DEB"
-            ],
-            "configurations": [
-                "Release"
-            ]
+          "type": "test",
+          "name": "linux-clang-debug-ninja"
         }
-    ],
-    "workflowPresets": [
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-debug-make",
+      "steps": [
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-debug-ninja"
-                }
-            ]
+          "type": "configure",
+          "name": "linux-clang-debug-make"
         },
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-debug-make"
-                }
-            ]
+          "type": "build",
+          "name": "linux-clang-debug-make"
         },
         {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-clang-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-clang-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-clang-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-clang-release-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-debug-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-debug-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "linux-gcc-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "linux-gcc-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "linux-gcc-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "linux-gcc-release-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-debug-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-debug-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-debug-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-debug-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-debug-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-debug-make"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-debug-make"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-debug-make"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-release-ninja",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-release-ninja"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-release-ninja"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-release-ninja"
-                }
-            ]
-        },
-        {
-            "description": "Developer workflow without installation",
-            "name": "macos-clang-release-make",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "macos-clang-release-make"
-                },
-                {
-                    "type": "build",
-                    "name": "macos-clang-release-make"
-                },
-                {
-                    "type": "test",
-                    "name": "macos-clang-release-make"
-                }
-            ]
+          "type": "test",
+          "name": "linux-clang-debug-make"
         }
-    ]
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-clang-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-clang-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-clang-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-clang-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-clang-release-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-clang-release-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-clang-release-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-debug-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-debug-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-debug-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-debug-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-debug-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-debug-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-debug-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-debug-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "linux-gcc-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "linux-gcc-release-make"
+        },
+        {
+          "type": "build",
+          "name": "linux-gcc-release-make"
+        },
+        {
+          "type": "test",
+          "name": "linux-gcc-release-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-debug-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-debug-ninja"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-debug-ninja"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-debug-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-debug-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-debug-make"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-debug-make"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-debug-make"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-release-ninja",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-release-ninja"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-release-ninja"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-release-ninja"
+        }
+      ]
+    },
+    {
+      "description": "Developer workflow without installation",
+      "name": "macos-clang-release-make",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macos-clang-release-make"
+        },
+        {
+          "type": "build",
+          "name": "macos-clang-release-make"
+        },
+        {
+          "type": "test",
+          "name": "macos-clang-release-make"
+        }
+      ]
+    }
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -199,6 +199,17 @@
       "description": "OreStudio release build for Linux GCC using Make."
     },
     {
+      "name": "linux-doc-only",
+      "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
+      "description": "Configures without vcpkg; use for deploy_site, deploy_skills, deploy_settings and similar doc-only targets.",
+      "inherits": [
+        "base-configuration"
+      ],
+      "cacheVariables": {
+        "ORES_VCPKG_ENABLED": "OFF"
+      }
+    },
+    {
       "name": "windows-arch-x64",
       "hidden": true,
       "architecture": {
@@ -472,6 +483,14 @@
     {
       "name": "linux-gcc-release-make",
       "configurePreset": "linux-gcc-release-make",
+      "inherits": [
+        "base-build"
+      ]
+    },
+    {
+      "name": "linux-doc-only",
+      "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
+      "configurePreset": "linux-doc-only",
       "inherits": [
         "base-build"
       ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -203,7 +203,8 @@
       "displayName": "Linux \u2014 doc/site builds (vcpkg disabled)",
       "description": "Configures without vcpkg; use for deploy_site, deploy_skills, deploy_settings and similar doc-only targets.",
       "inherits": [
-        "base-configuration"
+        "base-configuration",
+        "make"
       ],
       "cacheVariables": {
         "ORES_VCPKG_ENABLED": "OFF"

--- a/CTestSite.cmake
+++ b/CTestSite.cmake
@@ -58,9 +58,16 @@ set(CTEST_BUILD_NAME "${preset}-site")
 message(STATUS "CDash build name: ${CTEST_BUILD_NAME}")
 
 # Derive the generator from the preset's build-tool segment (…-<tool>).
+# Presets with fewer than 4 dash-separated segments (e.g. linux-doc-only)
+# default to Unix Makefiles — the platform default and the make mixin.
 string(TOLOWER "${preset}" preset_lower)
 string(REPLACE "-" ";" preset_list ${preset_lower})
-list(GET preset_list 3 build_tool)
+list(LENGTH preset_list preset_len)
+if(preset_len GREATER 3)
+    list(GET preset_list 3 build_tool)
+else()
+    set(build_tool "make")
+endif()
 if(build_tool STREQUAL "ninja")
     set(CTEST_CMAKE_GENERATOR "Ninja")
 elseif(build_tool STREQUAL "make")

--- a/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/story.org
+++ b/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 56E13507-50C4-4A7A-956A-FE66968B017E
+:END:
+#+title: Story: Skip vcpkg for doc-only cmake builds
+#+description: ORES_VCPKG_ENABLED cmake switch + linux-doc-only preset; site CI no longer needs sccache, Qt, or vcpkg.
+#+type: story
+#+level: s2
+#+filetags: :sprint_20:v0:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment: local3
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Doc-only cmake targets (=deploy_site=, =deploy_skills=, =deploy_settings=,
+etc.) should configure and build without triggering vcpkg package
+installation. Introduce =ORES_VCPKG_ENABLED= (default =ON=) as a cmake
+cache variable that gates the entire vcpkg + C++ toolchain setup; a new
+=linux-doc-only= preset flips it =OFF=. The site CI workflow adopts this
+preset, removing the sccache, Qt, and vcpkg setup steps it never needed.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Implementation in progress.            |
+| Waiting on    | Nothing.                               |
+| Next          | Raise PR.                              |
+| Last touched  | 2026-06-12                               |
+
+* Acceptance
+
+- =cmake --preset linux-doc-only= completes without running vcpkg or
+  installing any packages (configure time ~0.1s).
+- =cmake --build --preset linux-doc-only --target deploy_site= builds
+  the site successfully.
+- Normal C++ presets (=linux-clang-debug-ninja=, etc.) still find vcpkg
+  packages unchanged.
+- Site CI (=site-cdash.yml=) no longer includes sccache, Qt, or vcpkg
+  steps.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:EFA4E251-985D-4624-9041-3E4723E62AB8][Implement ORES_VCPKG_ENABLED cmake switch]] | STARTED | 2026-06-12 | | Add ORES_VCPKG_ENABLED cache variable; move emacs targets before C++ deps; add linux-doc-only preset; switch site-cdash.yml to the new preset. |
+
+* Decisions
+
+* Out of scope
+
+- Windows or macOS CI site builds (both use separate workflows).
+- Expanding the doc-only preset to cover other Emacs targets (manual PDF, help QCH) beyond the site build.

--- a/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
+++ b/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
@@ -64,7 +64,13 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | No generator for linux-doc-only preset | CMakePresets.json | Fixed | Inherit make mixin |
+| 2 | CTestSite.cmake fatal-error for linux-doc-only (3-segment name) | CTestSite.cmake | Fixed | list(LENGTH) guard; default to make |
+| 3 | Typo ORES_SIRE_DIRECTORY in deploy_skills COMMENT | CMakeLists.txt | Fixed | Corrected to ORES_SKILLS_DIRECTORY |
+| 4 | project(LANGUAGES CXX) unconditional; C++ compiler still required | CMakeLists.txt | Documented | Added note to ORES_VCPKG_ENABLED description |
+| 5 | Duplicate * Result heading in task doc | task_implement-vcpkg-enabled-switch.org | Fixed | Removed trailing empty heading |
+| 6 | vcpkg cache vars in doc-only preset (harmless) | CMakePresets.json | Accepted | No action; ignored when vcpkg disabled |
+| 7 | PlantUML detection runs before early return (harmless) | CMakeLists.txt | Accepted | No action; fast find_program, no C++ target uses it |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
+++ b/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
@@ -8,7 +8,7 @@
 #+filetags: :skip-vcpkg-for-doc-builds:sprint_20:v0:
 #+owner: marco
 #+branch: feature/skip-vcpkg-for-doc-builds
-#+pr:
+#+pr: 1270
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -58,7 +58,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1270][#1270]] | [cmake,ci] Skip vcpkg for doc-only cmake builds |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
+++ b/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
@@ -1,0 +1,82 @@
+:PROPERTIES:
+:ID: EFA4E251-985D-4624-9041-3E4723E62AB8
+:END:
+#+title: Task: Implement ORES_VCPKG_ENABLED cmake switch
+#+description: Add ORES_VCPKG_ENABLED cache variable; move emacs targets before C++ deps; add linux-doc-only preset; switch site-cdash.yml to the new preset.
+#+type: task
+#+level: s1
+#+filetags: :skip-vcpkg-for-doc-builds:sprint_20:v0:
+#+owner: marco
+#+branch: feature/skip-vcpkg-for-doc-builds
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment: local3
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:56E13507-50C4-4A7A-956A-FE66968B017E][Skip vcpkg for doc-only cmake builds]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Introduce =ORES_VCPKG_ENABLED= (default =ON=) as a cmake cache variable
+that gates the vcpkg overlay/toolchain setup and all C++ dependency
+discovery. Move the emacs doc targets before the first =find_package= call
+and add an early =return()= when the switch is =OFF=. Add a
+=linux-doc-only= configure + build preset that sets =ORES_VCPKG_ENABLED=OFF=.
+Switch =site-cdash.yml= to use this preset, dropping sccache, Qt, and
+vcpkg setup steps.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:56E13507-50C4-4A7A-956A-FE66968B017E][Skip vcpkg for doc-only cmake builds]] |
+| Now          | Implementation done; PR under review.  |
+| Waiting on   | Nothing.                               |
+| Next         | Merge PR.                              |
+| Last touched | 2026-06-12                               |
+
+* Acceptance
+
+- =CMakeLists.txt= guards vcpkg setup and all =find_package= calls with =ORES_VCPKG_ENABLED=.
+- Emacs doc targets are defined before the C++ section.
+- =CMakePresets.json= has a =linux-doc-only= configure + build preset.
+- =site-cdash.yml= uses =linux-doc-only= and omits sccache/Qt/vcpkg steps.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+- =ORES_VCPKG_ENABLED= (default =ON=) added to =CMakeLists.txt= before
+  =project()=; guards vcpkg overlay setup, toolchain file, and via the
+  early =return()= all =find_package= calls.
+- Emacs doc targets moved before the C++ dependency block.
+- =linux-doc-only= configure, build, and test presets added to
+  =CMakePresets.json=.
+- =site-cdash.yml= switched to =linux-doc-only=; sccache, Qt, vcpkg
+  setup steps removed.
+- Locally verified: configure 0.1s; =deploy_site= builds cleanly;
+  =linux-clang-debug-make= still finds vcpkg packages.
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
+++ b/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.org
@@ -78,5 +78,3 @@ plan itself stays — it is the historical record of what we did.)
   setup steps removed.
 - Locally verified: configure 0.1s; =deploy_site= builds cleanly;
   =linux-clang-debug-make= still finds vcpkg packages.
-
-* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -157,6 +157,7 @@ LLM-driven workflow frictionless.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
+| [[id:56E13507-50C4-4A7A-956A-FE66968B017E][Skip vcpkg for doc-only cmake builds]] | STARTED | 2026-06-12 | | ORES_VCPKG_ENABLED switch + linux-doc-only preset; site CI drops sccache, Qt, and vcpkg steps. |
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. Slipped in sprints 18 and 19. |
 | [[id:3F7752F8-B719-40B4-BA89-09223410999E][Retune CI for tens of merges an hour]] | DONE | 2026-06-06 | 2026-06-08 | Path-classified PR jobs behind one pr-gate check; main matrices on staggered 2h/3h/4h schedules with a doc-only skip guard; Claude review replaces Gemini. |
 | [[id:10B5F44F-5EE7-4026-BFD7-4DABAB6540B8][Fix nightly clang-format CI]] | DONE | 2026-06-08 | 2026-06-08 | Unpin clang-format-18; apply drift to 181 files; restore bot-PR approach. PR #1187. |


### PR DESCRIPTION
## Summary

Introduce ORES_VCPKG_ENABLED (default ON) cmake cache variable that gates vcpkg overlay setup and all C++ dependency discovery. Add linux-doc-only configure/build/test presets. Switch site-cdash.yml to the new preset, dropping sccache, Qt, and vcpkg setup steps.

## Changes

- Add ORES_VCPKG_ENABLED cmake cache variable (default ON); early return() skips all C++ deps when OFF
- Move emacs doc targets before find_package calls so they are reachable in doc-only mode
- Add linux-doc-only configure, build, and test presets to CMakePresets.json
- Switch site-cdash.yml to linux-doc-only preset; remove sccache, Qt, and vcpkg setup steps

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Skip vcpkg for doc-only cmake builds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/story.html) | 56E13507-50C4-4A7A-956A-FE66968B017E |
| Task | [Implement ORES_VCPKG_ENABLED cmake switch](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/skip-vcpkg-for-doc-builds/task_implement-vcpkg-enabled-switch.html) | EFA4E251-985D-4624-9041-3E4723E62AB8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)