### PR TITLE
doc: add next-sprint org-roam links to sprints 18–20

### DIFF
--- a/doc/agile/product_backlog/inbox/illustrative_org_links_break_site_build.org
+++ b/doc/agile/product_backlog/inbox/illustrative_org_links_break_site_build.org
@@ -1,0 +1,42 @@
+:PROPERTIES:
+:ID: C6350BAD-5E4E-443B-9CA3-496A3B84B699
+:END:
+#+title: Illustrative org-roam links in doc bodies break the site build
+#+description: Using bare [[id:...][label]] syntax as illustrative examples in org document bodies causes the site builder to attempt resolution, failing with 'Unable to resolve link' when the ID is not real.
+#+type: capture
+#+level: cross
+#+filetags: :documentation:org_roam:ci:site_build:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+When a document uses =[[id:...][label]]= or similar placeholder syntax as an
+illustrative example in prose, the org-roam site builder treats it as a real
+link and tries to resolve the ID. If the ID is not real (e.g. =id:...= or
+=id:UUID=) the build fails with =Unable to resolve link: "..."=. The safe
+workaround is to wrap any illustrative link syntax in a code span (=...=) so
+org-mode treats it as verbatim text rather than a link. A harder fix would be
+to update the site-build configuration or the org export pipeline to tolerate
+unresolvable links with a warning rather than an error; or to add a lint check
+that catches bare placeholder IDs before they reach CI.
+
+* Why
+
+This pattern caused a CI failure in PR #1277: the task Goal section used
+=[[id:...][Sprint NN]]= as an example to describe the link format being added,
+which broke the site build. The error is non-obvious — the doc looks correct in
+Emacs, the problem only surfaces during the Emacs batch export on CI. Any doc
+that explains org-roam link conventions (runbooks, recipes, task docs) is
+vulnerable to the same mistake.
+
+* References
+
+- PR #1277 — first instance of this failure: =task_add_next_sprint_links.org= Goal section.
+- The site build error message: =Build failed: Unable to resolve link: "..."=.
+
+* See also
+
+- [[id:E767A313-2E08-4682-8586-39138529385C][Agile Add Capture]] — the skill whose illustrative link syntax in the runbook could trigger the same issue.

--- a/doc/agile/product_backlog/inbox/product_identity_define_vision_concept.org
+++ b/doc/agile/product_backlog/inbox/product_identity_define_vision_concept.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: 8D521BEC-8E5A-4D3B-90A9-C79D58EB062F
+:END:
+#+title: Define what a product vision is before stating ORE Studio's
+#+description: The Vision section of product_identity.org goes straight to ORE Studio's specific vision statement without first explaining what a product vision is in general. Add a brief conceptual definition — probably sourced from the MASD methodology doc — before the project-specific content.
+#+type: capture
+#+level: cross
+#+filetags: :documentation:identity:agile:knowledge_graph:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+The =* Vision= section of =doc/identity/product_identity.org= opens
+directly with ORE Studio's specific vision statement, with no preamble
+explaining what a /product vision/ is as a concept. A short introductory
+paragraph — defining what a product vision is, why projects have one, and
+what role it plays in deciding what goes into the backlog — should precede
+the project-specific content. The MASD methodology document
+(https://mcraveiro.github.io/dogen/docs/the_masd_methodology.html) covers
+vision and mission as first-class concepts; the relevant text should be
+reviewed and, where appropriate, adapted or quoted directly so we are not
+reinventing the wheel.
+
+* Why
+
+Readers unfamiliar with the term encounter the heading =* Vision= and
+then immediately the ORE Studio statement, with no explanation of what
+that heading means or why it exists. Adding a brief conceptual definition
+makes the document self-contained, consistent with the Zettelkasten
+principle that each node should make sense in isolation, and aligned with
+how the MASD methodology treats these concepts.
+
+* References
+
+- =doc/identity/product_identity.org= — the file to update, specifically the =* Vision= section (line 25 onwards).
+- https://mcraveiro.github.io/dogen/docs/the_masd_methodology.html — MASD methodology doc covering vision/mission; check for reusable text.
+
+* See also
+
+- [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][Product Identity]] — the document to be updated.
+- [[id:2C35C57A-147A-40EB-86CE-A5815B214662][Document type: product_identity]] — contract for the product_identity doc type.

--- a/doc/agile/product_backlog/inbox/product_identity_define_vision_concept.org
+++ b/doc/agile/product_backlog/inbox/product_identity_define_vision_concept.org
@@ -37,6 +37,7 @@ how the MASD methodology treats these concepts.
 
 - =doc/identity/product_identity.org= — the file to update, specifically the =* Vision= section (line 25 onwards).
 - https://mcraveiro.github.io/dogen/docs/the_masd_methodology.html — MASD methodology doc covering vision/mission; check for reusable text.
