### PR TITLE
[recipes] Add codegen layer recipes using compass codegen regenerate

### DIFF
--- a/doc/recipes/codegen/codegen.org
+++ b/doc/recipes/codegen/codegen.org
@@ -34,3 +34,16 @@ recipes]] under "Authoring documents".
 - [[id:CB7713BA-544A-43CD-AEB3-30C2157CBBCC][How do I add a domain service?]] — edit the single service registry
   (a codegen model) and regenerate; it is the one source for
   =service_vars.sh=, the SQL users/roles/grants, and the =.env= creds.
+
+* Regenerating entity layers
+
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe; component-wide run with manual diff scoping.
+- [[id:C3E07D42-5B48-4566-AE67-6D20926B3376][How do I regenerate the SQL layer for an entity?]] — =sql= profile; writes to =ores.sql/=.
+- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the domain C++ layer for an entity?]] — =domain= profile; POCOs, JSON I/O, table I/O.
+- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the generator layer for an entity?]] — =generator= profile; test-data generators.
+- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the repository layer for an entity?]] — =repository= profile; sqlgen entities, mappers, CRUD.
+- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the service layer for an entity?]] — =service= profile; business-logic service layer.
+- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the protocol layer for an entity?]] — =protocol= profile; NATS request/response structs.
+- [[id:F4BA8D44-6940-487D-B38D-9DD27556B80A][How do I regenerate the NATS eventing layer for an entity?]] — =nats-eventing= profile; event type headers.
+- [[id:B8F158A2-3ECF-44A8-94A2-259DF7A2AF70][How do I regenerate the NATS handler layer for an entity?]] — =nats-handler= profile; NATS message handler class.
+- [[id:F77B0DF6-DA37-41BB-B4B6-D0F14F12A084][How do I regenerate the Qt UI layer for an entity?]] — =qt= profile; list, detail, history, delegate, validator, view-widget.

--- a/doc/recipes/codegen/codegen.org
+++ b/doc/recipes/codegen/codegen.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :recipe:codegen:index:knowledge:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-26
 
 Recipes related to *codegen* — the model-driven C++ generator and the
 documentation scaffold. Some entries below appear in both this
@@ -39,11 +39,11 @@ recipes]] under "Authoring documents".
 
 - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe; component-wide run with manual diff scoping.
 - [[id:C3E07D42-5B48-4566-AE67-6D20926B3376][How do I regenerate the SQL layer for an entity?]] — =sql= profile; writes to =ores.sql/=.
-- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the domain C++ layer for an entity?]] — =domain= profile; POCOs, JSON I/O, table I/O.
-- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the generator layer for an entity?]] — =generator= profile; test-data generators.
-- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the repository layer for an entity?]] — =repository= profile; sqlgen entities, mappers, CRUD.
-- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the service layer for an entity?]] — =service= profile; business-logic service layer.
-- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the protocol layer for an entity?]] — =protocol= profile; NATS request/response structs.
+- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the C++ domain layer for an entity?]] — =domain= profile; POCOs, JSON I/O, table I/O.
+- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the C++ generator layer for an entity?]] — =generator= profile; test-data generators.
+- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the C++ repository layer for an entity?]] — =repository= profile; sqlgen entities, mappers, CRUD.
+- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the C++ service layer for an entity?]] — =service= profile; business-logic service layer.
+- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the C++ protocol layer for an entity?]] — =protocol= profile; NATS request/response structs.
 - [[id:F4BA8D44-6940-487D-B38D-9DD27556B80A][How do I regenerate the NATS eventing layer for an entity?]] — =nats-eventing= profile; event type headers.
 - [[id:B8F158A2-3ECF-44A8-94A2-259DF7A2AF70][How do I regenerate the NATS handler layer for an entity?]] — =nats-handler= profile; NATS message handler class.
 - [[id:F77B0DF6-DA37-41BB-B4B6-D0F14F12A084][How do I regenerate the Qt UI layer for an entity?]] — =qt= profile; list, detail, history, delegate, validator, view-widget.

