### PR TITLE
[agile] Close verify_codegen_party_type; document codegen drift

### DIFF
--- a/doc/agile/versions/v0/sprint_21/commission_party_type/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/story.org
@@ -26,9 +26,9 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Verify SQL done (PR #1310). Verify codegen (wire JSON driver) is next. |
+| Now           | Verify codegen done. Drift found across C++ core, messaging, Qt.       |
 | Waiting on    | Nothing.                                                               |
-| Next          | Verify codegen gate; then sync C++ core, messaging, Qt if drift found. |
+| Next          | sync_cpp_core → sync_cpp_messaging → sync_qt (drift resolution).       |
 | Last touched  | 2026-06-25                                                  |
 
 * Acceptance
@@ -55,7 +55,7 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 |------+-------+-------+-----+-------------|
 | [[id:AFFB9C7D-96B0-4EC3-85AC-792A6B4C3100][Appraise party_type across all layers and produce evaluation checklist]] | DONE | 2026-06-25 | 2026-06-25 | Walk party_type across SQL, codegen, Qt, shell, CLI and score each layer against the commissioning checklist; note security-definer and bootstrap valid_to gaps. |
 | [[id:236920DE-78BE-43D8-BEEF-585C826CE424][Verify and fix party_type SQL (security definer + bootstrap valid_to filter)]] | DONE | 2026-06-25 | 2026-06-25 | Apply the two fixes established by the country commission (PR #1300): add security definer set search_path to both functions; fix bootstrap guard to filter valid_to = ores_utility_infinity_timestamp_fn(). |
-| [[id:97B9B4AD-1C1F-4257-A91C-F8668AC1FD24][Verify party_type codegen and identify regen drift]] | BACKLOG | | | Org models already registered; run regenerate for all profiles (SQL, C++ core, messaging, Qt), document drift per layer; zero-diff closes this task; drift resolved in three sync tasks. |
+| [[id:97B9B4AD-1C1F-4257-A91C-F8668AC1FD24][Verify party_type codegen and identify regen drift]] | DONE | 2026-06-25 | 2026-06-25 | Org models already registered; run regenerate for all profiles (SQL, C++ core, messaging, Qt), document drift per layer; zero-diff closes this task; drift resolved in three sync tasks. |
 | [[id:5B3E77C9-6279-40B9-ABB5-07C85B60051A][Sync C++ core codegen for party_type]] | BACKLOG | | | Ensure C++ core codegen templates (domain, repository, service, generator profiles) produce zero-diff output for party_type; fix template drift. |
 | [[id:734DE8CD-2EA4-44C9-8720-91B7627C172E][Sync C++ messaging codegen for party_type]] | BACKLOG | | | Ensure C++ messaging codegen templates (protocol, nats-eventing, nats-handler profiles) produce zero-diff output for party_type; fix template drift. |
 | [[id:5D712E14-C9CD-4040-B57F-850CA9D80393][Sync Qt codegen for party_type]] | BACKLOG | | | Ensure Qt codegen templates (qt profile) produce zero-diff output for party_type; fix template drift. |

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_party_type:sprint_21:v0:
 #+owner: marco
 #+branch: feature/verify-codegen-party-type
-#+pr:
+#+pr: 1321
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -59,7 +59,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1321][#1321]] | [agile] Close verify_codegen_party_type; document codegen drift |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-06-25
 #+updated: 2026-06-25
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -32,11 +32,11 @@ it is recorded here and resolved in the three dedicated sync tasks
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                 |
 | Parent story | [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Now          | Done. Drift documented; three sync tasks activated.          |
+| Waiting on   | Nothing.                                                     |
+| Next         | N/A.                                                         |
 | Last touched | 2026-06-25                               |
 
 * Acceptance
@@ -68,3 +68,65 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Regeneration run against all profiles on 2026-06-25. SQL is zero-diff.
+All C++ and Qt profiles show drift — broken down per sync task below.
+
+** SQL — PASS (zero diff)
+
+=codegen generate --model ores.refdata.party_type_table.org --profile sql=
+regenerated =refdata_party_types_create.sql= with zero git diff. SQL layer
+is clean.
+
+** C++ core (domain, repository, service, generator) — DRIFT → sync_cpp_core
+
+Three categories of drift:
+
+1. *Content drift in =party_type.hpp=* (old-structure path =projects/ores.refdata/api/...= correct):
+   - Template removes =tenant_id= field and its =#include=.
+   - Template adds =int display_order = 0;= (missing default initialiser in repo).
+   Decision: investigate in =sync_cpp_core= — whether =tenant_id= removal is a
+   template advance (system-scoped entity) or a regression.
+
+2. *Duplicate output for json_io / table / table_io*: codegen writes to new
+   structure =projects/ores.refdata.api/include/.../domain/= but existing files
+   live at old structure =projects/ores.refdata/api/include/.../domain/=. One
+   location must become authoritative.
+
+3. *Duplicate output for repository / mapper / service / generator*: codegen
+   writes to =projects/ores.refdata.core/= (new structure, matches currency
+   auxiliary pattern) but existing files live in =projects/ores.refdata/core/=.
+   Same old-vs-new resolution needed.
+
+** C++ messaging (protocol, nats-eventing, nats-handler) — PARTIAL → sync_cpp_messaging
+
+- =party_type_protocol.hpp= and =party_type_changed_event.hpp=: new files, no
+  existing version. Generated to =projects/ores.refdata.api/messaging/= and
+  =projects/ores.refdata.api/eventing/= — matching the currency auxiliary pattern.
+  Accept new locations; content to be verified in =sync_cpp_messaging=.
+
+- =party_type_handler.hpp=: *duplicate*. Existing file at
+  =projects/ores.refdata/core/include/.../messaging/party_type_handler.hpp=;
+  codegen generates to =projects/ores.refdata.core/include/.../messaging/=.
+  Same old-vs-new resolution as core domain files.
+
+** Qt — DRIFT → sync_qt
+
+All Qt files generated to =projects/ores.qt.refdata/= but actual files live in
+=projects/ores.qt/party/=. The org model lacks a Qt component path property; the
+=sync_qt= task must identify the correct property and regenerate to the right
+location.
+
+** Summary table
+
+| Profile | Result | Action |
+|---------+--------+--------|
+| sql | ✅ zero diff | Done |
+| domain | ⚠ content drift + duplicate-path drift | sync_cpp_core |
+| repository | ⚠ duplicate-path drift | sync_cpp_core |
+| service | ⚠ duplicate-path drift | sync_cpp_core |
+| generator | ⚠ duplicate-path drift | sync_cpp_core |
+| protocol | ⚠ new file (path ok, content unverified) | sync_cpp_messaging |
+| nats-eventing | ⚠ new file (path ok, content unverified) | sync_cpp_messaging |
+| nats-handler | ⚠ duplicate-path drift | sync_cpp_messaging |
+| qt | ⚠ wrong output path | sync_qt |


### PR DESCRIPTION
## Summary

Run `codegen regenerate` across all profiles for `party_type` (org models already registered in `refdata` and `refdata-cpp` components). SQL is zero-diff. C++ and Qt profiles show drift across domain, repository, service, generator, messaging, and Qt layers; findings documented per-profile in the task `* Result` section. Three sync tasks activated to resolve drift.

## Changes

- Mark `verify_codegen_party_type` (97B9B4AD) DONE
- Add per-profile drift findings to task `* Result` (domain, repository, service, generator, protocol, nats-eventing, nats-handler, qt)
- Update story Now/Next: drift found, sync tasks are next

## Traceability

| Artefact | Link | ID |
|----------|------|-----|
| Story | [Commission: party_type](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_party_type/story.html) | 59583AFF-7657-4F79-BB7E-2086BCA04A91 |
| Task | [Verify party_type codegen and identify regen drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_party_type/task_verify_codegen_party_type.html) | 97B9B4AD-1C1F-4257-A91C-F8668AC1FD24 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)