### PR TITLE
[agile] Close environment provisioning overhaul story

### DIFF
--- a/doc/agile/product_backlog/inbox/add_compass_story_done_command.org
+++ b/doc/agile/product_backlog/inbox/add_compass_story_done_command.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 0DFEBC29-C89D-4BDB-A9D4-8AC7559BF7BB
+:END:
+#+title: Add compass story done command
+#+description: compass task done exists but compass story done does not. Closing a story requires manually editing story.org (State, Now, Next, Last touched) and the sprint table. A compass story done command should set State DONE, stamp End date, update the sprint stories table row, and journal the close — analogue of compass task done.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-23
+#+updated: 2026-06-23
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/add_compass_story_done_command.org
+++ b/doc/agile/product_backlog/inbox/add_compass_story_done_command.org
@@ -13,15 +13,20 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbo
 
 * What
 
-(One paragraph: the idea.)
+Add a =compass story done <slug>= command that closes a story in one step: sets
+State → DONE, stamps the End date, updates the parent sprint's =* Stories= table
+row, and journals the close. Analogue of the existing =compass task done= command.
 
 * Why
 
-(Motivation, problem being solved, related context.)
+Closing a story currently requires manually editing =story.org= (State, Now, Next,
+Last touched) and the sprint table row — error-prone and easy to leave inconsistent.
+=compass task done= already automates the equivalent flow for tasks; stories deserve
+the same treatment.
 
 * References
 
--
+- [[id:31C868B9-306E-4282-BA8C-07E647021B34][Task]] — for comparison with the existing task lifecycle.
 
 * See also
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
@@ -25,12 +25,12 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 
 | Field         | Value                                                              |
 |---------------+--------------------------------------------------------------------|
-| State         | STARTED                                                            |
+| State         | DONE                                                               |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]          |
-| Now           | Design complete; implementing direct emacs commands and genesis env provisioning. |
+| Now           | All tasks complete or abandoned. Story closed.                     |
 | Waiting on    | Nothing.                                                           |
-| Next          | Add pillar-organised compass commands that invoke emacs directly.  |
-| Last touched  | 2026-06-14                                                         |
+| Next          | Nothing.                                                           |
+| Last touched  | 2026-06-23                                                         |
 
 * Acceptance
 
@@ -54,9 +54,9 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 | [[id:24CB5737-9F2D-4B42-97C9-3E10EC1FA3FE][Add ORES_ENV_TYPE property and propagate through the stack]] | DONE | 2026-06-15 | 2026-06-16 | Add an ORES_ENV_TYPE variable (e.g. development, staging, production) to the .env template. Propagate it to postgres (e.g. via set_config or role/schema naming conventions) and to ores.qt so the user can see the environment type clearly in the UI (e.g. status bar or window title). |
 | [[id:27985F41-8221-417B-8E89-3AA015D17DEC][Update bootstrap docs and add compass bearings warning for missing genesis env]] | DONE | 2026-06-16 | 2026-06-18 | Update README and any other new-machine bootstrap documentation to reflect the new provisioning model: genesis environment clone, then worktree environments via the new compass command. Add a check to 'compass bearings' that warns when the genesis environment cannot be found at the expected path, so users are alerted early on a fresh machine. |
 | [[id:FB164A88-BA47-4C6F-A1A2-DB582754AD1C][Migrate doc-build call-sites to compass --direct (retain vcpkg bypass)]] | DONE | 2026-06-18 | 2026-06-19 | Scouting reversed the original "remove the cmake vcpkg-bypass hacks" framing: the ORES_VCPKG_ENABLED bypass and linux-doc-only preset are load-bearing (they keep the CDash site build vcpkg-free and let cmake-only doc targets build in light environments). Instead, migrate every doc/agile call-site that has a compass equivalent (compass build --direct, compass sprint charts) off raw cmake, making the light-env path the default; keep cmake behind the bypass only for doc targets with no compass equivalent and for the CDash submission. |
-| [[id:E463343A-12A7-4BAF-9FCD-FEE52F583721][Investigate sharing vcpkg installed packages across environments]] | BACKLOG | | | Determine whether the per-checkout vcpkg_installed/ directory can be shared across full worktrees to reduce disk usage. The binary archive cache (~/.cache/vcpkg/archives) is already machine-global. Investigate using --x-install-root or symlinks to point all full envs at the genesis checkout's vcpkg_installed/, and assess risks (concurrent builds, branch version divergence). |
-| [[id:A2221F16-D2CC-4483-A53D-01813D0C0C9A][Integrate install_debian_packages.sh into compass env configure]] | STARTED | 2026-06-19 | | Wire the Debian package install script into compass env configure so environment provisioning is a single command. Depends on the genesis env / worktree provisioning command task. |
-| [[id:F5698935-A1BD-4B00-8725-7545315E92EE][Spike: investigate and implement compass story done and task done commands]] | BACKLOG | | | Compass has no story done or task done subcommands — closing a story requires manually editing story.org and the sprint table. Investigate what state transitions are needed, what side-effects should fire (journal stamp, sprint table update, PR linkage), and implement the missing commands. |
+| [[id:E463343A-12A7-4BAF-9FCD-FEE52F583721][Investigate sharing vcpkg installed packages across environments]] | ABANDONED | | | Determine whether the per-checkout vcpkg_installed/ directory can be shared across full worktrees to reduce disk usage. The binary archive cache (~/.cache/vcpkg/archives) is already machine-global. Investigate using --x-install-root or symlinks to point all full envs at the genesis checkout's vcpkg_installed/, and assess risks (concurrent builds, branch version divergence). |
+| [[id:A2221F16-D2CC-4483-A53D-01813D0C0C9A][Integrate install_debian_packages.sh into compass env configure]] | DONE | 2026-06-19 | 2026-06-23 | Wire the Debian package install script into compass env configure so environment provisioning is a single command. Depends on the genesis env / worktree provisioning command task. |
+| [[id:F5698935-A1BD-4B00-8725-7545315E92EE][Spike: investigate and implement compass story done and task done commands]] | ABANDONED | | | Compass has no story done or task done subcommands — closing a story requires manually editing story.org and the sprint table. Investigate what state transitions are needed, what side-effects should fire (journal stamp, sprint table update, PR linkage), and implement the missing commands. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_integrate_install_packages_into_compass_env.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_integrate_install_packages_into_compass_env.org
@@ -31,7 +31,7 @@ Allow =compass env configure= (and =compass env create=) to invoke =install_debi
 | Now          | Nothing. |
 | Waiting on   | [[id:93813CFA-BDCC-409A-B49E-638F8B224793][Implement genesis env concept and worktree provisioning command]] |
 | Next         | Nothing. |
