### PR TITLE
[ores.sql,doc] Commission country: verify SQL, add validate_country_fn, document trigger categories

### DIFF
--- a/doc/agile/product_backlog/inbox/add-security-definer-to-validate-fns.org
+++ b/doc/agile/product_backlog/inbox/add-security-definer-to-validate-fns.org
@@ -1,8 +1,8 @@
 :PROPERTIES:
 :ID: 4A2A1DBD-39D0-4537-82FC-CEDF415635CC
 :END:
-#+title: Add security definer to all ores_refdata_validate_*_fn functions
-#+description: All ores_refdata_validate_*_fn functions lack security definer and set search_path. Discovered during PR #1300 country SQL verification. Needs a coordinated sweep, not a one-off fix.
+#+title: Sweep pre-template-fix entities: add security definer and active-rows bootstrap filter
+#+description: All ores_refdata_validate_*_fn and insert trigger functions generated before PR #1300 (commit 1cb85c9a, sprint 21) lack security definer + set search_path and use a bare not-exists bootstrap check without a valid_to filter. The template is now fixed; this capture tracks whether a coordinated sweep of the existing generated files is warranted before natural recommissioning catches them.
 #+type: capture
 #+level: cross
 #+filetags: 
@@ -13,16 +13,44 @@ This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbo
 
 * What
 
-(One paragraph: the idea.)
+All =ores_refdata_validate_*_fn= functions and insert trigger functions
+generated before PR #1300 (commit =1cb85c9a=, sprint 21) carry two
+architectural gaps: they lack =security definer set search_path = public,
+pg_temp=, and their bootstrap pass-through checks for any rows rather than
+active rows (=valid_to = ores_utility_infinity_timestamp_fn()=).  The
+affected entities include currencies, rounding_types, monetary_natures,
+currency_market_tiers, party_id_schemes, party_statuses, party_types,
+book_statuses, contact_types, and purpose_types — all 10 entities currently
+generated from =sql_schema_create.mustache=.  The template has been fixed in
+PR #1300; future entity generations are correct automatically.  This capture
+tracks whether a coordinated sweep of the existing files is warranted before
+they are each naturally recommissioned.
 
 * Why
 
-(Motivation, problem being solved, related context.)
+The two gaps are architectural correctness issues: =security definer= +
+=set search_path= prevents search-path injection from a service role with a
+manipulated path; the active-rows bootstrap filter prevents a confusing
+"Must be one of: (empty list)" error when a table has only soft-deleted
+historical rows.  Both are now documented as mandatory rules in
+[[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and Conventions]] and as checklist criteria
+in [[id:897A7156-504D-4581-AD4C-026D643C0838][Domain entity evaluation checklist]].  The analysis and rationale live in
+[[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country § Analysis]].
+
+The commissioning pipeline will repair each entity naturally (each
+commission story's verify-SQL task now checks for these items via the
+checklist).  A proactive sweep would close the gap sooner but is only
+warranted if any of the affected entities are used as soft-FK targets in
+production before they are commissioned.
 
 * References
 
--
+- PR #1300: [[https://github.com/OreStudio/OreStudio/pull/1300][Commission country: verify SQL, add validate_country_fn, document trigger categories]]
+- Commit: =1cb85c9a= — fix validate fn security definer and bootstrap valid_to filter
 
 * See also
 
--
+- [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] — Analysis section documents the rationale in full
+- [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and Conventions]] — canonical rules
+- [[id:897A7156-504D-4581-AD4C-026D643C0838][Domain entity evaluation checklist]] — checklist criteria that ensure future commission stories pick this up
+- [[id:9C11F389-EB60-4BE2-A0D7-DBF3CEB86A26][sql_schema_create.mustache]] — the fixed template

--- a/doc/agile/product_backlog/inbox/add-security-definer-to-validate-fns.org
+++ b/doc/agile/product_backlog/inbox/add-security-definer-to-validate-fns.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 4A2A1DBD-39D0-4537-82FC-CEDF415635CC
+:END:
+#+title: Add security definer to all ores_refdata_validate_*_fn functions
+#+description: All ores_refdata_validate_*_fn functions lack security definer and set search_path. Discovered during PR #1300 country SQL verification. Needs a coordinated sweep, not a one-off fix.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_21/commission_country/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/story.org
@@ -48,6 +48,154 @@ entity chapter to the user manual. File backlog captures for Wt and HTTP support
 - All regressions found are fixed inline or filed as captures.
 - Site builds cleanly.
 
