### PR TITLE
[agile] Capture: manual shell intro and line wrap

### DIFF
--- a/doc/agile/product_backlog/inbox/manual_long_line_wrap.org
+++ b/doc/agile/product_backlog/inbox/manual_long_line_wrap.org
@@ -1,0 +1,38 @@
+:PROPERTIES:
+:ID: 0983A789-E6A9-4739-8A86-F64986C1ACB2
+:END:
+#+title: Handle long lines in manual with line wrapping
+#+description: The manual does not handle long lines gracefully; long content overflows without wrapping, hurting readability.
+#+type: capture
+#+level: cross
+#+filetags: :manual:documentation:formatting:css:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Add line-wrapping support to the manual so that long lines — command
+examples, file paths, log output — do not overflow their container.
+Options include CSS =overflow-wrap: break-word= / =word-break: break-all=
+on =pre= / =code= blocks, or a scroll-box with horizontal scroll for
+content where wrapping would harm readability (e.g. one-liner shell
+commands). The right choice may differ per block type; the fix should
+cover at least the common cases surfaced in the shell provisioning
+chapter.
+
+* Why
+
+Long unbroken lines currently overflow the page layout on narrow
+viewports and make copy-pasting unreliable. This is particularly
+visible in chapters with shell commands and file paths.
+
+* References
+
+- Related chapter: =doc/manual/provisioning_from_the_shell/=
+- Manual stylesheet: =projects/ores.site/= (wherever manual CSS lives)
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/manual_long_line_wrap.org
+++ b/doc/agile/product_backlog/inbox/manual_long_line_wrap.org
@@ -15,12 +15,12 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbo
 
 Add line-wrapping support to the manual so that long lines — command
 examples, file paths, log output — do not overflow their container.
-Options include CSS =overflow-wrap: break-word= / =word-break: break-all=
-on =pre= / =code= blocks, or a scroll-box with horizontal scroll for
-content where wrapping would harm readability (e.g. one-liner shell
-commands). The right choice may differ per block type; the fix should
-cover at least the common cases surfaced in the shell provisioning
-chapter.
+Preferred approach: apply =overflow-wrap: break-word= on =pre= / =code=
+blocks in =assets/style.css= as the baseline; use a horizontal
+scroll-box only for content where wrapping would harm readability (e.g.
+one-liner commands where a mid-word break is worse than scrolling). The
+fix should cover at least the common cases surfaced in the shell
+provisioning chapter.
 
 * Why
 
@@ -31,8 +31,8 @@ visible in chapters with shell commands and file paths.
 * References
 
 - Related chapter: =doc/manual/provisioning_from_the_shell/=
-- Manual stylesheet: =projects/ores.site/= (wherever manual CSS lives)
+- Stylesheet: =assets/style.css=
 
 * See also
 
--
+- [[id:8797AF0E-EAD1-40F2-AA76-EF38BAC0A240][Add shell introduction to Provisioning from the Shell chapter]]

--- a/doc/agile/product_backlog/inbox/shell_chapter_missing_shell_intro.org
+++ b/doc/agile/product_backlog/inbox/shell_chapter_missing_shell_intro.org
@@ -1,0 +1,37 @@
+:PROPERTIES:
+:ID: 8797AF0E-EAD1-40F2-AA76-EF38BAC0A240
+:END:
+#+title: Add shell introduction to Provisioning from the Shell chapter
+#+description: The manual chapter 'Provisioning from the Shell' dives straight into commands without first introducing the shell itself.
+#+type: capture
+#+level: cross
+#+filetags: :manual:documentation:shell:ux:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Add a brief introductory section to the "Provisioning from the Shell"
+manual chapter before the first command block. The intro should cover
+what the ORE Studio shell is, how to open it, and any prerequisites
+(e.g. services running, environment loaded). A short paragraph and
+perhaps a screenshot of the shell prompt is sufficient — the goal is
+that a first-time reader knows where they are before commands start
+appearing.
+
+* Why
+
+Readers arriving at the chapter cold have no context for what "the
+shell" is in the ORE Studio sense. Without an intro they must infer it
+from the commands themselves, which increases confusion and reduces the
+chapter's value as onboarding material.
+
+* References
+
+- Manual chapter: =doc/manual/provisioning_from_the_shell/=
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/shell_chapter_missing_shell_intro.org
+++ b/doc/agile/product_backlog/inbox/shell_chapter_missing_shell_intro.org
@@ -34,4 +34,4 @@ chapter's value as onboarding material.
 
 * See also
 
--
+- [[id:0983A789-E6A9-4739-8A86-F64986C1ACB2][Handle long lines in manual with line wrapping]]


### PR DESCRIPTION
## Summary

Two inbox captures for the user manual.

## Changes

- **Add shell introduction to Provisioning from the Shell chapter** — the chapter currently dives straight into commands; add an intro covering what the ORE Studio shell is, how to open it, and prerequisites.
- **Handle long lines in manual with line wrapping** — long commands and file paths overflow the page layout; add CSS `overflow-wrap` / scroll-box treatment.

## Test plan

- [ ] Verify both capture files are present in `doc/agile/product_backlog/inbox/`
- [ ] Confirm frontmatter, `* What`, `* Why`, and `* References` sections are filled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)