### PR TITLE
[agile] Close task: auto-assign base port in compass env provision

### DIFF
--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
@@ -37,7 +37,7 @@ Improve compass env provision so it never collides with existing environments by
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:0D4CC04E-B2C0-4658-B3F7-4C165801E14F][Auto-assign base port in compass env provision]] | DONE | 2026-06-24 | 2026-06-24 | Scan sibling .env files and pick next free port; no --base-port needed. |
+| [[id:0D4CC04E-B2C0-4658-B3F7-4C165801E14F][Auto-assign base port in compass env provision]] | DONE | 2026-06-24 | 2026-06-25 | Scan sibling .env files and pick next free port; no --base-port needed. |
 | [[id:6DAD3D23-489F-4E71-9740-22D77DADFE1A][Init vcpkg submodule in env provision for full environments]] | DONE | 2026-06-24 | 2026-06-25 | Auto-init vcpkg after git worktree add for full envs. |
 | [[id:51EBD8EB-EA76-4DD9-A0B2-4AC89F82C67A][compass fleet: show provision type (full/light) per worktree]] | DONE | 2026-06-24 | 2026-06-25 | Show ORES_PROVISION_TYPE in fleet output. |
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :sprint_21:v0:
 #+created: 2026-06-24
-#+updated: 2026-06-24
+#+updated: 2026-06-25
 #+environment: local1
 #+todo: BACKLOG STARTED | DONE ABANDONED
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-24
 #+updated: 2026-06-24
-#+environment: local1
+#+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,11 +26,11 @@ Update compass env provision to scan all sibling ores_dev_* directories, read th
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] |
-| Now          | Implementation complete; PR #1291 open for review. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Merge PR.                              |
+| Next         | Nothing. |
 | Last touched | 2026-06-24                               |
 
 * Acceptance
@@ -62,3 +62,5 @@ plan itself stays — it is the historical record of what we did.)
 | 4 | NATS monitor port: inconsistency risk if ORES_NATS_MONITOR_PORT invalid | env_init.py:413 | Declined — pre-existing on main, out of scope | 1 of 3 reviews flagged |
 
 * Result
+
+`compass env provision` now scans all sibling `ores_dev_*` directories, reads their `ORES_BASE_PORT`, and picks the next free slot (max + 1000). The `--base-port` flag is no longer required. Both acceptance criteria met: auto-selection works with no flag, and no port collision can occur with an existing environment. Shipped in PR #1291.

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-24
-#+updated: 2026-06-24
+#+updated: 2026-06-25
 #+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -31,7 +31,7 @@ Update compass env provision to scan all sibling ores_dev_* directories, read th
 | Now          | Nothing. |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
-| Last touched | 2026-06-24                               |
+| Last touched | 2026-06-25                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
+++ b/doc/agile/versions/v0/sprint_21/compass_env_improvements/task_auto_assign_base_port.org
@@ -60,6 +60,7 @@ plan itself stays — it is the historical record of what we did.)
 | 2 | Import placement: from env_init import _scan_ports mid-file, not at top | env_create.py:53 | Fixed in b28bea2db | 2 of 3 reviews flagged |
 | 3 | Doc boilerplate: State STARTED but Now says "Not yet started." | task_auto_assign_base_port.org | Fixed in b28bea2db | 2 of 3 reviews flagged |
 | 4 | NATS monitor port: inconsistency risk if ORES_NATS_MONITOR_PORT invalid | env_init.py:413 | Declined — pre-existing on main, out of scope | 1 of 3 reviews flagged |
+| 5 (PR #1302) | #+updated and Last touched not bumped to close date | task_auto_assign_base_port.org, story.org | Fixed in 9446a4997 | |
 
 * Result
 


### PR DESCRIPTION
## Summary

- Flips task `0D4CC04E` to DONE and writes the Result section
- Updates story task-row end-date to today

The implementation itself shipped in PR #1291 (merged 2026-06-24); this PR carries only the bookkeeping close-out that was missed at that time.

## Test plan

- [ ] `compass where` no longer shows the task as STARTED
- [ ] Task doc Result section is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)