+* Analysis
+
+Analysis commissioned during the [[id:722D1013-6867-48E5-BB7D-4C94817AD46C][Verify country SQL against the evaluation
+checklist]] task, prompted by two items deferred from the PR #1300 review.
+Goal: determine whether each item is a deliberate design choice or an
+historical artefact requiring correction, and fix it at the template level
+so future entities are correct on first generation.
+
+** Item 1: =security definer= absent from validate functions
+
+*** Observation
+
+All 50 =ores_refdata_validate_*_fn= functions in the codebase lacked
+=security definer= and =set search_path = public, pg_temp=.  Of the 115
+refdata create files at the time of analysis, only 5 carried =security
+definer= at all.  Country's insert trigger had it; currency's and most
+others did not.  The IAM layer (=ores_iam_validate_*_fn=,
+=ores_iam_*_insert_fn=) applied it consistently from the start.
+
+*** PostgreSQL security model
+
+A =BEFORE INSERT= trigger function runs under the security context of the
+calling role (the service role that issued the =INSERT=), not the function
+owner — unless the function declares =security definer=.  Without it, a
+service role with a misconfigured or compromised =search_path= that includes
+a schema it controls can shadow any =ores_*_tbl= reference inside the
+trigger, causing validation to query attacker-controlled data and silently
+accept any input.
+
+=security definer= and =set search_path= are required together.
+=security definer= alone pins the executing user but leaves the search path
+open; if =search_path= is not pinned, the function owner's own schemas are
+searched and an attacker with write access to one of them can still shadow
+tables.  Both are needed.
+
+Crucially, =security definer= does /not/ propagate from a caller to its
+callees.  When an insert function (=security definer=) calls a validate
+function (=security invoker=), the validate function inherits the effective
+current user at call time — which happens to be the function owner because
+the caller is definer-scoped.  This gives indirect protection only while
+called from a correctly annotated insert function.  If the insert function
+lacks =security definer= (as most existing ones did), the validate function
+is fully exposed.  Validate functions are also candidates for future direct
+application calls (pre-validation before insert); they must be independently
+safe.
+
+*** Verdict
+
+Historical artefact.  The IAM layer established the pattern; the refdata
+layer never adopted it.  The discrepancy is a latent security gap — not
+exploitable under the current role model without prior deep compromise, but
+semantically incorrect and a risk as the codebase grows.
+
+*** Correct approach
+
+Apply =security definer set search_path = public, pg_temp= to:
+- All insert trigger functions (primary protection layer)
+- All validate functions (defence in depth; enables future direct-call use)
+
+Fixed in [[id:722D1013-6867-48E5-BB7D-4C94817AD46C][refdata_countries_create.sql]] (the commissioning reference) and in the
+=sql_schema_create= literate template [[id:9C11F389-EB60-4BE2-A0D7-DBF3CEB86A26][sql_schema_create.mustache]].  Documented
+as a mandatory rule in [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and Conventions]]
+(§ Insert trigger patterns → Validation functions).
+
+Entities generated before this fix retain the old form until recommissioned
+or regenerated; that sweep occurs naturally through the commissioning
+pipeline, not as a separate remediation story.
+
+** Item 2: Bootstrap pass-through checks any rows, not active rows
+
+*** Observation
+
+All validate functions contained a bootstrap pass-through of this form:
+
+#+begin_src sql
+if not exists (
+    select 1 from ores_refdata_countries_tbl
+    where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+    limit 1  -- no valid_to filter
+) then
+    return p_value;
+end if;
+#+end_src
+
+The intent is: "skip validation if this tenant has never been seeded."  The
+implementation checks for /any/ row, including soft-deleted historical rows.
+
+*** The bug
+
+If a tenant has had data seeded and all rows have since been soft-deleted
+(=valid_to = current_timestamp=), the table contains historical rows but no
+active ones.  The bootstrap check finds those rows (=not exists= → false),
+skips the pass-through, then fails the active-row validation:
+
+#+begin_example
+ERROR: Invalid country: GB. Must be one of: (empty list)
+#+end_example
+
+This is both confusing and semantically wrong: the caller cannot distinguish
+"the value is not in the catalogue" from "there is no usable catalogue at
+all."
+
+The =limit 1= inside =EXISTS= is a no-op — =EXISTS= short-circuits on the
+first matching row regardless — and is omitted alongside the fix.
+
+*** Practical impact
+
+The scenario requires all active rows for a tenant to be soft-deleted —
+unusual but not impossible.  The more serious concern is that this code is
+the /template/ for all generated validate functions.  Left uncorrected, every
+future entity generated by codegen would inherit the bug.
+
+For the active-row convention see [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Timestamps: Architecture and Conventions]].
+
+*** Verdict
+
+Semantic bug, not a deliberate design choice.  Present in all 50 validate
+functions at the time of analysis.
+
+*** Correct approach
+
+Filter the bootstrap check for active rows:
+
+#+begin_src sql
+if not exists (
+    select 1 from ores_refdata_countries_tbl
+    where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+      and valid_to = ores_utility_infinity_timestamp_fn()
+) then
+    return p_value;
+end if;
+#+end_src
+
+Fixed in =refdata_countries_create.sql= (the commissioning reference) and in
+the [[id:9C11F389-EB60-4BE2-A0D7-DBF3CEB86A26][sql_schema_create.mustache]] template (all three scope variants:
+=scope_system=, =scope_both=, =scope_tenant=).  Documented in
+[[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and Conventions]] (§ Insert trigger patterns
+→ Validation functions).
+
+** Disposition
+
+Both items are historical artefacts now corrected at the template level.  The
+=country= commission story (sprint 21) serves as the canonical reference
+state: entities brought under codegen from this point forward will have both
+fixes applied automatically.  Existing generated entities (=currencies=,
+=rounding_types=, =monetary_natures=, etc.) retain the old patterns until
+recommissioned; no separate remediation story is needed.
+
 * Tasks
 
 | Task | State | Start | End | Description |

--- a/doc/agile/versions/v0/sprint_21/commission_country/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/story.org
@@ -8,6 +8,7 @@
 #+filetags: :product:refdata:commissioning:country:sprint_21:v0:
 #+created: 2026-05-29
 #+updated: 2026-06-12
+#+environment: prime_origin
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -22,12 +23,12 @@ entity chapter to the user manual. File backlog captures for Wt and HTTP support
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Postponed from sprint 20; codegen blocker cleared (org migration done). Appraise task done; remaining tasks unstarted. |
+| Now           | SQL verification done; validate_country_fn added. Next: verify shell/CLI. |
 | Waiting on    | Nothing.                               |
-| Next          | Pull into sprint 21.                   |
-| Last touched  | 2026-06-12                             |
+| Next          | Verify country shell and CLI commands post-NATS.  |
+| Last touched  | 2026-06-25                             |
 
 * Acceptance
 
