### PR TITLE
[doc] FX spot synthetic data PoC: inventory and architecture

### DIFF
--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -86,6 +86,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity. Carried fr
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:BED42DF9-6460-4B3C-A6F4-B585D66247AE][Consistent synthetic market data generation: approach analysis]] | STARTED | 2026-06-25 | | Survey three academic papers; catalogue ORE asset-class data requirements; produce a developer-ready approach document for consistent, evolvable synthetic market data. |
+| [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] | STARTED | 2026-06-25 | | Vertical PoC implementing FX spot synthetic data generation end-to-end: feed config persistence, generation service with 12 generator types, DB write, NATS tick publishing, and live chart display. |
 
 ** Tooling
 
@@ -137,7 +138,6 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 |-------+-------+-------+-----+-------------|
 | [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic PRs badge; fix stale Sprint-20 → Sprint-21 badge. |
 | [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] | STARTED | 2026-06-25 | | sccache_wrapper.sh is set as CMAKE_CXX_COMPILER_LAUNCHER on all platforms but .sh scripts are not valid Win32 executables; all Windows CI jobs fail with 'CreateProcess: %1 is not a valid Win32 application'. |
-| [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] | BACKLOG | | | Vertical PoC implementing FX spot synthetic data generation end-to-end: configuration UI with GMM parameters and tick frequency, generation service with configurable tick clock, DB persistence, NATS notifications, and live time-series chart display. Scoped to FX spot only to exercise the full architecture stack before broadening to other asset classes. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -137,6 +137,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 |-------+-------+-------+-----+-------------|
 | [[id:5422B06E-927F-4342-BCA0-45FCE55EBCC5][Fix readme badges]] | DONE | 2026-06-12 | 2026-06-12 | Replace broken dynamic PRs badge; fix stale Sprint-20 → Sprint-21 badge. |
 | [[id:7FE21B3F-9976-4948-AEF7-A3B3962E0C9E][Hotfix: sccache wrapper breaks Windows builds]] | STARTED | 2026-06-25 | | sccache_wrapper.sh is set as CMAKE_CXX_COMPILER_LAUNCHER on all platforms but .sh scripts are not valid Win32 executables; all Windows CI jobs fail with 'CreateProcess: %1 is not a valid Win32 application'. |
+| [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] | BACKLOG | | | Vertical PoC implementing FX spot synthetic data generation end-to-end: configuration UI with GMM parameters and tick frequency, generation service with configurable tick clock, DB persistence, NATS notifications, and live time-series chart display. Scoped to FX spot only to exercise the full architecture stack before broadening to other asset classes. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -59,6 +59,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 - [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — PoC architecture: gap analysis, new =ores.synthetic= service, tick data flow, NATS subjects, Qt chart window, open design questions, implementation order. Gates implementation.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document driving all algorithm choices in this PoC.
 - [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern used for typed feed config parameter serialisation: type-specific NATS subjects, discriminator on =market_feed_config.feed_type=, two-phase dispatch, wrapper structs.
+- [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — full taxonomy of the 12 generator types (5 deterministic + 7 stochastic); =IStochasticProcess= interface; performance design for high-frequency multi-pair generation.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -32,7 +32,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 
 - An inventory document exists cataloguing: existing market data DB schema and components; relevant workspace infrastructure; existing NATS channel conventions; existing UI patterns usable for charts.
 - A PoC scope document exists specifying: the minimal DB schema additions for FX spot ticks; the generation service interface; the NATS channel and message format for FX spot ticks; the configuration UI wireframe; the live chart UI wireframe.
-- FX spot can be configured via a dedicated UI: currency pair selection, GMM parameters (K, training window, stationarity transform), tick frequency (mode + parameters), target workspace, start/stop controls.
+- FX spot can be configured via a dedicated UI: currency pair selection, feed type (fixed/oscillator/GMM/…), type-specific parameters (e.g. GMM: K and initial price), tick frequency (mode + parameters), target workspace, start/stop controls.
 - A generation service ticks FX spot values at the configured frequency into the workspace, using GMM (seeded/static parameters acceptable for PoC — no live historical calibration required).
 - Each new FX spot tick is published to a NATS subject and persisted to the workspace DB table.
 - A Qt client screen subscribes to the NATS subject and displays a live updating time-series chart (x = time, y = FX spot mid-price); chart updates in real time as ticks arrive.
@@ -43,7 +43,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:DF38F297-C8BF-41C8-904B-C04622FF179C][Scaffold story: PoC: synthetic market data generation — FX spot vertical slice]] | STARTED | 2026-06-25 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] | STARTED | 2026-06-25 | | Catalogue existing market data infrastructure (DB, services, UI, messaging) and produce a PoC scope document defining what needs to be built vs reused for the FX spot vertical slice. |
+| [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] | DONE | 2026-06-25 | 2026-06-25 | Catalogue existing market data infrastructure (DB, services, UI, messaging) and produce a PoC scope document defining what needs to be built vs reused for the FX spot vertical slice. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -58,6 +58,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — existing stack inventory: DB schema, tenant scoping, NATS subjects, Qt components, ORE CSV format, service registry.
 - [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — PoC architecture: gap analysis, new =ores.synthetic= service, tick data flow, NATS subjects, Qt chart window, open design questions, implementation order. Gates implementation.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document driving all algorithm choices in this PoC.
+- [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern used for typed feed config parameter serialisation: type-specific NATS subjects, discriminator on =market_feed_config.feed_type=, two-phase dispatch, wrapper structs.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 8A65240D-C7A2-4F66-860F-97137B03B482
+:END:
+#+title: Story: PoC: synthetic market data generation — FX spot vertical slice
+#+description: Vertical PoC implementing FX spot synthetic data generation end-to-end: configuration UI with GMM parameters and tick frequency, generation service with configurable tick clock, DB persistence, NATS notifications, and live time-series chart display. Scoped to FX spot only to exercise the full architecture stack before broadening to other asset classes.
+#+type: story
+#+level: s2
+#+filetags: :market_data:synthetic:poc:sprint_21:v0:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: bright_faraday
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Validate the approach developed in the sprint-21 analysis story by building a working vertical PoC limited to FX spot. The PoC must exercise every architecture tier — configuration UI, generation service with configurable tick frequency, DB persistence, NATS event publishing, and live client chart — before the approach is broadened to other asset classes. The intent is to work slowly and carefully across the full stack with the narrowest possible data scope so that each architectural decision is validated before it is replicated for other asset classes.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Scaffold done; inventory and scoping task next.     |
+| Waiting on    | Nothing.                                            |
+| Next          | Inventory and PoC scope task (F8562D22).            |
+| Last touched  | 2026-06-25                               |
+
+* Acceptance
+
+- An inventory document exists cataloguing: existing market data DB schema and components; relevant workspace infrastructure; existing NATS channel conventions; existing UI patterns usable for charts.
+- A PoC scope document exists specifying: the minimal DB schema additions for FX spot ticks; the generation service interface; the NATS channel and message format for FX spot ticks; the configuration UI wireframe; the live chart UI wireframe.
+- FX spot can be configured via a dedicated UI: currency pair selection, GMM parameters (K, training window, stationarity transform), tick frequency (mode + parameters), target workspace, start/stop controls.
+- A generation service ticks FX spot values at the configured frequency into the workspace, using GMM (seeded/static parameters acceptable for PoC — no live historical calibration required).
+- Each new FX spot tick is published to a NATS subject and persisted to the workspace DB table.
+- A Qt client screen subscribes to the NATS subject and displays a live updating time-series chart (x = time, y = FX spot mid-price); chart updates in real time as ticks arrive.
+- All of the above works for at least one currency pair (EUR/USD as the canonical PoC pair).
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:DF38F297-C8BF-41C8-904B-C04622FF179C][Scaffold story: PoC: synthetic market data generation — FX spot vertical slice]] | STARTED | 2026-06-25 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] | BACKLOG | | | Catalogue existing market data infrastructure (DB, services, UI, messaging) and produce a PoC scope document defining what needs to be built vs reused for the FX spot vertical slice. |
+
+* Decisions
+
+- Scope is intentionally limited to FX spot mid-price only. FX forwards, bid/ask spread, and option vol surfaces are explicitly out of scope for this PoC.
+- Static/seeded GMM parameters are acceptable for the PoC. No live calibration to historical data is required.
+- EUR/USD is the canonical PoC pair; the implementation must be generic enough to trivially extend to other pairs but need not be tested on them.
+- The generation approach document ([[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]]) is the authoritative reference for all algorithm decisions.
+
+* Out of scope
+
+- FX forwards, option vol surfaces, swaption vols, credit spreads, equity, commodity, inflation — any asset class other than FX spot mid-price.
+- Live calibration of GMM parameters to historical market data.
+- Multi-workspace management UI (single workspace is sufficient for the PoC).
+- Production-grade error handling, schema migrations, or deployment.
+- Valuation/pricing validation (the sample trade portfolio feature from the approach doc is a separate story).
+- Any scripted trade types or ORE execution integration.

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -43,7 +43,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:DF38F297-C8BF-41C8-904B-C04622FF179C][Scaffold story: PoC: synthetic market data generation — FX spot vertical slice]] | STARTED | 2026-06-25 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] | BACKLOG | | | Catalogue existing market data infrastructure (DB, services, UI, messaging) and produce a PoC scope document defining what needs to be built vs reused for the FX spot vertical slice. |
+| [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] | STARTED | 2026-06-25 | | Catalogue existing market data infrastructure (DB, services, UI, messaging) and produce a PoC scope document defining what needs to be built vs reused for the FX spot vertical slice. |
 
 * Decisions
 
@@ -51,6 +51,12 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 - Static/seeded GMM parameters are acceptable for the PoC. No live calibration to historical data is required.
 - EUR/USD is the canonical PoC pair; the implementation must be generic enough to trivially extend to other pairs but need not be tested on them.
 - The generation approach document ([[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]]) is the authoritative reference for all algorithm decisions.