--- a/doc/recipes/codegen/how_do_i_add_a_new_codegen_entity_model.org
+++ b/doc/recipes/codegen/how_do_i_add_a_new_codegen_entity_model.org
@@ -66,7 +66,7 @@ to add another entity.
 ** 4. Regenerate
 
 #+begin_src sh :results verbatim
-projects/ores.codegen/codegen.sh regenerate \
+./compass.sh codegen regenerate \
     --component <component>-cpp --profile all-cpp
 #+end_src
 

--- a/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
@@ -24,10 +24,10 @@ For a =domain_entity= model (e.g. =rounding_type= in =refdata=):
 
 #+begin_src sh
 # 1. All C++ layers in one pass
-./projects/ores.codegen/codegen.sh regenerate --component refdata-cpp --profile all-cpp
+./compass.sh codegen regenerate --component refdata-cpp --profile all-cpp
 
 # 2. SQL layer (separate component — table models live here)
-./projects/ores.codegen/codegen.sh regenerate --component refdata --profile sql
+./compass.sh codegen regenerate --component refdata --profile sql
 
 # 3. Scope the diff to the target entity
 git diff -- projects/ores.refdata/ projects/ores.qt/refdata/ projects/ores.sql/

--- a/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB
+:END:
+#+title: How do I regenerate all layers for a domain entity?
+#+description: Run all codegen profiles (SQL, all C++) for a single domain entity in one pass and validate the output.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:entity:regenerate:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+This recipe covers all code generation profiles for a =domain_entity= model.
+See [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system and [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] for output location checks and drift classification.
+
+* Question
+
+How do I regenerate all the code for a domain entity?
+
+* Answer
+
+There is no single command that targets one entity across all profiles — the entity filter (=--entity=) does not exist yet (see [[id:A083FE26-521D-4046-9E58-AFB901B28809][Codegen developer experience improvements]]). Run component-wide and scope the diff manually.
+
+For a =domain_entity= model (e.g. =rounding_type= in =refdata=):
+
+#+begin_src sh
+# 1. All C++ layers in one pass
+./projects/ores.codegen/codegen.sh regenerate --component refdata-cpp --profile all-cpp
+
+# 2. SQL layer (separate component — table models live here)
+./projects/ores.codegen/codegen.sh regenerate --component refdata --profile sql
+
+# 3. Scope the diff to the target entity
+git diff -- projects/ores.refdata/ projects/ores.qt/refdata/ projects/ores.sql/
+
+# 4. Discard out-of-scope changes written by the component-wide run
+git checkout HEAD -- projects/ores.qt/refdata/
+git status --short | grep '^?' | awk '{print $2}' | xargs rm -f
+#+end_src
+
+*Before diffing*, verify each generated file landed in the correct split project directory — not the stale monolith paths. See [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] § Codegen sync task acceptance criteria, output location check.
+
+For per-layer details and drift notes, see the individual layer recipes in the See also section.
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — profile system, component registry, all-cpp composite profile.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — authoritative profile → template → output path table.
+- [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]] — maps component names (=refdata=, =refdata-cpp=, …) to model discovery roots.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check and drift classification.
+- [[id:A083FE26-521D-4046-9E58-AFB901B28809][Codegen developer experience improvements]] — tracks the missing =--entity= filter.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open story for stale output path fix.
+
+Per-layer recipes:
+
+- [[id:C3E07D42-5B48-4566-AE67-6D20926B3376][How do I regenerate the SQL layer for an entity?]]
+- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the domain C++ layer for an entity?]]
+- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the generator layer for an entity?]]
+- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the repository layer for an entity?]]
+- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the service layer for an entity?]]
+- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the protocol layer for an entity?]]
+- [[id:F4BA8D44-6940-487D-B38D-9DD27556B80A][How do I regenerate the NATS eventing layer for an entity?]]
+- [[id:B8F158A2-3ECF-44A8-94A2-259DF7A2AF70][How do I regenerate the NATS handler layer for an entity?]]
+- [[id:F77B0DF6-DA37-41BB-B4B6-D0F14F12A084][How do I regenerate the Qt UI layer for an entity?]]