-| Last touched | 2026-06-14                                                                                           |
+| Last touched | 2026-06-23                                                                                           |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_integrate_install_packages_into_compass_env.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_integrate_install_packages_into_compass_env.org
@@ -26,11 +26,11 @@ Allow =compass env configure= (and =compass env create=) to invoke =install_debi
 
 | Field        | Value                                                                                                |
 |--------------+------------------------------------------------------------------------------------------------------|
-| State        | STARTED                                                                                              |
+| State        | DONE                                                                                              |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul]]                    |
-| Now          | Not yet started.                                                                                     |
+| Now          | Nothing. |
 | Waiting on   | [[id:93813CFA-BDCC-409A-B49E-638F8B224793][Implement genesis env concept and worktree provisioning command]] |
-| Next         | Begin implementation once the genesis env / worktree provisioning command exists.                    |
+| Next         | Nothing. |
 | Last touched | 2026-06-14                                                                                           |
 
 * Acceptance
@@ -63,3 +63,8 @@ Allow =compass env configure= (and =compass env create=) to invoke =install_debi
 | 6 | clean/autoremove exit codes silently ignored | env_packages.py | Declined — intentional | Review 3; best-effort cleanup, non-fatal by design |
 
 * Result
+
+Added =compass env install-packages= command and wired it into =compass env configure=
+so Debian package installation is a single step. Ported =install_debian_packages.sh=
+logic into =env_packages.py=; removed the legacy script; updated CI workflows.
+PR #1286 merged.

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_investigate_vcpkg_build_sharing.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_investigate_vcpkg_build_sharing.org
@@ -26,7 +26,7 @@ Determine whether vcpkg_installed/ can be safely shared across worktrees and doc
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                            |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_investigate_vcpkg_build_sharing.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_investigate_vcpkg_build_sharing.org
@@ -30,8 +30,8 @@ Determine whether vcpkg_installed/ can be safely shared across worktrees and doc
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-14                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-23                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_spike_compass_story_done.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_spike_compass_story_done.org
@@ -30,8 +30,8 @@ Understand what compass task done and compass story done should do and implement
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-15                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-06-23                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_spike_compass_story_done.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_spike_compass_story_done.org
@@ -26,7 +26,7 @@ Understand what compass task done and compass story done should do and implement
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                            |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
+++ b/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.org
@@ -8,7 +8,7 @@
 #+filetags: :v0:sprint_21:site:fix_readme_badges:
 #+owner: marco
 #+branch: hotfix/fix-readme-badges
-#+pr: 1289
+#+pr: 1290
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-12
@@ -54,6 +54,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1290][#1290]] | [agile] Close environment provisioning overhaul story |
 | [[https://github.com/OreStudio/OreStudio/pull/1289][#1289]] | [ores.shell,agile] Fix barclays tenant hostname; close fix_readme_badges task |
 | [[https://github.com/OreStudio/OreStudio/pull/1276][#1276]] | [build] Fix readme badges: Sprint-21 label and broken PRs badge |
 


### PR DESCRIPTION
## Summary

Close out the environment provisioning overhaul story (FFD4CA8C): mark the integrate-install-packages task DONE (PR #1286 already merged), abandon two never-started backlog tasks (vcpkg sharing investigation, compass-story-done spike), close the story, and file a product backlog capture for compass story done.

## Changes

- Close task A2221F16 (integrate install packages into compass env): mark DONE, write result
- Abandon task E463343A (vcpkg sharing investigation): never started, not blocking
- Abandon task F5698935 (compass story done spike): never started; compass task done already exists; file capture for story done
- Close story FFD4CA8C (environment provisioning overhaul): all tasks done or abandoned
- Add product backlog capture: add compass story done command

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/story.html) | 5422B06E-927F-4342-BCA0-45FCE55EBCC5 |
| Task | [Fix readme badges](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/fix_readme_badges/task_fix_readme_badges.html) | 8BF0068E-C00F-4764-809D-944714667B5F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)