### PR TITLE
[compass] Fix review commands for Claude bot (issue-level) reviews

### DIFF
--- a/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/story.org
+++ b/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/story.org
@@ -32,12 +32,12 @@ or a human reviewer (review threads with inline comments).
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-06-17                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-26                               |
 
 * Acceptance
 
@@ -55,7 +55,7 @@ or a human reviewer (review threads with inline comments).
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:4829B4ED-97B9-409C-A7CF-26B592C6CADE][Implement: fix compass review commands for Claude-based code reviews]] | STARTED | 2026-06-26 | | Task for: Fix compass review workflow for Claude-based code reviews |
+| [[id:4829B4ED-97B9-409C-A7CF-26B592C6CADE][Implement: fix compass review commands for Claude-based code reviews]] | DONE | 2026-06-26 | 2026-06-26 | Task for: Fix compass review workflow for Claude-based code reviews |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/story.org
+++ b/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:review:ci:claude:github:sprint_21:v0:
 #+created: 2026-06-17
 #+updated: 2026-06-17
-#+environment:
+#+environment: merry_newton
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -32,7 +32,7 @@ or a human reviewer (review threads with inline comments).
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -55,7 +55,7 @@ or a human reviewer (review threads with inline comments).
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:4829B4ED-97B9-409C-A7CF-26B592C6CADE][Implement: fix compass review commands for Claude-based code reviews]] | STARTED | 2026-06-26 | | Task for: Fix compass review workflow for Claude-based code reviews |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/task_implement_fix-compass-review-for-claude.org
+++ b/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/task_implement_fix-compass-review-for-claude.org
@@ -26,11 +26,11 @@ compass review list, reply and resolve all work correctly when the automated rev
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:56F838D0-C23D-4343-B3DB-50ED9E99988A][Fix compass review workflow for Claude-based code reviews]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-26                               |
 
 * Acceptance
@@ -63,3 +63,5 @@ plan itself stays — it is the historical record of what we did.)
 | 1 | Extra round-trips per reply (informational) | compass_review.py | Decline | Acceptable for CLI tool; no change |
 
 * Result
+
+`compass review reply` now routes issue comment IDs to `issues/{pr}/comments` and review comment IDs to the review-comment reply API. `compass review resolve` correctly distinguishes Claude-only reviews (no resolvable thread) from reviews with unresolved threads. Bot comments are labelled `bot comment (issue-level)` in list output. PR #1338 merged 2026-06-26.

--- a/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/task_implement_fix-compass-review-for-claude.org
+++ b/doc/agile/versions/v0/sprint_21/fix_compass_review_for_claude/task_implement_fix-compass-review-for-claude.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 4829B4ED-97B9-409C-A7CF-26B592C6CADE
+:END:
+#+title: Task: Implement: fix compass review commands for Claude-based code reviews
+#+description: Task for: Fix compass review workflow for Claude-based code reviews
+#+type: task
+#+level: s1
+#+filetags: :fix_compass_review_for_claude:sprint_21:v0:
+#+owner: marco
+#+branch: feature/implement-fix-compass-review-for-claude
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+#+environment: merry_newton
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:56F838D0-C23D-4343-B3DB-50ED9E99988A][Fix compass review workflow for Claude-based code reviews]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+compass review list, reply and resolve all work correctly when the automated reviewer is the Claude bot (issue-level comments) rather than a human reviewer (GitHub review threads). The pr-address-review skill and runbook reflect the updated behaviour.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:56F838D0-C23D-4343-B3DB-50ED9E99988A][Fix compass review workflow for Claude-based code reviews]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-26                               |
+
+* Acceptance
+
+- compass review list --detail shows Claude bot comments with their issue comment IDs
+- compass review reply routes to the issue-comment API for bot comments and the review-comment API for human inline comments
+- compass review resolve handles the case where no resolvable threads exist (Claude-only reviews) without misleading output
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+| 1 | _comment_kind swallows non-404 errors (auth/rate-limit) | compass_review.py | Accept | Fixed 0fe6f55eb |
+| 1 | bot label misleads for non-review bots | compass_review.py | Accept | Fixed 0fe6f55eb — renamed to "bot comment (issue-level)" |
+| 1 | is_bot variable computed unnecessarily | compass_review.py | Accept | Fixed 0fe6f55eb — inlined |
+| 1 | Extra round-trips per reply (informational) | compass_review.py | Decline | Acceptable for CLI tool; no change |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/sprint.org
+++ b/doc/agile/versions/v0/sprint_21/sprint.org
@@ -117,7 +117,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 20.
 |-------+-------+-------+-----+-------------|
 | [[id:3A9DF70D-07F7-46A7-8219-57A024707B64][compass generate catalogue]] | BACKLOG | | | Auto-regenerate catalogue/index org files by scanning tagged org files. |
 | [[id:20998FA2-2073-4956-AE46-EFDD44C0CFD1][Fix orphan documents and tag taxonomy]] | BACKLOG | | | Fix orphaned docs in org-roam graph; create tag inventory; add compass tag validation. |