@@ -56,4 +57,4 @@ entity chapter to the user manual. File backlog captures for Wt and HTTP support
 | [[id:74FBDE3A-80F9-4ED8-88C0-541D14BBCEC8][Write country documentation (manual chapter, NATS reference)]] | BACKLOG | | | Manual chapter mirroring chapter 5 (currencies): entity description, Qt windows, shell and CLI commands; wire into user_manual.org. Extend the refdata NATS message reference with country subjects and the country_changed event. |
 | [[id:A1B58731-8F2E-4B7B-9098-A7DB9A51F92F][File Wt and HTTP gap captures for country]] | BACKLOG | | | Per the epic: file backlog captures for the missing Wt widgets and HTTP endpoints, referencing the appraisal. |
 | [[id:6DCF7776-5B2F-403E-8D38-A7512A952B7C][Bring country under codegen and verify zero-diff regeneration]] | BLOCKED | | | Country has no codegen model at all — the org-migration story only converted existing JSON models and country never had one; its SQL DDL and C++ are unmanaged. Create ores.refdata.country.org (and the party_country junction already exists) following the currency model shape, regenerate, and reconcile until regeneration is zero-diff against HEAD — or record explicitly why any part stays hand-written. |
-| [[id:722D1013-6867-48E5-BB7D-4C94817AD46C][Verify country SQL against the evaluation checklist]] | BACKLOG | | | Thorough DDL verification beyond the appraisal's spot-grep: every checklist criterion against refdata_countries_create.sql and the notify trigger — constraints, indexes, trigger validation functions, soft-delete rule, soft-FK validations — mirroring currency's verify-SQL task. |
+| [[id:722D1013-6867-48E5-BB7D-4C94817AD46C][Verify country SQL against the evaluation checklist]] | DONE | 2026-06-25 | 2026-06-25 | Thorough DDL verification beyond the appraisal's spot-grep: every checklist criterion against refdata_countries_create.sql and the notify trigger — constraints, indexes, trigger validation functions, soft-delete rule, soft-FK validations — mirroring currency's verify-SQL task. |

--- a/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
@@ -61,8 +61,9 @@ spot-grep.
 |---+-----------------+------+----------+-------|
 | 1 | Duplicate =party_countries= in Category 3 list | postgresql_architecture.org | Fixed in 5ab4ade | Typo — removed duplicate. |
 | 2 | Stale note says change_reason_code "not fixed here" | task_verify_sql.org | Fixed in 5ab4ade | Updated to reflect fix in a12d4863. |
-| 3 | =security definer= absent from validate_fn | refdata_countries_create.sql | Deferred | Consistent with all existing validate functions; needs a sweep, not a one-off. |
-| 4 | Bootstrap pass-through lacks =valid_to= filter | refdata_countries_create.sql | Not changed | Pre-existing behaviour matching the currency pattern. |
+| 3 | =security definer= absent from validate_fn | refdata_countries_create.sql | Fixed in 1cb85c9a | Architectural analysis concluded this is a genuine gap, not a deliberate omission. Added to validate_fn and to codegen template. |
+| 4 | Bootstrap pass-through lacks =valid_to= filter | refdata_countries_create.sql | Fixed in 1cb85c9a | Semantic bug: bare not-exists would skip pass-through for tables with only soft-deleted rows. Fixed in validate_fn and codegen template. |
+| 5 | Capture =add-security-definer-to-validate-fns.org= has placeholder body | product_backlog/inbox | Fixed in round 4 | Updated title, What, Why, References, See also to reflect narrowed scope post-template-fix. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_country:sprint_21:v0:
 #+owner: marco
 #+branch: feature/commission-country
