### PR TITLE
[build] Fix sccache wrapper breaking Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,19 +263,20 @@ endif()
 find_program(CCACHE_PROGRAM sccache)
 if (CCACHE_PROGRAM)
     message(STATUS "Found SCCache (${CCACHE_PROGRAM})...")
-    # Use a wrapper script rather than sccache directly so that
-    # SCCACHE_BASEDIR is always set to this worktree's root at build time.
-    # sccache normalises any absolute path under BASEDIR to a relative path
-    # before computing the cache key, which means every git worktree of the
-    # same commit shares a single cache entry per translation unit.  Without
-    # this, each worktree compiles every TU from scratch (100% cache misses).
-    # The wrapper resolves the project root from its own location at runtime,
-    # so it works correctly across worktrees and machines without hardcoding.
     if(WIN32)
         # .sh scripts are not valid Win32 executables; use sccache directly.
+        # SCCACHE_BASEDIR cross-worktree sharing is not available on Windows.
         set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "" FORCE)
         set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "" FORCE)
     else()
+        # Use a wrapper script rather than sccache directly so that
+        # SCCACHE_BASEDIR is always set to this worktree's root at build time.
+        # sccache normalises any absolute path under BASEDIR to a relative path
+        # before computing the cache key, which means every git worktree of the
+        # same commit shares a single cache entry per translation unit.  Without
+        # this, each worktree compiles every TU from scratch (100% cache misses).
+        # The wrapper resolves the project root from its own location at runtime,
+        # so it works correctly across worktrees and machines without hardcoding.
         set(_sccache_wrapper "${CMAKE_SOURCE_DIR}/build/scripts/sccache_wrapper.sh")
         if(NOT EXISTS "${_sccache_wrapper}")
             message(FATAL_ERROR "sccache wrapper not found: ${_sccache_wrapper}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,12 +271,18 @@ if (CCACHE_PROGRAM)
     # this, each worktree compiles every TU from scratch (100% cache misses).
     # The wrapper resolves the project root from its own location at runtime,
     # so it works correctly across worktrees and machines without hardcoding.
-    set(_sccache_wrapper "${CMAKE_SOURCE_DIR}/build/scripts/sccache_wrapper.sh")
-    if(NOT EXISTS "${_sccache_wrapper}")
-        message(FATAL_ERROR "sccache wrapper not found: ${_sccache_wrapper}")
+    if(WIN32)
+        # .sh scripts are not valid Win32 executables; use sccache directly.
+        set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "" FORCE)
+    else()
+        set(_sccache_wrapper "${CMAKE_SOURCE_DIR}/build/scripts/sccache_wrapper.sh")
+        if(NOT EXISTS "${_sccache_wrapper}")
+            message(FATAL_ERROR "sccache wrapper not found: ${_sccache_wrapper}")
+        endif()
+        set(CMAKE_C_COMPILER_LAUNCHER "${_sccache_wrapper}" CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${_sccache_wrapper}" CACHE STRING "" FORCE)
     endif()
-    set(CMAKE_C_COMPILER_LAUNCHER "${_sccache_wrapper}" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${_sccache_wrapper}" CACHE STRING "" FORCE)
 else()
     message(STATUS "SCCache NOT found.")
 endif()

--- a/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/story.org
+++ b/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/story.org
@@ -1,0 +1,49 @@
+:PROPERTIES:
+:ID: 7FE21B3F-9976-4948-AEF7-A3B3962E0C9E
+:END:
+#+title: Story: Hotfix: sccache wrapper breaks Windows builds
+#+description: sccache_wrapper.sh is set as CMAKE_CXX_COMPILER_LAUNCHER on all platforms but .sh scripts are not valid Win32 executables; all Windows CI jobs fail with 'CreateProcess: %1 is not a valid Win32 application'.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:build:sprint_21:v0:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: merry_newton
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore green Windows CI by ensuring sccache_wrapper.sh is only used as
+a compiler launcher on platforms that can execute POSIX shell scripts.
+On Windows, fall back to invoking sccache directly.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Applying fix in CMakeLists.txt.        |
+| Waiting on    | Nothing.                               |
+| Next          | PR and CI green.                       |
+| Last touched  | 2026-06-25                               |
+
+* Acceptance
+
+- All four Windows CI jobs (msvc-debug, msvc-release, clang-debug, clang-release) pass.
+- Linux/macOS builds are unaffected.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:BD442045-F006-49F4-A25F-313FB04A9D84][Scaffold story: Hotfix: sccache wrapper breaks Windows builds]] | STARTED | 2026-06-25 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:4BED0866-F925-4198-8FA0-F0813E54E9E1][Implement Hotfix: sccache wrapper breaks Windows builds]] | BACKLOG | | | Initial task for: Hotfix: sccache wrapper breaks Windows builds |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_implement_sccache-wrapper-windows.org
+++ b/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_implement_sccache-wrapper-windows.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: 4BED0866-F925-4198-8FA0-F0813E54E9E1
+:END:
+#+title: Task: Implement Hotfix: sccache wrapper breaks Windows builds
+#+description: Initial task for: Hotfix: sccache wrapper breaks Windows builds
+#+type: task
+#+level: s1
+#+filetags: :sccache-wrapper-windows:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Guard sccache_wrapper.sh usage with if(NOT WIN32) in CMakeLists.txt so
+Windows uses sccache directly and non-Windows continues to use the wrapper.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] |
+| Now          | Fix applied in CMakeLists.txt.         |
+| Waiting on   | Nothing.                               |
+| Next         | PR; wait for CI green.                 |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- CMakeLists.txt: on WIN32 set launcher to CCACHE_PROGRAM (sccache); on non-Windows use the wrapper.
+- All Windows CI jobs pass.
+
+* Plan
+
+Root cause: PR #1294 introduced build/scripts/sccache_wrapper.sh and
+unconditionally set it as CMAKE_C/CXX_COMPILER_LAUNCHER. On Windows,
+ninja tries to spawn this .sh file as a Win32 process, which fails with
+"CreateProcess: %1 is not a valid Win32 application" (seen at step 32/5004).
+
+Fix: in the sccache block in CMakeLists.txt, add an if(WIN32)/else split:
+- WIN32: set launcher to ${CCACHE_PROGRAM} (sccache binary directly)
+- non-WIN32: set launcher to the wrapper script as before
+
+* Notes
+
+Root cause confirmed from CI log (job 83350070016): ninja tried to spawn
+sccache_wrapper.sh as a Win32 process at build step 32/5004 (ores.database PCH).
+Error: "ninja: fatal: CreateProcess: %1 is not a valid Win32 application."
+
+Fix: added if(WIN32)/else block in CMakeLists.txt lines 274-285. On WIN32
+the launcher is ${CCACHE_PROGRAM} (the sccache binary); on non-WIN32 the
+wrapper script is used as before. All four Windows jobs should now pass.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
+++ b/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
@@ -20,7 +20,8 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Scaffold the hotfix story artefacts: story.org, task files, sprint wiring,
+and open the PR that carries the fix.
 
 * Status
 

