### PR TITLE
[ores.qt.trading] Fix book_status response field name

### DIFF
--- a/projects/ores.qt/trading/src/ClientBookStatusModel.cpp
+++ b/projects/ores.qt/trading/src/ClientBookStatusModel.cpp
@@ -169,9 +169,9 @@ void ClientBookStatusModel::refresh() {
                 }
 
                 BOOST_LOG_SEV(lg(), debug)
-                    << "Fetched " << response_result->book_statuses.size() << " book statuses";
+                    << "Fetched " << response_result->statuses.size() << " book statuses";
                 return {.success = true,
-                        .statuses = std::move(response_result->book_statuses),
+                        .statuses = std::move(response_result->statuses),
                         .error_message = {},
                         .error_details = {}};
             },


### PR DESCRIPTION
## Summary
Generated `book_status_protocol.hpp` uses `entity_plural_short` for the response vector field (`statuses`), not `entity_plural` (`book_statuses`). `ClientBookStatusModel.cpp` was referencing the old name, breaking the build.

## Changes
- `ClientBookStatusModel.cpp`: `response_result->book_statuses` → `response_result->statuses` (2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)