### PR TITLE
[ci] Hotfix: expand disk cleanup and drop sccache from site build

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -48,8 +48,10 @@ jobs:
           sudo rm -rf /home/linuxbrew/.linuxbrew
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/share/miniconda
+          sudo rm -rf /usr/share/miniconda3
           # Cloud CLIs
           sudo rm -rf /opt/az
+          sudo rm -rf /opt/pipx/venvs/azure-cli
           sudo rm -rf /usr/lib/google-cloud-sdk
           sudo rm -rf /usr/share/google-cloud-sdk
           sudo rm -rf /usr/local/share/powershell
@@ -64,6 +66,9 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/go
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf /usr/local/lib/node_modules
+          # Snap packages
+          sudo snap remove lxd 2>/dev/null || true
+          sudo rm -rf /var/cache/snapd
           # Docker images
           sudo docker image prune --all --force || true
           # apt cache

--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -39,19 +39,35 @@ jobs:
         run: |
           echo "=== Disk space before cleanup ==="
           df -h
-          # Remove large unused tools to free up disk space
+          # Language runtimes and SDKs not needed by this build
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /home/linuxbrew/.linuxbrew
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/miniconda
+          # Cloud CLIs
+          sudo rm -rf /opt/az
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/share/google-cloud-sdk
+          sudo rm -rf /usr/local/share/powershell
+          # Browser bundles
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/chrome_beta
+          sudo rm -rf /opt/google/chrome
+          # Pre-installed toolchain caches we don't use
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          # Additional unused runtimes
           sudo rm -rf /opt/hostedtoolcache/Ruby
           sudo rm -rf /opt/hostedtoolcache/node
           sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/node_modules
+          # Docker images
+          sudo docker image prune --all --force || true
+          # apt cache
+          sudo apt-get clean
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -107,8 +107,10 @@ jobs:
           sudo rm -rf /home/linuxbrew/.linuxbrew
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/share/miniconda
+          sudo rm -rf /usr/share/miniconda3
           # Cloud CLIs
           sudo rm -rf /opt/az
+          sudo rm -rf /opt/pipx/venvs/azure-cli
           sudo rm -rf /usr/lib/google-cloud-sdk
           sudo rm -rf /usr/share/google-cloud-sdk
           sudo rm -rf /usr/local/share/powershell
@@ -123,6 +125,9 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/go
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf /usr/local/lib/node_modules
+          # Snap packages
+          sudo snap remove lxd 2>/dev/null || true
+          sudo rm -rf /var/cache/snapd
           # Docker images
           sudo docker image prune --all --force || true
           # apt cache

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -98,19 +98,35 @@ jobs:
         run: |
           echo "=== Disk space before cleanup ==="
           df -h
-          # Remove large unused tools to free up disk space
+          # Language runtimes and SDKs not needed by this build
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /home/linuxbrew/.linuxbrew
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/miniconda
+          # Cloud CLIs
+          sudo rm -rf /opt/az
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/share/google-cloud-sdk
+          sudo rm -rf /usr/local/share/powershell
+          # Browser bundles
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/chrome_beta
+          sudo rm -rf /opt/google/chrome
+          # Pre-installed toolchain caches we don't use
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          # Additional unused runtimes
           sudo rm -rf /opt/hostedtoolcache/Ruby
           sudo rm -rf /opt/hostedtoolcache/node
           sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/node_modules
+          # Docker images
+          sudo docker image prune --all --force || true
+          # apt cache
+          sudo apt-get clean
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -71,19 +71,40 @@ jobs:
         run: |
           echo "=== Disk space before cleanup ==="
           df -h
-          # Remove large unused tools to free up disk space
+          # Language runtimes and SDKs not needed by this build
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /home/linuxbrew/.linuxbrew
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/miniconda
+          sudo rm -rf /usr/share/miniconda3
+          # Cloud CLIs
+          sudo rm -rf /opt/az
+          sudo rm -rf /opt/pipx/venvs/azure-cli
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/share/google-cloud-sdk
+          sudo rm -rf /usr/local/share/powershell
+          # Browser bundles
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/chrome_beta
+          sudo rm -rf /opt/google/chrome
+          # Pre-installed toolchain caches we don't use
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          # Additional unused runtimes
           sudo rm -rf /opt/hostedtoolcache/Ruby
           sudo rm -rf /opt/hostedtoolcache/node
           sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/node_modules
+          # Snap packages
+          sudo snap remove lxd 2>/dev/null || true
+          sudo rm -rf /var/cache/snapd
+          # Docker images
+          sudo docker image prune --all --force || true
+          # apt cache
+          sudo apt-get clean
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -26,7 +26,6 @@ name: Site CDash
 
 env:
   VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg-cache,readwrite'