+- Stallworth Williams, Linda (2008). /The mission statement: A corporate reporting tool with a past, present, and future/. Sage Publications, Los Angeles, CA.
 
 * See also
 

--- a/doc/agile/product_backlog/inbox/rename_or_split_glossary.org
+++ b/doc/agile/product_backlog/inbox/rename_or_split_glossary.org
@@ -1,0 +1,41 @@
+:PROPERTIES:
+:ID: 1518B7E1-582F-45DC-B2BA-EC6BD0BE74D4
+:END:
+#+title: Rename or split the project glossary
+#+description: The current glossary is really an agile glossary. A single project-wide glossary mixing agile, domain, and tooling terms would be confusing. Options: (1) rename it to 'Agile glossary'; (2) more in keeping with Zettelkasten, split it into separate focused documents — one per domain (agile, finance/ORE, tooling, etc.) — so each term lives in its natural context and is linked from relevant pages.
+#+type: capture
+#+level: cross
+#+filetags: :documentation:knowledge_graph:glossary:zettelkasten:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+The current =doc/meta/glossary.org= is in practice an agile glossary: it defines
+sprint, story, task, capture, and similar agile process terms. It does not cover
+finance/ORE domain concepts or tooling terms, yet it is presented as the
+project-wide glossary. The preferred fix — more in keeping with the Zettelkasten
+approach already used across the doc graph — is to split it: rename the existing
+file to =agile_glossary.org= (or retitle it "Agile Glossary") and, as domain and
+tooling knowledge grows, introduce focused companion documents (e.g. a finance /
+ORE domain glossary, a tooling glossary). Each term then lives in its natural
+context and is linked directly from the pages that use it, rather than all terms
+being lumped into one mixed-domain document.
+
+* Why
+
+A single project-wide glossary that mixes agile, finance/ORE, and tooling
+terminology is confusing: readers have to hunt through unrelated terms, and the
+implied promise that "everything is here" is never fulfilled. Zettelkasten
+practice calls for focused, single-topic documents linked by context — the same
+principle the rest of the doc graph already follows.
+
+* References
+
+- =doc/meta/glossary.org= — the current file to be renamed / split.
+
+* See also
+
+- [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — the document this capture proposes to rename or replace.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -38,7 +38,7 @@ Enable end-to-end [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] imports into 
 | End (actual)   | 2026-05-29                                                |
 | Now            | Sprint closed.                                            |
 | Waiting on     | —                                                         |
-| Next           | Open sprint 19.                                           |
+| Next           | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                 |
 | Release Notes  | Added at end of sprint.                                   |
 | Last touched   | 2026-05-29                                                |
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -28,7 +28,7 @@ Verify all entity functionality post-NATS migration, document entities in the ma
 | End            | 2026-06-06                                                             |
 | Now            | Nothing.                                                               |
 | Waiting on     | Nothing.                                                               |
-| Next           | Sprint 20: commission the refdata entities; codegen tidy-up.           |
+| Next           | [[id:D366207F-9E8D-46A2-A7DC-6808DC7FBF31][Sprint 20]]                                                              |
 | Release Notes  | [[id:E5937E51-772F-4D66-BB1E-67F10828AA11][Sprint 19 release notes]]                                               |
 | Last touched   | 2026-06-06                                                             |
 

--- a/doc/agile/versions/v0/sprint_20/sprint.org
+++ b/doc/agile/versions/v0/sprint_20/sprint.org
@@ -33,7 +33,7 @@ green.
 | End (actual)   | 2026-06-12                             |
 | Now            | Nothing.                               |
 | Waiting on     | Nothing.                               |
-| Next           | Nothing.                               |
+| Next           | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]                              |
 | Release Notes  | [[id:9C7B74E0-B7B2-441F-BDCA-ED52215A66CF][Sprint 20 Release Notes]]                |
 | Last touched   | 2026-06-12                               |
 

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
@@ -42,7 +42,7 @@ or the bucket empties.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:3D5BE6CE-5512-4C7A-8FFC-52D7CC6B7921][Add next-sprint org-roam links to all sprint docs]] | BACKLOG | | | Add a 'Next sprint' org-roam link (pointing to the following sprint's sprint.org) to every sprint document except the last one, so sprints are navigable as a chain in the knowledge graph. |
+| [[id:3D5BE6CE-5512-4C7A-8FFC-52D7CC6B7921][Add next-sprint org-roam links to all sprint docs]] | DONE | 2026-06-12 | 2026-06-12 | Add a 'Next sprint' org-roam link (pointing to the following sprint's sprint.org) to every sprint document except the last one, so sprints are navigable as a chain in the knowledge graph. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
@@ -28,9 +28,9 @@ or the bucket empties.
 |---------------+----------------------------------------|
 | State         | BACKLOG                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Not yet started.                       |
+| Now           | First task done: next-sprint links added to sprints 18-20.                       |
 | Waiting on    | Nothing.                               |
-| Next          | Start task: add next-sprint links.     |
+| Next          | Add tasks as issues are found.     |
 | Last touched  | 2026-06-12                               |
 
 * Acceptance
@@ -48,4 +48,4 @@ or the bucket empties.
 
 * Out of scope
 
--
+(Open ongoing bucket — no fixed exclusions.)

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/story.org
@@ -1,0 +1,51 @@
+:PROPERTIES:
+:ID: 91EF5D59-3313-4D63-99E8-AED6B3FADF90
+:END:
+#+title: Story: Knowledge graph housekeeping
+#+description: Ongoing bucket for small documentation and knowledge-graph fixes: broken links, missing cross-references, org-roam navigation gaps, and other low-effort improvements spotted during normal work.
+#+type: story
+#+level: s2
+#+filetags: :documentation:knowledge_graph:sprint_21:v0:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Keep the org-roam knowledge graph navigable and internally consistent.
+This is an open-ended bucket: each task is a small, self-contained fix
+spotted during normal work — a missing link, a broken cross-reference,
+an org-roam navigation gap, or a stale heading. Tasks are added
+incrementally as issues are found; the story closes when the sprint ends
+or the bucket empties.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Start task: add next-sprint links.     |
+| Last touched  | 2026-06-12                               |
+
+* Acceptance
+
+- Every task added to this bucket is individually done before the story closes.
+- No new broken links or orphaned nodes are introduced by the fixes.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:3D5BE6CE-5512-4C7A-8FFC-52D7CC6B7921][Add next-sprint org-roam links to all sprint docs]] | BACKLOG | | | Add a 'Next sprint' org-roam link (pointing to the following sprint's sprint.org) to every sprint document except the last one, so sprints are navigable as a chain in the knowledge graph. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 3D5BE6CE-5512-4C7A-8FFC-52D7CC6B7921
+:END:
+#+title: Task: Add next-sprint org-roam links to all sprint docs
+#+description: Add a 'Next sprint' org-roam link (pointing to the following sprint's sprint.org) to every sprint document except the last one, so sprints are navigable as a chain in the knowledge graph.
+#+type: task
+#+level: s1
+#+filetags: :documentation:knowledge_graph:sprint_21:v0:knowledge_graph_housekeeping:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-12
+#+updated: 2026-06-12
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:91EF5D59-3313-4D63-99E8-AED6B3FADF90][Knowledge graph housekeeping]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:91EF5D59-3313-4D63-99E8-AED6B3FADF90][Knowledge graph housekeeping]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-12                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :documentation:knowledge_graph:sprint_21:v0:knowledge_graph_housekeeping:
 #+owner: marco
