### PR TITLE
[agile] Extend Sprint 21 end date to 2026-06-29 (holiday sprint)

### DIFF
--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -8,7 +8,7 @@
 #+filetags: :v0:
 #+created: 2026-06-12
 #+start_date: 2026-06-12
-#+end_date: 2026-06-19
+#+end_date: 2026-06-29
 #+updated: 2026-06-25
 #+todo: STARTED | DONE
 


### PR DESCRIPTION
## Summary

- Sprint 21 end date was 2026-06-19 but the sprint ran over a holiday period
- Extended to 2026-06-29 (next Sunday) to reflect the actual sprint duration

## Changes

- `doc/agile/versions/v0/sprint_21/sprint.org`: bump `#+end_date` from `2026-06-19` to `2026-06-29`

🤖 Generated with [Claude Code](https://claude.com/claude-code)