### PR TITLE
[compass] Init vcpkg submodule on full env provision; show type in fleet

### DIFF
--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
@@ -39,7 +39,7 @@ Improve compass env provision so it never collides with existing environments by
 |------+-------+-------+-----+-------------|
 | [[id:0D4CC04E-B2C0-4658-B3F7-4C165801E14F][Auto-assign base port in compass env provision]] | DONE | 2026-06-24 | 2026-06-24 | Scan sibling .env files and pick next free port; no --base-port needed. |
 | [[id:6DAD3D23-489F-4E71-9740-22D77DADFE1A][Init vcpkg submodule in env provision for full environments]] | STARTED | 2026-06-24 | | Auto-init vcpkg after git worktree add for full envs. |
-| [[id:51EBD8EB-EA76-4DD9-A0B2-4AC89F82C67A][compass fleet: show provision type (full/light) per worktree]] | BACKLOG | | | Show ORES_PROVISION_TYPE in fleet output. |
+| [[id:51EBD8EB-EA76-4DD9-A0B2-4AC89F82C67A][compass fleet: show provision type (full/light) per worktree]] | STARTED | 2026-06-24 | | Show ORES_PROVISION_TYPE in fleet output. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
@@ -23,9 +23,9 @@ Improve compass env provision so it never collides with existing environments by
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Not yet started.                       |
+| Now           | Port auto-assign merged (PR #1291); vcpkg init and fleet env-type in progress. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | PR for vcpkg init + fleet env-type.    |
 | Last touched  | 2026-06-24                               |
 
 * Acceptance
@@ -37,7 +37,9 @@ Improve compass env provision so it never collides with existing environments by
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:0D4CC04E-B2C0-4658-B3F7-4C165801E14F][Auto-assign base port in compass env provision]] | DONE | 2026-06-24 | 2026-06-24 | Scan sibling .env files and pick next free port; no --base-port needed. |
+| [[id:6DAD3D23-489F-4E71-9740-22D77DADFE1A][Init vcpkg submodule in env provision for full environments]] | STARTED | 2026-06-24 | | Auto-init vcpkg after git worktree add for full envs. |
+| [[id:51EBD8EB-EA76-4DD9-A0B2-4AC89F82C67A][compass fleet: show provision type (full/light) per worktree]] | BACKLOG | | | Show ORES_PROVISION_TYPE in fleet output. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_env_improvements:sprint_21:v0:
 #+owner: marco
 #+branch: feature/compass-env-provision-vcpkg-and-fleet-type
-#+pr:
+#+pr: 1292
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-24
@@ -50,7 +50,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1292][#1292]] | [compass] Init vcpkg submodule on full env provision; show type in fleet |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_env_improvements:sprint_21:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compass-env-provision-vcpkg-and-fleet-type
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -26,11 +26,11 @@ Read ORES_PROVISION_TYPE from each worktree's .env and include it in compass fle
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] |
-| Now          | Not yet started.                       |
+| Now          | Implementation complete; PR open with vcpkg-init task. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Merge PR.                              |
 | Last touched | 2026-06-24                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.org
@@ -56,6 +56,8 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | r.get("provision_type") should be r["provision_type"] — key always set | compass.py:2126 | Fixed in c96ac90ff | 2 of 3 reviews flagged |
+| 2 | _worktree_env_value type annotation str \vert None inconsistent with zero-annotation style of compass.py | compass.py:2053 | Fixed in c96ac90ff — annotation removed entirely | 1 of 3 reviews flagged |
+| 3 | story.org fleet task state BACKLOG vs STARTED mismatch | story.org:42 | Fixed in c96ac90ff | 2 of 3 reviews flagged |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
@@ -65,6 +65,6 @@ Discovered while manually configuring solid-dirac, brave-hopper, and merry-newto
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | #+pr: field empty; PRs table not filled | task_provision_vcpkg_init.org | Fixed in c96ac90ff | 3 of 3 reviews flagged |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_env_improvements:sprint_21:v0:
 #+owner: marco
 #+branch: feature/compass-env-provision-vcpkg-and-fleet-type
-#+pr:
+#+pr: 1292
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-24
@@ -59,7 +59,7 @@ Discovered while manually configuring solid-dirac, brave-hopper, and merry-newto
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1292][#1292]] | [compass] Init vcpkg submodule on full env provision; show type in fleet |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_provision_vcpkg_init.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: 6DAD3D23-489F-4E71-9740-22D77DADFE1A
+:END:
+#+title: Task: Init vcpkg submodule in env provision for full environments
+#+description: Git worktrees do not auto-initialize submodules; full environments need vcpkg before cmake configure can run. env provision should do this automatically.
+#+type: task
+#+level: s1
+#+filetags: :compass_env_improvements:sprint_21:v0:
+#+owner: marco
+#+branch: feature/compass-env-provision-vcpkg-and-fleet-type
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-24
+#+updated: 2026-06-24
+#+environment: local1
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+When =env provision= creates a full (C++) environment it should automatically run =git submodule update --init vcpkg= in the new worktree so that =cmake --preset= works without a manual step. Light environments do not include vcpkg and should not have the submodule initialized.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] |
+| Now          | Fix implemented in env_create.py; on branch with fleet task. |
+| Waiting on   | Nothing.                               |
+| Next         | Raise PR with fleet task.              |
+| Last touched | 2026-06-24                               |
+
+* Acceptance
+
+- =compass env provision= with =--type full= (or default) automatically initializes the vcpkg submodule in the new worktree
+- =compass env provision --type light= does not touch the vcpkg submodule
+- =cmake --preset linux-clang-debug-make= works immediately after provision without a manual =git submodule update= step
+
+* Plan
+
+After =git worktree add= succeeds and before writing the skeleton .env, run:
+
+#+begin_src sh
+git submodule update --init vcpkg
+#+end_src
+
+in the new worktree directory when =env_type == "full"=. A non-zero return code prints a warning but does not abort provisioning (the user can retry the submodule init manually).
+
+* Notes
+
+Root cause: Git worktrees share the object store and ref list of the parent repository but do not automatically initialize submodules — each worktree is an independent working tree and submodule init must be run per-worktree.
+
+Discovered while manually configuring solid-dirac, brave-hopper, and merry-newton after provisioning from ores_dev_prime_origin. Each required a manual =git submodule update --init vcpkg= before =cmake --preset= would work.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2050,7 +2050,7 @@ def _org_link_text(link_str):
     m = _ORG_LINK_RE.match(link_str or "")
     return m.group(2) if m else link_str
 