--- a/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_all_layers_for_a_domain_entity.org
@@ -34,7 +34,8 @@ git diff -- projects/ores.refdata/ projects/ores.qt/refdata/ projects/ores.sql/
 
 # 4. Discard out-of-scope changes written by the component-wide run
 git checkout HEAD -- projects/ores.qt/refdata/
-git status --short | grep '^?' | awk '{print $2}' | xargs rm -f
+git status --short -- projects/ores.refdata/ projects/ores.qt/refdata/ projects/ores.sql/ \
+  | grep '^?' | awk '{print $2}' | xargs rm -f
 #+end_src
 
 *Before diffing*, verify each generated file landed in the correct split project directory — not the stale monolith paths. See [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] § Codegen sync task acceptance criteria, output location check.
@@ -43,11 +44,11 @@ For per-layer details and drift notes, see the individual layer recipes in the S
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate= is the entry point. The =all-cpp= composite profile runs domain, generator, repository, service, protocol, nats-eventing, nats-handler, and qt in one pass. The =sql= profile is a separate invocation on the =refdata= component. See [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile registry.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run both commands, inspect =git diff= scoped to the target entity, verify output paths against the location table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 
@@ -61,11 +62,11 @@ For per-layer details and drift notes, see the individual layer recipes in the S
 Per-layer recipes:
 
 - [[id:C3E07D42-5B48-4566-AE67-6D20926B3376][How do I regenerate the SQL layer for an entity?]]
-- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the domain C++ layer for an entity?]]
-- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the generator layer for an entity?]]
-- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the repository layer for an entity?]]
-- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the service layer for an entity?]]
-- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the protocol layer for an entity?]]
+- [[id:29427D10-2B11-4544-AE0C-363DE6365784][How do I regenerate the C++ domain layer for an entity?]]
+- [[id:CBD4498A-ED2D-4190-B600-7C2A72EB4385][How do I regenerate the C++ generator layer for an entity?]]
+- [[id:9B16B5F0-CBF5-4664-9637-8B9E74277C5D][How do I regenerate the C++ repository layer for an entity?]]
+- [[id:40658FAC-7CB1-403F-B6C8-B259465F58E9][How do I regenerate the C++ service layer for an entity?]]
+- [[id:6779B755-0A34-4E31-A274-8D9B77DFFB01][How do I regenerate the C++ protocol layer for an entity?]]
 - [[id:F4BA8D44-6940-487D-B38D-9DD27556B80A][How do I regenerate the NATS eventing layer for an entity?]]
 - [[id:B8F158A2-3ECF-44A8-94A2-259DF7A2AF70][How do I regenerate the NATS handler layer for an entity?]]
 - [[id:F77B0DF6-DA37-41BB-B4B6-D0F14F12A084][How do I regenerate the Qt UI layer for an entity?]]

