### PR TITLE
[agile] Close environment provisioning overhaul story

### DIFF
--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
@@ -25,11 +25,11 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 
 | Field         | Value                                                              |
 |---------------+--------------------------------------------------------------------|
-| State         | STARTED                                                               |
+| State         | DONE                                                               |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]          |
-| Now           | One task in flight: provision Claude Code settings and skills (PR #1296). |
+| Now           | All tasks complete or abandoned. Story closed.                     |
 | Waiting on    | Nothing.                                                           |
-| Next          | Merge PR #1296; close task and story.                              |
+| Next          | Nothing.                                                           |
 | Last touched  | 2026-06-25                                                         |
 
 * Acceptance
@@ -57,7 +57,7 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 | [[id:E463343A-12A7-4BAF-9FCD-FEE52F583721][Investigate sharing vcpkg installed packages across environments]] | ABANDONED | | | Determine whether the per-checkout vcpkg_installed/ directory can be shared across full worktrees to reduce disk usage. The binary archive cache (~/.cache/vcpkg/archives) is already machine-global. Investigate using --x-install-root or symlinks to point all full envs at the genesis checkout's vcpkg_installed/, and assess risks (concurrent builds, branch version divergence). |
 | [[id:A2221F16-D2CC-4483-A53D-01813D0C0C9A][Integrate install_debian_packages.sh into compass env configure]] | DONE | 2026-06-19 | 2026-06-23 | Wire the Debian package install script into compass env configure so environment provisioning is a single command. Depends on the genesis env / worktree provisioning command task. |
 | [[id:F5698935-A1BD-4B00-8725-7545315E92EE][Spike: investigate and implement compass story done and task done commands]] | ABANDONED | | | Compass has no story done or task done subcommands — closing a story requires manually editing story.org and the sprint table. Investigate what state transitions are needed, what side-effects should fire (journal stamp, sprint table update, PR linkage), and implement the missing commands. |
-| [[id:C62E9CBB-7322-4333-9E77-79057C6E8967][Provision Claude Code settings and skills into new environments]] | STARTED | 2026-06-25 | | When compass env provision creates a new worktree, copy or symlink the .claude/ directory (settings.json, skills/) so that Claude Code is immediately usable without manual setup. |
+| [[id:C62E9CBB-7322-4333-9E77-79057C6E8967][Provision Claude Code settings and skills into new environments]] | DONE | 2026-06-25 | 2026-06-25 | When compass env provision creates a new worktree, copy or symlink the .claude/ directory (settings.json, skills/) so that Claude Code is immediately usable without manual setup. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -26,11 +26,11 @@ Ensure every provisioned environment inherits the project Claude Code configurat
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
-| Now          | Implementation in PR #1296.            |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Merge PR #1296 and close task.         |
+| Next         | Nothing. |
 | Last touched | 2026-06-25                               |
 
 * Acceptance
@@ -64,3 +64,5 @@ plan itself stays — it is the historical record of what we did.)
 | 5 | story Now/Last-touched stale | story.org | Fixed in ddbe90867 | Updated to reflect re-opened status |
 
 * Result
+
+=compass env provision= now runs =compass build --direct --no-deps skills settings= inside the new worktree immediately after writing the skeleton =.env=. A =compass_sh.is_file()= guard produces a clear diagnostic if the worktree checkout is incomplete. The step is non-fatal (warn and continue) so a build failure never blocks a successfully provisioned worktree. Works for both =light= and =full= environment types. Merged in PR #1296.

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:env:provisioning:claude:infra:sprint_21:v0:environment_provisioning_overhaul:
 #+owner: marco
 #+branch: feature/provision-claude-settings-and-skills
-#+pr: 1296
+#+pr: 1297
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -51,6 +51,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1297][#1297]] | [agile] Close environment provisioning overhaul story |
 | [[https://github.com/OreStudio/OreStudio/pull/1296][#1296]] | [ores.compass] Build skills and settings during env provision |
 
 * Review

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -112,7 +112,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul]] | STARTED | 2026-06-14 | | GCP-style naming, genesis env, light env type, direct-emacs compass commands, env type through the stack, bootstrap docs. |
+| [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul]] | DONE | 2026-06-14 | 2026-06-25 | GCP-style naming, genesis env, light env type, direct-emacs compass commands, env type through the stack, bootstrap docs. |
 | [[id:1F153733-2043-41E5-8A38-EDE21C8787A9][Verify Windows and macOS CI builds]] | BACKLOG | | | Re-run MSVC and macOS builds; verify the rfl C1202 fix; fix or file follow-ups. |
 
 ** Documentation

--- a/doc/llm/skills/pr-merge/SKILL.org
+++ b/doc/llm/skills/pr-merge/SKILL.org
@@ -20,15 +20,14 @@ license: Complete terms in LICENSE.txt
 
 * When to use this skill
 
-Merging an approved PR. Guard rails refuse while review threads are unresolved or CI is red. Bookkeeping (agile-close-task) must already be on the branch — merge never touches task state.
+Merging an approved PR. Guard rails refuse while review threads are unresolved or CI is red.
 
 * How to use this skill
 
-1. /Ensure the bookkeeping rode the PR/: the task was closed with
-   =agile-close-task= on this branch. If the PR does not deliver its
-   task, just merge — merge never touches task state; a STARTED task
-   only draws a warning.
-
+1. /Close the task first/ — run =agile-close-task= on the feature branch
+   *before* merging. Bookkeeping must ride the PR, not follow it. A
+   STARTED task is a hard stop: do not proceed to merge until the task
+   is closed.
 
 2. /Merge/ (merge commit, never squash):
 


### PR DESCRIPTION
## Summary

Bookkeeping for the environment provisioning overhaul story: close the final task (provision Claude Code settings and skills), flip story and sprint row to DONE, and tighten the pr-merge skill to make agile-close-task a hard requirement before merging.

## Changes

- Task DONE: provision Claude Code settings and skills into new environments
- Story and sprint table row flipped to DONE (all 10 tasks complete or abandoned)
- pr-merge skill: agile-close-task is now a hard requirement before merge

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.html) | FFD4CA8C-13DE-4DFB-B242-F423B6D39796 |
| Task | [Provision Claude Code settings and skills into new environments](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_provision_claude_settings_and_skills.html) | C62E9CBB-7322-4333-9E77-79057C6E8967 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)