-def _worktree_env_value(worktree_path: str, key: str) -> str | None:
+def _worktree_env_value(worktree_path, key):
     """Read a single key from a worktree's .env; returns None if absent."""
     env_file = Path(worktree_path) / ".env"
     if not env_file.is_file():
@@ -2123,7 +2123,7 @@ def cmd_fleet(args):
         mark = "→" if r["current"] else " "
         branch = r["branch"] or "(detached)"
         chip, warning = staleness_lines(r["staleness"])
-        ptype = r.get("provision_type") or ""
+        ptype = r["provision_type"] or ""
         ptype_label = f"  [{ptype}]" if ptype else ""
         print(f"{mark} {r['worktree']}{ptype_label}   {branch}")
         print(f"      {chip}")

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2050,6 +2050,23 @@ def _org_link_text(link_str):
     m = _ORG_LINK_RE.match(link_str or "")
     return m.group(2) if m else link_str
 
+def _worktree_env_value(worktree_path: str, key: str) -> str | None:
+    """Read a single key from a worktree's .env; returns None if absent."""
+    env_file = Path(worktree_path) / ".env"
+    if not env_file.is_file():
+        return None
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() == key:
+            v = v.strip()
+            if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+                v = v[1:-1]
+            return v
+    return None
+
+
 def cmd_fleet(args):
     worktrees = list_worktrees()
     if not worktrees:
@@ -2094,6 +2111,7 @@ def cmd_fleet(args):
             "pr": ({"number": pr["number"], "state": pr["state"], "url": pr["url"]}
                    if pr else None),
             "staleness": branch_staleness(path),
+            "provision_type": _worktree_env_value(path, "ORES_PROVISION_TYPE"),
         })
 
     if args.format == "json":
@@ -2105,7 +2123,9 @@ def cmd_fleet(args):
         mark = "→" if r["current"] else " "
         branch = r["branch"] or "(detached)"
         chip, warning = staleness_lines(r["staleness"])
-        print(f"{mark} {r['worktree']}   {branch}")
+        ptype = r.get("provision_type") or ""
+        ptype_label = f"  [{ptype}]" if ptype else ""
+        print(f"{mark} {r['worktree']}{ptype_label}   {branch}")
         print(f"      {chip}")
         if warning:
             print(f"      {warning}")

--- a/projects/ores.compass/src/env_create.py
+++ b/projects/ores.compass/src/env_create.py
@@ -109,6 +109,18 @@ def run_provision(argv: list[str], project_root: Path) -> int:
         print("❌ Failed to create git worktree.", file=sys.stderr)
         return 1
 
+    # Full environments need the vcpkg submodule so cmake can run immediately
+    # after configure.  Git worktrees do not auto-initialize submodules.
+    if args.env_type == "full":
+        print("  Initialising vcpkg submodule...")
+        sub = subprocess.run(
+            ["git", "submodule", "update", "--init", "vcpkg"],
+            cwd=str(worktree_dir),
+        )
+        if sub.returncode != 0:
+            print("⚠️  vcpkg submodule init failed — cmake configure will need it later.",
+                  file=sys.stderr)
+
     # Write skeleton .env so compass env configure picks up the pre-assigned values.
     env_file = worktree_dir / ".env"
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")


### PR DESCRIPTION
## Summary

Two compass env improvements: (1) env provision now auto-initializes the vcpkg submodule for full environments so cmake --preset works immediately, without a manual git submodule step; (2) fleet output now shows [full] or [light] beside each worktree name from ORES_PROVISION_TYPE in its .env.

## Changes

- env provision: run git submodule update --init vcpkg after worktree add for full environments; skip for light
- fleet: read ORES_PROVISION_TYPE from each worktree .env and display [full]/[light] label beside worktree name
- Add task_provision_vcpkg_init and update story + fleet task docs

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass environment improvements: port auto-assignment and fleet env-type display](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.html) | 14AD67D6-E981-45BC-B843-ABC6C9B4CC12 |
| Task | [compass fleet: show provision type (full/light) per worktree](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_fleet_show_env_type.html) | 51EBD8EB-EA76-4DD9-A0B2-4AC89F82C67A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)