### PR TITLE
Upgrade LLVM to version 20 in Windows CI workflow

### DIFF
--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -116,7 +116,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         if: ${{ matrix.compiler == 'clang' }}
         with:
-          version: "19"
+          version: "20"
           arch: x64
 
       - name: Install NSIS


### PR DESCRIPTION
## Summary
Updates the LLVM version used in the Windows continuous integration workflow from version 19 to version 20.

## Changes
- Updated the `install-llvm-action` configuration to use LLVM version 20 instead of version 19 in the Windows CI pipeline

## Details
This change ensures that the Windows CI environment uses the latest stable LLVM version, which may include performance improvements, bug fixes, and new features available in LLVM 20.

https://claude.ai/code/session_01NufzsosVHu8ZWTRoPHmCum