### PR TITLE
[agile] Add story and tasks: improve site documentation discoverability

### DIFF
--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 7F306A93-6C30-47AC-BD37-7D762A49B475
+:END:
+#+title: Story: Improve site documentation discoverability
+#+description: Make key catalogue pages (skills, recipes, memories, knowledge) reachable from the site menu and cross-linked from their glossary entries, so website visitors can find reference material without knowing the URL.
+#+type: story
+#+level: s2
+#+filetags: :documentation:site:ux:sprint_21:v0:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+A visitor to the published website can reach any key catalogue page
+(skills, recipes, memories, knowledge) from the site menu, and every
+relevant glossary entry links directly to its catalogue.  Currently the
+skills catalogue is unreachable from the menus and the Skills glossary
+entry carries no link to it; the same gap exists for other catalogue
+types.  The fix is two-pronged: expose catalogue pages in the site
+navigation, and add cross-links from glossary entries so a reader who
+lands on a definition can immediately jump to the live catalogue.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-25                               |
+
+* Acceptance
+
+- Skills catalogue is reachable from the site menu (no URL knowledge required).
+- The Skills glossary entry links to the skills catalogue page.
+- Recipes, memories, and knowledge catalogue pages are similarly reachable from the site menu.
+- Glossary entries for recipe, memory, and knowledge cross-link to their respective catalogue pages.
+- No catalogue page is orphaned (reachable only by direct URL).
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
+
+* Decisions
+
+* Out of scope
+
+- Redesigning the site menu structure beyond adding catalogue entries.
+- Creating new catalogue pages — only wiring existing ones into navigation and glossary.
+- Glossary entries for concepts that have no corresponding catalogue.

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
@@ -48,6 +48,9 @@ lands on a definition can immediately jump to the live catalogue.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:48EBD816-122C-4C40-ADEA-0AFA75696493][Link skills glossary entry to skills catalogue and add catalogue to site menu]] | BACKLOG | | | Add an org-roam link from the Skills glossary entry to the skills catalogue page, and expose the skills catalogue in the published site navigation menu. |
+| [[id:2894F9FE-BC56-4F82-8A29-C23A91709227][Link recipes glossary entry to recipes catalogue and add catalogue to site menu]] | BACKLOG | | | Add an org-roam link from the Recipes glossary entry to the recipes catalogue page, and expose the recipes catalogue in the published site navigation menu. |
+| [[id:F99B5D02-9202-48D2-8155-532E9DC78E5A][Link memories glossary entry to memories catalogue and add catalogue to site menu]] | BACKLOG | | | Add an org-roam link from the Memory glossary entry to the memories catalogue page, and expose the memories catalogue in the published site navigation menu. |
+| [[id:5DC6AE6B-2BAB-45F3-A11B-CA6E9C16DF12][Link knowledge glossary entry to knowledge catalogue and add catalogue to site menu]] | BACKLOG | | | Add an org-roam link from the Knowledge glossary entry to the knowledge catalogue page, and expose the knowledge catalogue in the published site navigation menu. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
@@ -47,7 +47,7 @@ lands on a definition can immediately jump to the live catalogue.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:48EBD816-122C-4C40-ADEA-0AFA75696493][Link skills glossary entry to skills catalogue and add catalogue to site menu]] | BACKLOG | | | Add an org-roam link from the Skills glossary entry to the skills catalogue page, and expose the skills catalogue in the published site navigation menu. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.org
@@ -32,7 +32,7 @@ lands on a definition can immediately jump to the live catalogue.
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Pick first task to start.              |
 | Last touched  | 2026-06-25                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_knowledge_catalogue_menu_and_glossary_link.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_knowledge_catalogue_menu_and_glossary_link.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 5DC6AE6B-2BAB-45F3-A11B-CA6E9C16DF12