-#+pr:
+#+pr: 1300
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
@@ -53,7 +53,7 @@ spot-grep.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1300][#1300]] | [ores.sql,doc] Commission country: verify SQL, add validate_country_fn, document trigger categories |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
@@ -7,12 +7,13 @@
 #+level: s1
 #+filetags: :commission_country:sprint_21:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/commission-country
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-06
 #+updated: 2026-06-12
+#+environment: prime_origin
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -29,12 +30,12 @@ spot-grep.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                 |
 | Parent story | [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-06                               |
+| Next         | None.                                  |
+| Last touched | 2026-06-25                             |
 
 * Acceptance
 
@@ -45,10 +46,6 @@ spot-grep.
   criteria it lacks.
 
 * Plan
-
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
 
 * Notes
 
@@ -65,3 +62,69 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+All DB-layer checklist criteria evaluated for =refdata_countries_create.sql= and the notify
+trigger. One gap found and fixed inline; one pre-existing gap in the currencies file noted
+for follow-up.
+
+** =refdata_countries_create.sql= — domain entity
+
+| Criterion | Status | Notes |
+|-----------+--------+-------|
+| Table =ores_refdata_countries_tbl= | ✓ | |
+| =tenant_id= column | ✓ | Validated via =ores_iam_validate_tenant_fn= in insert trigger. |
+| =version= | ✓ | |
+| =modified_by=, =performed_by= | ✓ | Validated and set in insert trigger. |
+| =change_reason_code=, =change_commentary= | ✓ | Validated via =ores_dq_validate_change_reason_fn=. |
+| =valid_from=, =valid_to= | ✓ | |
+| CHECK =valid_from < valid_to= | ✓ | |
+| CHECK =alpha2_code <> ''= | ✓ | Natural key non-empty guard. |
+| GIST exclusion (tenant_id, alpha2_code, tstzrange) | ✓ | |
+| Primary key (tenant_id, alpha2_code, valid_from, valid_to) | ✓ | |
+| Version unique index =countries_version_uniq_idx= | ✓ | WHERE valid_to = infinity. |
+| Natural key unique index =countries_code_uniq_idx= | ✓ | WHERE valid_to = infinity. |
+| Tenant index =countries_tenant_idx= | ✓ | WHERE valid_to = infinity. |
+| Additional alpha3 index =countries_alpha3_idx= | ✓ | Country-specific; supports ISO alpha3 lookups. |
+| Additional numeric index =countries_numeric_idx= | ✓ | Country-specific; supports ISO numeric lookups. |
+| Insert trigger =ores_refdata_countries_insert_trg= | ✓ | BEFORE INSERT FOR EACH ROW. |
+| Insert function — =security definer= + =set search_path= | ✓ | Present; country is more secure than currency (noted below). |
+| Soft-FK: =coding_scheme_code= validated (optional) | ✓ | Nullable; validates against =ores_dq_coding_schemes_tbl=. |
+| Version management (optimistic lock, P0002) | ✓ | |
+| Upsert: closes old row with =valid_to = current_timestamp= | ✓ | |
+| Soft-delete rule =ores_refdata_countries_delete_rule= | ✓ | |
+| Validation function =ores_refdata_validate_country_fn= | ✓ | *Added in this task* — was missing. |
+| RLS policy =countries_tenant_isolation_policy= | ✓ | In =refdata_rls_policies_create.sql=. |
+| Drop file drops rule, trigger, insert fn, validate fn, table | ✓ | *validate fn drop added in this task*. |
+
+** Notify trigger (=refdata_countries_notify_trigger_create.sql=)
+
+| Criterion | Status | Notes |
+|-----------+--------+-------|
+| Entity name =ores.refdata.country= | ✓ | |
+| Channel =ores_refdata_countries= | ✓ | |
+| Payload: entity, timestamp, entity_ids, tenant_id | ✓ | Uses =ores_utility_iso8601_timestamp_fn=. |
+| AFTER INSERT OR UPDATE OR DELETE FOR EACH ROW | ✓ | |
+| Drop file drops trigger and function | ✓ | |
+
+** Gap fixed: missing =ores_refdata_validate_country_fn=
+
+Currency defines =ores_refdata_validate_currency_fn= for use by other entities' soft-FK
+validations. Country had no equivalent. Added =ores_refdata_validate_country_fn= to
+=refdata_countries_create.sql= following the currency pattern exactly (null/empty guard,
+freshly-provisioned pass-through, tenant+system-tenant lookup, descriptive error). Also
+added =drop function if exists ores_refdata_validate_country_fn;= to the drop file,
+following the =rounding_type= pattern (which currency's own drop file omits — see below).
+
+** Minor observation: =change_reason_code= validation placement
+
+In the country insert trigger, =ores_dq_validate_change_reason_fn= is called at the end
+of the function, after the version management block. In the currency trigger it is called
+before. Both are functionally correct (the whole trigger runs in one transaction), so this
+was not fixed here. Consistent with the junction table pattern (=party_currencies=,
+=party_countries=).
+
+** Pre-existing gap in currencies: drop file omits =ores_refdata_validate_currency_fn=
+
+=refdata_currencies_drop.sql= does not drop =ores_refdata_validate_currency_fn=, leaving
+it as a dangling function after the table is dropped. The =rounding_type= drop file
+correctly drops its validate function. Filed as a separate finding; not in scope here.

--- a/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
@@ -115,13 +115,13 @@ freshly-provisioned pass-through, tenant+system-tenant lookup, descriptive error
 added =drop function if exists ores_refdata_validate_country_fn;= to the drop file,
 following the =rounding_type= pattern (which currency's own drop file omits — see below).
 
-** Minor observation: =change_reason_code= validation placement
+** =change_reason_code= validation placement — fixed
 
-In the country insert trigger, =ores_dq_validate_change_reason_fn= is called at the end
-of the function, after the version management block. In the currency trigger it is called
-before. Both are functionally correct (the whole trigger runs in one transaction), so this
-was not fixed here. Consistent with the junction table pattern (=party_currencies=,
-=party_countries=).
+The country insert trigger originally called =ores_dq_validate_change_reason_fn= at the
+end of the function, after the version management block. The currency trigger calls it
+before. Fixed in commit =a12d4863= to match the Category 1 ordering rule (fail fast before
+acquiring the row lock). Junction tables (=party_currencies=, =party_countries=) retain
+the after-version placement — that is consistent with their Category 3 contract.
 
 ** Pre-existing gap in currencies: drop file omits =ores_refdata_validate_currency_fn=
 

--- a/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
+++ b/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.org
@@ -59,7 +59,10 @@ spot-grep.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Duplicate =party_countries= in Category 3 list | postgresql_architecture.org | Fixed in 5ab4ade | Typo — removed duplicate. |
+| 2 | Stale note says change_reason_code "not fixed here" | task_verify_sql.org | Fixed in 5ab4ade | Updated to reflect fix in a12d4863. |
+| 3 | =security definer= absent from validate_fn | refdata_countries_create.sql | Deferred | Consistent with all existing validate functions; needs a sweep, not a one-off. |
+| 4 | Bootstrap pass-through lacks =valid_to= filter | refdata_countries_create.sql | Not changed | Pre-existing behaviour matching the currency pattern. |
 
 * Result
 

--- a/doc/analysis/entity_evaluation_checklist.org
+++ b/doc/analysis/entity_evaluation_checklist.org
@@ -57,8 +57,11 @@ Use alongside the [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][Entity Coverage Mat
 | =display_order= column | Dropdown ordering | N/A | Always | =display_order integer not null default 0= |
 | =description= column | Human-readable meaning of code | N/A | Always | =description text not null= |
 | Insert trigger | Version management + validation | Always | Always | =create or replace function ores_refdata_<entity>s_insert_fn()= |
+| Insert trigger: =security definer= + =set search_path= | Prevents search-path injection attacks | Always | Always | Function header must carry =security definer= and =set search_path = public, pg_temp=. Without both, a service role with a manipulated search path can shadow =ores_*_tbl= references and bypass validation. See [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country § Analysis]]; rule is in [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL architecture § Insert trigger patterns]]. |
 | Soft-delete rule | History-preserving delete | Always | Always | =on delete to ... do instead update ... set valid_to = current_timestamp= |
 | Validation function | Allows parent entities to validate soft-FK | Always | Always | =create or replace function ores_refdata_validate_<entity>_fn(p_tenant_id uuid, p_value text)= |
+| Validation function: =security definer= + =set search_path= | Independently secure for direct-call use | Always | Always | Validate functions must carry both attributes independently of their callers. =security definer= does not propagate from caller to callee. See [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country § Analysis]]. |
+| Validation function: bootstrap checks active rows | Bootstrap pass-through must use =valid_to= filter | Always | Always | The =not exists= bootstrap guard must include =and valid_to = ores_utility_infinity_timestamp_fn()=. Without it, a table with only soft-deleted rows skips the pass-through and fails with a misleading "Must be one of: (empty list)" error. See [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country § Analysis]]. |
 | Entity-specific soft-FK validations | Trigger validates referenced lookup values | Always | N/A | =new.rounding_type := ores_refdata_validate_rounding_type_fn(...)= |
 | =party_id= soft-reference | Party-scoped entity | If applicable | N/A | Domain only; check =party_id uuid not null= and trigger validation |
 | =workspace_id= soft-reference | Workspace-scoped entity | If applicable | N/A | Domain only |
@@ -193,4 +196,6 @@ Use alongside the [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][Entity Coverage Mat
 
 - [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][Entity Coverage Matrix]] — canonical entity inventory (Y/N per layer per entity)
 - [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] — reference domain entity used to derive these criteria
+- [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] — extended the DB-layer criteria: =security definer= on insert and validate functions; active-rows bootstrap guard; full architectural rationale in the story's =* Analysis= section
+- [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and Conventions]] — canonical rules for insert trigger patterns, validate function security, and bootstrap pass-through
 - [[id:058DF966-13E0-4D97-9A8B-F22301411015][Entity evaluation skill]] — LLM skill for running this checklist against any entity