-| [[id:56F838D0-C23D-4343-B3DB-50ED9E99988A][Fix compass review workflow for Claude-based code reviews]] | BACKLOG | | | compass review reply and review resolve break with Claude bot reviews (issue comments, not review threads). |
+| [[id:56F838D0-C23D-4343-B3DB-50ED9E99988A][Fix compass review workflow for Claude-based code reviews]] | DONE | 2026-06-26 | 2026-06-26 | compass review reply and review resolve break with Claude bot reviews (issue comments, not review threads). |
 | [[id:14AD67D6-E981-45BC-B843-ABC6C9B4CC12][Compass environment improvements: port auto-assignment and fleet env-type display]] | STARTED | 2026-06-24 | | Auto-compute base port during env provision; show full/light type in compass fleet. |
 
 ** Infrastructure

--- a/projects/ores.compass/src/compass_review.py
+++ b/projects/ores.compass/src/compass_review.py
@@ -188,11 +188,10 @@ def _cmd_list(args, project_root):
 
     print("Conversation:\n" if conversation else "Conversation: (none)\n")
     for e in conversation:
-        is_bot = e["author"].endswith("[bot]")
         if e["kind"] == "review":
             kind = f"review summary ({e['state']})"
-        elif is_bot:
-            kind = "bot review (issue comment)"
+        elif e["author"].endswith("[bot]"):
+            kind = "bot comment (issue-level)"
         else:
             kind = "comment"
         when = (e["created_at"] or "")[:10]
@@ -206,22 +205,32 @@ def _cmd_list(args, project_root):
     return 0
 
 
+def _is_not_found(err):
+    """Return True iff ERR looks like a genuine 404 / not-found response."""
+    return bool(re.search(r"404|Not Found|not found", err, re.I))
+
+
 def _comment_kind(owner, repo, comment_id):
     """Return 'review' if comment_id is a PR review line comment,
-    'issue' if it is an issue-level conversation comment, or None if not found.
+    'issue' if it is an issue-level conversation comment, None if not found,
+    or raise RuntimeError on an unexpected API error (auth, rate-limit, …).
 
     Claude's automated reviews are posted as issue comments (not review
     threads), so their IDs are issue comment IDs and cannot be replied to
     via the review-comment reply API.
     """
