### PR TITLE
[compass,agile] Improve bearings warning to distinguish missing vs stale .claude/ artefacts

### DIFF
--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/story.org
@@ -58,6 +58,7 @@ descriptive adjective-noun name (GCP-style) rather than an ad-hoc =local1=/=remo
 | [[id:A2221F16-D2CC-4483-A53D-01813D0C0C9A][Integrate install_debian_packages.sh into compass env configure]] | DONE | 2026-06-19 | 2026-06-23 | Wire the Debian package install script into compass env configure so environment provisioning is a single command. Depends on the genesis env / worktree provisioning command task. |
 | [[id:F5698935-A1BD-4B00-8725-7545315E92EE][Spike: investigate and implement compass story done and task done commands]] | ABANDONED | | | Compass has no story done or task done subcommands — closing a story requires manually editing story.org and the sprint table. Investigate what state transitions are needed, what side-effects should fire (journal stamp, sprint table update, PR linkage), and implement the missing commands. |
 | [[id:C62E9CBB-7322-4333-9E77-79057C6E8967][Provision Claude Code settings and skills into new environments]] | DONE | 2026-06-25 | 2026-06-25 | When compass env provision creates a new worktree, copy or symlink the .claude/ directory (settings.json, skills/) so that Claude Code is immediately usable without manual setup. |
+| [[id:9A45DF71-79F0-48B0-84F9-5FB70BC49973][Improve compass bearings warning to distinguish missing vs stale .claude/ artefacts]] | DONE | | 2026-06-25 | compass bearings warned 'is older than' even when .claude/settings.json and .claude/skills/ did not exist, which was misleading. Fix to show 'does not exist' when absent. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
@@ -8,7 +8,7 @@
 #+filetags: :environment_provisioning_overhaul:sprint_21:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1299
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -26,7 +26,7 @@ Improve compass bearings warning to distinguish missing vs stale .claude/ artefa
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE                              |
+| State        | DONE                                   |
 | Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
 | Now          | Nothing. |
 | Waiting on   | Nothing.                               |
@@ -47,9 +47,9 @@ plan itself stays — it is the historical record of what we did.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                                                                       |
+|------+---------------------------------------------------------------------------------------------|
+| 1299 | Improve compass bearings warning to distinguish missing vs stale .claude/ artefacts         |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 9A45DF71-79F0-48B0-84F9-5FB70BC49973
+:END:
+#+title: Task: Improve compass bearings warning to distinguish missing vs stale .claude/ artefacts
+#+description: compass bearings warned 'is older than' even when .claude/settings.json and .claude/skills/ did not exist, which was misleading. Fix to show 'does not exist' when absent.
+#+type: task
+#+level: s1
+#+filetags: :environment_provisioning_overhaul:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: solid_dirac
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Improve compass bearings warning to distinguish missing vs stale .claude/ artefacts
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:FFD4CA8C-13DE-4DFB-B242-F423B6D39796][Environment provisioning overhaul: lightweight environments, GCP-style naming, bootstrap independence]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- bearings shows 'does not exist — run to provision' when .claude/settings.json or .claude/skills/ are absent, and 'is older than' only when they exist but are stale
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
+++ b/doc/agile/versions/v0/sprint_21/environment_provisioning_overhaul/task_improve-bearings-missing-vs-stale-warning.org
@@ -53,8 +53,11 @@ plan itself stays — it is the historical record of what we did.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                           | File          | Decision | Notes                                      |
+|---+-------------------------------------------+---------------+----------+--------------------------------------------|
+| 1 | Docstring incomplete (missing-artefact)   | compass.py    | Fixed    | c5aefe361                                  |
+| 2 | Task file: #+pr: blank, ragged alignment  | task.org      | Fixed    | c5aefe361                                  |
+| 3 | Edge case: empty skills dir               | compass.py    | Declined | Pre-existing; out of scope                 |
+| 4 | Redundant exists() call in display loop   | compass.py    | Declined | Reviewer agreed not worth changing         |
 
 * Result

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4272,8 +4272,13 @@ def _claude_refresh_warnings():
             warnings.append((".claude/skills/", "doc/llm/skills/",
                              "compass build --direct skills"))
     for target, source, cmd in warnings:
-        print(f"  {_C_YELLOW}⚠  {target} is older than {source} — "
-              f"a refresh may be required:{_C_RESET}")
+        target_path = PROJECT_ROOT / target.rstrip("/")
+        if not target_path.exists():
+            print(f"  {_C_YELLOW}⚠  {target} does not exist — "
+                  f"run to provision:{_C_RESET}")
+        else:
+            print(f"  {_C_YELLOW}⚠  {target} is older than {source} — "
+                  f"a refresh may be required:{_C_RESET}")
         print(f"     {_ycmd(cmd)}")
     if warnings:
         print()

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4244,7 +4244,7 @@ def _bearings_section(icon, title, cmd=None):
 
 
 def _claude_refresh_warnings():
-    """Warn when generated .claude/ artefacts are older than their org sources.
+    """Warn when generated .claude/ artefacts are missing or older than their org sources.
 
     .claude/ is never checked in; settings.json tangles from
     doc/llm/claude_code_settings.org and skills deploy from doc/llm/skills.


### PR DESCRIPTION
## Summary

- `compass bearings` now shows **"does not exist — run to provision"** when `.claude/settings.json` or `.claude/skills/` are absent, instead of the misleading "is older than" message
- Adds task `9A45DF71` to the environment provisioning overhaul story, closed immediately as DONE

## Test plan

- [ ] Run `compass bearings` in an environment without `.claude/` — confirm "does not exist" wording appears
- [ ] Run `compass build --direct settings && compass build --direct skills`, then run `compass bearings` again — confirm no warnings shown
- [ ] Run `compass bearings` in an environment where `.claude/` exists but is stale — confirm "is older than" wording still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)