--- a/doc/knowledge/architecture/postgresql_architecture.org
+++ b/doc/knowledge/architecture/postgresql_architecture.org
@@ -225,7 +225,7 @@ soft-FKs by other entities.
 
 Tables that control which entities a party can /see/, not data about
 the party itself: =party_currencies=, =party_countries=,
-=party_counterparty=, =party_countries=.
+=party_counterparty=.
 
 These carry version management and audit columns but their entity
 references (=currency_iso_code=, =country_alpha2_code=, =party_id=, …) are

--- a/doc/knowledge/architecture/postgresql_architecture.org
+++ b/doc/knowledge/architecture/postgresql_architecture.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :postgresql:database:architecture:knowledge:
 #+created: 2026-06-03
-#+updated: 2026-06-07
+#+updated: 2026-06-25
 
 ORE Studio uses PostgreSQL as its sole persistent store.  All services
 read and write through a shared database, each with a strictly scoped
@@ -170,6 +170,109 @@ the extension can be created.
 #+begin_src sql
 create extension if not exists timescaledb;
 #+end_src
+
+* Insert trigger patterns
+
+Every writable table has a =BEFORE INSERT= trigger that enforces the
+invariants the application layer is allowed to assume.  Triggers fall
+into three structural categories with different validation contracts.
+
+** Category 1 — Domain entities
+
+Full-CRUD entities with their own MDI windows, shell/CLI commands, and
+manual chapters (=currency=, =country=, =party=, =book=, …).
+
+Trigger structure (order is mandatory):
+
+1. =tenant_id= — =ores_iam_validate_tenant_fn(new.tenant_id)=
+2. Optional soft-FK fields (=coding_scheme_code= inline; named attributes
+   via =ores_refdata_validate_*_fn= / similar)
+3. =change_reason_code= — =ores_dq_validate_change_reason_fn(...)=
+4. Version management block (=SELECT … FOR UPDATE=, optimistic lock check,
+   =UPDATE … SET valid_to=, version increment)
+5. =valid_from= / =valid_to= set by trigger
+6. =modified_by= — =ores_iam_validate_account_username_fn(new.modified_by)=
+7. =performed_by= — =coalesce(ores_iam_current_service_fn(), current_user)=
+
+*Rule*: all validation (steps 1–3) must precede the version management
+block (step 4).  This ensures the trigger fails fast — before acquiring
+the row lock and before closing the previous temporal record — on any
+bad input.
+
+Domain entity triggers should declare =security definer= and
+=set search_path = public, pg_temp= to prevent search-path injection.
+
+** Category 2 — Owned sub-entities
+
+Records that are data /owned by/ a parent entity and carry their own
+temporal history: =party_identifiers=, =party_contact_informations=,
+=business_units=, …
+
+Trigger structure follows Category 1, with these additions:
+
+- Parent UUID FK (e.g. =party_id=) validated inline with
+  =if not exists (select 1 from ores_refdata_parties_tbl where id = NEW.party_id …)=.
+  No separate validate function exists for UUID-keyed parent references;
+  the inline check is the established pattern.
+- Type/scheme attributes (e.g. =id_scheme=) validated via
+  =ores_refdata_validate_party_id_scheme_fn(...)=.
+
+Sub-entities do not have an independent validate function (there is no
+=ores_refdata_validate_party_identifier_fn=); they are not referenced as
+soft-FKs by other entities.
+
+** Category 3 — Pure visibility junctions
+
+Tables that control which entities a party can /see/, not data about
+the party itself: =party_currencies=, =party_countries=,
+=party_counterparty=, =party_countries=.
+
+These carry version management and audit columns but their entity
+references (=currency_iso_code=, =country_alpha2_code=, =party_id=, …) are
+*not validated in the trigger*.  The validated fields are:
+
+- =tenant_id= — =ores_iam_validate_tenant_fn(...)=
+- =modified_by=, =performed_by= — same as Categories 1 & 2
+- =change_reason_code= — =ores_dq_validate_change_reason_fn(...)=
+
+*Why no entity FK validation?*  Junction rows represent an access-control
+decision ("party X may see country Y"), not a business datum.  An orphan
+junction row — pointing to a country that does not (yet) exist — is
+harmless: the join produces no rows and the UI shows nothing.  Contrast
+this with a =book.ledger_ccy= field: if the currency disappears, the
+book's P&L calculation breaks.  The semantic difference justifies the
+asymmetry.
+
+In practice these junctions are populated by trusted internal operations
+(the provisioner, bulk seeders) where the application layer already
+guarantees entity existence.
+
+** Validation functions (=ores_refdata_validate_*_fn=)
+
+Each refdata entity that may appear as a soft-FK attribute on another
+entity *must* define a validation function:
+
+#+begin_src sql
+create or replace function ores_refdata_validate_<entity>_fn(
+    p_tenant_id uuid,
+    p_value     text
+) returns text as $$
+-- Raises 23502 if null/empty.
+-- Returns p_value unchanged if no rows exist yet (bootstrap pass-through).
+-- Raises 23503 with a helpful list if the value is not found.
+$$ language plpgsql;
+#+end_src
+
+These functions are:
+- Called from Category 1 and 2 triggers, never from Category 3.
+- Defined in the same DDL file as their entity's table (at the bottom,
+  after the soft-delete rule).
+- Dropped in the entity's =drop/= file alongside the table and insert
+  function.
+
+The bootstrap pass-through (return =p_value= when the table is empty) is
+intentional: it allows provisioning to seed reference data before the
+validation catalogue is complete.
 
 * Notification triggers
 