-#+branch:
-#+pr:
+#+branch: claude/festive-hawking-4r88qh
+#+pr: 1277
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -20,7 +20,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Add a proper org-roam [[id:...][Sprint NN]] link to the Next field in every sprint Status table except the last sprint (Sprint 21), so the sprints form a navigable forward chain in the knowledge graph.
+Add a proper org-roam =[[id:UUID][Sprint NN]]= link to the Next field in every sprint Status table except the last sprint (Sprint 21), so the sprints form a navigable forward chain in the knowledge graph.
 
 * Status
 
@@ -50,7 +50,7 @@ using the target sprint's =:ID:= property.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1277][#1277]] | doc: add next-sprint org-roam links to sprints 18-20 |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
@@ -20,7 +20,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Add a proper org-roam =[[id:UUID][Sprint NN]]= link to the Next field in every sprint Status table except the last sprint (Sprint 21), so the sprints form a navigable forward chain in the knowledge graph.
+Add an org-roam id-link to the Next field in every sprint Status table except the last one, so each sprint points forward to its successor and the full sprint sequence is navigable as a linked chain in the knowledge graph.
 
 * Status
 
@@ -41,7 +41,7 @@ Add a proper org-roam =[[id:UUID][Sprint NN]]= link to the Next field in every s
 * Plan
 
 Audited all 20 sprint docs. Found sprints 18, 19, and 20 used plain-text
-placeholders. Replaced each with the standard =[[id:UUID][Sprint NN]]= org-roam link
+placeholders. Replaced each with an org-roam id-link of the form =[[id:TARGET-UUID][Sprint NN]]=
 using the target sprint's =:ID:= property.
 
 * Notes