--- a/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
+++ b/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: BD442045-F006-49F4-A25F-313FB04A9D84
+:END:
+#+title: Task: Scaffold story: Hotfix: sccache wrapper breaks Windows builds
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :sccache-wrapper-windows:sprint_21:v0:
+#+owner: marco
+#+branch: hotfix/sccache-wrapper-windows
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: merry_newton
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
+++ b/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.org
@@ -8,7 +8,7 @@
 #+filetags: :sccache-wrapper-windows:sprint_21:v0:
 #+owner: marco
 #+branch: hotfix/sccache-wrapper-windows
-#+pr:
+#+pr: 1301
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1301][#1301]] | [build] Fix sccache wrapper breaking Windows builds |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -128,6 +128,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic PRs badge; fix stale Sprint-20 → Sprint-21 badge. |
+| [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] | STARTED | 2026-06-25 | | sccache_wrapper.sh is set as CMAKE_CXX_COMPILER_LAUNCHER on all platforms but .sh scripts are not valid Win32 executables; all Windows CI jobs fail with 'CreateProcess: %1 is not a valid Win32 application'. |
 
 * Achievements
 


### PR DESCRIPTION
## Summary

sccache_wrapper.sh was unconditionally set as CMAKE_CXX_COMPILER_LAUNCHER. On Windows, ninja cannot spawn a .sh file as a Win32 process, causing all four Windows CI jobs to fail with CreateProcess error. Guard the wrapper with if(WIN32): on Windows use sccache directly, on other platforms use the wrapper as before.

## Changes

- CMakeLists.txt: added if(WIN32)/else block in the sccache launcher setup — WIN32 path uses ${CCACHE_PROGRAM} directly, non-WIN32 path continues to use sccache_wrapper.sh

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: sccache wrapper breaks Windows builds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/story.html) | 7FE21B3F-9976-4948-AEF7-A3B3962E0C9E |
| Task | [Scaffold story: Hotfix: sccache wrapper breaks Windows builds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/sccache-wrapper-windows/task_scaffold_sccache-wrapper-windows.html) | BD442045-F006-49F4-A25F-313FB04A9D84 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)