### PR TITLE
[ores.compass] Build skills and settings during env provision

### DIFF
--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
@@ -27,10 +27,10 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 |---------------+--------------------------------------------------------------------|
 | State         | STARTED                                                               |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]          |
-| Now           | All tasks complete or abandoned. Story closed.                     |
+| Now           | One task in flight: provision Claude Code settings and skills (PR #1296). |
 | Waiting on    | Nothing.                                                           |
-| Next          | Nothing.                                                           |
-| Last touched  | 2026-06-23                                                         |
+| Next          | Merge PR #1296; close task and story.                              |
+| Last touched  | 2026-06-25                                                         |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:env:bootstrap:provisioning:infra:sprint_21:v0:
 #+created: 2026-06-14
 #+updated: 2026-06-14
-#+environment: local1
+#+environment: prime_origin
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -25,7 +25,7 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 
 | Field         | Value                                                              |
 |---------------+--------------------------------------------------------------------|
-| State         | DONE                                                               |
+| State         | STARTED                                                               |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]          |
 | Now           | All tasks complete or abandoned. Story closed.                     |
 | Waiting on    | Nothing.                                                           |
@@ -57,6 +57,7 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 | [[id:E463343A-12A7-4BAF-9FCD-FEE52F583721][Investigate sharing vcpkg installed packages across environments]] | ABANDONED | | | Determine whether the per-checkout vcpkg_installed/ directory can be shared across full worktrees to reduce disk usage. The binary archive cache (~/.cache/vcpkg/archives) is already machine-global. Investigate using --x-install-root or symlinks to point all full envs at the genesis checkout's vcpkg_installed/, and assess risks (concurrent builds, branch version divergence). |
 | [[id:A2221F16-D2CC-4483-A53D-01813D0C0C9A][Integrate install_debian_packages.sh into compass env configure]] | DONE | 2026-06-19 | 2026-06-23 | Wire the Debian package install script into compass env configure so environment provisioning is a single command. Depends on the genesis env / worktree provisioning command task. |
 | [[id:F5698935-A1BD-4B00-8725-7545315E92EE][Spike: investigate and implement compass story done and task done commands]] | ABANDONED | | | Compass has no story done or task done subcommands — closing a story requires manually editing story.org and the sprint table. Investigate what state transitions are needed, what side-effects should fire (journal stamp, sprint table update, PR linkage), and implement the missing commands. |
+| [[id:C62E9CBB-7322-4333-9E77-79057C6E8967][Provision Claude Code settings and skills into new environments]] | STARTED | 2026-06-25 | | When compass env provision creates a new worktree, copy or symlink the .claude/ directory (settings.json, skills/) so that Claude Code is immediately usable without manual setup. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -28,9 +28,9 @@ Ensure every provisioned environment inherits the project Claude Code configurat
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
-| Now          | Not yet started.                       |
+| Now          | Implementation in PR #1296.            |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Merge PR #1296 and close task.         |
 | Last touched | 2026-06-25                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:env:provisioning:claude:infra:sprint_21:v0:environment_provisioning_overhaul:
 #+owner: marco
 #+branch: feature/provision-claude-settings-and-skills
