### PR TITLE
[build] Fix readme badges: Sprint-21 label and broken PRs badge

### DIFF
--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.org
@@ -1,0 +1,47 @@
+:PROPERTIES:
+:ID: 5422B06E-927F-4342-BCA0-45FCE55EBCC5
+:END:
+#+title: Story: Fix readme badges
+#+description: Fix broken dynamic PRs badge and stale Sprint badge in readme.org.
+#+type: story
+#+level: s2
+#+filetags: :v0:sprint_21:site:fix_readme_badges:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+readme.org badges are correct: Sprint badge shows the current sprint, PRs
+badge does not show a shields.io error.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                 |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Nothing.                               |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-12                               |
+
+* Acceptance
+
+- Sprint badge: "Sprint-21" label, href to sprint_21/sprint.html.
+- PRs badge: static (not dynamic JSON), no error state.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:8BF0068E-C00F-4764-809D-944714667B5F][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic badge; fix stale Sprint badge; update recipe. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 8BF0068E-C00F-4764-809D-944714667B5F
+:END:
+#+title: Task: Fix readme badges
+#+description: Fix broken dynamic PRs badge and stale Sprint badge.
+#+type: task
+#+level: s1
+#+filetags: :v0:sprint_21:site:fix_readme_badges:
+#+owner: marco
+#+branch: hotfix/fix-readme-badges
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix the broken "PRs since v0.0.20" badge (shields.io rejects the dynamic
+JSON url= parameter for GitHub Search API URLs) and the stale Sprint badge
+(was Sprint-20, should be Sprint-21). Update the version bump recipe to
+document both the static badge pattern and the sprint badge step.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                 |
+| Parent story | [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-12                               |
+
+* Acceptance
+
+- Sprint badge shows "Sprint-21" and links to sprint_21/sprint.html.
+- PRs badge shows "PRs since v0.0.20 | GitHub search" (static) and links to the GitHub PR search.
+- Version bump recipe documents: sprint badge update, static PRs badge format, commits-since badge, screenshot update.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -8,7 +8,7 @@
 #+filetags: :v0:sprint_21:site:fix_readme_badges:
 #+owner: marco
 #+branch: hotfix/fix-readme-badges
-#+pr:
+#+pr: 1276
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -54,7 +54,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1276][#1276]] | [build] Fix readme badges: Sprint-21 label and broken PRs badge |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -112,6 +112,13 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 |-------+-------+-------+-----+-------------|
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. |
 
+** Hotfixes
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic PRs badge; fix stale Sprint-20 → Sprint-21 badge. |
+
 * Achievements
 
 Milestones worth capturing as they happen, so the release notes at

--- a/doc/recipes/cmake/how_do_i_bump_the_project_version.org
+++ b/doc/recipes/cmake/how_do_i_bump_the_project_version.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :cmake:build:release:version:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-12
 
 The version bump is housekeeping that always accompanies [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]]. Land it as a separate commit on the same sprint-open PR.
 
@@ -46,14 +46,36 @@ Five files carry the version string. Edit them as a single commit.
 
    Each is a single =sed=-able substitution.
 
-5. /=readme.org=/ — three things:
+5. /=readme.org=/ — four things:
 
-   - The sprint-number badge URL and label.
-   - The "commits-since" badge, which uses the /previous/
-     version tag — so when bumping from =0.0.<OLD>= to
-     =0.0.<NEW>=, the commits-since badge moves from
-     =v0.0.<OLD-1>= to =v0.0.<OLD>=.
-   - The example version mentioned in the documentation prose.
+   a. The *sprint badge* (line 25): update both the =Sprint-<N>= label
+      and the href link =sprint_<N>/sprint.html= to the new sprint
+      number:
+
+      #+begin_src diff
+      -<a href="...sprint_<OLD>/sprint.html"><img ... src=".../Sprint-<OLD>-blue.svg"/></a>
+      +<a href="...sprint_<NEW>/sprint.html"><img ... src=".../Sprint-<NEW>-blue.svg"/></a>
+      #+end_src
+
+   b. The *"PRs since"* static badge (line 43): update the label and
+      the href's merged date filter to the new sprint start date.
+      Use a static badge (=img.shields.io/badge/PRs%20since%20v0.0.<NEW>-GitHub%20search-blue=);
+      do *not* use =badge/dynamic/json= with a GitHub Search API URL —
+      shields.io rejects the =url= parameter when the inner URL
+      contains query-string syntax:
+
+      #+begin_src diff
+      -<a href="...merged%3A%3E%3D<OLD-DATE>"><img alt="PRs since v0.0.<OLD>" src="...badge/PRs%20since%20v0.0.<OLD>-GitHub%20search-blue"/></a>
+      +<a href="...merged%3A%3E%3D<NEW-DATE>"><img alt="PRs since v0.0.<NEW>" src="...badge/PRs%20since%20v0.0.<NEW>-GitHub%20search-blue"/></a>
+      #+end_src
+
+   c. The *"commits-since"* badge, which uses the /previous/
+      version tag — so when bumping from =0.0.<OLD>= to
+      =0.0.<NEW>=, the commits-since badge moves from
+      =v0.0.<OLD-1>= to =v0.0.<OLD>=.
+
+   d. The *screenshot asset* reference: if a new =assets/images/ore_studio-v0.0.<NEW>.png=
+      screenshot exists, update the prose reference to point to it.
 
 6. /Verify/. Sanity-check that nothing else mentions the old
    version:

--- a/readme.org
+++ b/readme.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :readme:
 #+created: 2024-06-15
-#+updated: 2026-05-21
+#+updated: 2026-06-12
 #+options: title:nil <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
 #+startup: inlineimages
 

--- a/readme.org
+++ b/readme.org
@@ -22,7 +22,7 @@
 #+html: <a href="https://visualstudio.microsoft.com/vs/whatsnew/"><img alt="MSVC Version" src="https://img.shields.io/badge/MSVC-2022-blue.svg"/></a>
 #+html: <a href="https://doc.qt.io/qt-6/"><img alt="Qt6" src="https://img.shields.io/badge/Qt-6-blue"/></a>
 #+html: <a href="https://orestudio.github.io/OreStudio/doxygen/html/index.html"><img alt="Doxygen" src="https://raw.githubusercontent.com/OreStudio/OreStudio/main/assets/images/doxygen_badge.svg"/></a>
-#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_20/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-20-blue.svg"/></a>
+#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-21-blue.svg"/></a>
 #+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://img.shields.io/static/v1?logo=gnuemacs&logoColor=fafafa&label=Made%20with&message=GNU%20Emacs&color=7F5AB6&style=flat"/></a>
 #+html: <a href="https://discord.gg/ztAaxmsnUJ"><img alt="Discord" src="https://img.shields.io/discord/1254062142626332732?color=5865F2&amp;logo=discord&amp;logoColor=white"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/pulse"><img alt="Commit Activity" src="https://img.shields.io/github/commit-activity/m/OreStudio/OreStudio"/></a>
@@ -40,7 +40,7 @@
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml"><img alt="Continuous Windows" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml"><img alt="Continuous MacOS.yml" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml"><img alt="Nightly Linux" src="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml/badge.svg"/></a>
-#+html: <a href="https://github.com/OreStudio/OreStudio/pulls?q=is%3Apr+is%3Amerged+merged%3A%3E%3D2026-06-12"><img alt="PRs since v0.0.20" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Drepo%3AOreStudio%2FOreStudio%2Bis%3Apr%2Bis%3Amerged%2Bmerged%3A%3E%3D2026-06-12&query=%24.total_count&label=PRs%20since%20v0.0.20&color=blue"/></a>
+#+html: <a href="https://github.com/OreStudio/OreStudio/pulls?q=is%3Apr+is%3Amerged+merged%3A%3E%3D2026-06-12"><img alt="PRs since v0.0.20" src="https://img.shields.io/badge/PRs%20since%20v0.0.20-GitHub%20search-blue"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/commits/main"><img alt="Commits" src= "https://img.shields.io/github/commits-since/OreStudio/OreStudio/v0.0.20.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/OreStudio/OreStudio/total.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Releases" src="https://img.shields.io/github/release/OreStudio/OreStudio.svg"/></a>


### PR DESCRIPTION
## Summary

Fix two badge bugs in readme.org: Sprint badge was stale (Sprint-20 instead of Sprint-21), and the dynamic PRs badge showed 'invalid query parameter: url' because shields.io rejects badge/dynamic/json with GitHub Search API URLs.

## Changes

- Sprint badge updated to Sprint-21 with correct sprint_21 link; broken dynamic badge replaced with static badge linking to GitHub PR search; version bump recipe updated with correct badge steps (sprint badge, static PRs badge, screenshot).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.html) | 5422B06E-927F-4342-BCA0-45FCE55EBCC5 |
| Task | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.html) | 8BF0068E-C00F-4764-809D-944714667B5F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)