### PR TITLE
[agile] Add three codegen sync tasks for party_type; rename verify_codegen

### DIFF
--- a/doc/agile/versions/v0/sprint_21/commission_party_type/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/story.org
@@ -26,9 +26,9 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Verify SQL done (PR #1310). Verify codegen is next.         |
-| Waiting on    | Nothing.                                                    |
-| Next          | Bring party_type under codegen and verify zero-diff regen.  |
+| Now           | Verify SQL done (PR #1310). Verify codegen (wire JSON driver) is next. |
+| Waiting on    | Nothing.                                                               |
+| Next          | Verify codegen gate; then sync C++ core, messaging, Qt if drift found. |
 | Last touched  | 2026-06-25                                                  |
 
 * Acceptance
@@ -55,7 +55,10 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 |------+-------+-------+-----+-------------|
 | [[id:AFFB9C7D-96B0-4EC3-85AC-792A6B4C3100][Appraise party_type across all layers and produce evaluation checklist]] | DONE | 2026-06-25 | 2026-06-25 | Walk party_type across SQL, codegen, Qt, shell, CLI and score each layer against the commissioning checklist; note security-definer and bootstrap valid_to gaps. |
 | [[id:236920DE-78BE-43D8-BEEF-585C826CE424][Verify and fix party_type SQL (security definer + bootstrap valid_to filter)]] | DONE | 2026-06-25 | 2026-06-25 | Apply the two fixes established by the country commission (PR #1300): add security definer set search_path to both functions; fix bootstrap guard to filter valid_to = ores_utility_infinity_timestamp_fn(). |
-| [[id:97B9B4AD-1C1F-4257-A91C-F8668AC1FD24][Bring party_type under codegen and verify zero-diff regeneration]] | BACKLOG | | | Create the JSON driver model for party_type, wire it into generate_workspace_entities.sh, regenerate all artefacts, and confirm zero diff against HEAD. |
+| [[id:97B9B4AD-1C1F-4257-A91C-F8668AC1FD24][Verify party_type codegen (wire JSON driver and identify regen drift)]] | BACKLOG | | | Create the JSON driver model, wire into generate_workspace_entities.sh, run all profiles, document drift per layer; zero-diff closes this task; drift is resolved in the three sync tasks. |
+| [[id:5B3E77C9-6279-40B9-ABB5-07C85B60051A][Sync C++ core codegen for party_type]] | BACKLOG | | | Ensure C++ core codegen templates (domain, repository, service, generator profiles) produce zero-diff output for party_type; fix template drift. |
+| [[id:734DE8CD-2EA4-44C9-8720-91B7627C172E][Sync C++ messaging codegen for party_type]] | BACKLOG | | | Ensure C++ messaging codegen templates (protocol, nats-eventing, nats-handler profiles) produce zero-diff output for party_type; fix template drift. |
+| [[id:5D712E14-C9CD-4040-B57F-850CA9D80393][Sync Qt codegen for party_type]] | BACKLOG | | | Ensure Qt codegen templates (qt profile) produce zero-diff output for party_type; fix template drift. |
 | [[id:8F1AC9B4-566D-4043-B154-41A81689AD95][Implement and verify party_type shell and CLI commands]] | BACKLOG | | | Implement shell commands (list, add, get, delete, history) and CLI parser for party_type — not yet implemented. Verify all commands work end-to-end against a live environment. |
 | [[id:21E5D45B-9CAD-4146-8ECF-1ACDB6398508][Verify party_type Qt UI end-to-end post-NATS]] | BACKLOG | | | Verify the Qt list window, detail dialog, history dialog, delete, and eventing for party_type against a live environment post-NATS migration; fix any regressions found. |
 | [[id:6682E5F1-DCE2-42E3-8FE2-E5FC89E576C1][Write party_type documentation (manual chapter, NATS reference)]] | BACKLOG | | | Add the party_type entity chapter to the user manual covering all Qt windows, shell commands, and CLI commands; document the NATS message types. |

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_core_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_core_codegen_party_type.org
@@ -1,13 +1,13 @@
 :PROPERTIES:
-:ID: 97B9B4AD-1C1F-4257-A91C-F8668AC1FD24
+:ID: 5B3E77C9-6279-40B9-ABB5-07C85B60051A
 :END:
-#+title: Task: Verify party_type codegen (wire JSON driver and identify regen drift)
-#+description: Create the JSON driver model for party_type, wire it into generate_workspace_entities.sh, run the generator, and document any drift found per layer (C++ core, messaging, Qt). Drift resolution is delegated to the three sync tasks.
+#+title: Task: Sync C++ core codegen for party_type
+#+description: Ensure C++ core codegen templates (domain, repository, service, generator profiles) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
 #+filetags: :commission_party_type:sprint_21:v0:
 #+owner: marco
-#+branch: feature/verify-codegen-party-type
+#+branch: feature/sync-cpp-core-codegen-party-type
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -20,12 +20,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Create a JSON driver model for =party_type= following the currency model
-shape, wire it into =generate_workspace_entities.sh=, run the generator
-for all profiles (C++ core, messaging, Qt), and document the diff output
-per layer. This task is the gate: if generation runs clean, it is done;
-if drift is found, it is recorded here and resolved in the three dedicated
-sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
+Run codegen for party_type using the domain, repository, service, and generator profiles and validate that the generated output matches what is currently in the repository. Fix templates to match code — not the reverse — unless the code is genuinely wrong. Record per-category decisions in the Result.
 
 * Status
 
@@ -40,12 +35,11 @@ sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
 
 * Acceptance
 
-- A JSON driver model for =party_type= exists in =projects/ores.codegen/models/refdata/=.
-- =generate_workspace_entities.sh= lists =party_type= and runs without error.
-- Generator is run for all profiles: C++ core (domain, repository, service, generator), messaging (protocol, nats-eventing, nats-handler), and Qt (qt).
-- Drift per layer is documented in =* Result= (zero or a diff table).
-- If zero diff on all profiles: task is complete; the three sync tasks are ABANDONED.
-- If drift found: drift is recorded and the appropriate sync tasks pick it up.
+- codegen regenerate --component refdata-cpp --profile domain produces zero diff for party_type files.
+- Same for repository, service, and generator profiles.
+- Per-change-category decision recorded: fix template or fix code with justification.
+- No C++ build regressions after any template fixes.
+- Findings recorded in Result with a diff table.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_core_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_core_codegen_party_type.org
@@ -5,7 +5,7 @@
 #+description: Ensure C++ core codegen templates (domain, repository, service, generator profiles) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
-#+filetags: :commission_party_type:sprint_21:v0:
+#+filetags: :commission_party_type:sprint_21:v0:codegen:cpp:
 #+owner: marco
 #+branch: feature/sync-cpp-core-codegen-party-type
 #+pr:

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_messaging_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_messaging_codegen_party_type.org
@@ -1,13 +1,13 @@
 :PROPERTIES:
-:ID: 97B9B4AD-1C1F-4257-A91C-F8668AC1FD24
+:ID: 734DE8CD-2EA4-44C9-8720-91B7627C172E
 :END:
-#+title: Task: Verify party_type codegen (wire JSON driver and identify regen drift)
-#+description: Create the JSON driver model for party_type, wire it into generate_workspace_entities.sh, run the generator, and document any drift found per layer (C++ core, messaging, Qt). Drift resolution is delegated to the three sync tasks.
+#+title: Task: Sync C++ messaging codegen for party_type
+#+description: Ensure C++ messaging codegen templates (protocol, nats-eventing, nats-handler profiles) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
 #+filetags: :commission_party_type:sprint_21:v0:
 #+owner: marco
-#+branch: feature/verify-codegen-party-type
+#+branch: feature/sync-cpp-messaging-codegen-party-type
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -20,12 +20,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Create a JSON driver model for =party_type= following the currency model
-shape, wire it into =generate_workspace_entities.sh=, run the generator
-for all profiles (C++ core, messaging, Qt), and document the diff output
-per layer. This task is the gate: if generation runs clean, it is done;
-if drift is found, it is recorded here and resolved in the three dedicated
-sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
+Run codegen for party_type using the protocol, nats-eventing, and nats-handler profiles and validate that the generated output matches what is currently in the repository. These profiles generate: protocol — NATS request/response header structs (party_type_protocol.hpp); nats-eventing — domain changed-event struct with event_traits (party_type_changed_event.hpp); nats-handler — NATS message handler class (party_type_handler.hpp). Fix templates to match code unless the code is wrong.
 
 * Status
 
@@ -40,12 +35,10 @@ sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
 
 * Acceptance
 
-- A JSON driver model for =party_type= exists in =projects/ores.codegen/models/refdata/=.
-- =generate_workspace_entities.sh= lists =party_type= and runs without error.
-- Generator is run for all profiles: C++ core (domain, repository, service, generator), messaging (protocol, nats-eventing, nats-handler), and Qt (qt).
-- Drift per layer is documented in =* Result= (zero or a diff table).
-- If zero diff on all profiles: task is complete; the three sync tasks are ABANDONED.
-- If drift found: drift is recorded and the appropriate sync tasks pick it up.
+- codegen regenerate --component refdata-cpp --profile protocol produces zero diff for party_type files.
+- Same for nats-eventing and nats-handler profiles.
+- Per-change-category decision recorded for any drift found.
+- Findings recorded in Result.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_messaging_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_cpp_messaging_codegen_party_type.org
@@ -5,7 +5,7 @@
 #+description: Ensure C++ messaging codegen templates (protocol, nats-eventing, nats-handler profiles) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
-#+filetags: :commission_party_type:sprint_21:v0:
+#+filetags: :commission_party_type:sprint_21:v0:codegen:cpp:nats:
 #+owner: marco
 #+branch: feature/sync-cpp-messaging-codegen-party-type
 #+pr:

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
@@ -5,7 +5,7 @@
 #+description: Ensure Qt codegen templates (qt profile) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
-#+filetags: :commission_party_type:sprint_21:v0:
+#+filetags: :commission_party_type:sprint_21:v0:codegen:qt:
 #+owner: marco
 #+branch: feature/sync-qt-codegen-party-type
 #+pr:
@@ -35,7 +35,7 @@ Run codegen for party_type using the qt profile and validate that the generated 
 
 * Acceptance
 
-- codegen generate (qt profile) for party_type produces zero diff against the repo files in ores.qt.
+- =codegen generate= (=qt= profile) for party_type produces zero diff against the repo files in =ores.qt= (Qt uses =generate=, not =regenerate= — matching the currency commission pattern).
 - Per-change-category decision recorded for any drift found.
 - Findings recorded in Result.
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
@@ -1,13 +1,13 @@
 :PROPERTIES:
-:ID: 97B9B4AD-1C1F-4257-A91C-F8668AC1FD24
+:ID: 5D712E14-C9CD-4040-B57F-850CA9D80393
 :END:
-#+title: Task: Verify party_type codegen (wire JSON driver and identify regen drift)
-#+description: Create the JSON driver model for party_type, wire it into generate_workspace_entities.sh, run the generator, and document any drift found per layer (C++ core, messaging, Qt). Drift resolution is delegated to the three sync tasks.
+#+title: Task: Sync Qt codegen for party_type
+#+description: Ensure Qt codegen templates (qt profile) produce zero-diff output for party_type; fix template drift.
 #+type: task
 #+level: s1
 #+filetags: :commission_party_type:sprint_21:v0:
 #+owner: marco
-#+branch: feature/verify-codegen-party-type
+#+branch: feature/sync-qt-codegen-party-type
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -20,12 +20,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Create a JSON driver model for =party_type= following the currency model
-shape, wire it into =generate_workspace_entities.sh=, run the generator
-for all profiles (C++ core, messaging, Qt), and document the diff output
-per layer. This task is the gate: if generation runs clean, it is done;
-if drift is found, it is recorded here and resolved in the three dedicated
-sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
+Run codegen for party_type using the qt profile and validate that the generated output matches what is currently in the repository. The qt profile generates: client model (ClientPartyTypeModel.hpp/.cpp), MDI window (PartyTypeMdiWindow.hpp/.cpp), detail dialog (PartyTypeDetailDialog.hpp/.cpp), history dialog (PartyTypeHistoryDialog.hpp/.cpp), controller (PartyTypeController.hpp/.cpp), and UI files (PartyTypeDetailDialog.ui, PartyTypeHistoryDialog.ui). Fix templates to match code unless the code is wrong.
 
 * Status
 
@@ -40,12 +35,9 @@ sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
 
 * Acceptance
 
-- A JSON driver model for =party_type= exists in =projects/ores.codegen/models/refdata/=.
-- =generate_workspace_entities.sh= lists =party_type= and runs without error.
-- Generator is run for all profiles: C++ core (domain, repository, service, generator), messaging (protocol, nats-eventing, nats-handler), and Qt (qt).
-- Drift per layer is documented in =* Result= (zero or a diff table).
-- If zero diff on all profiles: task is complete; the three sync tasks are ABANDONED.
-- If drift found: drift is recorded and the appropriate sync tasks pick it up.
+- codegen generate (qt profile) for party_type produces zero diff against the repo files in ores.qt.
+- Per-change-category decision recorded for any drift found.
+- Findings recorded in Result.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_sync_qt_codegen_party_type.org
@@ -35,7 +35,7 @@ Run codegen for party_type using the qt profile and validate that the generated 
 
 * Acceptance
 
-- =codegen generate= (=qt= profile) for party_type produces zero diff against the repo files in =ores.qt= (Qt uses =generate=, not =regenerate= — matching the currency commission pattern).
+- =codegen regenerate --component refdata-cpp --profile qt= produces zero diff for party_type files in =ores.qt=.
 - Per-change-category decision recorded for any drift found.
 - Findings recorded in Result.
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
@@ -42,7 +42,7 @@ sync tasks (=sync_cpp_core=, =sync_cpp_messaging=, =sync_qt=).
 
 - A JSON driver model for =party_type= exists in =projects/ores.codegen/models/refdata/=.
 - =generate_workspace_entities.sh= lists =party_type= and runs without error.
-- Generator is run for all profiles: C++ core (domain, repository, service, generator), messaging (protocol, nats-eventing, nats-handler), and Qt (qt).
+- =codegen regenerate --component refdata-cpp= is run for all profiles: C++ core (domain, repository, service, generator), messaging (protocol, nats-eventing, nats-handler), and Qt (qt).
 - Drift per layer is documented in =* Result= (zero or a diff table).
 - If zero diff on all profiles: task is complete; the three sync tasks are ABANDONED.
 - If drift found: drift is recorded and the appropriate sync tasks pick it up.


### PR DESCRIPTION
## Summary

- Renames `verify_codegen_party_type` (97B9B4AD) from a catch-all codegen task to a focused gate: wire the JSON driver model, run all profiles, and document drift per layer.
- Adds three new tasks following the currency commission pattern:
  - `sync_cpp_core_codegen_party_type` (5B3E77C9) — domain/repository/service/generator profiles
  - `sync_cpp_messaging_codegen_party_type` (734DE8CD) — protocol/nats-eventing/nats-handler profiles
  - `sync_qt_codegen_party_type` (5D712E14) — qt profile
- Reorders story task table: verify_codegen gate → three sync tasks → shell/CLI → Qt → docs → Wt/HTTP captures.

## Test plan

- [ ] Story task table order and IDs look correct in story.org
- [ ] Three new task files present with correct goals/acceptance criteria
- [ ] verify_codegen task title and goal reflect gate-only scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)