### PR TITLE
[codegen] Scaffold: refactor ores.codegen — merge generator.py into codegen/

### DIFF
--- a/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/story.org
+++ b/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/story.org
@@ -1,0 +1,46 @@
+:PROPERTIES:
+:ID: 1E30455A-D67A-4D48-8CFD-FEB6EF6308BC
+:END:
+#+title: Story: Refactor ores.codegen: merge generator.py into codegen/ package
+#+description: Consolidate the two Python source trees in ores.codegen/src/. Move resolve_output_path, generate_from_model, load_profiles, and related logic from the top-level generator.py monolith into the codegen/ package. Remove the dynamic import hack in codegen/generate.py. Delete generator.py once empty.
+#+type: story
+#+level: s2
+#+filetags: :codegen:refactor:python:sprint_21:v0:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment: prime_origin
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-26                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:A48A3E59-BC18-4D5D-BB2C-F531F8C23D65][Scaffold story: Refactor ores.codegen: merge generator.py into codegen/ package]] | DONE | 2026-06-26 | 2026-06-26 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:4C3CEDD8-C737-44B0-810E-FF583F7BE23A][Move generator.py logic into codegen/ package and delete the monolith]] | BACKLOG | | | Initial task for: Refactor ores.codegen: merge generator.py into codegen/ package |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_implement_refactor-codegen-generator-merge.org
+++ b/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_implement_refactor-codegen-generator-merge.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 4C3CEDD8-C737-44B0-810E-FF583F7BE23A
+:END:
+#+title: Task: Move generator.py logic into codegen/ package and delete the monolith
+#+description: Initial task for: Refactor ores.codegen: merge generator.py into codegen/ package
+#+type: task
+#+level: s1
+#+filetags: :refactor-codegen-generator-merge:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1E30455A-D67A-4D48-8CFD-FEB6EF6308BC][Refactor ores.codegen: merge generator.py into codegen/ package]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:1E30455A-D67A-4D48-8CFD-FEB6EF6308BC][Refactor ores.codegen: merge generator.py into codegen/ package]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_scaffold_refactor-codegen-generator-merge.org
+++ b/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_scaffold_refactor-codegen-generator-merge.org
@@ -8,7 +8,7 @@
 #+filetags: :refactor-codegen-generator-merge:sprint_21:v0:
 #+owner: marco
 #+branch: feature/refactor-codegen-generator-merge
-#+pr:
+#+pr: 1329
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-26
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1329][#1329]] | [codegen] Scaffold: refactor ores.codegen — merge generator.py into codegen/ |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_scaffold_refactor-codegen-generator-merge.org
+++ b/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_scaffold_refactor-codegen-generator-merge.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: A48A3E59-BC18-4D5D-BB2C-F531F8C23D65
+:END:
+#+title: Task: Scaffold story: Refactor ores.codegen: merge generator.py into codegen/ package
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :refactor-codegen-generator-merge:sprint_21:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-generator-merge
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment: prime_origin
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1E30455A-D67A-4D48-8CFD-FEB6EF6308BC][Refactor ores.codegen: merge generator.py into codegen/ package]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:1E30455A-D67A-4D48-8CFD-FEB6EF6308BC][Refactor ores.codegen: merge generator.py into codegen/ package]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

Scaffold a new story to consolidate ores.codegen's two Python source trees. generator.py (the original rendering monolith) will be merged into the codegen/ package, eliminating the dynamic import hack and fixing the preprocessing/path-resolution timing split.

## Changes

- New story: Refactor ores.codegen: merge generator.py into codegen/ package
- New implementation task wired into sprint 21

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Refactor ores.codegen: merge generator.py into codegen/ package](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/story.html) | 1E30455A-D67A-4D48-8CFD-FEB6EF6308BC |
| Task | [Scaffold story: Refactor ores.codegen: merge generator.py into codegen/ package](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/refactor-codegen-generator-merge/task_scaffold_refactor-codegen-generator-merge.html) | A48A3E59-BC18-4D5D-BB2C-F531F8C23D65 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)