-    rc, _out, _err = _run_gh([
+    rc, _out, err = _run_gh([
         "api", f"repos/{owner}/{repo}/pulls/comments/{comment_id}"])
     if rc == 0:
         return "review"
-    rc, _out, _err = _run_gh([
+    if not _is_not_found(err):
+        raise RuntimeError(err.strip() or "gh API error (review comment probe)")
+    rc, _out, err = _run_gh([
         "api", f"repos/{owner}/{repo}/issues/comments/{comment_id}"])
     if rc == 0:
         return "issue"
+    if not _is_not_found(err):
+        raise RuntimeError(err.strip() or "gh API error (issue comment probe)")
     return None
 
 
@@ -229,7 +238,11 @@ def _cmd_reply(args, project_root):
     owner, repo = _resolve_owner_repo(args, project_root)
     if owner is None:
         return 1
-    kind = _comment_kind(owner, repo, args.comment_id)
+    try:
+        kind = _comment_kind(owner, repo, args.comment_id)
+    except RuntimeError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
     if kind == "review":
         rc, out, err = _run_gh([
             "api",
@@ -308,8 +321,8 @@ def _cmd_resolve(args, project_root):
                        if rc2 == 0 else [])
         if bot_reviews:
             print(f"✅ No resolvable review threads on PR #{args.pr}. "
-                  f"{len(bot_reviews)} bot review comment(s) are issue-level "
-                  f"comments — they have no resolvable thread.")
+                  f"{len(bot_reviews)} bot comment(s) are issue-level "
+                  f"— they have no resolvable thread.")
         else:
             print(f"✅ No unresolved review threads on PR #{args.pr}.")
         return 0

--- a/projects/ores.compass/src/compass_review.py
+++ b/projects/ores.compass/src/compass_review.py
@@ -188,8 +188,13 @@ def _cmd_list(args, project_root):
 
     print("Conversation:\n" if conversation else "Conversation: (none)\n")
     for e in conversation:
-        kind = (f"review summary ({e['state']})" if e["kind"] == "review"
-                else "comment")
+        is_bot = e["author"].endswith("[bot]")
+        if e["kind"] == "review":
+            kind = f"review summary ({e['state']})"
+        elif is_bot:
+            kind = "bot review (issue comment)"
+        else:
+            kind = "comment"
         when = (e["created_at"] or "")[:10]
         print(f"#{e['id']}  {e['author']}  {when}  [{kind}]")
         _print_body(e["body"], args.detail)
@@ -201,20 +206,59 @@ def _cmd_list(args, project_root):
     return 0
 
 
+def _comment_kind(owner, repo, comment_id):
+    """Return 'review' if comment_id is a PR review line comment,
+    'issue' if it is an issue-level conversation comment, or None if not found.
+
+    Claude's automated reviews are posted as issue comments (not review
+    threads), so their IDs are issue comment IDs and cannot be replied to
+    via the review-comment reply API.
+    """
+    rc, _out, _err = _run_gh([
+        "api", f"repos/{owner}/{repo}/pulls/comments/{comment_id}"])
+    if rc == 0:
+        return "review"
+    rc, _out, _err = _run_gh([
+        "api", f"repos/{owner}/{repo}/issues/comments/{comment_id}"])
+    if rc == 0:
+        return "issue"
+    return None
+
+
 def _cmd_reply(args, project_root):
     owner, repo = _resolve_owner_repo(args, project_root)
     if owner is None:
         return 1
-    rc, out, err = _run_gh([
-        "api",
-        f"repos/{owner}/{repo}/pulls/{args.pr}/comments/"
-        f"{args.comment_id}/replies",
-        "--method", "POST", "-f", f"body={args.message}"])
-    if rc != 0:
-        print(err.strip() or "❌ gh api call failed.", file=sys.stderr)
-        return rc
-    reply = json.loads(out)
-    print(f"✅ Reply #{reply['id']} created: {reply.get('html_url', '')}")
+    kind = _comment_kind(owner, repo, args.comment_id)
+    if kind == "review":
+        rc, out, err = _run_gh([
+            "api",
+            f"repos/{owner}/{repo}/pulls/{args.pr}/comments/"
+            f"{args.comment_id}/replies",
+            "--method", "POST", "-f", f"body={args.message}"])
+        if rc != 0:
+            print(err.strip() or "❌ gh api call failed.", file=sys.stderr)
+            return rc
+        reply = json.loads(out)
+        print(f"✅ Reply #{reply['id']} created: {reply.get('html_url', '')}")
+    elif kind == "issue":
+        # Claude bot posts issue-level comments, not resolvable review threads.
+        # Post a new issue comment as the reply.
+        rc, out, err = _run_gh([
+            "api",
+            f"repos/{owner}/{repo}/issues/{args.pr}/comments",
+            "--method", "POST", "-f", f"body={args.message}"])
+        if rc != 0:
+            print(err.strip() or "❌ gh api call failed.", file=sys.stderr)
+            return rc
+        comment = json.loads(out)
+        print(f"✅ Comment #{comment['id']} posted: "
+              f"{comment.get('html_url', '')} "
+              f"(issue comment — not an inline thread reply)")
+    else:
+        print(f"❌ Comment #{args.comment_id} not found as a review comment "
+              f"or issue comment on PR #{args.pr}.", file=sys.stderr)
+        return 1
     return 0
 
 
@@ -257,7 +301,17 @@ def _cmd_resolve(args, project_root):
     if rc != 0:
         return rc
     if not threads:
-        print(f"✅ No unresolved review threads on PR #{args.pr}.")
+        rc2, conversation = _fetch_conversation(owner, repo, args.pr)
+        bot_reviews = ([e for e in conversation
+                        if e["kind"] == "comment"
+                        and e["author"].endswith("[bot]")]
+                       if rc2 == 0 else [])
+        if bot_reviews:
+            print(f"✅ No resolvable review threads on PR #{args.pr}. "
+                  f"{len(bot_reviews)} bot review comment(s) are issue-level "
+                  f"comments — they have no resolvable thread.")
+        else:
+            print(f"✅ No unresolved review threads on PR #{args.pr}.")
         return 0
 
     for t in threads:


### PR DESCRIPTION
## Summary

Since switching from Gemini to Claude for automated code reviews, `compass review reply` and `compass review resolve` have been broken:

- **`reply`** called the PR review-comment reply API (`/pulls/{pr}/comments/{id}/replies`), which returns HTTP 404 for issue comment IDs. Claude posts its reviews as issue-level PR comments, not as inline review threads.
- **`resolve`** reported `✅ No unresolved review threads` when Claude was the only reviewer — misleading, because it implies all threads closed when in fact no review threads were ever opened.

## Changes

- **`_comment_kind()`** (new helper): probes whether a comment ID is a review comment or an issue comment, allowing `reply` to route correctly.
- **`_cmd_reply`**: routes to `issues/{pr}/comments` (new issue comment) for bot issue comment IDs; retains the existing review-comment reply path for inline human review comments.
- **`_cmd_resolve`**: when no resolvable threads are found, checks for bot issue comments and emits a clear status instead of the misleading "no unresolved threads" message.
- **`_cmd_list`**: labels bot review comments as `bot review (issue comment)` in output.

## Test plan

- [ ] `compass review list <PR with Claude review> --detail` shows Claude's comment labelled `bot review (issue comment)`
- [ ] `compass review reply <PR> <claude-comment-id> "message"` posts successfully (no HTTP 404)
- [ ] `compass review resolve <PR with Claude-only review>` reports bot comment count, not misleading "no unresolved threads"
- [ ] `compass review reply <PR> <human-inline-comment-id> "message"` still works via the review-comment API
- [ ] Linux canary passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)