-  SCCACHE_DIR: '${{ github.workspace }}/.sccache'
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:
@@ -47,11 +46,39 @@ jobs:
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby \
-            /opt/hostedtoolcache/node /opt/hostedtoolcache/go /usr/share/swift \
-            /usr/lib/jvm /usr/local/share/boost
+          echo "=== Disk space before cleanup ==="
+          df -h
+          # Language runtimes and SDKs not needed by this build
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /home/linuxbrew/.linuxbrew
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/miniconda
+          # Cloud CLIs
+          sudo rm -rf /opt/az
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/share/google-cloud-sdk
+          sudo rm -rf /usr/local/share/powershell
+          # Browser bundles
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/chrome_beta
+          sudo rm -rf /opt/google/chrome
+          # Pre-installed toolchain caches we don't use
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/go
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/node_modules
+          # Docker images
           sudo docker image prune --all --force || true
+          # apt cache
+          sudo apt-get clean
+          echo "=== Disk space after cleanup ==="
+          df -h
 
       - uses: actions/checkout@v6
         with:
@@ -61,20 +88,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-
-      - name: Restore sccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: sccache-linux-gcc-debug-ninja
-
-      - name: Ccache for gh actions
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          variant: sccache
-          key: linux-gcc-debug-ninja
-          max-size: 2000M
-          save: false
 
       - name: Install dev packages
         run: ./build/scripts/install_debian_packages.sh

--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -57,8 +57,10 @@ jobs:
           sudo rm -rf /home/linuxbrew/.linuxbrew
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/share/miniconda
+          sudo rm -rf /usr/share/miniconda3
           # Cloud CLIs
           sudo rm -rf /opt/az
+          sudo rm -rf /opt/pipx/venvs/azure-cli
           sudo rm -rf /usr/lib/google-cloud-sdk
           sudo rm -rf /usr/share/google-cloud-sdk
           sudo rm -rf /usr/local/share/powershell
@@ -73,6 +75,9 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/go
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf /usr/local/lib/node_modules
+          # Snap packages
+          sudo snap remove lxd 2>/dev/null || true
+          sudo rm -rf /var/cache/snapd
           # Docker images
           sudo docker image prune --all --force || true
           # apt cache

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/story.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/story.org
@@ -1,0 +1,46 @@
+:PROPERTIES:
+:ID: A85BA2F9-91EC-40A6-85AB-DC78FB152B3B
+:END:
+#+title: Story: Hotfix: CI runners run out of disk space
+#+description: The canary build exhausts disk on ubuntu-24.04; expand the free-disk-space cleanup step across all workflows and remove sccache from the site build.
+#+type: story
+#+level: s2
+#+filetags: :sprint_20:v0:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment: local1
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Prevent ubuntu-24.04 GitHub Actions runners from running out of disk during canary builds by expanding the cleanup step to cover linuxbrew, ghcup, snap, chromium, cloud CLIs, and other large pre-installed tools not needed by the build.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                   |
+| Parent sprint | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]] |
+| Now           | Closed. All acceptance criteria met.   |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-12                               |
+
+* Acceptance
+
+- Canary build completes without disk exhaustion. Free-disk-space step reclaims at least 10 GB extra. Site workflow does not restore sccache it cannot use.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:C1E2FBB2-73CB-4F90-B802-0BBBA85F95DE][Scaffold story: Hotfix: CI runners run out of disk space]] | DONE | 2026-06-12 | 2026-06-12 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:CCCFFD7A-71CB-4B3F-B3BB-09EC83E35E7A][Implement Hotfix: CI runners run out of disk space]] | DONE | 2026-06-12 | 2026-06-12 | Initial task for: Hotfix: CI runners run out of disk space |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: CCCFFD7A-71CB-4B3F-B3BB-09EC83E35E7A
+:END:
+#+title: Task: Implement Hotfix: CI runners run out of disk space
+#+description: Initial task for: Hotfix: CI runners run out of disk space
+#+type: task
+#+level: s1
+#+filetags: :hotfix_ci_disk_space:sprint_20:v0:
+#+owner: marco
+#+branch: feature/implement-hotfix-ci-disk-space
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A85BA2F9-91EC-40A6-85AB-DC78FB152B3B][Hotfix: CI runners run out of disk space]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Prevent ubuntu-24.04 GitHub Actions runners from running out of disk during canary builds by expanding the cleanup step to cover linuxbrew, ghcup, snap, chromium, cloud CLIs, and other large pre-installed tools not needed by the build.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:A85BA2F9-91EC-40A6-85AB-DC78FB152B3B][Hotfix: CI runners run out of disk space]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-12                               |
+
+* Acceptance
+
+- Canary build completes without disk exhaustion. Free-disk-space step reclaims at least 10 GB extra. Site workflow does not restore sccache it cannot use.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Expanded the "Free disk space" step in all three C++ build workflows
+(=canary-linux.yml=, =continuous-linux.yml=, =site-cdash.yml=) to also remove:
+linuxbrew, ghcup, miniconda, Azure/GCloud CLIs, PowerShell, Chromium/Chrome
+browser bundles, and node_modules.  Added =sudo apt-get clean= to each step.
+
+Also removed the sccache restore/warm-up steps from =site-cdash.yml= — the site
+build runs =emacs= and does not compile C++, so a 2 GB sccache restore was pure
+waste.  Removed the now-unused =SCCACHE_DIR= env var from that file.

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
@@ -8,7 +8,7 @@
 #+filetags: :hotfix_ci_disk_space:sprint_20:v0:
 #+owner: marco
 #+branch: feature/implement-hotfix-ci-disk-space
