### PR TITLE
[agile] Reopen Commission: currency; add 4 missing tasks

### DIFF
--- a/doc/agile/versions/v0/sprint_21/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_currency/story.org
@@ -27,11 +27,11 @@ same checklist applies.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                                   |
+| State         | STARTED                                |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | All 14 tasks complete. Currency and auxiliaries fully commissioned. |
+| Now           | Auxiliary codegen synced. Currency-entity codegen sync (C++ core, messaging, Qt) and Wt/HTTP captures remain. |
 | Waiting on    | Nothing.                               |
-| Next          | None.                                  |
+| Next          | Sync C++ core codegen for currency; then messaging; then Qt; then Wt/HTTP captures. |
 | Last touched  | 2026-06-26                             |
 
 * Acceptance
@@ -86,3 +86,7 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 | [[id:00B62E70-D961-4DFA-BAB4-BB3488B31C86][Sync C++ messaging codegen for currency auxiliaries]] | DONE | 2026-06-25 | 2026-06-26 | Re-run protocol, nats-eventing, and nats-handler profiles for rounding_type, monetary_nature, currency_market_tier; diff against repo; fix templates to match code. |
 | [[id:10B1976B-A785-44B0-8DFA-F315ADFD4B8B][Sync Qt codegen for currency auxiliaries]] | DONE | 2026-06-25 | 2026-06-26 | Re-run Qt profile for rounding_type, monetary_nature, currency_market_tier; diff against repo; fix templates to match code. |
 | [[id:84522F09-7044-4343-92E5-80588C2D325F][Define and implement entity view document type]] | DONE | | 2026-06-12 | Create entity view docs listing all artefacts per entity across every projection and component, with proj: links to artefacts and codegen archetypes; implement currency as the first example. |
+| [[id:8A84D304-431A-45CF-9E3C-6AC649F6A62F][Sync C++ core codegen for currency]] | BACKLOG | | | Re-run domain, repository, service, and generator profiles for currency; diff against repo; fix templates or code per drift classification. |
+| [[id:8B15EE84-1727-43B5-85E4-96E58F1BE03B][Sync C++ messaging codegen for currency]] | BACKLOG | | | Re-run protocol, nats-eventing, and nats-handler profiles for currency; diff against repo; fix templates or code per drift classification. |
+| [[id:EA647CBC-18C7-4555-9A49-FBF55BC192FD][Sync Qt codegen for currency]] | BACKLOG | | | Re-run the qt profile for currency; diff the 12 output files against the repo; fix templates or code per drift classification. |
+| [[id:3CE7779C-7D20-4203-A4E9-1FBDBFAEF537][File Wt and HTTP gap captures for currency]] | BACKLOG | | | Identify Wt UI and HTTP handler gaps for currency discovered during commissioning and file them as backlog captures for future work. |

--- a/doc/agile/versions/v0/sprint_21/commission_currency/task_file_wt_http_captures_currency.org
+++ b/doc/agile/versions/v0/sprint_21/commission_currency/task_file_wt_http_captures_currency.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 3CE7779C-7D20-4203-A4E9-1FBDBFAEF537
+:END:
+#+title: Task: File Wt and HTTP gap captures for currency
+#+description: Identify Wt UI and HTTP handler gaps for currency discovered during commissioning and file them as backlog captures for future work.
+#+type: task
+#+level: s1
+#+filetags: :commission_currency:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Review currency Wt UI and HTTP handler completeness; create compass captures for any gaps found; ensure no gap is silently dropped.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+- All Wt and HTTP gaps identified; captures filed in inbox; story references the captures.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_cpp_core_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_cpp_core_codegen_currency.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 8A84D304-431A-45CF-9E3C-6AC649F6A62F
+:END:
+#+title: Task: Sync C++ core codegen for currency
+#+description: Re-run domain, repository, service, and generator profiles for currency; diff against repo; fix templates or code per drift classification.
+#+type: task
+#+level: s1
+#+filetags: :commission_currency:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Ensure the C++ core codegen profiles (domain, repository, service, generator) produce output that matches the repository for currency. Fix templates to match code unless code is wrong. Record every delta with category and decision.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+- All four profiles produce zero diff or every delta is classified (template gap / bug / code bug / cosmetic) and the decision is recorded; fix commits present where required; build passes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_cpp_messaging_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_cpp_messaging_codegen_currency.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 8B15EE84-1727-43B5-85E4-96E58F1BE03B
+:END:
+#+title: Task: Sync C++ messaging codegen for currency
+#+description: Re-run protocol, nats-eventing, and nats-handler profiles for currency; diff against repo; fix templates or code per drift classification.
+#+type: task
+#+level: s1
+#+filetags: :commission_currency:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Ensure the C++ messaging codegen profiles (protocol, nats-eventing, nats-handler) produce output that matches the repository for currency. Record every delta with category and decision.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+- All three profiles produce zero diff or every delta is classified and the decision recorded; fix commits present where required; build passes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_qt_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_21/commission_currency/task_sync_qt_codegen_currency.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: EA647CBC-18C7-4555-9A49-FBF55BC192FD
+:END:
+#+title: Task: Sync Qt codegen for currency
+#+description: Re-run the qt profile for currency; diff the 12 output files against the repo; fix templates or code per drift classification.
+#+type: task
+#+level: s1
+#+filetags: :commission_currency:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Ensure the Qt codegen profile produces output matching the repository for currency (client model, MDI window, detail dialog, history dialog, controller, UI files). Record every delta with category and decision.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+- Qt profile produces zero diff or every delta is classified and the decision recorded; fix commits present where required; build passes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

- Currency-entity codegen sync tasks were absent: only the three auxiliaries had C++ core, messaging, and Qt profiles synced against the 16-task reference standard
- Wt/HTTP captures task (standard task 16) was missing entirely
- Story was prematurely closed as DONE

## Changes

- Added task: Sync C++ core codegen for currency (domain, repository, service, generator profiles)
- Added task: Sync C++ messaging codegen for currency (protocol, nats-eventing, nats-handler profiles)
- Added task: Sync Qt codegen for currency (12 output files)
- Added task: File Wt and HTTP gap captures for currency (standard task 16)
- Reopened story to STARTED; updated Now/Next status fields

## Test plan

- [ ] story.org shows STARTED with 4 new BACKLOG rows
- [ ] four new task files exist under commission_currency/
- [ ] site builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)