--- a/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
+++ b/doc/agile/versions/v0/sprint_21/knowledge_graph_housekeeping/task_add_next_sprint_links.org
@@ -20,28 +20,29 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add a proper org-roam [[id:...][Sprint NN]] link to the Next field in every sprint Status table except the last sprint (Sprint 21), so the sprints form a navigable forward chain in the knowledge graph.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:91EF5D59-3313-4D63-99E8-AED6B3FADF90][Knowledge graph housekeeping]] |
-| Now          | Not yet started.                       |
+| Now          | Done. Three sprints fixed: 18, 19, 20.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing — task complete.                  |
 | Last touched | 2026-06-12                               |
 
 * Acceptance
 
--
+- Every sprint doc from 01 to 20 has a proper org-roam link in the Next field.
+- Sprint 21 (the last) has no Next link.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Audited all 20 sprint docs. Found sprints 18, 19, and 20 used plain-text
+placeholders. Replaced each with the standard =[[id:UUID][Sprint NN]]= org-roam link
+using the target sprint's =:ID:= property.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -144,6 +144,7 @@ health review (promote to a story, move to =next=, or discard).
 |---------+------+-------------|
 | [[id:1518B7E1-582F-45DC-B2BA-EC6BD0BE74D4][Rename or split the project glossary]] | documentation, knowledge_graph | The glossary is really an agile glossary; rename it or split into focused Zettelkasten documents per domain. |
 | [[id:8D521BEC-8E5A-4D3B-90A9-C79D58EB062F][Define what a product vision is before stating ORE Studio's]] | documentation, identity | Add a brief conceptual definition of product vision to product_identity.org before the ORE Studio-specific statement; source from MASD methodology doc. |
+| [[id:C6350BAD-5E4E-443B-9CA3-496A3B84B699][Illustrative org-roam links in doc bodies break the site build]] | documentation, org_roam, ci | Bare id-link placeholder syntax in prose fails the site build; use code spans for examples; consider a lint check. |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -112,6 +112,13 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 |-------+-------+-------+-----+-------------|
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. |
 
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:91EF5D59-3313-4D63-99E8-AED6B3FADF90][Knowledge graph housekeeping]] | BACKLOG | | | Ongoing bucket for small doc and knowledge-graph fixes spotted during normal work. |
+
 ** Hotfixes
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -142,7 +142,7 @@ health review (promote to a story, move to =next=, or discard).
 #+ATTR_HTML: :class hug-leading
 | Capture | Tags | Description |
 |---------+------+-------------|
-|         |      |             |
+| [[id:1518B7E1-582F-45DC-B2BA-EC6BD0BE74D4][Rename or split the project glossary]] | documentation, knowledge_graph | The glossary is really an agile glossary; rename it or split into focused Zettelkasten documents per domain. |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -143,6 +143,7 @@ health review (promote to a story, move to =next=, or discard).
 | Capture | Tags | Description |
 |---------+------+-------------|
 | [[id:1518B7E1-582F-45DC-B2BA-EC6BD0BE74D4][Rename or split the project glossary]] | documentation, knowledge_graph | The glossary is really an agile glossary; rename it or split into focused Zettelkasten documents per domain. |
+| [[id:8D521BEC-8E5A-4D3B-90A9-C79D58EB062F][Define what a product vision is before stating ORE Studio's]] | documentation, identity | Add a brief conceptual definition of product vision to product_identity.org before the ORE Studio-specific statement; source from MASD methodology doc. |
 
 * Health Review
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Creates the **Knowledge graph housekeeping** story in sprint 21 — an open-ended bucket for small documentation and knowledge-graph fixes spotted during normal work.
- Adds the first task to that story: wire next-sprint org-roam links into all sprint docs except the last.
- Implements the task: sprints 18, 19, and 20 had plain-text placeholders in their `Next` Status field; replaces each with a proper `[[id:UUID][Sprint NN]]` org-roam link so the full sprint chain (01 → 21) is navigable in the knowledge graph. Sprints 1–17 already had correct links.
- Marks the task DONE in the story table.

## Test plan

- [ ] Open sprints 18, 19, 20 in org-roam and confirm the `Next` field is a clickable link to the following sprint.
- [ ] Confirm sprint 21 has no `Next` link (it is the current last sprint).
- [ ] Confirm org-roam-ui shows the sprint chain as connected nodes.

https://claude.ai/code/session_01FDtqh5LuuM8XNgVizUUXiH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDtqh5LuuM8XNgVizUUXiH)_