-#+pr:
+#+pr: 1271
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1271][#1271]] | [ci] Hotfix: expand disk cleanup and drop sccache from site build |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
@@ -59,10 +59,11 @@ plan itself stays — it is the historical record of what we did.)
 
 * Result
 
-Expanded the "Free disk space" step in all three C++ build workflows
-(=canary-linux.yml=, =continuous-linux.yml=, =site-cdash.yml=) to also remove:
-linuxbrew, ghcup, miniconda, Azure/GCloud CLIs, PowerShell, Chromium/Chrome
-browser bundles, and node_modules.  Added =sudo apt-get clean= to each step.
+Expanded the "Free disk space" step in all four C++ build workflows
+(=canary-linux.yml=, =continuous-linux.yml=, =nightly-linux.yml=, =site-cdash.yml=)
+to also remove: linuxbrew, ghcup, miniconda/miniconda3, Azure/GCloud CLIs
+(including =/opt/pipx/venvs/azure-cli=), PowerShell, Chromium/Chrome browser
+bundles, node_modules, snap/lxd, and snapd cache.  Added =sudo apt-get clean=.
 
 Also removed the sccache restore/warm-up steps from =site-cdash.yml= — the site
 build runs =emacs= and does not compile C++, so a 2 GB sccache restore was pure

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.org
@@ -55,7 +55,8 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| #4686354781 | nightly-linux.yml not updated; snap mention in docs vs code | workflows | Accept | Fixed in 387371d69: nightly updated, snap added |
+| #4686355288 | /usr/share/miniconda3 symlink; /opt/pipx/venvs/azure-cli; snap absent; composite action refactor | workflows | Accept most; decline composite action | miniconda3, pipx, snap fixed; refactor deferred |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_scaffold_hotfix_ci_disk_space.org
+++ b/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_scaffold_hotfix_ci_disk_space.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: C1E2FBB2-73CB-4F90-B802-0BBBA85F95DE
+:END:
+#+title: Task: Scaffold story: Hotfix: CI runners run out of disk space
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :hotfix_ci_disk_space:sprint_20:v0:
+#+owner: marco
+#+branch: feature/hotfix-ci-disk-space
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A85BA2F9-91EC-40A6-85AB-DC78FB152B3B][Hotfix: CI runners run out of disk space]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:A85BA2F9-91EC-40A6-85AB-DC78FB152B3B][Hotfix: CI runners run out of disk space]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-12                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -198,6 +198,7 @@ Public-facing documentation site improvements: navigation, UX, and new pages.
 | [[id:A87B7D14-2CB9-47E0-A8EA-1FDCF485860B][Hotfix: ores.shell tests fail to link on Windows]] | DONE | 2026-06-07 | 2026-06-07 | New command_args/command_feedback/script_runner symbols lack ORES_SHELL_EXPORT; Windows test exe cannot link against the DLL. |
 | [[id:E9CC8354-318C-4B08-B307-25910F536F2E][Hotfix: shell bundles gcc build]] | DONE | 2026-06-06 | 2026-06-06 | linux-gcc-debug-ninja red: four shell command files built std::string from std::vector<std::byte> iterators; converted to ores::nats::as_string_view. PR [[https://github.com/OreStudio/OreStudio/pull/1133][#1133]]. |
 | [[id:9246285C-5ACC-43F8-8F9C-ED086273F51D][Accumulate a tagged face dataset for profile pictures]] | BACKLOG | | | Build the external/facestudio/ seed catalog: move the 60 downloaded AI faces, add manifest/methodology metadata, document the FaceStudio licence, fix the accumulation script (age filter 20–70, 429 handling, multiple images per combination, correct output path), and wire into the seeder. |
+| [[id:A85BA2F9-91EC-40A6-85AB-DC78FB152B3B][Hotfix: CI runners run out of disk space]] | DONE | 2026-06-12 | 2026-06-12 | The canary build exhausts disk on ubuntu-24.04; expand the free-disk-space cleanup step across all workflows and remove sccache from the site build. |
 
 * Achievements
 


### PR DESCRIPTION
## Summary

The canary build exhausted disk on ubuntu-24.04 (run 27358907457). The existing free-disk-space step was missing several large pre-installed tools. Site build was also restoring a 2 GB sccache it never uses (no C++ compilation).

## Changes

- Expand free-disk-space in canary-linux.yml, continuous-linux.yml, site-cdash.yml: add linuxbrew, ghcup, miniconda, Azure/GCloud CLIs, PowerShell, Chromium, node_modules, apt-get clean
- Remove sccache restore and ccache-action from site-cdash.yml (site build never compiles C++)
- Remove now-unused SCCACHE_DIR env var from site-cdash.yml

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: CI runners run out of disk space](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/story.html) | A85BA2F9-91EC-40A6-85AB-DC78FB152B3B |
| Task | [Implement Hotfix: CI runners run out of disk space](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/hotfix_ci_disk_space/task_implement_hotfix_ci_disk_space.html) | CCCFFD7A-71CB-4B3F-B3BB-09EC83E35E7A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)