+
+* See also
+
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — existing stack inventory: DB schema, tenant scoping, NATS subjects, Qt components, ORE CSV format, service registry.
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — PoC architecture: gap analysis, new =ores.synthetic= service, tick data flow, NATS subjects, Qt chart window, open design questions, implementation order. Gates implementation.
+- [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document driving all algorithm choices in this PoC.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -54,6 +54,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 
 * See also
 
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, and ORE canonical key schemes; NATS tick subject mapping (=marketdata.v1.tick.fx.rate.eur.usd=); two-level subscription model (generation config vs client subscription).
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — existing stack inventory: DB schema, tenant scoping, NATS subjects, Qt components, ORE CSV format, service registry.
 - [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — PoC architecture: gap analysis, new =ores.synthetic= service, tick data flow, NATS subjects, Qt chart window, open design questions, implementation order. Gates implementation.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document driving all algorithm choices in this PoC.

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -100,5 +100,6 @@ intraday observations. See architecture doc §4.9 for the full change table.
 - [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — the architecture doc produced by this task.
 - [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key; produced by this task.
 - [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern for typed feed config params; produced by this task.
+- [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — full process taxonomy and performance design; produced by this task.
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-25
 #+updated: 2026-06-25
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,11 +26,11 @@ Produce two documents that together define exactly what needs to be built for th
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
-| Now          | Inventory and architecture docs written; awaiting architecture review.                                |
+| Now          | Nothing. |
 | Waiting on   | Architecture review (story decisions to be recorded after review before implementation tasks start).  |
-| Next         | Address review feedback; then close this task and open implementation tasks per architecture doc §8.  |
+| Next         | Nothing. |
 | Last touched | 2026-06-25                                                                                            |
 
 * Acceptance
@@ -41,7 +41,7 @@ Produce two documents that together define exactly what needs to be built for th
   - Any existing market data UI components (list windows, charts, time-series display) in the Qt codebase.
   - NATS subject conventions: how existing services publish entity events; the convention a market data tick subject should follow.
   - ORE market data file format: how =marketdata.csv= or equivalent is consumed; what the FX spot quote-key is (=FX/RATE/EUR/USD=).
-- PoC scope document (analysis doc in =doc/analysis/= or design doc in =doc/plans/=) specifying:
+- PoC scope document filed under =doc/knowledge/domain/= specifying:
   - Minimal DB schema additions: table name, columns, primary key, tenant/workspace FK.
   - Generation service: component name, language, entry point, tick loop design.
   - NATS subject: subject string pattern, message schema (protobuf/JSON struct with FX spot fields).
@@ -57,10 +57,10 @@ Qt plugin structure, and tenant scoping.  Produced two output documents:
 
 1. [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — factual inventory of the existing stack.
 2. [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — full PoC architecture: new =ores.synthetic=
-   service, tick data flow, new NATS subjects (=synthetic.v1.fxspot.start/stop/ticked=),
-   Qt =subscribeToRawEvent= extension, =SyntheticFxSpotChartWindow= and
-   =SyntheticFxSpotConfigDialog= designs, 7 open design questions, and an 8-step
-   recommended implementation order.
+   service, new =ores.marketdata.client= library, =IFxSpotFeed= interface, tick data flow,
+   new NATS subjects (=marketdata.v1.market_feed_configs.*=, =marketdata.v1.tick.fx.rate.*=),
+   =SyntheticFxSpotChartWindow= and =SyntheticFxSpotConfigDialog= designs, 8 open design
+   questions, and an 8-step recommended implementation order.
 
 Architecture doc is now awaiting review.  Implementation tasks will be opened once
 the architecture review is complete and open questions are resolved in the story
@@ -103,3 +103,11 @@ intraday observations. See architecture doc §4.9 for the full change table.
 - [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — full process taxonomy and performance design; produced by this task.
 
 * Result
+
+Delivered five knowledge documents (C9DACC7A, 29573D59, F3010EA7, C951B5F1, C6F45530)
+that together fully specify the FX spot synthetic data PoC architecture.  Key
+decisions recorded: =observation_date DATE= → =observation_datetime TIMESTAMPTZ=
+migration required as a prerequisite task; =IFxSpotFeed= coupling deferred to
+post-PoC; =ores.marketdata.client= library identified as the correct subscription
+abstraction; 12 generator process types defined with mathematical specs and a
+standalone-STL implementation approach.

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -8,7 +8,7 @@
 #+filetags: :synthetic_market_data_poc:sprint_21:v0:
 #+owner: marco
 #+branch: feature/synthetic-market-data-poc
-#+pr:
+#+pr: 1308
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -94,4 +94,11 @@ intraday observations. See architecture doc §4.9 for the full change table.
 |---+-----------------+------+----------+-------|
 |   |                 |      |          |       |
 
+* See also
+
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — the inventory produced by this task.
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — the architecture doc produced by this task.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key; produced by this task.
+- [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern for typed feed config params; produced by this task.
+
 * Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :synthetic_market_data_poc:sprint_21:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-synthetic-market-data-poc
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -68,6 +68,20 @@ the architecture review is complete and open questions are resolved in the story
 
 * Notes
 
+** Architecture review finding: observation_date → observation_datetime (breaking migration required)
+
+=market_observation.observation_date= is =year_month_day= (date only). The bi-temporal
+trigger matches on =(series_id, observation_date, point_id)=, so a second intraday tick
+for the same date closes the previous row. At 12 ticks/hour only the last tick of each
+calendar day survives in the live DB view.
+
+*Decision (review 2026-06-25):* update =ores.marketdata= to replace =observation_date DATE=
+with =observation_datetime TIMESTAMPTZ=. This is a breaking change affecting the C++
+domain struct, the repository mapper, the NATS protocol serialisation, the import
+service, the Qt observation list window, and the TimescaleDB hypertable partition
+dimension. Must be delivered as a dedicated task before the synthetic service writes
+intraday observations. See architecture doc §4.9 for the full change table.
+
 * PRs
 
 | PR | Title |

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :synthetic_market_data_poc:sprint_21:v0:
 #+owner: marco
-#+branch: feature/implement-synthetic-market-data-poc
+#+branch: feature/synthetic-market-data-poc
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -26,12 +26,12 @@ Produce two documents that together define exactly what needs to be built for th
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin inventory exploration.           |
-| Last touched | 2026-06-25                               |
+| Now          | Inventory and architecture docs written; awaiting architecture review.                                |
+| Waiting on   | Architecture review (story decisions to be recorded after review before implementation tasks start).  |
+| Next         | Address review feedback; then close this task and open implementation tasks per architecture doc §8.  |
+| Last touched | 2026-06-25                                                                                            |
 
 * Acceptance
 
@@ -52,9 +52,19 @@ Produce two documents that together define exactly what needs to be built for th
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Explored the existing =ores.marketdata= codebase to understand DB schema, NATS subjects,
+Qt plugin structure, and tenant scoping.  Produced two output documents:
+
+1. [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — factual inventory of the existing stack.
+2. [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — full PoC architecture: new =ores.synthetic=
+   service, tick data flow, new NATS subjects (=synthetic.v1.fxspot.start/stop/ticked=),
+   Qt =subscribeToRawEvent= extension, =SyntheticFxSpotChartWindow= and
+   =SyntheticFxSpotConfigDialog= designs, 7 open design questions, and an 8-step
+   recommended implementation order.
+
+Architecture doc is now awaiting review.  Implementation tasks will be opened once
+the architecture review is complete and open questions are resolved in the story
+=* Decisions=.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_implement_synthetic_market_data_poc.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: F8562D22-EFB1-4427-BA95-E72132D35076
+:END:
+#+title: Task: Inventory and PoC scope: FX spot synthetic data
+#+description: Initial task for: PoC: synthetic market data generation — FX spot vertical slice
+#+type: task
+#+level: s1
+#+filetags: :synthetic_market_data_poc:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce two documents that together define exactly what needs to be built for the FX spot synthetic data PoC: (1) an inventory of existing market data infrastructure across the full stack; (2) a PoC scope document specifying the minimal new work per tier. The inventory drives the scope; the scope document gates all subsequent implementation tasks.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin inventory exploration.           |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+- Inventory knowledge doc filed under =doc/knowledge/domain/= covering:
+  - Existing =ores.marketdata= component: purpose, schema, entities, any FX spot–related tables or views.
+  - Workspace DB schema: how workspaces are currently modelled; where generated market data would sit.
+  - Any existing market data UI components (list windows, charts, time-series display) in the Qt codebase.
+  - NATS subject conventions: how existing services publish entity events; the convention a market data tick subject should follow.
+  - ORE market data file format: how =marketdata.csv= or equivalent is consumed; what the FX spot quote-key is (=FX/RATE/EUR/USD=).
+- PoC scope document (analysis doc in =doc/analysis/= or design doc in =doc/plans/=) specifying:
+  - Minimal DB schema additions: table name, columns, primary key, tenant/workspace FK.
+  - Generation service: component name, language, entry point, tick loop design.
+  - NATS subject: subject string pattern, message schema (protobuf/JSON struct with FX spot fields).
+  - Configuration UI: which existing UI patterns apply; new screens vs extended existing screens.
+  - Chart UI: existing chart widget or new QtCharts integration; subscription model.
+  - Build integration: which CMakeLists.txt files need touching.
+- Both documents linked from the story =* See also=.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
@@ -8,7 +8,7 @@
 #+filetags: :synthetic_market_data_poc:sprint_21:v0:
 #+owner: marco
 #+branch: feature/synthetic-market-data-poc
-#+pr:
+#+pr: 1308
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -20,7 +20,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Produce the story, sprint wiring, and all analysis/architecture documents for the FX
+spot synthetic data PoC: the inventory of existing market data infrastructure, the
+full PoC architecture doc, market data identifiers reference, polymorphic types over
+NATS pattern doc, and the synthetic generator library specification.  Merge via PR
+#1308 to gate the implementation tasks that follow.
 
 * Status
 
@@ -28,33 +32,49 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | All analysis documents written and pushed; PR #1308 open, CI green, review comments addressed. |
+| Waiting on   | PR merge.                              |
+| Next         | Close task on merge; open implementation tasks per architecture §8. |
 | Last touched | 2026-06-25                               |
 
 * Acceptance
 
--
+- =doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org= filed (C9DACC7A).
+- =doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org= filed (29573D59).
+- =doc/knowledge/domain/market_data_identifiers.org= filed (F3010EA7).
+- =doc/knowledge/architecture/polymorphic_types_over_nats.org= filed (C951B5F1).
+- =doc/knowledge/domain/synthetic_market_data_generators.org= filed (C6F45530).
+- Story 8A65240D wired into sprint.org under =*** Market data generation=.
+- All documents cross-linked via org-roam IDs; knowledge.org index updated.
+- PR #1308 merged to main.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Explored the existing =ores.marketdata= codebase and produced five documents:
+
+1. [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — factual stack inventory.
+2. [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — full architecture gating implementation.
+3. [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key, NATS mapping.
+4. [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern for typed feed config param serialisation.
+5. [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — full process taxonomy (12 types) and performance design.
 
 * Notes
+
+** Architecture review findings (2026-06-25)
+
+- =market_observation.observation_date DATE= → =TIMESTAMPTZ= migration required (intraday ticks overwrite each other under the bi-temporal trigger at date granularity).  Recorded as dedicated prerequisite task in story decisions.
+- =IFxSpotFeed= coupling: for the PoC, =ores.synthetic.service= is standalone and owns its own start/stop handlers. Feed manager integration in =ores.marketdata.service= is post-PoC (design question 8).
 
 * PRs
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1308][#1308]] | PoC: synthetic market data generation — FX spot vertical slice (scaffold + analysis) |
 
 * Review
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+|   | See PR #1308 review thread | | All review comments addressed in commits 07523594, 85237e7b, and this round | |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
@@ -75,6 +75,7 @@ Explored the existing =ores.marketdata= codebase and produced five documents:
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   | See PR #1308 review thread | | All review comments addressed in commits 07523594, 85237e7b, and this round | |
+| 1–4 | fx_spot_tick_event link dep; stale subjects (synthetic.v1.fxspot.*); sprint section/state; scaffold boilerplate; story acceptance; task output location; inventory tenant/subject | architecture, sprint, tasks | All accepted. Fixed across commits f544901a, 8569ebef, 166d3446, 07523594, 85237e7b, e7c33ecf | claude-review bot; issue comments, not PR threads |
+| 5 | Inventory QueueChartWindow stale subject; task F8562D22 #+pr: empty; DQ2 security tradeoff unstated; tick clock drift unacknowledged | inventory, architecture, task | All accepted. Fixed in 4b4d46ef | claude-review bot |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_scaffold_synthetic_market_data_poc.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: DF38F297-C8BF-41C8-904B-C04622FF179C
+:END:
+#+title: Task: Scaffold story: PoC: synthetic market data generation — FX spot vertical slice
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :synthetic_market_data_poc:sprint_21:v0:
+#+owner: marco
+#+branch: feature/synthetic-market-data-poc
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-25                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/knowledge/architecture/polymorphic_types_over_nats.org
+++ b/doc/knowledge/architecture/polymorphic_types_over_nats.org
@@ -85,8 +85,8 @@ Examples:
 |---------------+--------------|
 | =fx_forward_instrument= | =trading.v1.fx_forward_instruments.save= |
 | =vanilla_swap_instrument= | =trading.v1.vanilla_swap_instruments.save= |
-| =synthetic_gmm_feed_config= | =marketdata.v1.synthetic_gmm_feed_configs.save= |
-| =synthetic_fixed_feed_config= | =marketdata.v1.synthetic_fixed_feed_configs.save= |
+| =synthetic_gmm_feed_params= | =marketdata.v1.synthetic_gmm_feed_params.save= |
+| =synthetic_fixed_feed_params= | =marketdata.v1.synthetic_fixed_feed_params.save= |
 
 * Discriminator on the containing entity
 

--- a/doc/knowledge/architecture/polymorphic_types_over_nats.org
+++ b/doc/knowledge/architecture/polymorphic_types_over_nats.org
@@ -1,0 +1,243 @@
+:PROPERTIES:
+:ID: C951B5F1-B51C-4274-BA4D-6297AD46A4FB
+:END:
+#+title: Polymorphic types over NATS
+#+description: How to transport inheritance-like (variant/polymorphic) data structures over NATS using RFL serialisation: the type-specific subject pattern, discriminator convention, two-phase dispatch for unavoidable variant responses, and the RFL std::variant index fragility pitfall. Canonical example: trading instruments.
+#+type: knowledge
+#+level: cross
+#+filetags: :architecture:nats:rfl:serialisation:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+* Summary
+
+When a domain concept has multiple concrete variants with different fields (e.g.
+instruments: FX forward, vanilla swap, equity option; or feed configs: synthetic GMM,
+tabular, fixed), the temptation is to put a polymorphic payload with a type tag into a
+single NATS message. This does not work well with RFL serialisation and creates
+untyped, fragile wire formats. The project convention is: *one NATS subject per
+concrete type*. Each subject carries exactly one strongly-typed RFL struct. A
+discriminator enum on the containing entity (not on the payload) identifies which
+subject to use. When a polymorphic response cannot be avoided, two-phase dispatch
+recovers the concrete type on the reading side without constructing an in-memory
+variant from the wire representation.
+
+* The problem with polymorphic wire messages
+
+** RFL =std::variant= serialises as an integer index
+
+RFL's default =std::variant= serialisation writes an =index= key:
+
+#+begin_src json
+{ "index": 2, "value": { ... } }
+#+end_src
+
+The index is the zero-based position of the active alternative in the variant
+declaration.  This is fragile: adding, removing, or reordering alternatives changes
+every index silently.  There is no human-readable type discriminator in the output.
+
+** JSON blobs lose type safety
+
+Storing parameters as a raw JSON blob (=std::string= or =nlohmann::json=) means the
+receiving side must deserialise a weakly-typed payload, losing compile-time checks and
+making schema evolution harder to reason about.
+
+* Preferred pattern: type-specific NATS subjects
+
+Use one NATS subject per concrete type.  Each request/response struct embeds exactly
+one typed payload.  The subject name encodes the type.
+
+** Canonical example: trading instruments
+
+=ores.trading= has 25+ concrete instrument types (FX forwards, vanilla swaps, equity
+options, …).  The protocol file
+=projects/ores.trading/api/include/ores.trading.api/messaging/instrument_protocol.hpp=
+defines a separate save request per type:
+
+#+begin_src cpp
+struct save_fx_forward_instrument_request {
+    using response_type = struct save_fx_forward_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_forward_instruments.save";
+    fx_forward_instrument instrument;
+};
+
+struct save_fx_vanilla_option_instrument_request {
+    using response_type = struct save_fx_vanilla_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_vanilla_option_instruments.save";
+    fx_vanilla_option_instrument instrument;
+};
+
+// … one struct per concrete type
+#+end_src
+
+The caller knows which concrete type it is saving; it picks the right struct and
+subject directly.  No dispatch needed on the write path.
+
+** Subject naming convention
+
+: <domain>.v1.<concrete_type_plural>.<verb>
+
+Examples:
+
+| Concrete type | Save subject |
+|---------------+--------------|
+| =fx_forward_instrument= | =trading.v1.fx_forward_instruments.save= |
+| =vanilla_swap_instrument= | =trading.v1.vanilla_swap_instruments.save= |
+| =synthetic_gmm_feed_config= | =marketdata.v1.synthetic_gmm_feed_configs.save= |
+| =synthetic_fixed_feed_config= | =marketdata.v1.synthetic_fixed_feed_configs.save= |
+
+* Discriminator on the containing entity
+
+The concrete type is identified by a discriminator field on the *containing* entity,
+not embedded inside the payload itself.  This keeps the payload clean and places the
+routing concern where it belongs.
+
+** Instruments example
+
+=trade.classification.product_type= (a =product_type= enum serialised as a lowercase
+string via =rfl::Reflector=) identifies the instrument family; =trade_type= (a string)
+identifies the leaf type within the family:
+
+#+begin_src cpp
+// product_type.hpp — serialised as "fx", "swap", "bond", etc.
+enum class product_type { fx, rates, swap, bond, credit, equity, commodity, ... };
+#+end_src
+
+On the reading side the caller inspects =product_type= first, then issues the right
+typed read.
+
+** Feed config example
+
+=market_feed_config.feed_type= plays the same role:
+
+#+begin_src cpp
+enum class feed_type { synthetic_fixed, synthetic_tabular, synthetic_gmm, bloomberg_fx, ... };
+
+struct market_feed_config {
+    boost::uuids::uuid id;
+    utility::uuid::tenant_id tenant_id;
+    boost::uuids::uuid series_id;   // → market_series
+    feed_type type;                 // ← discriminator
+    bool auto_start = false;
+    // runtime status (not config):
+    // feed_status status;
+};
+#+end_src
+
+Each concrete parameter struct is a separate entity with its own NATS save subject,
+linked to =market_feed_config= by =config_id=:
+
+#+begin_src cpp
+struct synthetic_fixed_feed_params {
+    boost::uuids::uuid config_id;
+    double price;
+};
+
+struct synthetic_tabular_feed_params {
+    boost::uuids::uuid config_id;
+    std::vector<double> prices;
+    bool wrap = true;
+};
+
+struct synthetic_gmm_feed_params {
+    boost::uuids::uuid config_id;
+    int k = 3;
+    std::vector<double> means;
+    std::vector<double> stdevs;
+    std::vector<double> weights;
+    double initial_price;
+    std::string tick_mode;   // "fixed" | "poisson" | "regime"
+    double tick_rate_per_hour = 12.0;
+};
+#+end_src
+
+The UI reads =market_feed_config.feed_type=, then issues the appropriate typed
+NATS request to fetch the matching params struct.
+
+* Two-phase dispatch for unavoidable variant responses
+
+Sometimes a single endpoint must return different concrete types — for example
+=trading.v1.trades.instrument= which must return whichever instrument type a trade
+carries.  The project handles this with two-phase dispatch, implemented in
+=projects/ores.qt/api/src/parse_trade_instrument.cpp=.
+
+** Phase 1: parse the envelope
+
+Define a stripped response struct that omits the polymorphic field.  RFL silently
+skips unknown JSON keys, so this succeeds regardless of which concrete type is present:
+
+#+begin_src cpp
+// Phase 1: envelope — rfl silently skips the "instrument" JSON key.
+struct response_envelope {
+    bool success = false;
+    std::string message;
+    td::trade trade;   // carries trade.classification.product_type — the discriminator
+};
+
+auto base = rfl::json::read<response_envelope>(raw);
+#+end_src
+
+** Phase 2: dispatch on discriminator, parse concrete type
+
+Inspect the discriminator, wrap the expected concrete type in a thin struct (so the
+=instrument= JSON key matches), and call =rfl::json::read= on the *same raw string*:
+
+#+begin_src cpp
+// Thin wrappers — mirrors the "instrument" key in the JSON response.
+struct fx_forward_wrapper   { td::fx_forward_instrument instrument; };
+struct bond_wrapper         { td::bond_instrument instrument; };
+// … one wrapper per concrete type
+
+switch (base->trade.classification.product_type) {
+    case product_type::fx: {
+        if (trade_type == "FxForward") {
+            auto r = rfl::json::read<fx_forward_wrapper>(raw);
+            populator.populate(r->instrument);
+        } else if (trade_type == "FxOption") {
+            auto r = rfl::json::read<fx_vanilla_option_wrapper>(raw);
+            // ...
+        }
+        break;
+    }
+    case product_type::bond: {
+        auto r = rfl::json::read<bond_wrapper>(raw);
+        populator.populate(r->instrument);
+        break;
+    }
+    // ...
+}
+#+end_src
+
+The raw JSON string is parsed twice — once to get the discriminator, once to get the
+payload.  This is intentional: it avoids constructing a =std::variant= from the wire
+format and its fragile =index= key.
+
+** Why not =rfl::TaggedUnion=?
+
+RFL provides =rfl::TaggedUnion<"type", A, B, C>= which writes a human-readable
+={"type": "A", ...}= discriminator.  This is better than the default integer =index=
+for readability and robustness.  It was not used in =ores.trading= due to MSVC C1202
+template-graph depth limits with complex nested types.  For simpler hierarchies
+(e.g. feed params with small structs) =rfl::TaggedUnion= is worth evaluating — it
+would allow a single NATS subject with a tagged payload instead of per-type subjects.
+Investigate before committing either way on new polymorphic types.
+
+* Decision guide
+
+| Situation | Pattern |
+|-----------+---------|
+| Writing a known concrete type (save, create) | Type-specific NATS subject. One struct per type. |
+| Reading when caller knows the type | Type-specific NATS subject. Direct =rfl::json::read<ConcreteType>=. |
+| Reading when type is unknown until runtime (get-by-id, export) | Two-phase dispatch: envelope first, discriminator second, typed read third. |
+| Small struct hierarchy, no MSVC limits concern | Evaluate =rfl::TaggedUnion= for a cleaner single-subject approach. |
+| Untyped JSON blob / =std::string= params field | *Never*. Use a typed struct per variant. |
+
+* See also
+
+- [[id:6A62D943-FAC9-4B77-9E22-F265557DCF1A][ores.marketdata.api]] — defines the NATS protocol structs this pattern applies to.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — NATS subject naming conventions for market data.
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — first application of this pattern to feed config params.
+- [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story driving this pattern's first use for feed configs.
+- [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] — the task that surfaced this pattern question.

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -12,15 +12,16 @@
 * Summary
 
 The FX spot synthetic data PoC introduces one new service (=ores.synthetic=), one new
-NATS subject for tick fan-out (=synthetic.v1.fxspot.ticked=), and one new Qt MDI
-window (=SyntheticFxSpotChartWindow= in =ores.qt.mktdata=) for live chart display.
+NATS client library (=ores.marketdata.client=) for typed tick subscriptions, a new
+=IFxSpotFeed= interface and =fx_spot_tick= struct in =ores.marketdata.api=, and one new Qt
+MDI window (=SyntheticFxSpotChartWindow= in =ores.qt.mktdata=) for live chart display.
 Everything else — market data storage, tenant scoping, NATS infrastructure, Qt plugin
 machinery — is reused from existing components unchanged. The synthetic service
-operates as a configurable tick loop: on each tick it generates an FX spot value via
-seeded GMM, writes it to the existing =market_observation= store via a NATS
-request-reply to the market data service, then publishes a lightweight fan-out
-notification. The Qt chart window subscribes to the fan-out subject and appends each
-tick value in real time.
+operates as a configurable tick loop: on each tick it generates an FX spot value via a
+stochastic process, writes it to the existing =market_observation= store via a NATS
+request-reply to the market data service, then publishes a typed =fx_spot_tick= to the
+per-ORE-key NATS subject (e.g. =marketdata.v1.tick.fx.rate.eur.usd=). The Qt chart
+window subscribes via =ores.marketdata.client= and appends each tick in real time.
 
 * Existing architecture review
 
@@ -134,8 +135,9 @@ writes.  The =synthetic= entry is already registered:
 | No NATS fan-out subject for live ticks | Required for chart subscription. |
 | No tick payload format | Needed for service → client communication. |
 | No chart window in =ores.qt.mktdata= | Required for live display acceptance criterion. |
-| No Qt subscription path for streaming data with payload | Existing =subscribeToEvent= parses =entity_change_event= only; no raw payload delivery. |
-| No configuration UI | Required for acceptance: currency pair, GMM params, tick frequency, start/stop. |
+| No =nats_client()= accessor on =ClientManager= | =fx_spot_subscription= (=ores.marketdata.client=) needs a raw =nats::client&= from the Qt session layer; =ClientManager= must expose this. Blocks implementation step 5. |
+| No =ores.marketdata.client= library | New sub-component; wraps typed NATS tick subscriptions. Needed by chart window. |
+| No configuration UI | Required for acceptance: currency pair, generator params, tick frequency, start/stop. |
 | No =ores.synthetic= CMake component | New top-level project needed. |
 
 * PoC architecture
@@ -155,16 +157,20 @@ rectangle "ores.qt.mktdata (extended)" {
 }
 
 rectangle "NATS" {
-  queue "synthetic.v1.fxspot.start (req-rep)" as StartSubj
-  queue "synthetic.v1.fxspot.stop (req-rep)" as StopSubj
-  queue "synthetic.v1.fxspot.ticked (fan-out)" as TickSubj
+  queue "marketdata.v1.market_feed_configs.start (req-rep)" as StartSubj
+  queue "marketdata.v1.market_feed_configs.stop (req-rep)" as StopSubj
+  queue "marketdata.v1.tick.fx.rate.eur.usd (fan-out)" as TickSubj
   queue "marketdata.v1.observations.save (req-rep)" as SaveSubj
 }
 
 rectangle "ores.synthetic.service (new)" {
   component tick_loop
-  component gmm_generator
+  component process_factory
   component tick_clock
+}
+
+rectangle "ores.marketdata.client (new)" {
+  component fx_spot_subscription
 }
 
 rectangle "ores.marketdata.service (existing)" {
@@ -182,13 +188,14 @@ SyntheticFxSpotConfigDialog --> StopSubj : stop_request
 StartSubj --> tick_loop : start
 StopSubj --> tick_loop : stop
 
-tick_loop --> gmm_generator : generate tick value
+tick_loop --> process_factory : generate tick value
 tick_loop --> SaveSubj : save observation
-tick_loop --> TickSubj : publish tick event
+tick_loop --> TickSubj : publish fx_spot_tick
 SaveSubj --> market_observations_service
 market_observations_service --> ores_marketdata_observations
 
-TickSubj --> SyntheticFxSpotChartWindow : tick notification
+fx_spot_subscription --> TickSubj : subscribe
+fx_spot_subscription --> SyntheticFxSpotChartWindow : on_tick callback
 SyntheticFxSpotChartWindow --> User : live chart update
 @enduml
 #+end_src
@@ -205,12 +212,13 @@ One complete tick cycle in sequence:
    =marketdata.v1.observations.save= with a single =market_observation= (=series_id= of
    EUR/USD, =observation_date=, =point_id=null=, =value=, =source="SYNTHETIC"=).  Awaits
    acknowledgement.
-4. On success, =tick_loop= publishes an =fx_spot_tick_event= to
-   =synthetic.v1.fxspot.ticked= (core NATS, fire-and-forget — the tick is already
-   durable in the DB).
-5. =SyntheticFxSpotChartWindow= (in the Qt client) receives the NATS message, decodes
-   the =fx_spot_tick_event=, and appends =(observation_date, value)= to the live chart
-   series.
+4. On success, =tick_loop= serialises an =fx_spot_tick= (=rfl::json=) and publishes it to
+   the per-ORE-key subject, e.g. =marketdata.v1.tick.fx.rate.eur.usd= (core NATS,
+   fire-and-forget — the tick is already durable in the DB).
+5. =SyntheticFxSpotChartWindow= (in the Qt client) receives the callback from its
+   =fx_spot_subscription= member (=ores.marketdata.client=), which has already
+   deserialised the payload into =fx_spot_tick=.  The window appends =(datetime, mid)=
+   to the live chart series.
 
 The DB write (step 3) is the source of truth; the fan-out (step 4) is a convenience
 notification for live display.  A chart client that reconnects after a gap fetches
@@ -248,9 +256,12 @@ public:
 };
 #+end_src
 
-The feed manager in =ores.marketdata.service= calls =start(handler)= where the handler
-(1) converts =fx_spot_tick= to =market_observation= and writes to DB, then (2) serialises
-and publishes the tick to =marketdata.v1.tick.<ore-key-mapped>=.
+For the PoC, =ores.synthetic.service= calls =start(handler)= internally on its own
+tick loop.  The handler (1) converts =fx_spot_tick= to =market_observation= and writes
+to DB via =marketdata.v1.observations.save=, then (2) publishes the tick to
+=marketdata.v1.tick.<ore-key-mapped>=.  The feed manager pattern in
+=ores.marketdata.service= (which would acquire and call =IFxSpotFeed= via a registered
+factory) is a post-PoC concern — see open design question 8.
 
 ** New NATS subjects
 
@@ -416,7 +427,7 @@ An MDI window in =ores.qt.mktdata= using =QtCharts::QLineSeries= + =QDateTimeAxi
 
 - X axis: =QDateTimeAxis=, auto-scrolling; shows the last N minutes.
 - Y axis: =QValueAxis=, auto-ranging.
-- Subscribes to =synthetic.v1.fxspot.ticked= via =subscribeToRawEvent=.
+- Holds an =fx_spot_subscription= member (=ores.marketdata.client=); subscribes on window open using =clientManager_->nats_client()=; unsubscribes on close.  No direct NATS wiring in Qt code.
 - On open: fetches the last 100 observations from =marketdata.v1.observations.list= to backfill the chart before live ticks arrive.
 - On each tick: appends a new =(QDateTime, double)= point to the live series.
 - Toolbar: time range selector (last 5 min / 30 min / 2 h / all), manual refresh button.
@@ -538,23 +549,24 @@ recorded in the story =* Decisions= when resolved.
 | 1 | How does the synthetic service look up or create the EUR/USD =market_series= at startup? | (a) Series must be pre-created by the operator; (b) service upserts it at startup. | (b) — upsert at startup simplifies setup for the PoC. |
 | 2 | Which tenant does the synthetic service write as? | (a) Its own IAM tenant (=SyntheticService=); (b) a configurable workspace UUID passed in the start request. | (b) — pass =workspace_tenant_id= in the start request so the Qt client and service share the same tenant context. |
 | 3 | Should the fan-out use core NATS or JetStream? | (a) Core NATS (fire-and-forget, no replay); (b) JetStream (durable, late subscribers can replay). | (a) for PoC — the DB is the source of truth for replay; chart backfills from DB on connect. |
-| 4 | Is =subscribeToRawEvent= needed, or can we use option A (extend subscribeToEvent)? | See §6.5 above. | Option B (=subscribeToRawEvent=) — keeps =ClientManager= decoupled from synthetic types. |
+| 4 | How should the Qt chart window receive typed tick payloads without coupling Qt to =ores.synthetic=? | **Resolved** — adopted design is =ores.marketdata.client= / =fx_spot_subscription= taking =clientManager_->nats_client()= directly.  =ClientManager= requires a new =nats_client()= accessor; this is a smaller surface change than a =subscribeToRawEvent= extension and keeps subscription logic in the client library, not in Qt code. | — |
 | 5 | Config dialog vs config panel (MDI subwindow)? | Modal dialog (simpler); or docked MDI subwindow (persistent). | Modal dialog for PoC; upgrade to MDI subwindow if needed. |
 | 6 | Chart window: open from config dialog on start, or always visible? | (a) Opens on start, closes on stop; (b) opens from Market Data menu independently. | (a) for PoC — simplest wiring; the chart and generator are tied together. |
 | 7 | Where does the config dialog/controller live? | Extend =MarketDataController= with a =showSyntheticFxSpotConfig()= method; add to menu. | Yes — keep within =ores.qt.mktdata= plugin to avoid a new Qt plugin for the PoC. |
+| 8 | How does =ores.marketdata.service= acquire an =IFxSpotFeed= instance from =ores.synthetic= at runtime? | =ores.marketdata.service= is a binary; it cannot link against =ores.synthetic.service= without a circular dependency.  (a) *PoC resolution*: =ores.synthetic.service= is standalone and owns its own =market_feed_configs.start/stop= NATS handlers directly — no =ores.marketdata.service= involvement in the PoC feed lifecycle.  (b) *Post-PoC*: extract =ores.synthetic.api= library; =ores.marketdata.service= registers feed factories from =ores.synthetic.api= via a plugin/factory pattern. | (a) for PoC — =ores.synthetic.service= handles start/stop directly; =IFxSpotFeed= lives in =ores.marketdata.api= as a forward-looking interface but is not exercised by =ores.marketdata.service= until post-PoC. |
 
 * Implementation order
 
 The recommended order of implementation tasks (one story task per item):
 
 1. *=ores.synthetic.service= scaffold* — CMakeLists, registrar, skeleton main; service registers and starts but does nothing yet. Validates build wiring.
-2. *Tick loop + GMM generator* — tick_loop with fixed-mode clock, seeded GMM; publishes to =synthetic.v1.fxspot.ticked= only (no DB write yet). Validates generation logic in isolation.
+2. *Tick loop + process factory* — tick_loop with fixed-mode clock, seeded GMM (=GmmProcess=); publishes typed =fx_spot_tick= to =marketdata.v1.tick.fx.rate.eur.usd= only (no DB write yet). Validates generation and NATS publishing in isolation.
 3. *DB write integration* — add =marketdata.v1.observations.save= call per tick; verify observations appear in existing =MarketSeriesMdiWindow= observation view.
-4. *Start/stop NATS handlers* — add =synthetic.v1.fxspot.start= / =stop= request-reply handlers; service becomes remotely controllable.
-5. *=subscribeToRawEvent= on =ClientManager=* — minimal extension; validated with a logging subscriber.
-6. *=SyntheticFxSpotChartWindow=* — chart window with backfill + live subscription; added to =ores.qt.mktdata=.
-7. *=SyntheticFxSpotConfigDialog=* — config dialog with start/stop; wired into =MarketDataController= and the Market Data menu.
-8. *End-to-end integration test* — manual smoke test: configure EUR/USD, start, observe chart ticking, stop, verify DB observations.
+4. *Start/stop NATS handlers* — add =marketdata.v1.market_feed_configs.start= / =stop= request-reply handlers in =ores.synthetic.service=; service becomes remotely controllable. Save feed config to DB via =marketdata.v1.market_feed_configs.save=.
+5. *=ores.marketdata.client= library + =ClientManager::nats_client()=* — new sub-component with =fx_spot_subscription=; add =nats_client()= accessor to =ClientManager=; validate with a logging subscriber.
+6. *=SyntheticFxSpotChartWindow=* — chart window with backfill + live =fx_spot_subscription=; added to =ores.qt.mktdata=.
+7. *=SyntheticFxSpotConfigDialog=* — config dialog with save/start/stop; wired into =MarketDataController= and the Market Data menu.
+8. *End-to-end integration test* — manual smoke test: configure EUR/USD, save, start, observe chart ticking, stop, verify DB observations.
 
 * See also
 

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -494,6 +494,14 @@ The tick loop runs on its own =std::thread= (not the ASIO executor) and uses the
 =client::request_sync= method for the DB write (synchronous, blocks until acknowledged).
 Fan-out publish is fire-and-forget and does not block.
 
+*Known PoC limitation — tick clock drift under DB writes*: because =request_sync= blocks
+per tick, the effective period is =sleep_for(period)= + DB round-trip.  For Fixed mode
+this causes actual tick rate to fall below target under DB load.  For Poisson and
+regime-switching modes, serialising a blocking call through the drawn inter-arrival
+time biases the distribution — the true inter-arrival time is longer than drawn.  A
+production implementation should decouple DB writes from the tick clock (separate
+thread or async write queue); for the PoC, drift is an acceptable limitation.
+
 ** GMM generator (PoC approximation)
 
 The approach document specifies GMM for return generation, with parameters fitted to
@@ -547,7 +555,7 @@ recorded in the story =* Decisions= when resolved.
 | # | Question | Options | Recommendation |
 |---+----------+---------+----------------|
 | 1 | How does the synthetic service look up or create the EUR/USD =market_series= at startup? | (a) Series must be pre-created by the operator; (b) service upserts it at startup. | (b) — upsert at startup simplifies setup for the PoC. |
-| 2 | Which tenant does the synthetic service write as? | (a) Its own IAM tenant (=SyntheticService=); (b) a configurable workspace UUID passed in the start request. | (b) — pass =workspace_tenant_id= in the start request so the Qt client and service share the same tenant context. |
+| 2 | Which tenant does the synthetic service write as? | (a) Its own IAM tenant (=SyntheticService=); (b) a configurable workspace UUID passed in the start request. | (b) — pass =workspace_tenant_id= in the start request so the Qt client and service share the same tenant context. *PoC security tradeoff*: option (b) allows any authenticated client to instruct the service to write observations under an arbitrary tenant; the =ctx.tenant_id()= IAM pattern does not have this property. Acceptable for PoC; must be replaced with server-side tenant validation before production use. |
 | 3 | Should the fan-out use core NATS or JetStream? | (a) Core NATS (fire-and-forget, no replay); (b) JetStream (durable, late subscribers can replay). | (a) for PoC — the DB is the source of truth for replay; chart backfills from DB on connect. |
 | 4 | How should the Qt chart window receive typed tick payloads without coupling Qt to =ores.synthetic=? | **Resolved** — adopted design is =ores.marketdata.client= / =fx_spot_subscription= taking =clientManager_->nats_client()= directly.  =ClientManager= requires a new =nats_client()= accessor; this is a smaller surface change than a =subscribeToRawEvent= extension and keeps subscription logic in the client library, not in Qt code. | — |
 | 5 | Config dialog vs config panel (MDI subwindow)? | Modal dialog (simpler); or docked MDI subwindow (persistent). | Modal dialog for PoC; upgrade to MDI subwindow if needed. |

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -283,13 +283,27 @@ JSON blobs.
 
 *** market_feed_config
 
-The configuration entity persisted to DB.  The =feed_type= enum is the discriminator:
+The configuration entity persisted to DB.  The =feed_type= enum is the discriminator.
+All 12 generator types (5 deterministic + 7 stochastic) are enumerated upfront; P1
+types return =not_implemented= until implemented — see
+[[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] for the full taxonomy and mathematical specs.
 
 #+begin_src cpp
 enum class feed_type {
-    synthetic_fixed,    // constant price at fixed intervals
-    synthetic_tabular,  // price table, wraps on exhaustion
-    synthetic_gmm,      // Gaussian Mixture Model log-return generator
+    // Deterministic (P0: fixed, oscillator; P1: ramp, sawtooth, step)
+    synthetic_fixed,          // constant price
+    synthetic_ramp,           // linear drift, optional reflecting bounds
+    synthetic_oscillator,     // bounded sine wave
+    synthetic_sawtooth,       // linear ramp + instant reset
+    synthetic_step,           // cycles through a price table
+    // Stochastic (P0: gbm, gmm; P1: ou, gjr_garch, regime_switching, jump_diffusion, heston)
+    synthetic_gbm,            // Geometric Brownian Motion
+    synthetic_ou,             // Ornstein-Uhlenbeck (mean-reverting)
+    synthetic_gmm,            // Gaussian Mixture Model
+    synthetic_gjr_garch,      // GARCH with leverage effect
+    synthetic_regime_switching, // Markov chain between GBM regimes
+    synthetic_jump_diffusion, // GBM + Poisson jumps (Merton 1976)
+    synthetic_heston,         // Stochastic volatility (Heston 1993)
 };
 
 struct market_feed_config {
@@ -420,21 +434,36 @@ projects/ores.synthetic/
     include/ores.synthetic.service/
       ...
     src/
-      CMakeLists.txt   ← add_library(.lib) + add_executable(.exe)
+      CMakeLists.txt        ← add_library(.lib) + add_executable(.exe)
       main.cpp
-      tick_loop.cpp / .hpp
-      gmm_generator.cpp / .hpp
-      registrar.cpp / .hpp   ← registers NATS handlers for start/stop
+      fx_spot_feed.cpp/.hpp         ← FxSpotFeed (thin wrapper over IStochasticProcess)
+      processes/
+        fixed_process.cpp/.hpp
+        ramp_process.cpp/.hpp
+        oscillator_process.cpp/.hpp
+        sawtooth_process.cpp/.hpp
+        step_process.cpp/.hpp
+        gbm_process.cpp/.hpp
+        ou_process.cpp/.hpp
+        gmm_process.cpp/.hpp
+        gjr_garch_process.cpp/.hpp
+        regime_switching_process.cpp/.hpp
+        jump_diffusion_process.cpp/.hpp
+        heston_process.cpp/.hpp
+      process_factory.cpp/.hpp      ← constructs IStochasticProcess from feed_type + params
+      registrar.cpp/.hpp            ← registers NATS handlers for feed config CRUD + start/stop
     tests/
 #+end_src
 
-For the PoC, a single-layer =ores.synthetic.service= (no separate =ores.synthetic.api= or
-=ores.synthetic.core=) is sufficient.  There are currently no other services that need
-to depend on synthetic API types.  A public API layer can be extracted if other
-components need to subscribe to the tick event type.
+=IStochasticProcess= lives in =ores.marketdata.api= (not =ores.synthetic=) because a
+future calibration service needs to instantiate processes without depending on the
+synthetic service executable.  All process implementations live in =ores.synthetic.service=.
+
+For the first pass, a single-layer =ores.synthetic.service= (no separate =ores.synthetic.api=
+or =ores.synthetic.core=) is sufficient.
 
 The service binary links against:
-- =ores.marketdata.api.lib= — for =save_market_observations_request= and protocol subjects.
+- =ores.marketdata.api.lib= — for =IStochasticProcess=, =IFxSpotFeed=, =fx_spot_tick=, and NATS protocol subjects.
 - =ores.nats.lib= — for =client::publish= and =client::queue_subscribe=.
 - =ores.service.lib= — for the service lifecycle base.
 - =ores.iam.core.lib= — for IAM context (=ctx.tenant_id()=).
@@ -532,6 +561,7 @@ The recommended order of implementation tasks (one story task per item):
 - [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key, NATS subject mapping, two-level subscription model.
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — detailed inventory of the existing stack this architecture builds on.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the algorithm choices (GMM, tick clock modes) this architecture implements.
+- [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — full taxonomy and mathematical specification of all 12 process types; =IStochasticProcess= interface; =FxSpotFeed= wrapper; ring-buffer pre-generation; QuantLib vs standalone analysis.
 - [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — the pattern used for typed feed config parameter serialisation (=market_feed_config= discriminator, type-specific NATS subjects, two-phase dispatch on read).
 - [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story tracking this PoC work.
 - [[id:759530D8-2314-44F3-A50E-71CE7AD02558][ores.marketdata.core]] — existing component overview.

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -1,0 +1,415 @@
+:PROPERTIES:
+:ID: 29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB
+:END:
+#+title: FX spot synthetic data PoC: architecture
+#+description: Architecture design for the FX spot synthetic data PoC vertical slice. Reviews the existing ores.marketdata stack, then specifies the new ores.synthetic service, NATS fan-out, DB writes, and Qt chart display. Gates implementation.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:synthetic:architecture:poc:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+* Summary
+
+The FX spot synthetic data PoC introduces one new service (=ores.synthetic=), one new
+NATS subject for tick fan-out (=synthetic.v1.fxspot.ticked=), and one new Qt MDI
+window (=SyntheticFxSpotChartWindow= in =ores.qt.mktdata=) for live chart display.
+Everything else — market data storage, tenant scoping, NATS infrastructure, Qt plugin
+machinery — is reused from existing components unchanged. The synthetic service
+operates as a configurable tick loop: on each tick it generates an FX spot value via
+seeded GMM, writes it to the existing =market_observation= store via a NATS
+request-reply to the market data service, then publishes a lightweight fan-out
+notification. The Qt chart window subscribes to the fan-out subject and appends each
+tick value in real time.
+
+* Existing architecture review
+
+** ores.marketdata: the existing stack
+
+The market data domain is split across three sub-components (see
+[[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] for the full
+inventory):
+
+#+begin_src plantuml :exports results :file poc_existing.png
+@startuml
+!include <tupadr3/common>
+left to right direction
+
+rectangle "ores.marketdata.api" {
+  class market_series
+  class market_observation
+  class market_fixing
+  class protocols <<nats protocol structs>>
+}
+
+rectangle "ores.marketdata.core" {
+  class market_series_service
+  class market_observations_service
+  class market_series_repository
+  class market_observations_repository
+}
+
+rectangle "ores.marketdata.service" {
+  class registrar
+  note right: lib + exe\nNATS entry point
+}
+
+database "TimescaleDB" {
+  table ores_marketdata_series
+  table ores_marketdata_observations
+}
+
+protocols --> market_series_service : NATS req/rep
+market_series_service --> market_series_repository
+market_observations_service --> market_observations_repository
+market_series_repository --> ores_marketdata_series
+market_observations_repository --> ores_marketdata_observations
+@enduml
+#+end_src
+
+Key architectural invariants established by this stack:
+
+- All data scoped by =tenant_id=; services derive =tenant_id= from their IAM context.
+- =market_series= is the catalog; =market_observation= is the time series.  Corrections are
+  bi-temporal (insert trigger closes previous row, opens a fresh one).
+- All NATS operations are request-reply — no push/fan-out subjects exist for market
+  data today.
+- FX spot uses =is_scalar=true= on its series; observation =point_id= is always =null=.
+- The full ORE key =FX/RATE/EUR/USD= decomposes to =series_type="FX"=, =metric="RATE"=,
+  =qualifier="EUR/USD"=.
+
+** Qt market data plugin
+
+=ores.qt.mktdata= contains:
+
+- =MarketDataController= — owns the two list windows, wires drill-down signals.
+- =MarketSeriesMdiWindow= — paginated table of all market series, filter by asset class.
+- =MarketFixingsMdiWindow= — fixings series list.
+
+There is no chart display in this plugin today.  The =onShowMarketObservations= signal
+drills into an observation list window (tabular, not a time-series chart).
+
+** Qt NATS subscription model
+
+=ClientManager= provides the subscription infrastructure:
+
+#+begin_src text
+subscribeToEvent(subject)     →  internally calls nats::client::subscribe()
+                               parses payload as entity_change_event (JSON/rfl)
+                               emits notificationReceived(eventType, ts, ids, tenantId, payloadType=0, payload={})
+#+end_src
+
+The existing =notificationReceived= signal carries =payloadType= (always 0 today) and
+=payload= (always empty today).  These fields exist for future extension.
+
+The existing pattern is designed for entity-change notifications, not for streaming
+tick data.  The payload fields are unused; the subscriber calls back into a service to
+fetch the changed entity by ID.
+
+** NATS transport layer
+
+From =ores.nats::client=:
+
+- =publish(subject, data)= — fire-and-forget (core NATS, no durability).
+- =js_publish(subject, data)= — durable JetStream publish; blocks on server ACK.
+- =subscribe(subject, handler)= — fan-out subscription; all subscribers receive every message.
+- =queue_subscribe(subject, group, handler)= — competing-consumer; one subscriber per message; used by all server-side handlers.
+- =request_sync(subject, data)= — synchronous request-reply; used by Qt clients.
+
+** Service IAM pattern
+
+Each service runs with an IAM identity from the service registry.  The IAM context
+provides =ctx.tenant_id()= which is used as the =tenant_id= on all DB records the service
+writes.  The =synthetic= entry is already registered:
+
+: psql_var  = synthetic_service
+: iam_role  = SyntheticService
+: email     = synthetic_service@system.ores
+
+* Gap analysis
+
+| Gap | Impact on PoC |
+|-----+---------------|
+| No synthetic generation service | Core new work. |
+| No NATS fan-out subject for live ticks | Required for chart subscription. |
+| No tick payload format | Needed for service → client communication. |
+| No chart window in =ores.qt.mktdata= | Required for live display acceptance criterion. |
+| No Qt subscription path for streaming data with payload | Existing =subscribeToEvent= parses =entity_change_event= only; no raw payload delivery. |
+| No configuration UI | Required for acceptance: currency pair, GMM params, tick frequency, start/stop. |
+| No =ores.synthetic= CMake component | New top-level project needed. |
+
+* PoC architecture
+
+** Component overview
+
+#+begin_src plantuml :exports results :file poc_overview.png
+@startuml
+!include <tupadr3/common>
+
+actor User
+
+rectangle "ores.qt.mktdata (extended)" {
+  component SyntheticFxSpotConfigDialog
+  component SyntheticFxSpotChartWindow
+  component MarketDataController as MDC
+}
+
+rectangle "NATS" {
+  queue "synthetic.v1.fxspot.start (req-rep)" as StartSubj
+  queue "synthetic.v1.fxspot.stop (req-rep)" as StopSubj
+  queue "synthetic.v1.fxspot.ticked (fan-out)" as TickSubj
+  queue "marketdata.v1.observations.save (req-rep)" as SaveSubj
+}
+
+rectangle "ores.synthetic.service (new)" {
+  component tick_loop
+  component gmm_generator
+  component tick_clock
+}
+
+rectangle "ores.marketdata.service (existing)" {
+  component market_observations_service
+}
+
+database "TimescaleDB" {
+  table ores_marketdata_observations
+}
+
+User --> SyntheticFxSpotConfigDialog : configure + start/stop
+SyntheticFxSpotConfigDialog --> StartSubj : start_request
+SyntheticFxSpotConfigDialog --> StopSubj : stop_request
+
+StartSubj --> tick_loop : start
+StopSubj --> tick_loop : stop
+
+tick_loop --> gmm_generator : generate tick value
+tick_loop --> SaveSubj : save observation
+tick_loop --> TickSubj : publish tick event
+SaveSubj --> market_observations_service
+market_observations_service --> ores_marketdata_observations
+
+TickSubj --> SyntheticFxSpotChartWindow : tick notification
+SyntheticFxSpotChartWindow --> User : live chart update
+@enduml
+#+end_src
+
+** Per-tick data flow
+
+One complete tick cycle in sequence:
+
+1. =tick_clock= fires (interval determined by configured tick mode and parameters).
+2. =gmm_generator= draws a new log-return from the fitted Gaussian mixture and applies
+   it to the current spot price, producing a new =value= string and the current UTC
+   =observation_date=.
+3. =tick_loop= sends =save_market_observations_request= to
+   =marketdata.v1.observations.save= with a single =market_observation= (=series_id= of
+   EUR/USD, =observation_date=, =point_id=null=, =value=, =source="SYNTHETIC"=).  Awaits
+   acknowledgement.
+4. On success, =tick_loop= publishes an =fx_spot_tick_event= to
+   =synthetic.v1.fxspot.ticked= (core NATS, fire-and-forget — the tick is already
+   durable in the DB).
+5. =SyntheticFxSpotChartWindow= (in the Qt client) receives the NATS message, decodes
+   the =fx_spot_tick_event=, and appends =(observation_date, value)= to the live chart
+   series.
+
+The DB write (step 3) is the source of truth; the fan-out (step 4) is a convenience
+notification for live display.  A chart client that reconnects after a gap fetches
+historical observations from =marketdata.v1.observations.list= to backfill the gap.
+
+** New domain type: fx_spot_tick_event
+
+A lightweight struct in =ores.synthetic.api=:
+
+#+begin_src cpp
+struct fx_spot_tick_event {
+    std::string series_id;         // UUID of the EUR/USD market_series
+    std::string observation_date;  // "YYYY-MM-DDThh:mm:ssZ"
+    std::string value;             // e.g. "1.08456"
+    std::string tenant_id;         // tenant UUID string
+    std::string pair;              // "EUR/USD"
+};
+#+end_src
+
+Serialised as JSON using =rfl::json= (consistent with the rest of the codebase).  No
+separate API component is needed for the PoC; the struct can live in the service
+source until a second consumer arises.
+
+** New NATS subjects
+
+| Subject | Direction | Owner | Notes |
+|---------+-----------+-------+-------|
+| =synthetic.v1.fxspot.start= | Request-reply | =ores.synthetic.service= | Carries =fx_spot_start_request= (config + series_id). Returns =fx_spot_start_response= (success, message). |
+| =synthetic.v1.fxspot.stop= | Request-reply | =ores.synthetic.service= | Carries =fx_spot_stop_request=. Returns =fx_spot_stop_response=. |
+| =synthetic.v1.fxspot.ticked= | Fan-out (publish) | =ores.synthetic.service= | Carries =fx_spot_tick_event=. Zero or more Qt clients subscribe. |
+
+The start request carries the full configuration so the service is stateless between
+start/stop cycles:
+
+#+begin_src cpp
+struct fx_spot_start_request {
+    std::string series_id;          // which EUR/USD series to write into
+    std::string workspace_tenant_id;
+    // GMM parameters (seeded for PoC)
+    int gmm_k = 3;
+    double initial_price = 1.08;
+    // Tick clock parameters
+    std::string tick_mode;          // "fixed" | "poisson" | "regime"
+    double tick_rate_per_hour = 12.0;  // for fixed and poisson
+};
+#+end_src
+
+** Qt extension: raw tick subscription
+
+The existing =subscribeToEvent= path parses all payloads as =entity_change_event= and
+discards the raw bytes.  Tick data needs to reach the chart window as a structured
+value, not just a notification-to-poll.
+
+Two options considered:
+
+| Option | Description | Trade-offs |
+|--------+-------------+------------|
+| A: Extend =subscribeToEvent= | Check subject prefix; if =synthetic.v1.*=, parse as =fx_spot_tick_event= and populate the =payload= field on =notificationReceived=. | Simple addition, but couples =ClientManager= to =ores.synthetic.api= types. |
+| B: Add =subscribeToRawEvent= | New =ClientManager= method taking a =std::function<void(QByteArray)>= handler; bypasses =entity_change_event= parsing entirely. | Cleaner separation; the chart window owns its own deserialization. |
+
+*Recommendation:* Option B for the PoC. Add to =ClientManager=:
+
+#+begin_src cpp
+void subscribeToRawEvent(const std::string& subject,
+                         std::function<void(QByteArray)> handler);
+void unsubscribeFromRawEvent(const std::string& subject);
+#+end_src
+
+The chart window calls =subscribeToRawEvent("synthetic.v1.fxspot.ticked", ...)= on
+=loggedIn= and =reconnected=, parses the =QByteArray= as =fx_spot_tick_event= in its own
+slot, and updates the chart.
+
+** New Qt components
+
+*** SyntheticFxSpotConfigDialog
+
+A modal dialog (or docked widget, TBD) in =ores.qt.mktdata=. Fields:
+
+- Currency pair selector (EUR/USD for PoC; combo populated from =market_series= filtered by =asset_class=fx, subclass=spot=).
+- GMM parameters: K (integer spinbox), initial price (double spinbox).
+- Tick frequency: mode selector (Fixed / Poisson / Regime-switching), rate $\lambda$ (double spinbox, units: ticks/hour).
+- Start button → sends =synthetic.v1.fxspot.start=.
+- Stop button → sends =synthetic.v1.fxspot.stop=.
+
+Start success opens (or focuses) the chart window.
+
+*** SyntheticFxSpotChartWindow
+
+An MDI window in =ores.qt.mktdata= using =QtCharts::QLineSeries= + =QDateTimeAxis=:
+
+- X axis: =QDateTimeAxis=, auto-scrolling; shows the last N minutes.
+- Y axis: =QValueAxis=, auto-ranging.
+- Subscribes to =synthetic.v1.fxspot.ticked= via =subscribeToRawEvent=.
+- On open: fetches the last 100 observations from =marketdata.v1.observations.list= to backfill the chart before live ticks arrive.
+- On each tick: appends a new =(QDateTime, double)= point to the live series.
+- Toolbar: time range selector (last 5 min / 30 min / 2 h / all), manual refresh button.
+
+The =QueueChartWindow= (=ores.qt.compute=) provides a reference implementation for embedding =QChartView= and wiring toolbar actions; the new window follows the same structural pattern.
+
+** New service component: ores.synthetic
+
+Proposed structure following the project's three-layer convention:
+
+#+begin_src text
+projects/ores.synthetic/
+  service/
+    CMakeLists.txt
+    include/ores.synthetic.service/
+      ...
+    src/
+      CMakeLists.txt   ← add_library(.lib) + add_executable(.exe)
+      main.cpp
+      tick_loop.cpp / .hpp
+      gmm_generator.cpp / .hpp
+      registrar.cpp / .hpp   ← registers NATS handlers for start/stop
+    tests/
+#+end_src
+
+For the PoC, a single-layer =ores.synthetic.service= (no separate =ores.synthetic.api= or
+=ores.synthetic.core=) is sufficient.  There are currently no other services that need
+to depend on synthetic API types.  A public API layer can be extracted if other
+components need to subscribe to the tick event type.
+
+The service binary links against:
+- =ores.marketdata.api.lib= — for =save_market_observations_request= and protocol subjects.
+- =ores.nats.lib= — for =client::publish= and =client::queue_subscribe=.
+- =ores.service.lib= — for the service lifecycle base.
+- =ores.iam.core.lib= — for IAM context (=ctx.tenant_id()=).
+
+** Tick clock implementation
+
+The tick clock is the configurable time source for the generation loop.  Three modes
+for the PoC:
+
+| Mode | Implementation | Config fields |
+|------+----------------+---------------|
+| Fixed | =std::this_thread::sleep_for(period)= loop in a dedicated =std::thread=. | =rate= (ticks/hour). |
+| Poisson | Draw inter-arrival times from $\text{Exp}(\lambda)$ using =std::exponential_distribution<>=. | $\lambda$ (ticks/hour). |
+| Regime-switching | Two Poisson states (active/quiet) with fixed transition probabilities; state transition drawn from Bernoulli each tick. | $\lambda_{\text{active}}$, $\lambda_{\text{quiet}}$, $p_{\text{active}\to\text{quiet}}$, $p_{\text{quiet}\to\text{active}}$. |
+
+The tick loop runs on its own =std::thread= (not the ASIO executor) and uses the NATS
+=client::request_sync= method for the DB write (synchronous, blocks until acknowledged).
+Fan-out publish is fire-and-forget and does not block.
+
+** GMM generator (PoC approximation)
+
+The approach document specifies GMM for return generation, with parameters fitted to
+historical returns.  For the PoC:
+
+- Parameters are statically seeded (hardcoded in the start request or compiled in).
+- The generator maintains a running spot price and draws log-returns from a $K=3$
+  Gaussian mixture with pre-set means and standard deviations.
+- The returned =value= is the new spot price formatted to 5 decimal places.
+- The standard library =std::normal_distribution= is sufficient; no external stats
+  library is required for the PoC.
+
+Live GMM calibration to historical data is explicitly out of scope.
+
+** DB schema: no additions required
+
+FX spot observations fit directly into the existing =market_observation= table.  The
+synthetic service creates or looks up the EUR/USD =market_series= catalog entry (using
+=marketdata.v1.series.save= with =is_scalar=true=, =series_type="FX"=, =metric="RATE"=,
+=qualifier="EUR/USD"=) and then writes observations against it.  No new tables, columns,
+or migrations are needed.
+
+* Open design questions
+
+The following require a decision before or during implementation. They should be
+recorded in the story =* Decisions= when resolved.
+
+| # | Question | Options | Recommendation |
+|---+----------+---------+----------------|
+| 1 | How does the synthetic service look up or create the EUR/USD =market_series= at startup? | (a) Series must be pre-created by the operator; (b) service upserts it at startup. | (b) — upsert at startup simplifies setup for the PoC. |
+| 2 | Which tenant does the synthetic service write as? | (a) Its own IAM tenant (=SyntheticService=); (b) a configurable workspace UUID passed in the start request. | (b) — pass =workspace_tenant_id= in the start request so the Qt client and service share the same tenant context. |
+| 3 | Should the fan-out use core NATS or JetStream? | (a) Core NATS (fire-and-forget, no replay); (b) JetStream (durable, late subscribers can replay). | (a) for PoC — the DB is the source of truth for replay; chart backfills from DB on connect. |
+| 4 | Is =subscribeToRawEvent= needed, or can we use option A (extend subscribeToEvent)? | See §6.5 above. | Option B (=subscribeToRawEvent=) — keeps =ClientManager= decoupled from synthetic types. |
+| 5 | Config dialog vs config panel (MDI subwindow)? | Modal dialog (simpler); or docked MDI subwindow (persistent). | Modal dialog for PoC; upgrade to MDI subwindow if needed. |
+| 6 | Chart window: open from config dialog on start, or always visible? | (a) Opens on start, closes on stop; (b) opens from Market Data menu independently. | (a) for PoC — simplest wiring; the chart and generator are tied together. |
+| 7 | Where does the config dialog/controller live? | Extend =MarketDataController= with a =showSyntheticFxSpotConfig()= method; add to menu. | Yes — keep within =ores.qt.mktdata= plugin to avoid a new Qt plugin for the PoC. |
+
+* Implementation order
+
+The recommended order of implementation tasks (one story task per item):
+
+1. *=ores.synthetic.service= scaffold* — CMakeLists, registrar, skeleton main; service registers and starts but does nothing yet. Validates build wiring.
+2. *Tick loop + GMM generator* — tick_loop with fixed-mode clock, seeded GMM; publishes to =synthetic.v1.fxspot.ticked= only (no DB write yet). Validates generation logic in isolation.
+3. *DB write integration* — add =marketdata.v1.observations.save= call per tick; verify observations appear in existing =MarketSeriesMdiWindow= observation view.
+4. *Start/stop NATS handlers* — add =synthetic.v1.fxspot.start= / =stop= request-reply handlers; service becomes remotely controllable.
+5. *=subscribeToRawEvent= on =ClientManager=* — minimal extension; validated with a logging subscriber.
+6. *=SyntheticFxSpotChartWindow=* — chart window with backfill + live subscription; added to =ores.qt.mktdata=.
+7. *=SyntheticFxSpotConfigDialog=* — config dialog with start/stop; wired into =MarketDataController= and the Market Data menu.
+8. *End-to-end integration test* — manual smoke test: configure EUR/USD, start, observe chart ticking, stop, verify DB observations.
+
+* See also
+
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — detailed inventory of the existing stack this architecture builds on.
+- [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the algorithm choices (GMM, tick clock modes) this architecture implements.
+- [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story tracking this PoC work.
+- [[id:759530D8-2314-44F3-A50E-71CE7AD02558][ores.marketdata.core]] — existing component overview.
+- [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — IPlugin lifecycle and menu wiring conventions.
+- [[id:2FDDC2F6-C510-4A86-8C50-D79C83EDDFFF][Qt entity patterns]] — ClientModel, async-fetch, and MDI window patterns.

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -216,72 +216,95 @@ The DB write (step 3) is the source of truth; the fan-out (step 4) is a convenie
 notification for live display.  A chart client that reconnects after a gap fetches
 historical observations from =marketdata.v1.observations.list= to backfill the gap.
 
-** New domain type: fx_spot_tick_event
+** New domain types
 
-A lightweight struct in =ores.synthetic.api=:
+Both types live in =ores.marketdata.api= so they are shared by the service (publisher)
+and =ores.marketdata.client= (subscriber) without coupling either to =ores.synthetic=.
+
+*** fx_spot_tick
+
+The strongly-typed output of =IFxSpotFeed=, serialised as JSON via =rfl::json=:
 
 #+begin_src cpp
-struct fx_spot_tick_event {
-    std::string series_id;         // UUID of the EUR/USD market_series
-    std::string observation_date;  // "YYYY-MM-DDThh:mm:ssZ"
-    std::string value;             // e.g. "1.08456"
-    std::string tenant_id;         // tenant UUID string
-    std::string pair;              // "EUR/USD"
+struct fx_spot_tick {
+    std::string ore_key;     // "FX/RATE/EUR/USD" — ORE canonical key
+    std::chrono::system_clock::time_point datetime;
+    double mid;              // mid-price, e.g. 1.08456
 };
 #+end_src
 
-Serialised as JSON using =rfl::json= (consistent with the rest of the codebase).  No
-separate API component is needed for the PoC; the struct can live in the service
-source until a second consumer arises.
+*** IFxSpotFeed
+
+Pure interface in =ores.marketdata.api=; =ores.synthetic= implements it:
+
+#+begin_src cpp
+class IFxSpotFeed {
+public:
+    virtual ~IFxSpotFeed() = default;
+    using handler = std::function<void(const fx_spot_tick&)>;
+    virtual std::string ore_key() const = 0;
+    virtual void start(handler on_tick) = 0;
+    virtual void stop() = 0;
+};
+#+end_src
+
+The feed manager in =ores.marketdata.service= calls =start(handler)= where the handler
+(1) converts =fx_spot_tick= to =market_observation= and writes to DB, then (2) serialises
+and publishes the tick to =marketdata.v1.tick.<ore-key-mapped>=.
 
 ** New NATS subjects
 
+Tick fan-out subjects follow the ORE canonical key mapping defined in
+[[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]]: lowercase the ORE key and replace =/= with =.=,
+then prefix with =marketdata.v1.tick.=.
+
 | Subject | Direction | Owner | Notes |
 |---------+-----------+-------+-------|
-| =synthetic.v1.fxspot.start= | Request-reply | =ores.synthetic.service= | Carries =fx_spot_start_request= (config + series_id). Returns =fx_spot_start_response= (success, message). |
-| =synthetic.v1.fxspot.stop= | Request-reply | =ores.synthetic.service= | Carries =fx_spot_stop_request=. Returns =fx_spot_stop_response=. |
-| =synthetic.v1.fxspot.ticked= | Fan-out (publish) | =ores.synthetic.service= | Carries =fx_spot_tick_event=. Zero or more Qt clients subscribe. |
+| =marketdata.v1.feed.start= | Request-reply | =ores.marketdata.service= | Carries feed configuration (list of ORE keys, clock, model params). |
+| =marketdata.v1.feed.stop= | Request-reply | =ores.marketdata.service= | Stops the running feed. |
+| =marketdata.v1.tick.fx.rate.eur.usd= | Fan-out (publish) | =ores.marketdata.service= | Carries =fx_spot_tick= for EUR/USD. Derived from ORE key =FX/RATE/EUR/USD=. |
+| =marketdata.v1.tick.fx.rate.>= | Wildcard (subscribe) | clients | Subscribe to all FX spot pairs. |
 
-The start request carries the full configuration so the service is stateless between
-start/stop cycles:
+The feed start request specifies which ORE keys to generate and the shared model
+parameters:
 
 #+begin_src cpp
-struct fx_spot_start_request {
-    std::string series_id;          // which EUR/USD series to write into
+struct feed_start_request {
+    std::vector<std::string> ore_keys;   // ["FX/RATE/EUR/USD", "FX/RATE/GBP/USD"]
     std::string workspace_tenant_id;
     // GMM parameters (seeded for PoC)
     int gmm_k = 3;
-    double initial_price = 1.08;
     // Tick clock parameters
-    std::string tick_mode;          // "fixed" | "poisson" | "regime"
-    double tick_rate_per_hour = 12.0;  // for fixed and poisson
+    std::string tick_mode;               // "fixed" | "poisson" | "regime"
+    double tick_rate_per_hour = 12.0;
 };
 #+end_src
 
-** Qt extension: raw tick subscription
+** Client subscription via ores.marketdata.client
 
-The existing =subscribeToEvent= path parses all payloads as =entity_change_event= and
-discards the raw bytes.  Tick data needs to reach the chart window as a structured
-value, not just a notification-to-poll.
-
-Two options considered:
-
-| Option | Description | Trade-offs |
-|--------+-------------+------------|
-| A: Extend =subscribeToEvent= | Check subject prefix; if =synthetic.v1.*=, parse as =fx_spot_tick_event= and populate the =payload= field on =notificationReceived=. | Simple addition, but couples =ClientManager= to =ores.synthetic.api= types. |
-| B: Add =subscribeToRawEvent= | New =ClientManager= method taking a =std::function<void(QByteArray)>= handler; bypasses =entity_change_event= parsing entirely. | Cleaner separation; the chart window owns its own deserialization. |
-
-*Recommendation:* Option B for the PoC. Add to =ClientManager=:
+Tick subscriptions are handled by the new =ores.marketdata.client= library, not by Qt
+code directly. This library is reusable by Qt, Wt, and shell without modification.
 
 #+begin_src cpp
-void subscribeToRawEvent(const std::string& subject,
-                         std::function<void(QByteArray)> handler);
-void unsubscribeFromRawEvent(const std::string& subject);
+// In ores.marketdata.client
+class fx_spot_subscription {
+public:
+    using handler = std::function<void(const fx_spot_tick&)>;
+
+    // ore_key: "FX/RATE/EUR/USD" — converted internally to NATS subject
+    fx_spot_subscription(nats::client&, std::string ore_key, handler);
+    ~fx_spot_subscription(); // auto-unsubscribes
+};
 #+end_src
 
-The chart window calls =subscribeToRawEvent("synthetic.v1.fxspot.ticked", ...)= on
-=loggedIn= and =reconnected=, parses the =QByteArray= as =fx_spot_tick_event= in its own
-slot, and updates the chart.
+The library handles: NATS subject derivation from ORE key (lowercase, =/= → =.=),
+=rfl::json= deserialization into =fx_spot_tick=, and thread marshalling (callbacks
+delivered on the NATS client thread; callers are responsible for queuing to their
+own event loop if needed).
+
+The Qt chart window holds an =fx_spot_subscription= member and re-subscribes on
+=ClientManager::loggedIn= and =reconnected=. It passes =clientManager_->nats_client()=
+to the subscription constructor. No direct NATS wiring lives in Qt code.
 
 ** New Qt components
 
@@ -430,6 +453,7 @@ The recommended order of implementation tasks (one story task per item):
 
 * See also
 
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key, NATS subject mapping, two-level subscription model.
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — detailed inventory of the existing stack this architecture builds on.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the algorithm choices (GMM, tick clock modes) this architecture implements.
 - [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story tracking this PoC work.

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -260,25 +260,94 @@ then prefix with =marketdata.v1.tick.=.
 
 | Subject | Direction | Owner | Notes |
 |---------+-----------+-------+-------|
-| =marketdata.v1.feed.start= | Request-reply | =ores.marketdata.service= | Carries feed configuration (list of ORE keys, clock, model params). |
-| =marketdata.v1.feed.stop= | Request-reply | =ores.marketdata.service= | Stops the running feed. |
+| =marketdata.v1.market_feed_configs.save= | Request-reply | =ores.marketdata.service= | Creates/updates a feed config entity (=feed_type= discriminator + =auto_start=). |
+| =marketdata.v1.market_feed_configs.start= | Request-reply | =ores.marketdata.service= | Runtime start command: activates a persisted feed by =config_id=. |
+| =marketdata.v1.market_feed_configs.stop= | Request-reply | =ores.marketdata.service= | Runtime stop command: deactivates a running feed by =config_id=. |
+| =marketdata.v1.synthetic_fixed_feed_params.save= | Request-reply | =ores.marketdata.service= | Saves typed params for a fixed-price feed; linked to config by =config_id=. |
+| =marketdata.v1.synthetic_tabular_feed_params.save= | Request-reply | =ores.marketdata.service= | Saves typed params for a tabular feed. |
+| =marketdata.v1.synthetic_gmm_feed_params.save= | Request-reply | =ores.marketdata.service= | Saves typed params for a GMM feed. |
 | =marketdata.v1.tick.fx.rate.eur.usd= | Fan-out (publish) | =ores.marketdata.service= | Carries =fx_spot_tick= for EUR/USD. Derived from ORE key =FX/RATE/EUR/USD=. |
 | =marketdata.v1.tick.fx.rate.>= | Wildcard (subscribe) | clients | Subscribe to all FX spot pairs. |
 
-The feed start request specifies which ORE keys to generate and the shared model
-parameters:
+Feed configuration is a two-step operation: (1) save the =market_feed_config= entity;
+(2) save the type-specific params struct linked by =config_id=.  Start and stop are
+runtime commands on the persisted config ID — they change status only, not config.
+See [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] for the full pattern rationale.
+
+** Feed configuration: DB entity and typed parameters
+
+Feed configuration follows the *polymorphic types over NATS* pattern (see
+[[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]]): one NATS subject per concrete params type; a
+discriminator enum on the containing entity identifies which subject to use; no
+JSON blobs.
+
+*** market_feed_config
+
+The configuration entity persisted to DB.  The =feed_type= enum is the discriminator:
 
 #+begin_src cpp
-struct feed_start_request {
-    std::vector<std::string> ore_keys;   // ["FX/RATE/EUR/USD", "FX/RATE/GBP/USD"]
-    std::string workspace_tenant_id;
-    // GMM parameters (seeded for PoC)
-    int gmm_k = 3;
-    // Tick clock parameters
-    std::string tick_mode;               // "fixed" | "poisson" | "regime"
+enum class feed_type {
+    synthetic_fixed,    // constant price at fixed intervals
+    synthetic_tabular,  // price table, wraps on exhaustion
+    synthetic_gmm,      // Gaussian Mixture Model log-return generator
+};
+
+struct market_feed_config {
+    boost::uuids::uuid id;
+    utility::uuid::tenant_id tenant_id;
+    boost::uuids::uuid series_id;    // → market_series (which ORE key)
+    feed_type type;                  // ← discriminator
+    bool auto_start = false;         // restart on service restart
+};
+#+end_src
+
+=auto_start= is a configuration choice: if true the feed manager reactivates this
+feed on service start.  Start and stop at runtime change the feed's live status
+only — they do not modify this field.
+
+*** Typed parameter structs
+
+Each feed type carries its own params struct, linked to the config by =config_id=:
+
+#+begin_src cpp
+struct synthetic_fixed_feed_params {
+    boost::uuids::uuid config_id;
+    double price;
+    std::string tick_mode;            // "fixed" | "poisson" | "regime"
+    double tick_rate_per_hour = 12.0;
+};
+
+struct synthetic_tabular_feed_params {
+    boost::uuids::uuid config_id;
+    std::vector<double> prices;
+    bool wrap = true;
+    std::string tick_mode;
+    double tick_rate_per_hour = 12.0;
+};
+
+struct synthetic_gmm_feed_params {
+    boost::uuids::uuid config_id;
+    int k = 3;
+    std::vector<double> means;
+    std::vector<double> stdevs;
+    std::vector<double> weights;
+    double initial_price;
+    std::string tick_mode;            // "fixed" | "poisson" | "regime"
     double tick_rate_per_hour = 12.0;
 };
 #+end_src
+
+*** Two-phase dispatch on read
+
+When the service or UI loads a feed config and needs its params, it applies
+two-phase dispatch:
+
+1. Read =market_feed_config= (gets =feed_type= discriminator).
+2. Switch on =feed_type= → issue typed NATS request to the appropriate
+   params subject → =rfl::json::read<ConcreteParamsWrapper>(raw)=.
+
+The UI uses the same discriminator to decide which dialog panel to display.
+No JSON blobs; no =std::variant= on the wire.
 
 ** Client subscription via ores.marketdata.client
 
@@ -313,12 +382,19 @@ to the subscription constructor. No direct NATS wiring lives in Qt code.
 A modal dialog (or docked widget, TBD) in =ores.qt.mktdata=. Fields:
 
 - Currency pair selector (EUR/USD for PoC; combo populated from =market_series= filtered by =asset_class=fx, subclass=spot=).
-- GMM parameters: K (integer spinbox), initial price (double spinbox).
-- Tick frequency: mode selector (Fixed / Poisson / Regime-switching), rate $\lambda$ (double spinbox, units: ticks/hour).
-- Start button → sends =synthetic.v1.fxspot.start=.
-- Stop button → sends =synthetic.v1.fxspot.stop=.
+- Feed type selector (Fixed / Tabular / GMM) — determines which params panel is shown.
+- *Fixed params panel*: price (double spinbox).
+- *Tabular params panel*: price table (editable list), wrap checkbox.
+- *GMM params panel*: K (integer spinbox), initial price (double spinbox).
+- Tick frequency (all types): mode selector (Fixed / Poisson / Regime-switching), rate λ (double spinbox, units: ticks/hour).
+- Auto-start checkbox — if checked the feed restarts on service restart.
+- Save button → POSTs =market_feed_config= to =marketdata.v1.market_feed_configs.save=,
+  then POSTs typed params to the corresponding =marketdata.v1.<type>_feed_params.save= subject.
+- Start button → sends =marketdata.v1.market_feed_configs.start= with the saved =config_id=.
+- Stop button → sends =marketdata.v1.market_feed_configs.stop= with the =config_id=.
 
-Start success opens (or focuses) the chart window.
+Save followed by Start is the normal workflow.  Start success opens (or focuses)
+the chart window.
 
 *** SyntheticFxSpotChartWindow
 
@@ -456,6 +532,7 @@ The recommended order of implementation tasks (one story task per item):
 - [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — RIC, Bloomberg, ORE canonical key, NATS subject mapping, two-level subscription model.
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — detailed inventory of the existing stack this architecture builds on.
 - [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the algorithm choices (GMM, tick clock modes) this architecture implements.
+- [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — the pattern used for typed feed config parameter serialisation (=market_feed_config= discriminator, type-specific NATS subjects, two-phase dispatch on read).
 - [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story tracking this PoC work.
 - [[id:759530D8-2314-44F3-A50E-71CE7AD02558][ores.marketdata.core]] — existing component overview.
 - [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — IPlugin lifecycle and menu wiring conventions.

--- a/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
+++ b/doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org
@@ -369,13 +369,36 @@ historical returns.  For the PoC:
 
 Live GMM calibration to historical data is explicitly out of scope.
 
-** DB schema: no additions required
+** DB schema: observation_date → observation_datetime
 
-FX spot observations fit directly into the existing =market_observation= table.  The
-synthetic service creates or looks up the EUR/USD =market_series= catalog entry (using
-=marketdata.v1.series.save= with =is_scalar=true=, =series_type="FX"=, =metric="RATE"=,
-=qualifier="EUR/USD"=) and then writes observations against it.  No new tables, columns,
-or migrations are needed.
+The existing =market_observation= table uses =observation_date: year_month_day= (date
+only) as its financial valid-time.  The bi-temporal insert trigger matches rows on
+=(series_id, observation_date, point_id)=: a second tick for the same calendar date
+closes the previous row and replaces it.  At 12 ticks/hour only one observation per
+day survives in the live view — all earlier intraday ticks are overwritten.
+
+*Decision:* update the =market_observation= schema to replace the date field with a
+full timestamp field so each intraday tick is a distinct financial valid-time point.
+
+Required changes:
+
+| Layer | Change |
+|-------+--------|
+| DB column | =observation_date DATE= → =observation_datetime TIMESTAMPTZ= |
+| Bi-temporal trigger | Match key changes from =(series_id, observation_date, point_id)= to =(series_id, observation_datetime, point_id)= |
+| C++ domain struct | =std::chrono::year_month_day observation_date= → =std::chrono::system_clock::time_point observation_datetime= |
+| Repository mapper | Update =market_observation_mapper= to read/write the new column name and type |
+| NATS protocol | Update =market_observation= JSON serialisation (field rename); callers pass a timestamp, not a date string |
+| Existing import service | =import_service.cpp= currently sets =obs.observation_date= from the CSV date; update to set =obs.observation_datetime= (keep date-at-midnight for imported EOD data) |
+| TimescaleDB hypertable | Hypertable partition dimension must be re-pointed from =observation_date= to =observation_datetime=; requires recreating the hypertable if the column type changes |
+
+The migration is a *breaking change* to =ores.marketdata= and must be delivered as a
+dedicated task ahead of any synthetic service work that writes intraday observations.
+All other callers of the =market_observation= API (import service, the Qt observation
+list window, the report writer) must be updated in the same PR.
+
+Existing imported data (currently stored as EOD dates) can be migrated by converting
+each =observation_date= to midnight UTC of that date.
 
 * Open design questions
 

--- a/doc/knowledge/domain/market_data_identifiers.org
+++ b/doc/knowledge/domain/market_data_identifiers.org
@@ -1,0 +1,277 @@
+:PROPERTIES:
+:ID: F3010EA7-6A0E-405C-81FA-1EF051749B5E
+:END:
+#+title: Market data identifiers
+#+description: How market data series are identified across external schemes (RIC, Bloomberg) and within ORE Studio: the ORE canonical key format, its decomposition into series_type/metric/qualifier, and the mapping to NATS tick subjects.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:identifiers:nats:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+* Summary
+
+Market data series are identified differently across data vendors and internal
+systems. Reuters uses RICs (e.g. =EUR==), Bloomberg uses its own ticker syntax (e.g.
+=EURUSD BGN Curncy=), and ORE uses a slash-delimited canonical key
+(e.g. =FX/RATE/EUR/USD=). ORE Studio adopts the *ORE canonical key* as its internal
+identifier for all market data series: it is already the native format of every ORE
+input file, it maps directly to the =market_series= columns
+=(series_type, metric, qualifier)=, and it converts to a clean NATS subject token by
+replacing =/= with =.=. External vendor identifiers (RIC, Bloomberg) are stored as
+optional fields on =market_series= for future real-data feed integration but are not
+used internally.
+
+* External identifier schemes
+
+** RIC (Reuters Instrument Code)
+
+RIC is the identifier scheme used by Reuters/Refinitiv (now LSEG). It is widely used
+in sell-side systems and data terminals. The structure is instrument-type-specific and
+not fully systematic — conventions differ by asset class.
+
+*** FX
+
+| Instrument | RIC | Notes |
+|------------+-----+-------|
+| EUR/USD spot | =EUR== | Major pairs: base currency code + ==. |
+| GBP/USD spot | =GBP== | |
+| USD/JPY spot | =JPY== | |
+| EUR/GBP cross | =EURGBP== | Crosses: 6-char pair + ==. |
+| EUR/USD 1M forward | =EURUSD1MF== | Outright forwards append tenor + =F=. |
+
+*** Interest rates
+
+| Instrument | RIC | Notes |
+|------------+-----+-------|
+| USD overnight rate (SOFR) | =USDSOFR== | |
+| EUR 6M EURIBOR | =EUR6MFSR== | |
+| USD 5Y IRS par rate | =USDSB5Y=ICAP= | Broker-specific suffix. |
+| EUR 10Y IRS par rate | =EURABS10Y=ICAP= | |
+| 10Y US Treasury yield | =US10YT=RR= | =RR= = Reuters composite. |
+| 10Y German Bund yield | =DE10YT=RR= | |
+
+*** Equities and indices
+
+| Instrument | RIC | Notes |
+|------------+-----+-------|
+| Apple (NASDAQ) | =AAPL.OQ= | Exchange suffix: =.OQ= = NASDAQ. |
+| Vodafone (LSE) | =VOD.L= | =.L= = London. |
+| S&P 500 index | =.SPX= | Indices prefixed with =.=. |
+| FTSE 100 | =.FTSE= | |
+| S&P 500 front-month future | =ESc1= | =c1= = continuous front month. |
+
+*** Credit
+
+| Instrument | RIC | Notes |
+|------------+-----+-------|
+| iTraxx Europe 5Y CDS index | =ITRAXX-EUROPE-5Y-CDS=GFI= | Broker-specific. |
+| Single-name CDS (Vodafone) | =VOD5YEUAM=ICAP= | |
+
+*** Commodities
+
+| Instrument | RIC | Notes |
+|------------+-----+-------|
+| WTI crude front-month future | =CLc1= | =CL= = WTI, =c1= = continuous. |
+| Brent crude front-month | =LCOc1= | |
+| Gold spot | =XAU== | Treated as FX-like spot. |
+
+RICs are vendor-specific, require a Reuters/LSEG licence, and contain characters
+(==, =.=) that conflict with NATS subject syntax. They are stored on =market_series=
+for reference but are *not* used as internal identifiers in ORE Studio.
+
+** Bloomberg ticker
+
+Bloomberg uses a space-separated composite: =<ticker> <yellow-key>=. The yellow key
+identifies the asset class. Spaces and mixed case make Bloomberg tickers unsuitable
+for NATS subjects.
+
+*** FX
+
+| Instrument | Bloomberg ticker | Notes |
+|------------+-----------------+-------|
+| EUR/USD spot (BGN fixing) | =EURUSD BGN Curncy= | BGN = Bloomberg Generic. |
+| GBP/USD spot | =GBPUSD BGN Curncy= | |
+| EUR/USD 1M forward | =EURUSD1M BGN Curncy= | |
+
+*** Interest rates
+
+| Instrument | Bloomberg ticker | Notes |
+|------------+-----------------+-------|
+| USD SOFR overnight | =SOFRRATE Index= | |
+| EUR 6M EURIBOR | =EUR006M Index= | |
+| USD 5Y IRS par rate | =USSA5 Curncy= | |
+| EUR 10Y IRS par rate | =EUSA10 Curncy= | |
+| 10Y US Treasury yield | =USGG10YR Index= | |
+| 10Y German Bund yield | =GDBR10 Index= | |
+
+*** Equities and indices
+
+| Instrument | Bloomberg ticker | Notes |
+|------------+-----------------+-------|
+| Apple | =AAPL US Equity= | Exchange suffix in yellow key. |
+| Vodafone | =VOD LN Equity= | |
+| S&P 500 index | =SPX Index= | |
+| FTSE 100 | =UKX Index= | |
+
+*** Credit
+
+| Instrument | Bloomberg ticker | Notes |
+|------------+-----------------+-------|
+| iTraxx Europe 5Y | =ITRX EUR 5Y Corp= | |
+
+*** Commodities
+
+| Instrument | Bloomberg ticker | Notes |
+|------------+-----------------+-------|
+| WTI crude front-month | =CL1 Comdty= | =1= = front month. |
+| Brent crude front-month | =CO1 Comdty= | |
+| Gold spot | =XAU BGN Curncy= | |
+
+Bloomberg tickers require a Bloomberg licence and terminal API. Like RICs, they are
+stored as optional reference data on =market_series= but are *not* used internally.
+
+* The ORE canonical key
+
+ORE identifies every market data series with a slash-delimited key consumed
+directly by the ORE pricing engine. All ORE =marketdata.csv= files use this format:
+
+: <series_type>/<metric>/<qualifier>[/<point_id>]
+
+The first three segments identify the *series*; the optional =point_id= identifies
+a specific point within a term structure (tenor, vol surface coordinate).
+
+| Segment | Meaning | Example |
+|---------+---------+---------|
+| =series_type= | Asset class and curve family | =FX=, =DISCOUNT=, =SWAPTION=, =CAPFLOOR= |
+| =metric= | What is being quoted | =RATE=, =RATE_LNVOL=, =PRICE=, =SPREAD= |
+| =qualifier= | Series-specific identifier (CCY, CCY pair, index name, credit name) | =EUR/USD=, =EUR=, =CPTY_A/SR/USD= |
+| =point_id= | Tenor or surface coordinate (absent for scalar series) | =1Y=, =5Y/2Y/ATM=, =6M/25RR= |
+
+** FX spot examples
+
+FX spot is a scalar series (no =point_id= segment):
+
+| Pair | ORE canonical key | =series_type= | =metric= | =qualifier= |
+|------+-------------------+--------------+---------+------------|
+| EUR/USD | =FX/RATE/EUR/USD= | =FX= | =RATE= | =EUR/USD= |
+| GBP/USD | =FX/RATE/GBP/USD= | =FX= | =RATE= | =GBP/USD= |
+| EUR/GBP | =FX/RATE/EUR/GBP= | =FX= | =RATE= | =EUR/GBP= |
+
+Scalar series have =is_scalar=true= on their =market_series= record and =point_id=null=
+on all =market_observation= rows.
+
+** IR discount curve examples
+
+Yield curves are term-structure series (=point_id= carries the tenor):
+
+| Key | Series | point_id |
+|-----+--------+----------|
+| =DISCOUNT/RATE/EUR/2Y= | =DISCOUNT/RATE/EUR= | =2Y= |
+| =DISCOUNT/RATE/USD/5Y= | =DISCOUNT/RATE/USD= | =5Y= |
+
+** Swaption vol surface examples
+
+Swaption surfaces carry a two-dimensional =point_id= (expiry/tenor/strike):
+
+| Key | Series | point_id |
+|-----+--------+----------|
+| =SWAPTION/RATE_LNVOL/EUR/5Y/2Y/ATM= | =SWAPTION/RATE_LNVOL/EUR= | =5Y/2Y/ATM= |
+
+* Mapping to NATS subjects
+
+NATS subjects use =.= as the level delimiter; =/= is not permitted. The mapping from
+an ORE canonical key to a NATS subject token is a simple substitution:
+
+#+begin_src text
+replace '/' with '.'
+#+end_src
+
+The mapping lowercases all characters and replaces =/= with =.=:
+
+#+begin_src text
+lowercase(replace '/' with '.')
+#+end_src
+
+The tick notification subject is then:
+
+: marketdata.v1.tick.<ore-key-lowercased-with-dots>
+
+Examples:
+
+| ORE canonical key | NATS tick subject |
+|-------------------+-------------------|
+| =FX/RATE/EUR/USD= | =marketdata.v1.tick.fx.rate.eur.usd= |
+| =FX/RATE/GBP/USD= | =marketdata.v1.tick.fx.rate.gbp.usd= |
+| =DISCOUNT/RATE/EUR= | =marketdata.v1.tick.discount.rate.eur= |
+| =SWAPTION/RATE_LNVOL/EUR= | =marketdata.v1.tick.swaption.rate_lnvol.eur= |
+
+Lowercasing is consistent with all other NATS subjects in the project
+(e.g. =marketdata.v1.series.list=, =marketdata.v1.observations.save=).
+
+Note: for term-structure series the subject identifies the *series*, not a specific
+point. The =point_id= travels inside the message payload, not in the subject. This
+keeps the subject hierarchy stable regardless of how many points a surface has.
+
+** NATS wildcard subscriptions
+
+The hierarchical structure enables efficient server-side filtering:
+
+| Wildcard subject | Receives |
+|------------------+----------|
+| =marketdata.v1.tick.fx.rate.eur.usd= | EUR/USD spot only |
+| =marketdata.v1.tick.fx.rate.>= | All FX spot pairs |
+| =marketdata.v1.tick.fx.>= | All FX market data (spot, forwards, vols) |
+| =marketdata.v1.tick.discount.>= | All IR discount curve ticks |
+| =marketdata.v1.tick.>= | All market data ticks (full feed) |
+
+A client subscribes using the ORE canonical key; the client library converts it to
+the NATS subject internally. A portfolio pricer needing all EUR-denominated data
+subscribes to =marketdata.v1.tick.fx.rate.eur.>= and
+=marketdata.v1.tick.discount.rate.eur= in two calls.
+
+** Utility function
+
+A single conversion function should live in =ores.marketdata.api=:
+
+#+begin_src cpp
+// Returns the NATS tick subject for a given ORE canonical key.
+// "FX/RATE/EUR/USD" -> "marketdata.v1.tick.fx.rate.eur.usd"
+std::string ore_key_to_tick_subject(std::string_view ore_key);
+#+end_src
+
+The inverse (strip the =marketdata.v1.tick.= prefix, replace =.= with =/=, uppercase)
+reconstructs the ORE key from an incoming NATS subject for logging and routing.
+
+* Two-level market data subscription model
+
+Clients and the generation service operate independently:
+
+| Level | Owner | What it specifies |
+|-------+-------+-------------------|
+| *Generation configuration* | =ores.marketdata.service= (via feed manager) | Which ORE keys to generate ticks for; tick clock and model parameters per series. The generator produces all configured series regardless of client subscriptions. |
+| *Client subscription* | Each client (Qt, Wt, shell) via =ores.marketdata.client= | Which ORE keys the client is interested in. =fx_spot_subscription= takes an ORE key and subscribes to the corresponding NATS subject. Clients receive only the series they ask for. |
+
+NATS handles the fan-out and filtering at the broker level — unsubscribed clients
+incur zero processing overhead for ticks they did not request.
+
+* Identifier fields on market_series
+
+The =market_series= entity should carry optional vendor identifier fields alongside
+the ORE canonical key, for future real-data feed integration:
+
+| Field | Type | Notes |
+|-------+------+-------|
+| =series_type= / =metric= / =qualifier= | strings | ORE canonical key components (existing). |
+| =ric= | optional string | Reuters Instrument Code (e.g. =EUR==). Null until a Reuters feed is connected. |
+| =bbg_ticker= | optional string | Bloomberg ticker (e.g. =EURUSD BGN Curncy=). Null until a Bloomberg feed is connected. |
+
+These fields are stored for traceability and future feed wiring but are not part of
+any current subscription or generation logic.
+
+* See also
+
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — =market_series= schema, existing NATS request-reply subjects.
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — uses ORE canonical keys as tick subject identifiers.
+- [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the generation approach this identifier scheme supports.
+- [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][Open Source Risk Engine (ORE)]] — source of the canonical key format.

--- a/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
+++ b/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
@@ -176,8 +176,9 @@ and =QLineSeries=. It is not reusable for market data ticks as-is, but it demons
 - How to configure axes, time ranges, and data series.
 - The =QtCharts= dependency is already pulled into the build for the compute plugin.
 
-The FX spot tick chart should follow the same =QChartView= pattern but subscribe to the
-=synthetic.v1.fxspot.ticked= NATS subject instead of polling queue stats.
+The FX spot tick chart should follow the same =QChartView= pattern; instead of polling
+queue stats it subscribes to =marketdata.v1.tick.fx.rate.eur.usd= via an
+=fx_spot_subscription= from =ores.marketdata.client=.
 
 * ORE market data file format
 

--- a/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
+++ b/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
@@ -104,9 +104,10 @@ All market data entities carry =tenant_id= (a strongly-typed UUID wrapper define
 | =live_workspace_id()= | =aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa= | The Live workspace sentinel. Defined as =live_workspace_uuid_str= in C++ and =ores_utility_live_workspace_id_fn()= in SQL. |
 
 The import service sets =tenant_id= from the IAM service context (=ctx_.tenant_id()=).
-The synthetic service will follow the same pattern: its IAM context determines which
-workspace's data it writes. For the PoC, the service should operate in the Live
-workspace context so generated observations appear in the default UI view.
+*Architecture resolution (design question 2 in [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]])*:
+the synthetic service does not use its own IAM tenant for tick writes.  Instead, a
+=workspace_tenant_id= is passed in the start request so generated observations appear
+under the caller's workspace context, not the service's own tenant.
 
 * NATS subjects
 
@@ -138,14 +139,17 @@ each request struct).
 
 ** Missing: live tick fan-out
 
-No publish (push) subject exists today. The synthetic service will need to introduce
-a new fan-out subject for streaming ticks to Qt clients. Proposed convention:
+No publish (push) subject exists today. The synthetic service introduces fan-out
+subjects for streaming ticks to Qt clients.  *Convention resolved* in
+[[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] §4.4 and [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]]:
+subjects are derived from the ORE canonical key by lowercasing and replacing =/= with
+=.=, then prefixed with =marketdata.v1.tick.=:
 
-: synthetic.v1.fxspot.ticked
+: marketdata.v1.tick.fx.rate.eur.usd   ← EUR/USD spot ticks
+: marketdata.v1.tick.fx.rate.>         ← wildcard: all FX spot pairs
 
-This follows the project NATS subject convention =<domain>.v1.<entity>.<verb>= and
-places synthetic events under their own domain prefix, separate from historical
-market data.
+This keeps tick subjects under =marketdata.v1.= alongside all other market data
+subjects, consistent with the rest of the protocol.
 
 * Qt components
 

--- a/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
+++ b/doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org
@@ -1,0 +1,222 @@
+:PROPERTIES:
+:ID: C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE
+:END:
+#+title: ores.marketdata infrastructure inventory
+#+description: Inventory of existing market data infrastructure across all tiers: DB schema, workspace scoping, NATS subjects, Qt components, ORE file format, and CMake patterns. Written to scope the FX spot synthetic data PoC.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:synthetic:inventory:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+* Summary
+
+=ores.marketdata= is an existing, production-quality component that stores market
+series (catalog), observations (time series), and fixings in TimescaleDB, scoped by
+tenant. FX spot is already a first-class citizen: =series_type="FX"=, =is_scalar=true=,
+=point_id= null. NATS request-reply subjects cover query and save operations for all
+three entity types, but no fan-out (publish) subject exists yet for live ticks. The
+Qt market data plugin has tabular list windows only — no chart display. The sole
+charting widget in the codebase is =QueueChartWindow= in =ores.qt.compute=, which
+plots NATS queue statistics using Qt Charts. A =synthetic= IAM role is already
+registered in the service registry, but no =ores.synthetic= component exists yet.
+
+* Component structure
+
+=ores.marketdata= is organised as three sub-components:
+
+| Sub-component          | Role |
+|------------------------+------|
+| =ores.marketdata.api=  | Shared domain types (=market_series=, =market_observation=, =market_fixing=) and NATS protocol structs (request/response pairs with embedded subject string constants). |
+| =ores.marketdata.core= | Handlers, repositories, and services. Repositories use SOCI against TimescaleDB. Services hold business logic. |
+| =ores.marketdata.service= | NATS service entry point. Follows the standard lib+exe CMake split: =ores.marketdata.service.lib= + =ores.marketdata.service.exe=. |
+
+* Domain entities
+
+** market_series
+
+Catalog entry for a market data series. Temporal entity with GIST exclusion (at most one
+current record per =(tenant, series_type, metric, qualifier)=).
+
+| Field         | Type                | Notes |
+|---------------+---------------------+-------|
+| =id=          | UUID                | Stable identifier for this series. |
+| =tenant_id=   | =tenant_id= wrapper | Multi-tenancy scoping; set from IAM context. |
+| =series_type= | string              | ORE key segment 1 (e.g. =FX=, =DISCOUNT=, =SWAPTION=). |
+| =metric=      | string              | ORE key segment 2 (e.g. =RATE=, =RATE_LNVOL=). |
+| =qualifier=   | string              | ORE key segment 3 onwards (e.g. =EUR/USD=, =EUR=). |
+| =asset_class= | enum                | Coarse class: =fx=, =rates=, =credit=, =equity=, =commodity=, =inflation=, =bond=, =cross_asset=. |
+| =subclass=    | enum                | Fine class: =yield=, =spot=, =forward=, =volatility=, =basis=, =xccy=, etc. |
+| =is_scalar=   | bool                | True when the series has no tenor/surface dimension (FX spot, equity spot). Observations for scalar series always have =point_id= null. |
+| =recorded_at= | timestamp           | Transaction time (inserted). |
+
+** market_observation
+
+Individual time-series values for a series. Stored in a TimescaleDB hypertable
+partitioned by =observation_date=. An insert trigger implements bi-temporal correction:
+inserting a new =(series, date, point)= tuple closes the previous row and opens a fresh
+one, preserving full transaction-time history.
+
+| Field              | Type              | Notes |
+|--------------------+-------------------+-------|
+| =id=               | UUID              | Row identifier. |
+| =tenant_id=        | =tenant_id= wrapper | Scoping. |
+| =series_id=        | UUID              | FK → =market_series.id=. |
+| =observation_date= | =year_month_day=  | Financial valid-time (the market date). |
+| =point_id=         | optional string   | Tenor or surface coordinate (e.g. ="1Y"=, ="1Y/ATM"=). Null for scalar series (FX spot, equity spot). |
+| =value=            | string            | Observed value, e.g. ="1.08456"=. Stored as string to preserve precision verbatim. |
+| =source=           | optional string   | Data source tag, e.g. ="BLOOMBERG"=. |
+| =recorded_at=      | timestamp         | Transaction time (inserted). |
+
+** market_fixing
+
+Historical index fixings (IBOR, SOFR, etc.). Separate entity from
+=market_observation= because fixings have distinct semantics (no bi-temporal
+correction; fixing is immutable once published). FX spot PoC does not touch fixings.
+
+* FX spot encoding
+
+EUR/USD spot mid-price is stored as:
+
+| Field         | Value |
+|---------------+-------|
+| =series_type= | =FX= |
+| =metric=      | =RATE= |
+| =qualifier=   | =EUR/USD= |
+| =asset_class= | =fx= |
+| =subclass=    | =spot= |
+| =is_scalar=   | =true= |
+| =point_id=    | null (all observations) |
+| ORE key       | =FX/RATE/EUR/USD= |
+
+A synthetic EUR/USD tick is a =save_market_observations_request= with a single
+=market_observation= with =series_id= pointing to the EUR/USD series and =value= as a
+decimal string.
+
+* Tenant and workspace scoping
+
+All market data entities carry =tenant_id= (a strongly-typed UUID wrapper defined in
+=ores.utility/uuid/tenant_id.hpp=). Key values:
+
+| Sentinel        | UUID                                    | Meaning |
+|-----------------+-----------------------------------------+---------|
+| =tenant_id::system()= | =ffffffff-ffff-ffff-ffff-ffffffffffff= | System / privileged tenant. Default construction value is rejected by the factory (nil UUID is not valid). |
+| =live_workspace_id()= | =aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa= | The Live workspace sentinel. Defined as =live_workspace_uuid_str= in C++ and =ores_utility_live_workspace_id_fn()= in SQL. |
+
+The import service sets =tenant_id= from the IAM service context (=ctx_.tenant_id()=).
+The synthetic service will follow the same pattern: its IAM context determines which
+workspace's data it writes. For the PoC, the service should operate in the Live
+workspace context so generated observations appear in the default UI view.
+
+* NATS subjects
+
+All current subjects are request-reply (=nats_subject= embedded as a =constexpr= string in
+each request struct).
+
+** Series
+
+| Subject                                 | Direction       | Notes |
+|-----------------------------------------+-----------------+-------|
+| =marketdata.v1.series.list=             | Request-reply   | Returns paginated market series; filter by =series_type=. |
+| =marketdata.v1.series.save=             | Request-reply   | Upsert a batch of =market_series= records. |
+| =marketdata.v1.series.delete=           | Request-reply   | Delete by =id=. |
+| =marketdata.v1.series.export-to-storage= | Request-reply  | Serialize all series to object storage (used by report workflow). |
+
+** Observations
+
+| Subject                                   | Direction     | Notes |
+|-------------------------------------------+---------------+-------|
+| =marketdata.v1.observations.list=         | Request-reply | Returns observations for a series with date range filter. |
+| =marketdata.v1.observations.save=         | Request-reply | Upsert a batch of =market_observation= records. |
+| =marketdata.v1.observations.delete=       | Request-reply | Delete all observations for a series. |
+
+** Import
+
+| Subject               | Direction     | Notes |
+|-----------------------+---------------+-------|
+| =marketdata.v1.import= | Request-reply | Trigger ORE =marketdata.csv= import from object storage. |
+
+** Missing: live tick fan-out
+
+No publish (push) subject exists today. The synthetic service will need to introduce
+a new fan-out subject for streaming ticks to Qt clients. Proposed convention:
+
+: synthetic.v1.fxspot.ticked
+
+This follows the project NATS subject convention =<domain>.v1.<entity>.<verb>= and
+places synthetic events under their own domain prefix, separate from historical
+market data.
+
+* Qt components
+
+** ores.qt.mktdata plugin
+
+| Class                    | File                                     | Purpose |
+|--------------------------+------------------------------------------+---------|
+| =MarketDataController=   | =include/ores.qt/MarketDataController.hpp= | Controller owning both list windows; wires drill-down signals. |
+| =MarketSeriesMdiWindow=  | =include/ores.qt/MarketSeriesMdiWindow.hpp= | Tabular list of all market series; asset-class/subclass filter combo boxes; drill-down emits =showMarketObservations=. |
+| =MarketFixingsMdiWindow= | =include/ores.qt/MarketFixingsMdiWindow.hpp= | Tabular list of fixings series. |
+| =ClientMarketSeriesModel= | =include/ores.qt/ClientMarketSeriesModel.hpp= | =QAbstractTableModel= backed by a =market_series= vector; paginated fetch via NATS. |
+
+The plugin has no chart display and no live-subscription model. All data is fetched
+on demand (reload button / navigation). Adding a live time-series chart for FX spot
+ticks requires new classes within this plugin.
+
+** ores.qt.compute: QueueChartWindow
+
+=QueueChartWindow= (=projects/ores.qt/compute/=) is the only existing chart widget in
+the codebase. It renders NATS JetStream queue statistics using =QtCharts::QChartView=
+and =QLineSeries=. It is not reusable for market data ticks as-is, but it demonstrates:
+
+- How to embed =QChartView= inside a =QWidget=.
+- How to configure axes, time ranges, and data series.
+- The =QtCharts= dependency is already pulled into the build for the compute plugin.
+
+The FX spot tick chart should follow the same =QChartView= pattern but subscribe to the
+=synthetic.v1.fxspot.ticked= NATS subject instead of polling queue stats.
+
+* ORE market data file format
+
+ORE consumes a flat CSV file (=marketdata.csv=) with the format:
+
+: <ORE-key>,<date>,<value>
+: FX/RATE/EUR/USD,20231215,1.08456
+
+The ORE key is slash-delimited. For FX spot the key has exactly three segments:
+=FX/RATE/<CCY1>/<CCY2>=. The synthetic data service writes to the =ores.marketdata=
+database; the existing =ores.reporting.core= layer constructs the =marketdata.csv= from
+those DB records at report time. The PoC does not need to write CSV files directly.
+
+* Service registry
+
+A =synthetic= IAM entry already exists in =projects/modeling/service_registry.org=:
+
+| Field        | Value |
+|--------------+-------|
+| =psql_var=   | =synthetic_service= |
+| =env_key=    | =SYNTHETIC_SERVICE= |
+| =iam_role=   | =SyntheticService= |
+| =role=       | =tooling= |
+| =email=      | =synthetic_service@system.ores= |
+
+No =ores.synthetic= CMake component exists yet. The new service will need:
+
+1. A new top-level CMake project under =projects/ores.synthetic/=.
+2. Optionally sub-components =ores.synthetic.api=, =ores.synthetic.core=,
+   =ores.synthetic.service= following the same three-layer split as =ores.marketdata=.
+3. Or a single =ores.synthetic.service= (lib+exe) for the PoC without a public API
+   layer (no other service depends on it yet).
+
+* Build patterns
+
+| Pattern          | Example target          | CMake |
+|------------------+-------------------------+-------|
+| Service lib+exe  | =ores.marketdata.service= | =add_library(<name>.lib)= + =add_executable(<name>.exe)= in =src/CMakeLists.txt=. Lib excludes =main.cpp=; exe links against lib. |
+| Qt plugin        | =ores.qt.mktdata=        | =add_library(SHARED)= with =Q_PLUGIN_METADATA=. No exe. |
+| Tests            | CTest via =add_test=     | Under =tests/CMakeLists.txt= using Catch2. |
+
+* See also
+
+- [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document that drives the PoC.
+- [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story this inventory supports.
+- [[id:759530D8-2314-44F3-A50E-71CE7AD02558][ores.marketdata.core]] — component overview for the existing market data service.

--- a/doc/knowledge/domain/synthetic_market_data_generators.org
+++ b/doc/knowledge/domain/synthetic_market_data_generators.org
@@ -1,0 +1,663 @@
+:PROPERTIES:
+:ID: C6F45530-4B5D-4C03-95DF-65D13F7A4142
+:END:
+#+title: Synthetic market data generators
+#+description: Architecture and specification of the synthetic market data generator library: the IStochasticProcess/IFxSpotFeed split, all deterministic and stochastic process types with their mathematical specifications, per-process RNG design, pre-generation buffer architecture, QuantLib vs standalone trade-off, and performance design for high-frequency multi-pair tick generation.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:synthetic:generators:architecture:
+#+created: 2026-06-25
+#+updated: 2026-06-25
+
+* Summary
+
+The synthetic market data generator library is built around a strict two-layer
+separation: *stochastic processes* (pure mathematics, asset-class agnostic) and *feeds*
+(thin wrappers that apply process output to an FX spot price, manage the tick clock,
+and publish =fx_spot_tick= events). This separation means that GBM, GARCH, Heston, and
+every other process are reusable across any asset class; the FX spot feed simply
+selects a process, maintains a running price, and delegates all mathematics to it.
+
+Processes are implemented as standalone C++ classes using only the STL random
+facility (=std::mt19937_64=, =std::normal_distribution=, etc.) — not QuantLib. For
+streaming tick generation QuantLib's path-generation machinery introduces unnecessary
+overhead and is architecturally mismatched to a real-time feed. The standalone
+implementations are short recurrences that generate millions of samples per second
+on a single core.
+
+Each process instance owns its own seeded RNG; no shared state exists between
+processes, so 100 concurrent FX feeds scale linearly with no mutex contention.  A
+pre-generation ring buffer decouples the (CPU-bound) generation phase from the
+(I/O-bound) NATS dispatch phase, enabling batch tick publishing to further reduce
+per-tick NATS overhead.
+
+* Process / Feed architecture
+
+** The separation principle
+
+A stochastic process knows nothing about:
+- What asset class the output will be used for.
+- How the output is transmitted.
+- When the next tick fires.
+- What currency pair the price represents.
+
+A feed knows nothing about:
+- How numbers are generated.
+- What the probability distribution of returns is.
+
+#+begin_src plantuml :exports results :file generators_arch.png
+@startuml
+interface IStochasticProcess {
+  +next_price(current: double, tick_index: size_t): double
+  +generate(initial: double, start_index: size_t, out: span<double>): void
+  +reset(): void
+}
+
+interface IFxSpotFeed {
+  +ore_key(): string
+  +start(handler): void
+  +stop(): void
+}
+
+class GbmProcess
+class GmmProcess
+class GjrGarchProcess
+class HestonProcess
+class JumpDiffusionProcess
+class RegimeSwitchingProcess
+class OuProcess
+class FixedProcess
+class RampProcess
+class OscillatorProcess
+class SawtoothProcess
+class StepProcess
+
+class FxSpotFeed {
+  -process_: IStochasticProcess
+  -current_price_: double
+  -ore_key_: string
+  -tick_clock_: ITickClock
+  -buffer_: RingBuffer<double>
+}
+
+IStochasticProcess <|.. GbmProcess
+IStochasticProcess <|.. GmmProcess
+IStochasticProcess <|.. GjrGarchProcess
+IStochasticProcess <|.. HestonProcess
+IStochasticProcess <|.. JumpDiffusionProcess
+IStochasticProcess <|.. RegimeSwitchingProcess
+IStochasticProcess <|.. OuProcess
+IStochasticProcess <|.. FixedProcess
+IStochasticProcess <|.. RampProcess
+IStochasticProcess <|.. OscillatorProcess
+IStochasticProcess <|.. SawtoothProcess
+IStochasticProcess <|.. StepProcess
+
+IFxSpotFeed <|.. FxSpotFeed
+FxSpotFeed o-- IStochasticProcess
+@enduml
+#+end_src
+
+** IStochasticProcess interface
+
+#+begin_src cpp
+class IStochasticProcess {
+public:
+    virtual ~IStochasticProcess() = default;
+
+    // Returns the next price given the running price and tick count.
+    // For return-based processes: exp(log_return) * current_price
+    // For level-based processes: f(tick_index), current_price ignored
+    virtual double next_price(double current_price, std::size_t tick_index) = 0;
+
+    // Pre-generate a contiguous block of N prices into `out`.
+    // out[0] is the price after the first tick from initial_price.
+    // More efficient than calling next_price() in a loop — allows SIMD.
+    virtual void generate(double initial_price,
+                          std::size_t start_index,
+                          std::span<double> out) = 0;
+
+    // Resets internal state (useful for scenario replay with fixed seed).
+    virtual void reset() = 0;
+};
+#+end_src
+
+The =generate()= bulk method is the performance-critical path.  Implementations
+should pre-allocate all normal draws in one batch call to =std::normal_distribution=,
+which allows the compiler to vectorise the inner loop.
+
+** FxSpotFeed as a thin wrapper
+
+#+begin_src cpp
+class FxSpotFeed : public IFxSpotFeed {
+public:
+    FxSpotFeed(std::string ore_key,
+               double initial_price,
+               std::unique_ptr<IStochasticProcess> process,
+               std::unique_ptr<ITickClock> clock,
+               std::size_t prefetch_size = 4096);
+
+    std::string ore_key() const override { return ore_key_; }
+    void start(handler on_tick) override;
+    void stop() override;
+
+private:
+    void refill_buffer();   // runs on generator thread
+    void dispatch_loop();   // runs on dispatch thread
+
+    std::string ore_key_;
+    double current_price_;
+    std::unique_ptr<IStochasticProcess> process_;
+    std::unique_ptr<ITickClock> clock_;
+    RingBuffer<double> buffer_;      // prices pre-generated by process_
+    std::size_t tick_index_ = 0;
+    std::atomic<bool> running_{false};
+    std::thread generator_thread_;
+    std::thread dispatch_thread_;
+};
+#+end_src
+
+The feed runs two threads: a generator thread that pre-fills the ring buffer by
+calling =process_->generate()=, and a dispatch thread that pops prices from the
+buffer, wraps them as =fx_spot_tick=, and fires the =on_tick= handler.
+
+* QuantLib vs standalone
+
+| Criterion | QuantLib | Standalone STL |
+|-----------+----------+----------------|
+| Dependency | Heavy (pulls ORE, Boost::date, etc.) | None beyond C++23 STL |
+| API fit | Path-oriented (full path at once, date-grid-driven) | Iterator/streaming-friendly |
+| Performance | Single-threaded path generator; no SIMD paths | Vectorisable inner loops; per-instance RNG |
+| Correctness | Validated MC implementations | Must be validated independently |
+| Stochastic vol | =HestonProcess= available | Euler-Maruyama ~30 lines |
+| GARCH | Not in QuantLib | Recurrence ~10 lines |
+| GMM | Not in QuantLib | Mixture draw ~15 lines |
+
+QuantLib is the right choice for *pricing* (DCF, smile calibration, Greeks). For
+*streaming tick generation* — where each model step is a simple recurrence applied
+millions of times — the standalone approach is simpler, faster, and removes a
+compile-time dependency from the hot path.
+
+All process implementations use =std::mt19937_64= (the Mersenne Twister 64-bit
+variant) seeded from =std::random_device=. Each process instance owns its own engine;
+no global RNG exists. This gives:
+
+- Zero contention between concurrent feeds.
+- Reproducible scenarios by supplying a fixed seed at construction.
+- Statistically independent streams per process.
+
+* Deterministic processes
+
+Deterministic processes have no random component; they are fully reproducible given
+the same parameters and =tick_index=. They are indispensable for:
+
+- Testing feed lifecycle, DB write, NATS publish, chart rendering.
+- Isolating bugs in downstream analytics from noise in generation.
+- Providing null hypotheses for signal detection.
+
+** Fixed
+
+Price is constant for all ticks.
+
+: P(t) = P₀
+
+Config: =price=.
+
+#+begin_src cpp
+struct fixed_process_params {
+    double price;
+};
+#+end_src
+
+Use: validating that the full pipeline (tick → NATS → DB → chart) is wired
+correctly without any generation noise.
+
+** Ramp
+
+Price drifts linearly by a fixed absolute delta each tick.  Optional reflecting
+bounds: if =reflect = true= the drift reverses direction when it hits =low= or =high=.
+Without bounds the price increases (or decreases) without limit.
+
+: P(k) = P₀ + k × Δ        (no bounds)
+: P(k) = trianglewave(P₀, Δ, low, high, k)   (with reflect)
+
+Config: =initial_price=, =delta_per_tick=, =low=, =high=, =reflect=.
+
+#+begin_src cpp
+struct ramp_process_params {
+    double initial_price;
+    double delta_per_tick;           // signed; negative = downward ramp
+    std::optional<double> low;
+    std::optional<double> high;
+    bool reflect = false;
+};
+#+end_src
+
+Use: testing P&L sign-flip at a strike; testing trend signals; testing
+that the chart axis rescales when price exits its initial range.
+
+** Oscillator
+
+Bounded sinusoidal wave.  The price oscillates around a centre value with
+configurable amplitude and period.
+
+: P(t) = center + amplitude × sin(2π × tick_index / ticks_per_period)
+
+Config: =center_price=, =amplitude=, =ticks_per_period=.
+
+#+begin_src cpp
+struct oscillator_process_params {
+    double center_price;
+    double amplitude;               // max deviation from center; price ∈ [center-A, center+A]
+    std::size_t ticks_per_period;   // period in tick count, not wall time
+};
+#+end_src
+
+Note: period expressed in ticks, not wall-clock seconds, so it is independent of the
+configured tick rate.  At 12 ticks/hour and =ticks_per_period=48= the price completes
+one cycle per 4 hours.
+
+Use: testing mean-reversion detection; testing chart time-axis scrolling; verifying
+that a portfolio's P&L oscillates as expected.
+
+** Sawtooth
+
+Linear ramp from floor to ceiling, then an instant reset to floor.  Useful for
+testing threshold-crossing detection and sharp discontinuities.
+
+: P(k) = floor + (ceiling − floor) × ((k mod ticks_per_period) / ticks_per_period)
+
+Config: =floor_price=, =ceiling_price=, =ticks_per_period=.
+
+#+begin_src cpp
+struct sawtooth_process_params {
+    double floor_price;
+    double ceiling_price;
+    std::size_t ticks_per_period;
+};
+#+end_src
+
+Use: testing limit-order triggers; testing that charts handle price resets cleanly.
+
+** Step
+
+Cycles through a pre-defined list of prices.  Each price is held for
+=ticks_per_level= ticks before advancing to the next.  Wraps at end of list.
+
+: P(k) = prices[ (k / ticks_per_level) mod |prices| ]
+
+Config: =prices[]=, =ticks_per_level=.
+
+#+begin_src cpp
+struct step_process_params {
+    std::vector<double> prices;
+    std::size_t ticks_per_level = 1;
+};
+#+end_src
+
+Use: calibration testing with known price levels; step-shaped P&L testing;
+scenario simulation with scripted price moves.
+
+* Stochastic processes
+
+All stochastic processes generate log-returns (or correlated log-return pairs for
+Heston) which the feed applies as:
+
+: P_{k+1} = P_k × exp(r_k)
+
+The =Δt= for each process step is =1 / tick_rate_per_hour= hours, expressed in years
+as =Δt_years = 1 / (tick_rate_per_hour × 8760)=.  Annualised parameters (drift,
+volatility) are converted to per-tick scale by the process constructor.
+
+** GBM — Geometric Brownian Motion
+
+The Black-Scholes baseline: log-normal returns with constant drift and volatility.
+The simplest non-trivial stochastic process.
+
+: log(P_{k+1}/P_k) ~ N((μ − σ²/2)Δt,  σ²Δt)
+
+Equivalently:
+
+: P_{k+1} = P_k × exp((μ − σ²/2)Δt + σ√Δt × Z),   Z ~ N(0,1)
+
+Config: =initial_price=, =drift_pa= (μ, annualised), =volatility_pa= (σ, annualised).
+
+#+begin_src cpp
+struct gbm_process_params {
+    double initial_price;
+    double drift_pa;       // annualised drift (e.g. 0.02 for 2% p.a.)
+    double volatility_pa;  // annualised vol (e.g. 0.10 for 10% p.a.)
+};
+#+end_src
+
+Reference: Black and Scholes (1973), Merton (1973).
+
+Use: simplest realistic stochastic baseline; sanity-checking option pricing against
+Black-Scholes formula; comparing risk metrics against closed-form solutions.
+
+** OU — Ornstein-Uhlenbeck (mean-reverting)
+
+A Gaussian mean-reverting process.  FX rates in managed-float regimes (e.g. pairs
+with a central bank target) or interest rate spreads exhibit OU-like dynamics.
+Also useful for FX cross rates where both legs have correlated GBM dynamics.
+
+: dX = κ(θ − X)dt + σ dW
+
+Exact discrete update (no Euler error):
+
+: X_{k+1} = X_k × e^{−κΔt} + θ(1 − e^{−κΔt}) + σ√((1 − e^{−2κΔt}) / 2κ) × Z
+
+Config: =long_run_mean= (θ), =reversion_speed= (κ), =volatility= (σ).
+
+#+begin_src cpp
+struct ou_process_params {
+    double initial_level;
+    double long_run_mean;     // θ: level to which process reverts
+    double reversion_speed;   // κ > 0; larger = faster reversion
+    double volatility;        // σ: diffusion coefficient (not annualised — per-tick units)
+};
+#+end_src
+
+Note: OU generates absolute levels, not log-returns.  The feed uses =P_{k+1} = X_{k+1}=
+directly (or =P_{k+1} = exp(X_{k+1})= for a log-price variant).
+
+Reference: Ornstein and Uhlenbeck (1930); Vasicek (1977) for interest rate application.
+
+** GMM — Gaussian Mixture Model
+
+Log-returns are drawn from a K-component Gaussian mixture:
+
+: r_k ~ Σᵢ wᵢ × N(μᵢ, σᵢ²)
+
+The component is sampled via a multinomial draw on weights; then the return is drawn
+from the corresponding Gaussian.  This captures fat tails, skewness, and bimodality
+present in empirical FX return distributions.
+
+Config: =initial_price=, =k=, =means[]=, =stdevs[]=, =weights[]= (must sum to 1).
+
+#+begin_src cpp
+struct gmm_process_params {
+    double initial_price;
+    int k;
+    std::vector<double> means;    // per-component mean log-return (per tick)
+    std::vector<double> stdevs;   // per-component standard deviation (per tick)
+    std::vector<double> weights;  // sum to 1.0
+};
+#+end_src
+
+Implementation: one =std::discrete_distribution<int>= for component selection; one
+=std::normal_distribution<double>= per component (or draw Z ~ N(0,1) and scale inline).
+
+Reference: McLachlan and Peel (2000), /Finite Mixture Models/; empirical
+justification: Kon (1984), /Models of stock returns: a comparison/.
+
+** GJR-GARCH — GARCH with leverage effect
+
+GARCH(1,1) captures *volatility clustering* (large moves cluster in time).
+GJR-GARCH adds the *leverage effect*: negative returns increase future volatility
+more than positive returns of the same magnitude.
+
+Variance update:
+
+: σ²_k = ω + α ε²_{k−1} + γ I_{ε_{k−1}<0} ε²_{k−1} + β σ²_{k−1}
+
+Return: =ε_k = σ_k × Z_k=, =Z_k ~ N(0,1)=.
+
+Stationarity constraint: =α + β + γ/2 < 1=.
+
+Config: =initial_price=, =initial_variance= (σ²₀), =omega= (ω), =alpha= (α), =beta= (β),
+=gamma= (γ).
+
+#+begin_src cpp
+struct gjr_garch_process_params {
+    double initial_price;
+    double initial_variance;   // σ²₀; often set to ω/(1−α−β−γ/2) (unconditional var)
+    double omega;              // ω > 0
+    double alpha;              // α ≥ 0
+    double beta;               // β ≥ 0
+    double gamma;              // γ ≥ 0 (leverage; 0 reduces to standard GARCH)
+    // Constraint: α + β + γ/2 < 1 (checked at construction)
+};
+#+end_src
+
+State that must be carried between ticks: =sigma2_prev=, =epsilon_prev=. The process
+struct holds these as mutable member variables; they are reset by =reset()=.
+
+Reference: Glosten, Jagannathan, and Runkle (1993); GARCH(1,1) original: Bollerslev
+(1986); Engle (1982) for ARCH.
+
+** Regime-switching
+
+A Markov chain selects a regime at each tick; each regime has its own GBM
+parameters.  Two-state (calm / stressed) is the canonical case:
+
+- *Calm* regime: low drift, low vol.  e.g. μ=0, σ=8% p.a.
+- *Stressed* regime: negative drift, high vol.  e.g. μ=−20% p.a., σ=30% p.a.
+
+State transition at each tick:
+
+: P(calm → stressed) = p_cs,   P(stressed → calm) = p_sc
+
+Within the active regime, the return is standard GBM:
+
+: r_k = (μ_reg − σ²_reg/2)Δt + σ_reg √Δt × Z,   Z ~ N(0,1)
+
+Config: =initial_price=, =regimes[]= (each with =drift_pa=, =volatility_pa=, =initial_state=),
+=transition_matrix= (row = from, col = to; rows sum to 1).
+
+#+begin_src cpp
+struct regime_params {
+    double drift_pa;
+    double volatility_pa;
+};
+
+struct regime_switching_process_params {
+    double initial_price;
+    std::vector<regime_params> regimes;
+    std::vector<std::vector<double>> transition_matrix;  // [from][to], rows sum to 1
+    int initial_regime = 0;
+};
+#+end_src
+
+Reference: Hamilton (1989), /A new approach to the economic analysis of nonstationary
+time series and the business cycle/.
+
+** Jump-diffusion (Merton)
+
+Standard GBM plus a compound Poisson jump process.  Captures sudden large moves
+(macro data surprises, geopolitical events, flash crashes).
+
+: dS/S = (μ − λk̄) dt + σ dW + (e^J − 1) dN(λ)
+
+where =dN(λ)= is a Poisson process with intensity λ (jumps/tick), and
+=J ~ N(μ_J, σ_J²)= is the log-size of each jump.  =k̄ = exp(μ_J + σ_J²/2) − 1= is
+the mean jump size (compensator).
+
+Per-tick: draw number of jumps =n ~ Poisson(λΔt)=; total jump return =Σ Jᵢ=.
+
+#+begin_src cpp
+struct jump_diffusion_process_params {
+    double initial_price;
+    double drift_pa;              // μ (annualised), excluding jump compensator
+    double diffusion_vol_pa;      // σ (annualised diffusion vol)
+    double jump_intensity_pa;     // λ (expected jumps per year)
+    double jump_mean_log;         // μ_J: mean of log(jump size)
+    double jump_stdev_log;        // σ_J: stdev of log(jump size)
+};
+#+end_src
+
+Reference: Merton (1976), /Option pricing when underlying stock returns are
+discontinuous/.
+
+** Heston — stochastic volatility
+
+The spot price and its instantaneous variance follow correlated SDEs:
+
+: dS = μ S dt + √V S dW_S
+: dV = κ(θ − V) dt + ξ √V dW_V
+: dW_S · dW_V = ρ dt
+
+=V= is the variance (not volatility); it mean-reverts to =θ= at speed =κ=.  =ξ= is the
+vol-of-vol.  =ρ < 0= is the typical empirical case (down moves → vol spikes).
+
+Discretised using Euler-Maruyama (sufficient for generation; not for pricing):
+
+: V_{k+1} = max(0,  V_k + κ(θ − V_k)Δt + ξ√(V_k Δt) × Z_V)
+: S_{k+1} = S_k × exp((μ − V_k/2)Δt + √(V_k Δt) × Z_S)
+: Z_S = ρ Z_V + √(1−ρ²) Z_indep
+
+where =Z_V=, =Z_indep= are independent N(0,1) draws.
+
+Feller condition (ensures V stays non-negative): =2κθ > ξ²= — checked at construction.
+The =max(0,·)= clamp provides a fallback when Euler approximation violates this.
+
+Config: =initial_price=, =initial_variance=, =kappa= (κ), =theta= (θ), =xi= (ξ), =rho= (ρ),
+=drift_pa= (μ).
+
+#+begin_src cpp
+struct heston_process_params {
+    double initial_price;
+    double initial_variance;   // V₀; often set to theta
+    double drift_pa;           // μ
+    double kappa;              // mean-reversion speed (κ > 0)
+    double theta;              // long-run variance (θ > 0)
+    double xi;                 // vol-of-vol (ξ > 0)
+    double rho;                // correlation ∈ (−1, 1); typically −0.7 to −0.3 for FX
+    // Feller condition: 2κθ > ξ² (checked at construction; warns if violated)
+};
+#+end_src
+
+Reference: Heston (1993), /A closed-form solution for options with stochastic
+volatility/.
+
+* Performance design
+
+** Why performance matters here
+
+A realistic deployment might have:
+- 50–100 FX spot pairs (major, minor, EM).
+- Each ticking at 1–10 ticks/second during market hours.
+- Peaks at 500–1000 ticks/second across the full book.
+
+This is well within the capability of a single-threaded generator loop.  The real
+bottleneck is *NATS publish overhead*, not generation cost.  A NATS fire-and-forget
+publish is roughly 50–200 µs including serialisation.  At 1000 ticks/second that is
+50–200 ms of pure NATS overhead per second — potentially causing queuing jitter.
+
+** Per-process RNG
+
+Each =IStochasticProcess= instance owns a private =std::mt19937_64= seeded
+independently from =std::random_device= (or from a supplied seed for reproducibility).
+
+#+begin_src cpp
+class GbmProcess : public IStochasticProcess {
+    std::mt19937_64 rng_;
+    std::normal_distribution<double> dist_{0.0, 1.0};
+    // per-tick precomputed params:
+    double drift_per_tick_;
+    double vol_per_tick_;
+    // ...
+};
+#+end_src
+
+No shared mutable state → zero lock contention → linear scaling with feed count.
+
+** Ring-buffer pre-generation
+
+Each feed runs two threads:
+
+- *Generator thread* calls =process_->generate(initial, start_index, buffer)= to
+  pre-fill a ring buffer in batches of =N= prices (default: 4096).  Wakes when buffer
+  drops below a low-water mark.
+- *Dispatch thread* reads one price at a time from the buffer, fires the =on_tick=
+  handler, then sleeps until the next tick time.
+
+This isolates generation jitter (occasional GC, cache miss) from dispatch jitter.
+The buffer depth (4096 prices × 8 bytes = 32 KB — fits in L1/L2 cache on most CPUs)
+provides ~70 minutes of headroom at 1 tick/second with no head-of-line blocking.
+
+** Batch NATS publish
+
+The =on_tick= handler (owned by =FeedManager= in =ores.marketdata.service=) can
+accumulate several ticks and publish them as a batch:
+
+#+begin_src cpp
+struct fx_spot_tick_batch {
+    std::string ore_key;
+    std::vector<fx_spot_tick> ticks;   // up to batch_size
+};
+#+end_src
+
+Batch publish subject: =marketdata.v1.tick_batch.fx.rate.eur.usd=.
+
+Subscribers that need low-latency display (chart window) subscribe to the per-tick
+subject =marketdata.v1.tick.fx.rate.eur.usd=.  Subscribers that need historical
+backfill or bulk DB writes subscribe to the batch subject.  The feed manager can
+publish both from the same tick: per-tick for latency, batch for throughput.
+
+For the PoC, per-tick-only publishing is sufficient.  Batch publish is a
+performance optimisation to be added when the system is under load.
+
+** Bulk generation for scenarios
+
+For scenario simulation (not real-time display) the =generate()= method can be called
+directly to produce a large pre-computed trajectory:
+
+#+begin_src cpp
+// Generate 1 million ticks for EUR/USD at once
+std::vector<double> prices(1'000'000);
+process->generate(1.0850, 0, prices);
+// Prices can be replayed at arbitrary speed, stored, or analysed.
+#+end_src
+
+This is also how regression tests work: compare a seeded run against a golden file to
+catch accidental changes in process parameters or discretisation.
+
+* Feed type to process mapping
+
+| =feed_type= enum | Process class | Category | PoC priority |
+|------------------+---------------+----------+--------------|
+| =synthetic_fixed= | =FixedProcess= | Deterministic | P0 |
+| =synthetic_ramp= | =RampProcess= | Deterministic | P1 |
+| =synthetic_oscillator= | =OscillatorProcess= | Deterministic | P0 |
+| =synthetic_sawtooth= | =SawtoothProcess= | Deterministic | P1 |
+| =synthetic_step= | =StepProcess= | Deterministic | P1 |
+| =synthetic_gbm= | =GbmProcess= | Stochastic | P0 |
+| =synthetic_ou= | =OuProcess= | Stochastic | P1 |
+| =synthetic_gmm= | =GmmProcess= | Stochastic | P0 |
+| =synthetic_gjr_garch= | =GjrGarchProcess= | Stochastic | P1 |
+| =synthetic_regime_switching= | =RegimeSwitchingProcess= | Stochastic | P1 |
+| =synthetic_jump_diffusion= | =JumpDiffusionProcess= | Stochastic | P1 |
+| =synthetic_heston= | =HestonProcess= | Stochastic | P1 |
+
+P0 = first-pass implementation (validates the full stack).
+P1 = second-pass (same pipeline, different process class).
+
+All 12 types are declared in the =feed_type= enum from the start, with type-specific
+NATS subjects for params.  P1 types return =not_implemented= until coded.
+
+* Component placement
+
+| Artefact | Location |
+|----------+----------|
+| =IStochasticProcess= interface | =ores.marketdata.api= (shared with tests and any future calibration service) |
+| All process implementations | =ores.synthetic.service= (linked only by the synthetic service and unit tests) |
+| =IFxSpotFeed= interface | =ores.marketdata.api= (already there) |
+| =FxSpotFeed= implementation | =ores.synthetic.service= |
+| =FeedManager= (lifecycle, NATS handlers) | =ores.marketdata.service= |
+| Ring buffer utility | =ores.synthetic.service= or =ores.utility.lib= if reused elsewhere |
+
+=IStochasticProcess= lives in =ores.marketdata.api= (not =ores.synthetic=) because a
+future calibration service (in =ores.marketdata.core=) needs to create and evaluate
+process instances to fit parameters to historical data, without depending on the
+synthetic service executable.
+
+* See also
+
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — system architecture; NATS subjects for feed configs; =IFxSpotFeed= and =fx_spot_tick= types.
+- [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — pattern for feed config parameter serialisation (one NATS subject per concrete params type; two-phase dispatch on read).
+- [[id:BB2B7C4C-FD4E-4DCA-BF1D-00F929622B87][Synthetic market data generation: approach]] — the approach document driving algorithm selection for each process type.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — ORE canonical key mapping to NATS tick subjects.
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — existing market data stack this generator library feeds into.
+- [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] — the story this design supports.
+- [[id:F8562D22-EFB1-4427-BA95-E72132D35076][Inventory and PoC scope: FX spot synthetic data]] — the task that produced this design.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -73,6 +73,11 @@ Finance concepts the codebase relies on.
   =ores.synthetic= service design, per-tick data flow, new NATS subjects and
   message types, Qt =subscribeToRawEvent= extension, chart window design, open
   design questions, and recommended implementation order. Gates implementation.
+- [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — architecture and specification of the generator
+  library: =IStochasticProcess= / =IFxSpotFeed= separation, all 12 process types
+  (5 deterministic + 7 stochastic) with mathematical specifications, per-process RNG
+  design, ring-buffer pre-generation, QuantLib vs standalone analysis, and performance
+  design for 50–100 concurrent high-frequency FX feeds.
 - [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — how to transport inheritance-like data
   structures (instrument variants, feed config params) over NATS using RFL: the
   type-specific subject pattern, discriminator-on-containing-entity convention,

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -70,9 +70,10 @@ Finance concepts the codebase relies on.
   conventions. Reference for the FX spot synthetic data PoC.
 - [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — architecture design for the FX
   spot PoC vertical slice: gap analysis against the existing stack, new
-  =ores.synthetic= service design, per-tick data flow, new NATS subjects and
-  message types, Qt =subscribeToRawEvent= extension, chart window design, open
-  design questions, and recommended implementation order. Gates implementation.
+  =ores.synthetic= service and =ores.marketdata.client= library designs, =IFxSpotFeed=
+  interface, per-tick data flow, new NATS subjects, chart window and config dialog
+  designs, 8 open design questions, and recommended 8-step implementation order.
+  Gates implementation.
 - [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] — architecture and specification of the generator
   library: =IStochasticProcess= / =IFxSpotFeed= separation, all 12 process types
   (5 deterministic + 7 stochastic) with mathematical specifications, per-process RNG

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -73,6 +73,13 @@ Finance concepts the codebase relies on.
   =ores.synthetic= service design, per-tick data flow, new NATS subjects and
   message types, Qt =subscribeToRawEvent= extension, chart window design, open
   design questions, and recommended implementation order. Gates implementation.
+- [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]] — how to transport inheritance-like data
+  structures (instrument variants, feed config params) over NATS using RFL: the
+  type-specific subject pattern, discriminator-on-containing-entity convention,
+  two-phase dispatch for read paths that cannot know the type upfront, the RFL
+  =std::variant= index fragility pitfall, and the wrapper struct idiom. Canonical
+  example from =ores.trading= instruments; applied example from =ores.marketdata=
+  feed config parameters.
 - [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]] — named, versioned bundles of valuation
   settings: model mapping, smile surfaces, Greeks, layered
   overrides.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -56,6 +56,12 @@ Finance concepts the codebase relies on.
   environment covering all ORE-supported asset classes: chosen method per
   asset class, cross-asset constraint equations, P/Q-measure bridge, time
   evolution strategy, UI requirements, phased implementation roadmap.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]] — how market data series are identified across
+  external schemes (RIC, Bloomberg) and internally: the ORE canonical key
+  format (=FX/RATE/EUR/USD=), its decomposition into =series_type/metric/qualifier=,
+  the two-level subscription model (generation config vs client subscription),
+  and the mapping from ORE key to NATS tick subject (lowercase, =/= → =.=,
+  e.g. =marketdata.v1.tick.fx.rate.eur.usd=).
 - [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — inventory of the existing
   market data stack across all tiers: DB schema and entities (=market_series=,
   =market_observation=, =market_fixing=), FX spot encoding, tenant/workspace

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -56,6 +56,17 @@ Finance concepts the codebase relies on.
   environment covering all ORE-supported asset classes: chosen method per
   asset class, cross-asset constraint equations, P/Q-measure bridge, time
   evolution strategy, UI requirements, phased implementation roadmap.
+- [[id:C9DACC7A-BF0D-47E9-A357-1B45DABFBDEE][ores.marketdata infrastructure inventory]] — inventory of the existing
+  market data stack across all tiers: DB schema and entities (=market_series=,
+  =market_observation=, =market_fixing=), FX spot encoding, tenant/workspace
+  scoping, NATS request-reply subjects, Qt list windows, =QueueChartWindow=
+  chart pattern, ORE CSV format, service registry entry, and CMake build
+  conventions. Reference for the FX spot synthetic data PoC.
+- [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] — architecture design for the FX
+  spot PoC vertical slice: gap analysis against the existing stack, new
+  =ores.synthetic= service design, per-tick data flow, new NATS subjects and
+  message types, Qt =subscribeToRawEvent= extension, chart window design, open
+  design questions, and recommended implementation order. Gates implementation.
 - [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]] — named, versioned bundles of valuation
   settings: model mapping, smile surfaces, Greeks, layered
   overrides.


### PR DESCRIPTION
## Summary

- Adds **ores.marketdata infrastructure inventory** (`doc/knowledge/domain/ores_marketdata_infrastructure_inventory.org`, ID: C9DACC7A): factual inventory of the existing market data stack — DB schema with `market_series` / `market_observation` / `market_fixing`, FX spot encoding (`is_scalar=true`, `point_id` null), tenant scoping via `tenant_id` / `ores_utility_live_workspace_id_fn()`, NATS request-reply subjects for series and observations, Qt market data plugin components (`MarketDataController`, `MarketSeriesMdiWindow`), `QueueChartWindow` chart pattern, ORE CSV key format, `synthetic` service registry entry, and CMake lib+exe build pattern.
- Adds **FX spot synthetic data PoC: architecture** (`doc/knowledge/domain/fx_spot_synthetic_poc_architecture.org`, ID: 29573D59): full PoC architecture design. Covers: review of the existing stack and gap analysis; new `ores.synthetic.service` structure (lib+exe, links against `ores.marketdata.api`); per-tick data flow (GMM → DB save via `marketdata.v1.observations.save` → NATS fan-out); new NATS subjects (`synthetic.v1.fxspot.start/stop/ticked`); `fx_spot_tick_event` message type; `subscribeToRawEvent` extension to `ClientManager`; `SyntheticFxSpotChartWindow` (backfill + live QtCharts display) and `SyntheticFxSpotConfigDialog` (GMM params, tick frequency, start/stop); 7 open design questions; 8-step implementation order.
- Wires both docs into `doc/knowledge/knowledge.org` Domain section.
- Updates the inventory task (`F8562D22`) to STARTED, records plan, and sets status to awaiting architecture review.
- Updates story `8A65240D` See also with both new documents.

## Test plan

- [ ] Both knowledge doc files are present under `doc/knowledge/domain/`
- [ ] Both have unique `:ID:` values (C9DACC7A, 29573D59) distinct from all other org files
- [ ] Both follow the `* Summary` / topic sections / `* See also` schema
- [ ] `knowledge.org` Domain section links to both docs
- [ ] Story `8A65240D` See also links to both docs
- [ ] Task `F8562D22` status is STARTED; plan section is populated
- [ ] Architecture doc open design questions table is complete (7 rows)
- [ ] Architecture doc implementation order section lists 8 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)