+:END:
+#+title: Task: Link knowledge glossary entry to knowledge catalogue and add catalogue to site menu
+#+description: Add an org-roam link from the Knowledge glossary entry to the knowledge catalogue page, and expose the knowledge catalogue in the published site navigation menu.
+#+type: task
+#+level: s1
+#+filetags: :site_doc_discoverability:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A reader who lands on the Knowledge glossary entry can follow a direct
+link to the knowledge catalogue without knowing its URL.  A first-time
+visitor browsing the published site menu can reach the knowledge catalogue
+from the navigation without any prior knowledge of where it lives.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- The Knowledge glossary entry contains an =[[id:...]]= org-roam link pointing to the knowledge catalogue page.
+- The knowledge catalogue page appears as a reachable item in the published site navigation menu.
+- No URL knowledge is required to reach the knowledge catalogue from the site menu.
+- The site builds without error after the changes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_memories_catalogue_menu_and_glossary_link.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_memories_catalogue_menu_and_glossary_link.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: F99B5D02-9202-48D2-8155-532E9DC78E5A
+:END:
+#+title: Task: Link memories glossary entry to memories catalogue and add catalogue to site menu
+#+description: Add an org-roam link from the Memory glossary entry to the memories catalogue page, and expose the memories catalogue in the published site navigation menu.
+#+type: task
+#+level: s1
+#+filetags: :site_doc_discoverability:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A reader who lands on the Memory glossary entry can follow a direct
+link to the memories catalogue without knowing its URL.  A first-time
+visitor browsing the published site menu can reach the memories catalogue
+from the navigation without any prior knowledge of where it lives.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- The Memory glossary entry contains an =[[id:...]]= org-roam link pointing to the memories catalogue page.
+- The memories catalogue page appears as a reachable item in the published site navigation menu.
+- No URL knowledge is required to reach the memories catalogue from the site menu.
+- The site builds without error after the changes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_recipes_catalogue_menu_and_glossary_link.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_recipes_catalogue_menu_and_glossary_link.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 2894F9FE-BC56-4F82-8A29-C23A91709227
+:END:
+#+title: Task: Link recipes glossary entry to recipes catalogue and add catalogue to site menu
+#+description: Add an org-roam link from the Recipes glossary entry to the recipes catalogue page, and expose the recipes catalogue in the published site navigation menu.
+#+type: task
+#+level: s1
+#+filetags: :site_doc_discoverability:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A reader who lands on the Recipes glossary entry can follow a direct
+link to the recipes catalogue without knowing its URL.  A first-time
+visitor browsing the published site menu can reach the recipes catalogue
+from the navigation without any prior knowledge of where it lives.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- The Recipes glossary entry contains an =[[id:...]]= org-roam link pointing to the recipes catalogue page.
+- The recipes catalogue page appears as a reachable item in the published site navigation menu.
+- No URL knowledge is required to reach the recipes catalogue from the site menu.
+- The site builds without error after the changes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_skills_catalogue_menu_and_glossary_link.org
+++ b/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_skills_catalogue_menu_and_glossary_link.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 48EBD816-122C-4C40-ADEA-0AFA75696493
+:END:
+#+title: Task: Link skills glossary entry to skills catalogue and add catalogue to site menu
+#+description: Add an org-roam link from the Skills glossary entry to the skills catalogue page, and expose the skills catalogue in the published site navigation menu.
+#+type: task
+#+level: s1
+#+filetags: :site_doc_discoverability:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A reader who lands on the Skills glossary entry — whether from a search
+result or a glossary link in prose — can follow a direct link to the
+skills catalogue without knowing its URL.  Simultaneously, a first-time
+visitor browsing the published site menu can reach the skills catalogue
+from the navigation without any prior knowledge of where it lives.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- The Skills glossary entry contains an =[[id:...]]= org-roam link pointing to the skills catalogue page.
+- The skills catalogue page appears as a reachable item in the published site navigation menu.
+- No URL knowledge is required to reach the skills catalogue from the site menu.
+- The site builds without error after the changes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -128,6 +128,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:91EF5D59-3313-4D63-99E8-AED6B3FADF90][Knowledge graph housekeeping]] | DONE | 2026-06-12 | 2026-06-15 | Ongoing bucket for small doc and knowledge-graph fixes spotted during normal work. |
+| [[id:7F306A93-6C30-47AC-BD37-7D762A49B475][Improve site documentation discoverability]] | BACKLOG | | | Expose catalogue pages in the site menu; cross-link glossary entries (skills, recipes, memories, knowledge) to their catalogues. |
 
 ** Hotfixes
 


### PR DESCRIPTION
## Summary

Scaffold a new Sprint 21 story to improve navigation to catalogue pages on the published website. The immediate trigger is that key catalogue pages (skills, recipes, memories, knowledge) are unreachable from the site menus, and their glossary entries carry no cross-links to them. This PR adds the story and its four tasks — one per catalogue type.

## Changes

- Add story: *Improve site documentation discoverability* (Sprint 21, Documentation section)
- Add task: link skills glossary entry to skills catalogue and expose catalogue in site menu
- Add task: link recipes glossary entry to recipes catalogue and expose catalogue in site menu
- Add task: link memories glossary entry to memories catalogue and expose catalogue in site menu
- Add task: link knowledge glossary entry to knowledge catalogue and expose catalogue in site menu

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve site documentation discoverability](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/site_doc_discoverability/story.html) | 7F306A93-6C30-47AC-BD37-7D762A49B475 |
| Task | [Link skills glossary entry to skills catalogue and add catalogue to site menu](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_skills_catalogue_menu_and_glossary_link.html) | 48EBD816-122C-4C40-ADEA-0AFA75696493 |
| Task | [Link recipes glossary entry to recipes catalogue and add catalogue to site menu](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_recipes_catalogue_menu_and_glossary_link.html) | 2894F9FE-BC56-4F82-8A29-C23A91709227 |
| Task | [Link memories glossary entry to memories catalogue and add catalogue to site menu](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_memories_catalogue_menu_and_glossary_link.html) | F99B5D02-9202-48D2-8155-532E9DC78E5A |
| Task | [Link knowledge glossary entry to knowledge catalogue and add catalogue to site menu](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/site_doc_discoverability/task_knowledge_catalogue_menu_and_glossary_link.html) | 5DC6AE6B-2BAB-45F3-A11B-CA6E9C16DF12 |