-#+pr:
+#+pr: 1296
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -51,7 +51,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1296][#1296]] | [ores.compass] Build skills and settings during env provision |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -57,6 +57,10 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Add compass_sh.is_file() guard before subprocess.run | env_create.py | Fixed in ddbe90867 | Cleaner diagnostic on degenerate worktree |
+| 2 | Pass --no-deps to skip pip round-trip | env_create.py | Fixed in ddbe90867 | Only stdlib + emacs needed |
+| 3 | No timeout on subprocess.run | env_create.py | Declined | Consistent with vcpkg init pattern above it |
+| 4 | task Now/Next fields stale | task.org | Fixed in ddbe90867 | Updated to reflect in-flight status |
+| 5 | story Now/Last-touched stale | story.org | Fixed in ddbe90867 | Updated to reflect re-opened status |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: C62E9CBB-7322-4333-9E77-79057C6E8967
+:END:
+#+title: Task: Provision Claude Code settings and skills into new environments
+#+description: When compass env provision creates a new worktree, copy or symlink the .claude/ directory (settings.json, skills/) so that Claude Code is immediately usable without manual setup.
+#+type: task
+#+level: s1
+#+filetags: :compass:env:provisioning:claude:infra:sprint_21:v0:environment_provisioning_overhaul:
+#+owner: marco
+#+branch: feature/provision-claude-settings-and-skills
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: prime_origin
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Ensure every provisioned environment inherits the project Claude Code configuration (settings.json and skills/) automatically, eliminating the need for manual post-provision steps.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- compass env provision creates or symlinks .claude/ in the new worktree
+- .claude/settings.json and .claude/skills/ are present and correct after provision
+- Existing worktrees are not affected by the change
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.compass/src/env_create.py
+++ b/projects/ores.compass/src/env_create.py
@@ -141,15 +141,20 @@ def run_provision(argv: list[str], project_root: Path) -> int:
 
     # Build skills and settings from their org sources into the new worktree.
     # --direct bypasses cmake/vcpkg so this works for both light and full envs.
+    # --no-deps skips the pip round-trip since only stdlib + emacs are needed.
     compass_sh = worktree_dir / "projects" / "ores.compass" / "compass.sh"
-    print("  Deploying skills and settings...")
-    build = subprocess.run(
-        ["bash", str(compass_sh), "build", "--direct", "skills", "settings"],
-        cwd=str(worktree_dir),
-    )
-    if build.returncode != 0:
-        print("⚠️  Skills/settings build failed — run 'compass build --direct skills settings' manually.",
+    if not compass_sh.is_file():
+        print("⚠️  compass.sh not found in new worktree — run 'compass build --direct skills settings' manually.",
               file=sys.stderr)
+    else:
+        print("  Deploying skills and settings...")
+        build = subprocess.run(
+            ["bash", str(compass_sh), "--no-deps", "build", "--direct", "skills", "settings"],
+            cwd=str(worktree_dir),
+        )
+        if build.returncode != 0:
+            print("⚠️  Skills/settings build failed — run 'compass build --direct skills settings' manually.",
+                  file=sys.stderr)
 
     print(f"\n✅ Environment '{name}' provisioned")
     print(f"   Path:      {worktree_dir}")

--- a/projects/ores.compass/src/env_create.py
+++ b/projects/ores.compass/src/env_create.py
@@ -139,6 +139,18 @@ def run_provision(argv: list[str], project_root: Path) -> int:
     env_file.chmod(0o600)
     print(f"  Wrote skeleton .env to {env_file}")
 
+    # Build skills and settings from their org sources into the new worktree.
+    # --direct bypasses cmake/vcpkg so this works for both light and full envs.
+    compass_sh = worktree_dir / "projects" / "ores.compass" / "compass.sh"
+    print("  Deploying skills and settings...")
+    build = subprocess.run(
+        ["bash", str(compass_sh), "build", "--direct", "skills", "settings"],
+        cwd=str(worktree_dir),
+    )
+    if build.returncode != 0:
+        print("⚠️  Skills/settings build failed — run 'compass build --direct skills settings' manually.",
+              file=sys.stderr)
+
     print(f"\n✅ Environment '{name}' provisioned")
     print(f"   Path:      {worktree_dir}")
     print(f"   Provision: {args.env_type}")


### PR DESCRIPTION
## Summary

compass env provision now runs compass build --direct skills settings inside the new worktree immediately after the skeleton .env is written, so every provisioned environment has a working Claude Code setup without manual follow-up.

## Changes

- Run compass build --direct skills settings in the new worktree after .env is written
- Non-fatal: warns and continues if the build step fails so provision itself is not blocked

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.html) | FFD4CA8C-13DE-4DFB-B242-F423B6D39796 |
| Task | [Provision Claude Code settings and skills into new environments](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.html) | C62E9CBB-7322-4333-9E77-79057C6E8967 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)