--- a/doc/knowledge/architecture/postgresql_architecture.org
+++ b/doc/knowledge/architecture/postgresql_architecture.org
@@ -256,10 +256,13 @@ entity *must* define a validation function:
 create or replace function ores_refdata_validate_<entity>_fn(
     p_tenant_id uuid,
     p_value     text
-) returns text as $$
+) returns text
+security definer
+set search_path = public, pg_temp
+as $$
 -- Raises 23502 if null/empty.
--- Returns p_value unchanged if no rows exist yet (bootstrap pass-through).
--- Raises 23503 with a helpful list if the value is not found.
+-- Returns p_value unchanged if no active rows exist yet (bootstrap pass-through).
+-- Raises 23503 with a helpful list if the value is not found among active rows.
 $$ language plpgsql;
 #+end_src
 
@@ -269,10 +272,24 @@ These functions are:
   after the soft-delete rule).
 - Dropped in the entity's =drop/= file alongside the table and insert
   function.
+- Declared =security definer= + =set search_path = public, pg_temp=
+  unconditionally — see below.
 
-The bootstrap pass-through (return =p_value= when the table is empty) is
-intentional: it allows provisioning to seed reference data before the
-validation catalogue is complete.
+*Security*: validate functions must carry =security definer= and
+=set search_path = public, pg_temp= independently of their callers.
+=security definer= prevents the function from executing as the calling
+service role (which may have a manipulated search path).  =set search_path=
+is required alongside it to pin table resolution to =public= and =pg_temp=;
+=security definer= alone, without a pinned path, is still vulnerable to
+search-path injection.  =security definer= does /not/ propagate to callees —
+each function must declare it explicitly.
+
+*Bootstrap pass-through*: the pass-through check must test for /active/ rows
+(=valid_to = ores_utility_infinity_timestamp_fn()=), not any rows.  A table
+with only soft-deleted historical rows is semantically empty for validation
+purposes; checking without the =valid_to= filter would skip the pass-through,
+then fail the active-row validation with a misleading "Must be one of: (empty
+list)" error.  The =limit 1= inside =EXISTS= is a no-op and is omitted.
 
 * Notification triggers
 

--- a/projects/ores.codegen/library/templates/sql_schema_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_create.mustache
@@ -190,7 +190,7 @@ begin
 
     return new;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger {{table.product}}_{{table.component}}_{{table.entity_plural}}_insert_trg
 before insert on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