--- a/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =domain= profile via =compass codegen regenerate=, generating the domain POCO header and its JSON I/O, table I/O, and secondary include. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -39,11 +38,11 @@ Scope the diff and classify unexpected differences using the drift table in [[id
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile domain=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata/api/=, verify four files per entity are present, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the C++ domain class and I/O files for a domain entity?
 The =domain= profile generates the POCO class header plus JSON and table I/O pairs. It supports =schema= and =domain_entity= model types.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile domain
+./compass.sh codegen regenerate --component refdata-cpp --profile domain
 #+end_src
 
 Expected output (entity =rounding_type=, =component_include=refdata.api=):
@@ -47,8 +47,8 @@ Scope the diff and classify unexpected differences using the drift table in [[id
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =domain= profile entry with template → output path table.
-- - [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — known path inconsistency for secondary domain templates.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =domain= profile entry with template → output path table.
+- [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — known path inconsistency for secondary domain templates.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_domain_cpp_layer_for_an_entity.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: 29427D10-2B11-4544-AE0C-363DE6365784
+:END:
+#+title: How do I regenerate the C++ domain layer for an entity?
+#+description: Run the domain codegen profile for a single entity and validate the output (class header, JSON I/O, table I/O).
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:domain:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the C++ domain class and I/O files for a domain entity?
+
+* Answer
+
+The =domain= profile generates the POCO class header plus JSON and table I/O pairs. It supports =schema= and =domain_entity= model types.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile domain
+#+end_src
+
+Expected output (entity =rounding_type=, =component_include=refdata.api=):
+- =projects/ores.refdata/api/include/ores.refdata.api/domain/rounding_type.hpp= (class template — written to =ores.{component}/api/=)
+- =projects/ores.refdata.api/include/ores.refdata.api/domain/rounding_type_json_io.hpp= (⚠ secondary templates write to stale =ores.{component_include}/= path — see known path issue)
+- =projects/ores.refdata.api/src/domain/rounding_type_json_io.cpp=
+- =projects/ores.refdata.api/include/…/domain/rounding_type_table.hpp=
+- =projects/ores.refdata.api/src/domain/rounding_type_table.cpp=
+- =projects/ores.refdata.api/include/…/domain/rounding_type_table_io.hpp=
+- =projects/ores.refdata.api/src/domain/rounding_type_table_io.cpp=
+
+⚠ *Known path issue:* the six secondary templates write to =projects/ores.refdata.api/= (a stale decommissioned directory), not =projects/ores.refdata/api/=. Git shows them as untracked, giving a false-clean diff. Compare manually against the hand-written files in =projects/ores.refdata/api/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Scope the diff and classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =domain= profile entry with template → output path table.
+- - [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — known path inconsistency for secondary domain templates.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the C++ test-data generator files for a domain entity?
 The =generator= profile generates the faker-based test-data generator header and implementation.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile generator
+./compass.sh codegen regenerate --component refdata-cpp --profile generator
 #+end_src
 
 Expected output (entity =rounding_type=, =component_include=refdata.api=):
@@ -42,7 +42,7 @@ Scope the diff and classify unexpected differences using the drift table in [[id
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =generator= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =generator= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =generator= profile via =compass codegen regenerate=, generating the per-entity test-data generator header and implementation. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -34,11 +33,11 @@ Scope the diff and classify unexpected differences using the drift table in [[id
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile generator=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.api/=, verify two files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_generator_layer_for_an_entity.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: CBD4498A-ED2D-4190-B600-7C2A72EB4385
+:END:
+#+title: How do I regenerate the C++ generator layer for an entity?
+#+description: Run the generator codegen profile to regenerate fake-data generator headers and implementations.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:generator:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the C++ test-data generator files for a domain entity?
+
+* Answer
+
+The =generator= profile generates the faker-based test-data generator header and implementation.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile generator
+#+end_src
+
+Expected output (entity =rounding_type=, =component_include=refdata.api=):
+- =projects/ores.refdata.api/include/ores.refdata.api/generators/rounding_type_generator.hpp=
+- =projects/ores.refdata.api/src/generators/rounding_type_generator.cpp=
+
+⚠ Both files write to =projects/ores.refdata.api/= (stale decommissioned directory). Compare manually against the hand-written files in =projects/ores.refdata/api/include/ores.refdata.api/generators/= and =projects/ores.refdata/api/src/generators/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Scope the diff and classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =generator= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
@@ -1,0 +1,47 @@
+:PROPERTIES:
+:ID: F4BA8D44-6940-487D-B38D-9DD27556B80A
+:END:
+#+title: How do I regenerate the NATS eventing layer for an entity?
+#+description: Run the nats-eventing codegen profile to regenerate event type headers for a domain entity.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:nats:eventing:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the NATS eventing event-type files for a domain entity?
+
+* Answer
+
+The =nats-eventing= profile generates the per-entity event type header in the api sub-component.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile nats-eventing
+#+end_src
+
+Expected output (entity =rounding_type=, =component_include=refdata.api=):
+- =projects/ores.refdata.api/include/ores.refdata.api/messaging/rounding_type_event.hpp=
+
+⚠ The file writes to =projects/ores.refdata.api/= (stale decommissioned directory). Compare manually against the hand-written file in =projects/ores.refdata/api/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-eventing= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the NATS eventing event-type files for a domain entity?
 The =nats-eventing= profile generates the per-entity event type header in the api sub-component.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile nats-eventing
+./compass.sh codegen regenerate --component refdata-cpp --profile nats-eventing
 #+end_src
 
 Expected output (entity =rounding_type=, =component_include=refdata.api=):
@@ -41,7 +41,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-eventing= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-eventing= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_eventing_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =nats-eventing= profile via =compass codegen regenerate=, generating the per-entity NATS event type header. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -33,11 +32,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile nats-eventing=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.api/=, verify one file per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the NATS message handler files for a domain entity?
 The =nats-handler= profile generates the per-entity NATS handler header and implementation in the core sub-component.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile nats-handler
+./compass.sh codegen regenerate --component refdata-cpp --profile nats-handler
 #+end_src
 
 Expected output (entity =rounding_type=, =component_core=refdata.core=):
@@ -42,7 +42,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-handler= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-handler= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =nats-handler= profile via =compass codegen regenerate=, generating the per-entity NATS message handler header and implementation. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -34,11 +33,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile nats-handler=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.core/=, verify two files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_nats_handler_layer_for_an_entity.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: B8F158A2-3ECF-44A8-94A2-259DF7A2AF70
+:END:
+#+title: How do I regenerate the NATS handler layer for an entity?
+#+description: Run the nats-handler codegen profile to regenerate the NATS message handler class for a domain entity.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:nats:handler:cpp:messaging:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the NATS message handler files for a domain entity?
+
+* Answer
+
+The =nats-handler= profile generates the per-entity NATS handler header and implementation in the core sub-component.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile nats-handler
+#+end_src
+
+Expected output (entity =rounding_type=, =component_core=refdata.core=):
+- =projects/ores.refdata.core/include/ores.refdata.core/messaging/rounding_type_handler.hpp=
+- =projects/ores.refdata.core/src/messaging/rounding_type_handler.cpp=
+
+⚠ Both files write to =projects/ores.refdata.core/= (stale decommissioned directory). Compare manually against hand-written files in =projects/ores.refdata/core/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =nats-handler= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =protocol= profile via =compass codegen regenerate=, generating per-entity NATS request and response struct headers. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -34,11 +33,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile protocol=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.api/=, verify two files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 6779B755-0A34-4E31-A274-8D9B77DFFB01
+:END:
+#+title: How do I regenerate the C++ protocol layer for an entity?
+#+description: Run the protocol codegen profile to regenerate NATS protocol structs for a domain entity.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:protocol:cpp:messaging:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the C++ NATS protocol files for a domain entity?
+
+* Answer
+
+The =protocol= profile generates the per-entity NATS request/response structs in the api sub-component.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile protocol
+#+end_src
+
+Expected output (entity =rounding_type=, =component_include=refdata.api=):
+- =projects/ores.refdata.api/include/ores.refdata.api/messaging/rounding_type_request.hpp=
+- =projects/ores.refdata.api/include/ores.refdata.api/messaging/rounding_type_response.hpp=
+
+⚠ Both files write to =projects/ores.refdata.api/= (stale decommissioned directory). Compare manually against hand-written files in =projects/ores.refdata/api/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =protocol= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_protocol_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the C++ NATS protocol files for a domain entity?
 The =protocol= profile generates the per-entity NATS request/response structs in the api sub-component.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile protocol
+./compass.sh codegen regenerate --component refdata-cpp --profile protocol
 #+end_src
 
 Expected output (entity =rounding_type=, =component_include=refdata.api=):
@@ -42,7 +42,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =protocol= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =protocol= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the Qt UI files for a domain entity?
 The =qt= profile generates per-entity Qt list, detail, history, and delegate headers and implementations.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile qt
+./compass.sh codegen regenerate --component refdata-cpp --profile qt
 #+end_src
 
 Expected output (entity =rounding_type=, component =ores.qt.refdata=):
@@ -52,7 +52,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =qt= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner (C++ profiles only; Qt path is correct).
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =qt= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner (C++ profiles only; Qt path is correct).

--- a/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =qt= profile via =compass codegen regenerate=, generating all twelve Qt UI files for an entity (list, detail, history, delegate, validator, view-widget — each as header and implementation). See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -44,11 +43,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile qt=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.qt/refdata/=, verify twelve files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_qt_ui_layer_for_an_entity.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: F77B0DF6-DA37-41BB-B4B6-D0F14F12A084
+:END:
+#+title: How do I regenerate the Qt UI layer for an entity?
+#+description: Run the qt codegen profile to regenerate all Qt UI headers and implementations for a domain entity.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:qt:ui:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the Qt UI files for a domain entity?
+
+* Answer
+
+The =qt= profile generates per-entity Qt list, detail, history, and delegate headers and implementations.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile qt
+#+end_src
+
+Expected output (entity =rounding_type=, component =ores.qt.refdata=):
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_list_window.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_list_window.cpp=
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_detail_window.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_detail_window.cpp=
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_history_window.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_history_window.cpp=
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_delegate.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_delegate.cpp=
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_validator.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_validator.cpp=
+- =projects/ores.qt/refdata/include/ores.qt.refdata/rounding_type_view_widget.hpp=
+- =projects/ores.qt/refdata/src/rounding_type_view_widget.cpp=
+
+Qt files write to =projects/ores.qt/refdata/= — this path is *correct* (not stale). Verify before and after diffs use this root.
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =qt= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner (C++ profiles only; Qt path is correct).

--- a/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =repository= profile via =compass codegen regenerate=, generating sqlgen entities, mappers, and CRUD repository header and implementation. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -38,11 +37,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile repository=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.core/=, verify six files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the C++ repository files (entity, mapper, repository) for a 
 The =repository= profile generates the sqlgen entity, mapper, and repository header/implementation pairs.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile repository
+./compass.sh codegen regenerate --component refdata-cpp --profile repository
 #+end_src
 
 Expected output (entity =rounding_type=, =component_core=refdata.core=):
@@ -46,7 +46,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =repository= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =repository= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_repository_layer_for_an_entity.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: 9B16B5F0-CBF5-4664-9637-8B9E74277C5D
+:END:
+#+title: How do I regenerate the C++ repository layer for an entity?
+#+description: Run the repository codegen profile to regenerate sqlgen entity, mapper, and repository files.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:repository:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the C++ repository files (entity, mapper, repository) for a domain entity?
+
+* Answer
+
+The =repository= profile generates the sqlgen entity, mapper, and repository header/implementation pairs.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile repository
+#+end_src
+
+Expected output (entity =rounding_type=, =component_core=refdata.core=):
+- =projects/ores.refdata.core/include/ores.refdata.core/repository/rounding_type_entity.hpp=
+- =projects/ores.refdata.core/src/repository/rounding_type_entity.cpp=
+- =projects/ores.refdata.core/include/ores.refdata.core/repository/rounding_type_mapper.hpp=
+- =projects/ores.refdata.core/src/repository/rounding_type_mapper.cpp=
+- =projects/ores.refdata.core/include/ores.refdata.core/repository/rounding_type_repository.hpp=
+- =projects/ores.refdata.core/src/repository/rounding_type_repository.cpp=
+
+⚠ All six files write to =projects/ores.refdata.core/= (stale decommissioned directory). Compare manually against hand-written files in =projects/ores.refdata/core/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =repository= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 40658FAC-7CB1-403F-B6C8-B259465F58E9
+:END:
+#+title: How do I regenerate the C++ service layer for an entity?
+#+description: Run the service codegen profile to regenerate the business-logic service header and implementation.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:service:cpp:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the C++ service files for a domain entity?
+
+* Answer
+
+The =service= profile generates the per-entity service header and implementation in the core sub-component.
+
+#+begin_src sh
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile service
+#+end_src
+
+Expected output (entity =rounding_type=, =component_core=refdata.core=):
+- =projects/ores.refdata.core/include/ores.refdata.core/service/rounding_type_service.hpp=
+- =projects/ores.refdata.core/src/service/rounding_type_service.cpp=
+
+⚠ Both files write to =projects/ores.refdata.core/= (stale decommissioned directory). Compare manually against hand-written files in =projects/ores.refdata/core/=. Tracked in [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]].
+
+Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =service= profile entry.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
@@ -21,7 +21,7 @@ How do I regenerate the C++ service files for a domain entity?
 The =service= profile generates the per-entity service header and implementation in the core sub-component.
 
 #+begin_src sh
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile service
+./compass.sh codegen regenerate --component refdata-cpp --profile service
 #+end_src
 
 Expected output (entity =rounding_type=, =component_core=refdata.core=):
@@ -42,7 +42,7 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =service= profile entry.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =service= profile entry.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — output location check; drift classification table.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — open path issue owner.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_service_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =service= profile via =compass codegen regenerate=, generating the per-entity business-logic service header and implementation. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] for the profile system.
 
 * Question
 
@@ -34,11 +33,11 @@ Classify unexpected differences using the drift table in [[id:F556E446-EB91-4656
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata-cpp --profile service=.
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.refdata.core/=, verify two files per entity, classify unexpected deltas per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 

--- a/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: C3E07D42-5B48-4566-AE67-6D20926B3376
+:END:
+#+title: How do I regenerate the SQL layer for an entity?
+#+description: Run the sql codegen profile for a single entity and validate the output against the repository.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:recipe:sql:regenerate:entity:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+(One- or two-sentence pointer to the component model and any knowledge
+doc this recipe relies on.)
+
+* Question
+
+How do I regenerate the SQL DDL files for a domain entity?
+
+* Answer
+
+The =sql= profile supports =domain_entity=, =junction=, =schema=, and =table= model types. For =refdata= entities use the =refdata= component (table models) or =refdata-cpp= (domain_entity models — also fires the SQL template).
+
+#+begin_src sh
+# For entities driven by table models (e.g. currency, country)
+./projects/ores.codegen/codegen.sh regenerate     --component refdata --profile sql
+
+# For domain_entity models (e.g. rounding_type, monetary_nature)
+./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile sql
+#+end_src
+
+Expected output (=refdata= component, entity =rounding_type=):
+- =projects/ores.sql/create/refdata/refdata_rounding_types_create.sql=
+- =projects/ores.sql/create/refdata/refdata_rounding_types_notify_trigger_create.sql=
+- =projects/ores.sql/drop/refdata/refdata_rounding_types_drop.sql=
+- =projects/ores.sql/drop/refdata/refdata_rounding_types_notify_trigger_drop.sql=
+
+No per-entity filter exists — scope the diff manually after the run:
+#+begin_src sh
+git diff -- projects/ores.sql/create/refdata/ projects/ores.sql/drop/refdata/
+git checkout HEAD -- projects/ores.sql/  # revert non-target entities
+#+end_src
+
+If the diff contains unexpected differences, classify each delta using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] before applying any fix.
+
+* Script
+
+(Pointer to the script or wrapper that does the work, if applicable.)
+
+* Tested by
+
+(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+
+* See also
+
+- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe for running all profiles.
+- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =sql= profile entry with template → output path table.
+- - [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]] — =refdata= and =refdata-cpp= component definitions.
+- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — drift classification table; output location check.
+- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — tracks open drift and path issues.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
@@ -22,10 +22,10 @@ The =sql= profile supports =domain_entity=, =junction=, =schema=, and =table= mo
 
 #+begin_src sh
 # For entities driven by table models (e.g. currency, country)
-./projects/ores.codegen/codegen.sh regenerate     --component refdata --profile sql
+./compass.sh codegen regenerate --component refdata --profile sql
 
 # For domain_entity models (e.g. rounding_type, monetary_nature)
-./projects/ores.codegen/codegen.sh regenerate     --component refdata-cpp --profile sql
+./compass.sh codegen regenerate --component refdata-cpp --profile sql
 #+end_src
 
 Expected output (=refdata= component, entity =rounding_type=):
@@ -52,8 +52,8 @@ If the diff contains unexpected differences, classify each delta using the drift
 
 * See also
 
-- - [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe for running all profiles.
-- - [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =sql= profile entry with template → output path table.
-- - [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]] — =refdata= and =refdata-cpp= component definitions.
-- - [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — drift classification table; output location check.
-- - [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — tracks open drift and path issues.
+- [[id:90BD6F75-FFCC-4D27-B92F-5EBCB923B4AB][How do I regenerate all layers for a domain entity?]] — master recipe for running all profiles.
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] — =sql= profile entry with template → output path table.
+- [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]] — =refdata= and =refdata-cpp= component definitions.
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] — drift classification table; output location check.
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — tracks open drift and path issues.

--- a/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
+++ b/doc/recipes/codegen/how_do_i_regenerate_the_sql_layer_for_an_entity.org
@@ -9,8 +9,7 @@
 #+created: 2026-06-26
 #+updated: 2026-06-26
 
-(One- or two-sentence pointer to the component model and any knowledge
-doc this recipe relies on.)
+Runs the =sql= profile via =compass codegen regenerate=, which writes SQL DDL create/drop scripts and notify-trigger scripts. See [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]] for the template list and [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]] for component-to-model-root mapping.
 
 * Question
 
@@ -37,18 +36,18 @@ Expected output (=refdata= component, entity =rounding_type=):
 No per-entity filter exists — scope the diff manually after the run:
 #+begin_src sh
 git diff -- projects/ores.sql/create/refdata/ projects/ores.sql/drop/refdata/
-git checkout HEAD -- projects/ores.sql/  # revert non-target entities
+git checkout HEAD -- projects/ores.sql/create/ projects/ores.sql/drop/  # revert non-target entities
 #+end_src
 
 If the diff contains unexpected differences, classify each delta using the drift table in [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]] before applying any fix.
 
 * Script
 
-(Pointer to the script or wrapper that does the work, if applicable.)
+=./compass.sh codegen regenerate --component refdata --profile sql= (table models) or =--component refdata-cpp --profile sql= (domain_entity models).
 
 * Tested by
 
-(How this recipe is exercised — CI workflow, manual smoke test, etc.)
+Manual: run the command, inspect =git diff -- projects/ores.sql/create/ projects/ores.sql/drop/=, verify four files per entity are updated, classify any unexpected delta per [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]].
 
 * See also
 


### PR DESCRIPTION
## Summary

- Adds 10 new codegen recipes covering the master flow and each of the 9 codegen profiles (sql, domain, generator, repository, service, protocol, nats-eventing, nats-handler, qt).
- All recipes use the new `compass codegen regenerate` interface introduced in latest main.
- Each recipe documents expected output files, known stale path issues (tracked in the C++ refactor story), and drift classification guidance.
- All 10 recipes are cross-linked to each other and to the entity commissioning reference, facet catalogue, and component catalogue via org-roam links.
- The `codegen.org` recipe index is updated to list all new recipes.
- Fixes a double-bullet formatting issue (`- -`) in see-also sections of all per-layer recipes.

## Test plan

- [ ] Site build passes (confirmed locally — exit code 0)
- [ ] `compass search "regenerate"` surfaces the new recipes
- [ ] Each recipe's command (`./compass.sh codegen regenerate --component ... --profile ...`) matches the compass codegen regenerate help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)