### PR TITLE
[ores.shell,agile] Fix barclays tenant hostname; close fix_readme_badges task

### DIFF
--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.org
@@ -38,7 +38,7 @@ badge does not show a shields.io error.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:8BF0068E-C00F-4764-809D-944714667B5F][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic badge; fix stale Sprint badge; update recipe. |
+| [[id:8BF0068E-C00F-4764-809D-944714667B5F][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-22 | Replace broken dynamic badge; fix stale Sprint badge; update recipe. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
-#+updated: 2026-06-12
+#+updated: 2026-06-22
 #+environment: local1
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-12
 #+updated: 2026-06-12
-#+environment:
+#+environment: local1
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -31,9 +31,9 @@ document both the static badge pattern and the sprint badge step.
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] |
-| Now          | Nothing.                               |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing.                               |
+| Next         | Nothing. |
 | Last touched | 2026-06-12                               |
 
 * Acceptance
@@ -63,3 +63,6 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Fixed the broken dynamic PRs badge and stale Sprint badge in =readme.org=.
+Updated the badge URLs and version bump recipe. PR #1276 merged.

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -8,7 +8,7 @@
 #+filetags: :v0:sprint_21:site:fix_readme_badges:
 #+owner: marco
 #+branch: hotfix/fix-readme-badges
-#+pr: 1276
+#+pr: 1289
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -54,6 +54,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1289][#1289]] | [ores.shell,agile] Fix barclays tenant hostname; close fix_readme_badges task |
 | [[https://github.com/OreStudio/OreStudio/pull/1276][#1276]] | [build] Fix readme badges: Sprint-21 label and broken PRs badge |
 
 * Review

--- a/doc/recipes/shell/provisioning/barclays_system_provision.org
+++ b/doc/recipes/shell/provisioning/barclays_system_provision.org
@@ -39,14 +39,14 @@ is hard-coded to an environment.
 #+begin_src ores-shell :exports none
 connect $ORES_NATS_URL
 
-provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays --tenant-name "Barclays Plc" --tenant-hostname barclays
+provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays --tenant-name "Barclays Plc" --tenant-hostname barclays_plc
 logout
 
-login tenant_admin@barclays Secure-Password-123
+login tenant_admin@barclays_plc Secure-Password-123
 provision tenant --source gleif --root-lei 213800LBQA1Y9L22JB70
 logout
 
-login tenant_admin@barclays Secure-Password-123
+login tenant_admin@barclays_plc Secure-Password-123
 provision party "BARCLAYS PLC" --dataset-size small --reports all
 logout
 

--- a/projects/ores.shell/scripts/library/provisioning/barclays_system_provision.ores
+++ b/projects/ores.shell/scripts/library/provisioning/barclays_system_provision.ores
@@ -6,7 +6,7 @@
 #
 connect $ORES_NATS_URL
 
-provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays_plc --tenant-name "Barclays Plc" --tenant-hostname barclays_plc
+provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays --tenant-name "Barclays Plc" --tenant-hostname barclays_plc
 logout
 
 login tenant_admin@barclays_plc Secure-Password-123

--- a/projects/ores.shell/scripts/library/provisioning/barclays_system_provision.ores
+++ b/projects/ores.shell/scripts/library/provisioning/barclays_system_provision.ores
@@ -6,13 +6,13 @@
 #
 connect $ORES_NATS_URL
 
-provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays --tenant-name "Barclays Plc" --tenant-hostname barclays
+provision system super_admin Secure-Password-123 super_admin@localhost.com --tenant-admin-password Secure-Password-123 --tenant-code barclays_plc --tenant-name "Barclays Plc" --tenant-hostname barclays_plc
 logout
 
-login tenant_admin@barclays Secure-Password-123
+login tenant_admin@barclays_plc Secure-Password-123
 provision tenant --source gleif --root-lei 213800LBQA1Y9L22JB70
 logout
 
-login tenant_admin@barclays Secure-Password-123
+login tenant_admin@barclays_plc Secure-Password-123
 provision party "BARCLAYS PLC" --dataset-size small --reports all
 logout


### PR DESCRIPTION
## Summary

Two trailing items from the fix_readme_badges hotfix: fix the barclays tenant hostname from 'barclays' to 'barclays_plc' in both the recipe and provisioning script, and close out the fix_readme_badges task bookkeeping (PR #1276 was already merged).

## Changes

- Fix barclays tenant hostname to barclays_plc in provisioning recipe and .ores script
- Close fix_readme_badges task: mark DONE, write result, sync story

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.html) | 5422B06E-927F-4342-BCA0-45FCE55EBCC5 |
| Task | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.html) | 8BF0068E-C00F-4764-809D-944714667B5F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)