@@ -247,8 +247,12 @@ begin
     end if;
 
 {{#table.validation_fn.scope_system}}
-    -- Allow pass-through during bootstrap (empty table)
-    if not exists (select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl limit 1) then
+    -- Allow pass-through during bootstrap (no active rows for system tenant).
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id = ores_utility_system_tenant_id_fn()
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
         return p_value;
     end if;
 
@@ -269,11 +273,11 @@ begin
 {{/table.validation_fn.scope_system}}
 {{#table.validation_fn.scope_both}}
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded {{table.entity_plural}} yet (freshly provisioned tenant).
+    -- seeded active {{table.entity_plural}} yet (freshly provisioned tenant).
     if not exists (
         select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
-        limit 1
+          and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         return p_value;
     end if;
@@ -294,11 +298,11 @@ begin
     end if;
 {{/table.validation_fn.scope_both}}
 {{#table.validation_fn.scope_tenant}}
-    -- Allow pass-through if this tenant has no seeded {{table.entity_plural}} yet.
+    -- Allow pass-through if this tenant has no active {{table.entity_plural}} yet.
     if not exists (
         select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
         where tenant_id = p_tenant_id
-        limit 1
+          and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         return p_value;
     end if;
@@ -321,6 +325,6 @@ begin
 
     return p_value;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 {{/table.validation_fn}}
 {{/table.has_tenant_id}}

--- a/projects/ores.codegen/library/templates/sql_schema_create.org
+++ b/projects/ores.codegen/library/templates/sql_schema_create.org
@@ -213,7 +213,7 @@ begin
 
     return new;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger {{table.product}}_{{table.component}}_{{table.entity_plural}}_insert_trg
 before insert on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
@@ -270,8 +270,12 @@ begin
     end if;
 
 {{#table.validation_fn.scope_system}}
-    -- Allow pass-through during bootstrap (empty table)
-    if not exists (select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl limit 1) then
+    -- Allow pass-through during bootstrap (no active rows for system tenant).
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id = ores_utility_system_tenant_id_fn()
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
         return p_value;
     end if;
 
@@ -292,11 +296,11 @@ begin
 {{/table.validation_fn.scope_system}}
 {{#table.validation_fn.scope_both}}
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded {{table.entity_plural}} yet (freshly provisioned tenant).
+    -- seeded active {{table.entity_plural}} yet (freshly provisioned tenant).
     if not exists (
         select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
-        limit 1
+          and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         return p_value;
     end if;
@@ -317,11 +321,11 @@ begin
     end if;
 {{/table.validation_fn.scope_both}}
 {{#table.validation_fn.scope_tenant}}
-    -- Allow pass-through if this tenant has no seeded {{table.entity_plural}} yet.
+    -- Allow pass-through if this tenant has no active {{table.entity_plural}} yet.
     if not exists (
         select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
         where tenant_id = p_tenant_id
-        limit 1
+          and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         return p_value;
     end if;
@@ -344,10 +348,84 @@ begin
 
     return p_value;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 {{/table.validation_fn}}
 {{/table.has_tenant_id}}
 #+end_src
+
+* Design notes
+
+** Security: =security definer= + =set search_path= on all trigger functions
+
+Both the insert trigger function and every validate function must carry
+=SECURITY DEFINER= and =SET search_path = public, pg_temp=.
+
+A =BEFORE INSERT= trigger function executes under the security context of
+the calling role (the service role that issued the =INSERT=), not the
+function owner, unless =SECURITY DEFINER= is declared.  A service role with
+a misconfigured or compromised =search_path= that includes a schema it
+controls can shadow any =ores_*_tbl= table reference inside the function,
+causing validation to query attacker-controlled data and silently accept any
+input.
+
+=SECURITY DEFINER= and =SET search_path= are required together:
+=SECURITY DEFINER= alone pins the executing user but leaves the search path
+open; an attacker whose schema appears earlier than =public= in the
+connection's =search_path= can still shadow tables even under the owner's
+identity.  Both are needed.
+
+Crucially, =SECURITY DEFINER= does /not/ propagate from a caller to its
+callees.  When an insert function (caller, security definer) calls a validate
+function (callee, security invoker), the callee inherits the /effective
+current user/ at call time (which happens to be the owner, because the caller
+is definer-scoped).  This gives indirect protection — but only while called
+from a correctly annotated insert function.  If the insert function lacks
+=security definer=, the validate function is fully exposed.  Validate
+functions also appear as candidates for future direct application calls (e.g.
+pre-validation before insert); they must be independently safe.
+
+The rule, documented in [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL: Database Architecture and
+Conventions]] (§ Insert trigger patterns), is: every insert trigger function
+and every validate function carries the pair unconditionally.
+
+Historical note: the IAM layer (=ores_iam_validate_*_fn=,
+=ores_iam_*_insert_fn=) applied this consistently from the start.  The
+refdata layer did not; only =refdata_countries_insert_fn= and a handful of
+others had it.  The country commission story (sprint 21) established this as
+the canonical rule and fixed it in the template.  Entities generated before
+this fix retain the gap until recommissioned.
+
+** Bootstrap pass-through: active rows only
+
+The bootstrap pass-through returns =p_value= unchanged when the entity table
+has not yet been seeded.  This allows provisioning to insert reference data
+rows before the validation catalogue is complete.
+
+The check must test for /active/ rows (=valid_to = ores_utility_infinity_timestamp_fn()=),
+not any rows.  If the check uses a bare =select 1 ... limit 1= without the
+=valid_to= filter, a table that contains only soft-deleted historical rows
+(all active rows closed) will fail the bootstrap test (rows exist, so
+=not exists= is false), skip the pass-through, then fail the validation
+lookup with a misleading error:
+
+#+begin_example
+ERROR: Invalid country: GB. Must be one of: (empty list)
+#+end_example
+
+The caller cannot distinguish "value is not in the catalogue" from "there is
+no catalogue."  The correct semantic is: "has this table been seeded with
+usable reference data?" — which means active rows.  See
+[[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Timestamps: Architecture and Conventions]] for the active-row
+convention (=valid_to = ores_utility_infinity_timestamp_fn()=).
+
+The =limit 1= inside an =EXISTS= predicate is a no-op (=EXISTS= short-circuits
+on the first matching row regardless) and is omitted for clarity.
+
+Historical note: all 50 =ores_refdata_validate_*_fn= functions in the
+codebase at the time of the country commission carried the unfixed form.
+The fix is applied here in the template; existing generated functions
+(=currencies=, =rounding_types=, etc.) will be corrected when recommissioned
+or regenerated via codegen.
 
 * See also
 

--- a/projects/ores.sql/create/refdata/refdata_countries_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_create.sql
@@ -141,3 +141,48 @@ do instead
   where tenant_id = old.tenant_id
   and alpha2_code = old.alpha2_code
   and valid_to = ores_utility_infinity_timestamp_fn();
+
+-- =============================================================================
+-- Validation function for country
+-- Validates that an alpha2_code exists in the countries table.
+-- Returns the validated value.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
+-- =============================================================================
+create or replace function ores_refdata_validate_country_fn(
+    p_tenant_id uuid,
+    p_value text
+) returns text as $$
+begin
+    if p_value is null or p_value = '' then
+        raise exception 'Invalid country: value cannot be null or empty'
+            using errcode = '23502';
+    end if;
+
+    -- Allow pass-through if neither this tenant nor the system tenant has
+    -- seeded countries yet (freshly provisioned tenant).
+    if not exists (
+        select 1 from ores_refdata_countries_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+        limit 1
+    ) then
+        return p_value;
+    end if;
+
+    -- Validate against this tenant's values and the system tenant's canonical set.
+    if not exists (
+        select 1 from ores_refdata_countries_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+          and alpha2_code = p_value
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid country: %. Must be one of: %', p_value, (
+            select string_agg(alpha2_code::text, ', ' order by alpha2_code)
+            from ores_refdata_countries_tbl
+            where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) using errcode = '23503';
+    end if;
+
+    return p_value;
+end;
+$$ language plpgsql;

--- a/projects/ores.sql/create/refdata/refdata_countries_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_create.sql
@@ -92,6 +92,9 @@ begin
         using errcode = '23503';
     end if;
 
+    -- Validate change_reason_code
+    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
+
     select version into current_version
     from "ores_refdata_countries_tbl"
     where tenant_id = new.tenant_id
@@ -121,8 +124,6 @@ begin
     new.valid_to = ores_utility_infinity_timestamp_fn();
     new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
     new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
-
-    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
 
     return new;
 end;

--- a/projects/ores.sql/create/refdata/refdata_countries_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_create.sql
@@ -152,7 +152,10 @@ do instead
 create or replace function ores_refdata_validate_country_fn(
     p_tenant_id uuid,
     p_value text
-) returns text as $$
+) returns text
+security definer
+set search_path = public, pg_temp
+as $$
 begin
     if p_value is null or p_value = '' then
         raise exception 'Invalid country: value cannot be null or empty'
@@ -160,11 +163,11 @@ begin
     end if;
 
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded countries yet (freshly provisioned tenant).
+    -- seeded active countries yet (freshly provisioned tenant).
     if not exists (
         select 1 from ores_refdata_countries_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
-        limit 1
+          and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         return p_value;
     end if;

--- a/projects/ores.sql/drop/refdata/refdata_countries_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_countries_drop.sql
@@ -21,4 +21,5 @@
 drop rule if exists ores_refdata_countries_delete_rule on "ores_refdata_countries_tbl";
 drop trigger if exists ores_refdata_countries_insert_trg on "ores_refdata_countries_tbl";
 drop function if exists ores_refdata_countries_insert_fn;
+drop function if exists ores_refdata_validate_country_fn;
 drop table if exists "ores_refdata_countries_tbl";


### PR DESCRIPTION
## Summary

SQL verification of refdata_countries_create.sql against the domain entity evaluation checklist. Fixed missing ores_refdata_validate_country_fn (following the currency pattern), fixed change_reason_code validation ordering in the insert trigger, and documented the three insert trigger categories in postgresql_architecture.org. Follow-up commits fix two architectural gaps identified in the review analysis: missing security definer on validate functions, and the bootstrap pass-through checking any rows rather than active rows.

## Changes

- Add ores_refdata_validate_country_fn to refdata_countries_create.sql (was missing; needed for future soft-FK callers)
- Add drop function if exists ores_refdata_validate_country_fn to the countries drop file
- Move change_reason_code validation before the version management block in the country insert trigger, matching the established currency pattern
- Add Insert trigger patterns section to postgresql_architecture.org: three categories, validate_*_fn convention, ordering rule, and rationale for junction FK omission
- Fix ores_refdata_validate_country_fn: add security definer + set search_path = public, pg_temp (independently secure for future direct-call use; security definer does not propagate from caller to callee)
- Fix ores_refdata_validate_country_fn: bootstrap not-exists check now filters for valid_to = ores_utility_infinity_timestamp_fn() (active rows only); previous bare select 1 would skip the pass-through for tables with only soft-deleted rows, producing a misleading "Must be one of: (empty list)" error
- Fix sql_schema_create.mustache and its literate source sql_schema_create.org: same security definer and active-rows fixes applied to all three validation scopes (scope_system, scope_both, scope_tenant) and to the insert function; add Design notes section with architectural rationale and org-roam links
- Update entity_evaluation_checklist.org: three new DB-layer rows for insert trigger security definer, validate function security definer, and bootstrap active-rows requirement; each links to Commission: country Analysis section for rationale
- Add Analysis section to commission_country story.org: full first-principles reasoning for both items with verdicts, impact assessment, correct approach, and org-roam cross-links

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: country](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_country/story.html) | F0FC905B-6A70-486F-A23F-0064B6A3EE75 |
| Task | [Verify country SQL against the evaluation checklist](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_country/task_verify_sql.html) | 722D1013-6867-48E5-BB7D-4C94817AD46C |

🤖 Generated with [Claude Code](https://claude.com/claude-code)