### PR TITLE
[ci] Select Xcode 16 on macos-14 to fix std::expected libc++ bug

### DIFF
--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -98,6 +98,20 @@ jobs:
         with:
           submodules: true
 
+      - name: Select Xcode 16
+        # Xcode 15.4 (macos-14 default) has a broken std::expected destructor
+        # constraint (fixed in Xcode 16.0+). Select the newest Xcode 16.x
+        # available on the image to get the fixed libc++.
+        run: |
+          xcode16=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          if [[ -z "$xcode16" ]]; then
+            echo "No Xcode 16.x found — keeping default"
+          else
+            echo "Selecting $xcode16"
+            sudo xcode-select -s "$xcode16"
+            xcodebuild -version
+          fi
+
       - name: Restore sccache
         uses: actions/cache/restore@v5
         with:

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_status_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_status_handler.hpp
@@ -157,7 +157,7 @@ public:
             BOOST_LOG_SEV(book_status_handler_lg(), debug) << "Completed " << msg.subject;
             reply(nats_,
                   msg,
-                  get_book_status_history_response{.success = true, .statuses = std::move(h)});
+                  get_book_status_history_response{.statuses = std::move(h), .success = true});
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(book_status_handler_lg(), error)
                 << msg.subject << " failed: " << e.what();


### PR DESCRIPTION
## Summary

- Xcode 15.4 (macos-14 default) has a broken `std::expected` destructor: it requires both T and E to be trivially destructible even for non-trivial paths, rejecting e.g. `std::expected<tenant_id, std::string>` with *invalid reference to function '~expected': constraints not satisfied*.
- This was fixed in Xcode 16.0+. The macos-14 runner ships Xcode 16.x alongside 15.4.
- The `SCCACHE_BASEDIR` change (PR #1294) invalidated the macOS sccache, forcing a full recompile that exposed this latent issue (same root cause as the base32 paren-init fix in PR #1318).
- New step selects the newest Xcode 16.x found on the image; falls back gracefully if none is present.

Fixes macOS CI failure in run [28217017073](https://github.com/OreStudio/OreStudio/actions/runs/28217017073).

## Test plan

- [ ] macOS CI compiles `ores.database` without `std::expected` destructor error
- [ ] `xcodebuild -version` in the log shows Xcode 16.x
- [ ] Linux CI unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)