### PR TITLE
[ores.refdata] Sync messaging codegen for all refdata entities

### DIFF
--- a/doc/agile/versions/v0/sprint_21/commission_party_status/story.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/story.org
@@ -24,12 +24,12 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | STARTED                                |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
-| Now           | Not yet started.                       |
+| Now           | Messaging codegen sync in progress; Qt codegen, verify Qt, shell, CLI, manual, captures pending. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-05-29                               |
+| Next          | Complete messaging codegen sync; then Qt codegen sync. |
+| Last touched  | 2026-06-26                             |
 
 * Acceptance
 
@@ -41,9 +41,13 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 - Shell list command: implemented and working (new implementation).
 - Shell add command: implemented and working (new implementation).
 - Shell remove command: implemented and working (new implementation).
+- Shell history command: implemented and working (new implementation).
+- Shell help: implemented.
+- Shell commands call service via NATS (not direct repository access).
 - CLI list command: implemented and working (new implementation).
 - CLI add command: implemented and working (new implementation).
 - CLI remove command: implemented and working (new implementation).
+- CLI commands call service via NATS (not direct repository access).
 - Manual: entity chapter documents all Qt windows, shell, and CLI commands.
 - Backlog captures filed for Wt and HTTP support.
 - All regressions found are fixed inline or filed as captures.
@@ -59,8 +63,8 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 | [[id:4A3938FF-CFE0-4696-BB6B-8C4009FD428B][Implement CLI list/add/remove commands for party_status]] | BACKLOG | | | Add party_status support to ores.cli following the same pattern as countries and currencies: options struct, entity parser, and list/add/remove subcommands. |
 | [[id:6C764E76-A0D0-4DF1-81AB-2CA254CFC1A4][Write party_status chapter in user manual]] | BACKLOG | | | Add a dedicated party_status chapter to the Qt user manual covering the list window, detail dialog, history, delete, and the shell and CLI commands. |
 | [[id:ED6674DE-A7B1-4199-B9CC-50B064E81B8B][File backlog captures for party_status Wt and HTTP support]] | BACKLOG | | | Record the missing Wt web UI and HTTP REST endpoint for party_status as product-backlog captures so the gaps are tracked for future commissioning. |
-| [[id:408DA433-CD01-4050-A548-F01BC4BB7404][Sync SQL codegen for party_status]] | BACKLOG | | | Re-run SQL codegen for party_status; diff against repo; fix templates or repo to eliminate drift. |
-| [[id:94A50F97-A7FC-4486-BD0B-0FB305998C01][Sync C++ core codegen for party_status]] | BACKLOG | | | Re-run domain, repository, service, and generator profiles for party_status; diff against repo; fix templates to match code. |
-| [[id:7F64F55A-32BA-4774-8508-FF7F05FD984F][Sync C++ messaging codegen for party_status]] | BACKLOG | | | Re-run protocol, nats-eventing, and nats-handler profiles for party_status; diff against repo; fix templates to match code. |
+| [[id:408DA433-CD01-4050-A548-F01BC4BB7404][Sync SQL codegen for party_status]] | DONE | 2026-06-25 | 2026-06-25 | Re-run SQL codegen for party_status; diff against repo; fix templates or repo to eliminate drift. |
+| [[id:94A50F97-A7FC-4486-BD0B-0FB305998C01][Sync C++ core codegen for party_status]] | DONE | 2026-06-25 | 2026-06-25 | Re-run domain, repository, service, and generator profiles for party_status; diff against repo; fix templates to match code. |
+| [[id:7F64F55A-32BA-4774-8508-FF7F05FD984F][Sync C++ messaging codegen for party_status]] | STARTED | 2026-06-26 | | Re-run protocol, nats-eventing, and nats-handler profiles for party_status; diff against repo; fix templates to match code. |
 | [[id:6E67EFF3-D794-46D2-8D70-8216B1662659][Sync Qt codegen for party_status]] | BACKLOG | | | Re-run Qt profile for party_status; diff against repo; fix templates to match code. |
 | [[id:8388B86F-EEDF-4C5E-9B52-2CC8A3ABD796][Verify and fix party_status SQL DDL]] | BACKLOG | | | Verify party_status SQL DDL against the evaluation checklist criteria and fix any deviations. |

--- a/doc/agile/versions/v0/sprint_21/commission_party_status/task_implement_cli_party_status.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/task_implement_cli_party_status.org
@@ -40,6 +40,7 @@ Create the CLI support for party_status in projects/ores.cli — options header 
 - list subcommand implemented and working.
 - add subcommand implemented and working.
 - remove subcommand implemented and working.
+- All subcommands call the service via NATS (not direct repository access).
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_status/task_implement_shell_party_status.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/task_implement_shell_party_status.org
@@ -35,12 +35,13 @@ Create the party_status shell script set (list/get, add, remove, history, help) 
 
 * Acceptance
 
-- party_statuses/ directory created under the shell library.
+- party_statuses/ submenu registered in the REPL.
 - list (get) script implemented and working against a live environment.
 - add script implemented and working.
 - remove script implemented and working.
+- history script implemented and working.
 - help script implemented.
-- history script implemented.
+- All commands call the service via NATS (not direct repository access).
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_status/task_sync_cpp_messaging_codegen_party_status.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/task_sync_cpp_messaging_codegen_party_status.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_party_status:sprint_21:v0:
 #+owner: marco
 #+branch: feature/sync-cpp-messaging-codegen-party-status
-#+pr:
+#+pr: 1342
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
@@ -52,7 +52,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1342][#1342]] | [ores.refdata] Sync messaging codegen for all refdata entities |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/commission_party_status/task_sync_cpp_messaging_codegen_party_status.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/task_sync_cpp_messaging_codegen_party_status.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :commission_party_status:sprint_21:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/sync-cpp-messaging-codegen-party-status
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-25
 #+updated: 2026-06-25
-#+environment:
+#+environment: jolly_knuth
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8B3D478B-DD68-44B7-A8BF-DB50F76C9506][Commission: party_status]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ Ensure the C++ messaging codegen templates (protocol, nats-eventing, nats-handle
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:8B3D478B-DD68-44B7-A8BF-DB50F76C9506][Commission: party_status]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_21/commission_party_status/task_write_manual_party_status.org
+++ b/doc/agile/versions/v0/sprint_21/commission_party_status/task_write_manual_party_status.org
@@ -36,9 +36,9 @@ Document party_status fully in the user manual with a standalone chapter (parall
 * Acceptance
 
 - New manual chapter file created under doc/manual/user_guide/.
-- Chapter covers: concept, list window, detail dialog, history, delete.
-- Chapter covers shell list/add/remove commands.
-- Chapter covers CLI list/add/remove commands.
+- Chapter covers: concept (what and why), list window walkthrough, detail dialog (field-by-field), history, delete.
+- Chapter covers shell list/add/remove/history/help commands with examples.
+- Chapter covers CLI list/add/remove subcommands with flags.
 - Chapter linked from the manual table of contents.
 - Site builds cleanly with the new chapter.
 

--- a/doc/analysis/codegen-model-unification.org
+++ b/doc/analysis/codegen-model-unification.org
@@ -1,0 +1,299 @@
+:PROPERTIES:
+:ID: D2256981-78C5-4980-B488-CB4E16111A27
+:END:
+#+title: Codegen model unification analysis
+#+description: Analysis of the two parallel org-mode model types (entity vs table) used by ores.codegen, a complete inventory of refdata models, the six blockers to unification, and the recommended migration path.
+#+type: investigation
+#+level: cross
+#+filetags: :codegen:model:unification:investigation:
+#+created: 2026-06-26
+#+updated: 2026-06-26
+
+* Summary
+
+ORE Studio's [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] generates C++, SQL, and Qt
+artefacts from org-mode model files. Today the same logical entity is
+described by *two parallel org-mode model types*: a =domain_entity= file
+(=ores.refdata.<name>.org=) and, for some entities, a separate =table=
+file (=ores.refdata.<name>_table.org=). The two types are governed by
+the same conceptual schema (see the [[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][org entity meta model]] and the
+[[id:2A2E8B6D-179D-452C-9169-04E6BB46CC07][codegen input org-file schema reference]]) but are detected, parsed, and
+rendered through entirely separate code paths.
+
+This split creates three problems: *confusion* (two files of record per
+entity), *redundancy* (overlapping column and identity declarations),
+and a *live overwrite risk* (both files can target the identical SQL
+output path, and the entity pathway produces a structurally incomplete
+file).
+
+This document establishes the current state, inventories every model in
+=projects/ores.refdata/modeling/=, classifies each by type, enumerates
+the six concrete blockers to unification, and recommends a migration to a
+*single org file per entity* that carries all SQL, C++, and Qt sections.
+
+* Current State
+
+** Model type detection
+
+=generator.py= determines a model's type from its *filename*, in a fixed
+priority order. =get_model_type()= and =load_model()= are both keyed off
+filename suffixes:
+
+| Priority | Filename pattern                        | Detected type   | Loader                   | Root key                   |
+|----------+-----------------------------------------+-----------------+--------------------------+----------------------------|
+|        1 | =ores.*.org= (no recognised suffix)     | =domain_entity= | =load_org_model()=       | ={"domain_entity": {...}}= |
+|        2 | =*_table.org=                            | =table=         | =load_org_table_model()= | ={"table": {...}}=         |
+|        3 | =*_junction.org=                        | =junction=      | (table-family loader)    | ={"junction": {...}}=      |
+|        4 | =*_field_group.org=                     | =field_group=   |                          |                            |
+|        5 | =*_lookup_entity.org= / =*_entity.json=  | =schema=        |                          |                            |
+|        6 | service_registry, component, enum, data | (various)       |                          |                            |
+
+The first matching rule wins. A file named =ores.refdata.party_status.org=
+is therefore a =domain_entity=, while =ores.refdata.party_status_table.org=
+is a =table= — purely because of the =_table= suffix.
+
+** Profile dispatch by model type
+
+Which [[id:A8145FD7-0651-40FD-857E-BC37C9320020][facets]] fire is a function of the detected model type. The
+profile × model_type matrix, drawn from the facet catalogue:
+
+| Profile         | domain_entity | table | junction | schema | Notes                                                  |
+|-----------------+---------------+-------+----------+--------+--------------------------------------------------------|
+| =sql=           | yes (4 tmpl)  | yes   | yes      | yes    | 4 templates on entity; 1 each on table/junction/schema |
+| =domain=        | yes           | no    | no       | yes    | skips table and junction                               |
+| =generator=     | yes           | no    | no       | yes    |                                                        |
+| =repository=    | yes           | no    | no       | yes    |                                                        |
+| =service=       | yes           | no    | no       | yes    |                                                        |
+| =protocol=      | yes           | no    | no       | yes    |                                                        |
+| =nats-eventing= | yes           | no    | no       | yes    |                                                        |
+| =nats-handler=  | yes           | no    | no       | yes    |                                                        |
+| =qt=            | yes (12 tmpl) | no    | no       | no     | fires on domain_entity ONLY                            |
+| =all= (composite)| yes          | no    | no       | no     | explicitly guarded: refuses =table= and =schema=       |
+
+The =sql= profile fires on every type. The C++ and messaging profiles
+(=domain=, =generator=, =repository=, =service=, =protocol=,
+=nats-eventing=, =nats-handler=) fire only on =domain_entity= and
+=schema=, skipping =table= and =junction= entirely. The =qt= profile
+fires on =domain_entity= only. The composite =--profile all= is
+explicitly guarded to refuse =table= and =schema= types.
+
+** Component split
+
+The two file types are discovered by two different [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][components]]:
+
+- =refdata= — discovers =*_table.org= and =*_junction.org= files, then
+  dispatches SQL-only profiles.
+- =refdata-cpp= — discovers =ores.refdata.*.org= entity files, then
+  dispatches C++ and messaging profiles.
+
+This split exists *only because the two file types are physically
+separate*. The discovery globs are disjoint by construction.
+
+** Legacy JSON models
+
+No JSON models remain in =projects/ores.refdata/=. The =models_dir=
+config entries in the [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][component catalogue]] for both =refdata= and
+=refdata-cpp= point to non-existent directories. They are vestigial
+after the org migration and are dead code.
+
+* Model Inventory
+
+Complete inventory of =projects/ores.refdata/modeling/=, classified by
+model type. See the [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][entity coverage matrix]] for the corresponding
+generation coverage per layer.
+
+** =ores.codegen.entity= — 27 files (C++ + SQL + Qt capable)
+
+*Dual-file entities* — also have a =_table.org= counterpart, so SQL
+generation is split across two files:
+
+| book_status          | contact_type    | country         |
+| currency_market_tier | monetary_nature | party_id_scheme |
+| party_status         | party_type      | rounding_type   |
+
+*Entity-only* — no =_table.org=; SQL is generated by
+=sql_schema_domain_entity_create.mustache= from this file, or SQL is not
+yet generated:
+
+| book                  | business_unit                    | cds_convention             |
+| counterparty          | counterparty_contact_information | counterparty_identifier    |
+| deposit_convention    | fra_convention                   | fx_convention              |
+| ibor_index_convention | ois_convention                   | overnight_index_convention |
+| party                 | party_contact_information        | party_identifier           |
+| portfolio             | swap_convention                  | zero_convention            |
+
+** =ores.codegen.table= — 11 files (SQL-only)
+
+*Dual-file* — paired with an entity file:
+
+| book_status          | contact_type    | country         |
+| currency_market_tier | monetary_nature | party_id_scheme |
+| party_status         | party_type      | rounding_type   |
+
+*Table-only* — no entity counterpart; SQL-only, no C++ or Qt:
+
+| currency | purpose_type |
+
+** =ores.codegen.junction= — 3 files
+
+| party_counterparty_junction | party_country_junction | party_currency_junction |
+
+** =ores.codegen.module= — 1 file
+
+=ores.refdata.module= — index only; skipped by the generator.
+
+** Not processed by the generator — 1 file
+
+=component_overview.org=.
+
+* The Duplication Problem
+
+** The SQL overwrite risk
+
+Both =ores.refdata.party_status.org= (a =domain_entity=) and
+=ores.refdata.party_status_table.org= (a =table=) target the *identical
+output path*:
+
+#+begin_src text
+projects/ores.sql/create/refdata/refdata_party_statuses_create.sql
+#+end_src
+
+The files on disk carry =Template: sql_schema_create.mustache= — the
+table pathway. Running =--profile sql= on the =refdata-cpp= component,
+which discovers entity org files, would overwrite this output with the
+structurally incomplete =sql_schema_domain_entity_create.mustache=
+output. The entity file's SQL template cannot generate the validation
+function body — only its drop stub, via paste-marker
+=5E47F108-1350-4540-B3C2-E83DD5379B2D=.
+
+The result is a silent regression: a valid SQL artefact replaced with one
+that cannot enforce the entity's validation contract.
+
+** Why the two templates are not interchangeable
+
+| Concern             | =sql_schema_create.mustache= (table)           | =sql_schema_domain_entity_create.mustache= (entity) |
+|---------------------+------------------------------------------------+-----------------------------------------------------|
+| Root key            | =table=                                        | =domain_entity=                                     |
+| Validation function | full body (=table.validation_fn.tenant_scope=) | drop stub only (paste-marker)                       |
+| Insert trigger      | =table.insert_trigger.validations[]=           | not represented                                     |
+| Coding scheme       | =table.coding_scheme=                          | not represented                                     |
+| Tenancy             | =table.has_tenant_id=                          | derived, partial                                    |
+
+The table template consumes a *richer* data shape than the entity
+template can supply. No single template currently handles both richness
+levels.
+
+* Blockers to Unification
+
+1. *Two incompatible SQL templates with divergent data shapes.*
+   =sql_schema_create.mustache= consumes =table.validation_fn.tenant_scope=,
+   =table.insert_trigger.validations[]=, =table.coding_scheme=, and
+   =table.has_tenant_id=. =sql_schema_domain_entity_create.mustache=
+   consumes the =domain_entity= root key and paste-marker fragments. No
+   single template currently handles both richness levels.
+
+2. *=get_model_type()= and =load_model()= are hard-coupled to filename
+   suffixes.* Merging requires detection based on =#+type:= frontmatter
+   rather than filename patterns, plus a unified parse path.
+
+3. *Entirely separate parsers.* =load_org_table_model()= and
+   =load_org_model()= share no code. The =* Validation function= and
+   =* Insert trigger= sections are not parsed by =load_org_model()= at
+   all.
+
+4. *The =refdata= vs =refdata-cpp= component split relies on the two file
+   types being separate.* Unification collapses this into one component
+   with one discovery glob.
+
+5. *SQL-only entities must remain expressible.* =currency= and
+   =purpose_type= have no C++ layer. A unified schema needs
+   =#+sql_only: true= (or equivalent) so the generator suppresses C++
+   profile dispatch for those entities.
+
+6. *The =* C++ / ** Qt= subsection is mandatory in the current
+   =load_org_model()= preprocessing path.* Roughly 200 lines of field
+   derivation assume a C++ context. Making all C++ fields optional
+   requires significant defensive template logic, or an explicit
+   =#+has_qt: false= guard.
+
+* Target State
+
+A single =ores.codegen.entity= file per entity, containing all SQL, C++,
+and Qt sections. Concretely:
+
+- The table-specific sections move into the entity file schema:
+  =* Validation function=, =* Insert trigger / ** Validations=,
+  =#+has_tenant_id=, =#+coding_scheme=, and =#+image_id=.
+- The =refdata= and =refdata-cpp= component entries in the
+  [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][component catalogue]] merge into one component with one discovery glob.
+- The =ores.codegen.table= type is retired. The 11 =*_table.org= files
+  are migrated into their entity counterparts (or, for table-only
+  entities, into new =sql_only= entity files).
+- A =#+sql_only: true= flag handles SQL-only entities (=currency=,
+  =purpose_type=), suppressing C++ and Qt profile dispatch.
+- The SQL overwrite risk is eliminated: one file, one SQL output path,
+  one template capable of the full validation-function and insert-trigger
+  body.
+
+The unified file schema is governed by the [[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][org entity meta model]] and
+the [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][variability (profile) metamodel]], with =sql_only= and =has_qt= as
+new variability points.
+
+* Migration Path
+
+The recommended order minimises overwrite risk during the transition and
+keeps the generator runnable at each step.
+
+1. *Detection by frontmatter.* Change =get_model_type()= to read
+   =#+type:= rather than the filename suffix. Keep the filename-suffix
+   fallback temporarily so existing files still resolve. This unblocks
+   blocker 2 without moving any content.
+
+2. *Unify the SQL template.* Extend
+   =sql_schema_domain_entity_create.mustache= (or fold both into a single
+   template) so the =domain_entity= data shape carries the full
+   validation-function body and insert-trigger validations — sourced from
+   the migrated sections, not the paste-marker stub. This retires the
+   distinction at the template layer (blocker 1).
+
+3. *Merge the parsers.* Teach =load_org_model()= to parse the
+   =* Validation function= and =* Insert trigger= sections, and to
+   populate =has_tenant_id=, =coding_scheme=, and =image_id=. Reuse the
+   logic from =load_org_table_model()=; then delete the table loader
+   (blocker 3).
+
+4. *Add the variability guards.* Introduce =#+sql_only: true= and
+   =#+has_qt: false=. Make C++ and Qt field derivation conditional on
+   these flags so SQL-only entities and C++-without-Qt entities are
+   expressible (blockers 5 and 6).
+
+5. *Migrate content, one entity at a time.* For each of the 9 dual-file
+   entities, move the =_table.org= sections into the entity file, verify
+   the generated SQL is byte-identical to the table-pathway output, then
+   delete the =_table.org= file. For the 2 table-only entities
+   (=currency=, =purpose_type=), create =sql_only= entity files and
+   delete the table files. Use the [[id:897A7156-504D-4581-AD4C-026D643C0838][domain entity evaluation checklist]]
+   and the [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][entity commissioning process]] to validate each migrated
+   entity.
+
+6. *Collapse the components.* Merge =refdata= and =refdata-cpp= into one
+   component with a single discovery glob over =ores.refdata.*.org=
+   (excluding junctions and the module index). Remove the dead
+   =models_dir= entries (blocker 4).
+
+7. *Retire the table type.* Once no =*_table.org= files remain, remove the
+   =table= branch from =get_model_type()=, =load_model()=, and the profile
+   matrix. Junctions remain a distinct type and are out of scope for this
+   merge.
+
+* See also
+
+- [[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][Org entity meta model]]
+- [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]]
+- [[id:A8145FD7-0651-40FD-857E-BC37C9320020][Facet catalogue]]
+- [[id:B3CBBDED-7CD9-423B-94D8-F5C4C0488CEA][Component catalogue]]
+- [[id:2A2E8B6D-179D-452C-9169-04E6BB46CC07][Codegen input org-file schema reference]]
+- [[id:F556E446-EB91-4656-BEDC-15AE0F7B5ECD][Entity commissioning process reference]]
+- [[id:897A7156-504D-4581-AD4C-026D643C0838][Domain entity evaluation checklist]]
+- [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][Entity coverage matrix]]
+- [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model (Profile Metamodel)]]

--- a/doc/analysis/codegen-model-unification.org
+++ b/doc/analysis/codegen-model-unification.org
@@ -89,6 +89,31 @@ The two file types are discovered by two different [[id:B3CBBDED-7CD9-423B-94D8-
 This split exists *only because the two file types are physically
 separate*. The discovery globs are disjoint by construction.
 
+** Component field migration (partial)
+
+Entity files declare which API component they belong to via a field in
+the =* C++ / ** Flags= property drawer. The schema for this field has
+changed:
+
+| Era    | Fields                                          | Status     |
+|--------+-------------------------------------------------+------------|
+| Legacy | =:component_include:= and =:component_core:=    | Deprecated |
+| Current| =:subcomponent: api=                            | Active     |
+
+=generator.py= now requires =:subcomponent:= to be present in order to
+dispatch messaging profiles. As of the main branch, at least one entity
+(=book_status=) reached a transitional state where all three fields
+coexist — both the deprecated pair and the new field — because separate
+PRs applied the migration inconsistently. The deprecated fields are
+silently ignored by the generator once =:subcomponent:= is present, but
+they represent schema debt and should be removed.
+
+A scan for remaining legacy fields:
+
+#+begin_src sh
+grep -rl "component_include\|component_core" projects/ores.refdata/modeling/
+#+end_src
+
 ** Legacy JSON models
 
 No JSON models remain in =projects/ores.refdata/=. The =models_dir=

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_changed_event.hpp
@@ -20,23 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_BOOK_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_BOOK_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that book data has changed.
  *
- * This event is published when any book entity is created, updated, or
- * deleted in the database. Subscribers can use the timestamp to query for
- * changes since that point.
+ * Published when any book entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct book_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed book UUIDs (as strings).
+     */
+    std::vector<std::string> book_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -44,9 +54,13 @@ struct book_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for book_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::book_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.book_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.book_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_status_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_status_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_BOOK_STATUS_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_BOOK_STATUS_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that book status data has changed.
+ *
+ * Published when any book status entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct book_status_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed book status codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for book_status_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::book_status_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.book_status_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/business_unit_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/business_unit_changed_event.hpp
@@ -20,23 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_BUSINESS_UNIT_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_BUSINESS_UNIT_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that business unit data has changed.
  *
- * This event is published when any business unit entity is created,
- * updated, or deleted in the database. Subscribers can use the timestamp
- * to query for changes since that point.
+ * Published when any business unit entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct business_unit_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed business unit UUIDs (as strings).
+     */
+    std::vector<std::string> business_unit_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -44,9 +54,13 @@ struct business_unit_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for business_unit_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::business_unit_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.business_unit_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.business_unit_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/cds_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/cds_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_CDS_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_CDS_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that cds convention data has changed.
+ *
+ * Published when any cds convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct cds_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed cds convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for cds_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::cds_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.cds_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/contact_type_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/contact_type_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_CONTACT_TYPE_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_CONTACT_TYPE_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that contact type data has changed.
+ *
+ * Published when any contact type entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct contact_type_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed contact type codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for contact_type_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::contact_type_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.contact_type_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_changed_event.hpp
@@ -20,23 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that counterparty data has changed.
  *
- * This event is published when any counterparty entity is created, updated, or
- * deleted in the database. Subscribers can use the timestamp to query for
- * changes since that point.
+ * Published when any counterparty entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct counterparty_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed counterparty UUIDs (as strings).
+     */
+    std::vector<std::string> counterparty_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -44,9 +54,13 @@ struct counterparty_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for counterparty_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::counterparty_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.counterparty_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.counterparty_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_contact_information_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_contact_information_changed_event.hpp
@@ -20,19 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that counterparty contact information has changed.
+ * @brief Domain event indicating that counterparty contact information data has changed.
+ *
+ * Published when any counterparty contact information entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct counterparty_contact_information_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed counterparty contact information UUIDs (as strings).
+     */
+    std::vector<std::string> counterparty_contact_information_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -40,7 +54,10 @@ struct counterparty_contact_information_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for counterparty_contact_information_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::counterparty_contact_information_changed_event> {
     static constexpr std::string_view name =
         "ores.refdata.counterparty_contact_information_changed";

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_identifier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_identifier_changed_event.hpp
@@ -20,19 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_IDENTIFIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_IDENTIFIER_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that counterparty identifier data has changed.
+ *
+ * Published when any counterparty identifier entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct counterparty_identifier_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed counterparty identifier UUIDs (as strings).
+     */
+    std::vector<std::string> counterparty_identifier_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -40,9 +54,13 @@ struct counterparty_identifier_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for counterparty_identifier_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::counterparty_identifier_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.counterparty_identifier_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.counterparty_identifier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/currency_market_tier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/currency_market_tier_changed_event.hpp
@@ -20,35 +20,27 @@
 #ifndef ORES_REFDATA_API_EVENTING_CURRENCY_MARKET_TIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_CURRENCY_MARKET_TIER_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that currency market tier data has changed.
  *
- * This event is published when any currency market tier entity is created,
- * updated, or deleted in the database. Subscribers can use the timestamp
- * to query for changes since that point.
+ * Published when any currency market tier entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct currency_market_tier_changed_event final {
     /**
      * @brief The timestamp of when the change occurred (in UTC).
-     *
-     * Clients can use this timestamp to query the database for entities
-     * that have changed since this point.
      */
     std::chrono::system_clock::time_point timestamp;
 
     /**
-     * @brief Codes of currency market tiers that changed.
-     *
-     * Contains the codes (e.g., "g10", "emerging") of currency market
-     * tiers that were created, updated, or deleted. May contain multiple
-     * codes for batch operations.
+     * @brief Changed currency market tier codes.
      */
     std::vector<std::string> codes;
 
@@ -65,9 +57,10 @@ namespace ores::eventing::domain {
 /**
  * @brief Event traits specialization for currency_market_tier_changed_event.
  */
-template <>
+template<>
 struct event_traits<ores::refdata::eventing::currency_market_tier_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.currency_market_tier_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.currency_market_tier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/deposit_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/deposit_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_DEPOSIT_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_DEPOSIT_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that deposit convention data has changed.
+ *
+ * Published when any deposit convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct deposit_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed deposit convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for deposit_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::deposit_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.deposit_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/fra_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/fra_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_FRA_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_FRA_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that fra convention data has changed.
+ *
+ * Published when any fra convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct fra_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed fra convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for fra_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::fra_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.fra_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/fx_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/fx_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_FX_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_FX_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that fx convention data has changed.
+ *
+ * Published when any fx convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct fx_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed fx convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for fx_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::fx_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.fx_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/ibor_index_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/ibor_index_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_IBOR_INDEX_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_IBOR_INDEX_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that ibor index convention data has changed.
+ *
+ * Published when any ibor index convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct ibor_index_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed ibor index convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for ibor_index_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::ibor_index_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.ibor_index_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/monetary_nature_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/monetary_nature_changed_event.hpp
@@ -20,35 +20,27 @@
 #ifndef ORES_REFDATA_API_EVENTING_MONETARY_NATURE_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_MONETARY_NATURE_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that currency asset class data has changed.
+ * @brief Domain event indicating that monetary nature data has changed.
  *
- * This event is published when any currency asset class entity is created,
- * updated, or deleted in the database. Subscribers can use the timestamp
- * to query for changes since that point.
+ * Published when any monetary nature entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct monetary_nature_changed_event final {
     /**
      * @brief The timestamp of when the change occurred (in UTC).
-     *
-     * Clients can use this timestamp to query the database for entities
-     * that have changed since this point.
      */
     std::chrono::system_clock::time_point timestamp;
 
     /**
-     * @brief Codes of currency asset classes that changed.
-     *
-     * Contains the codes (e.g., "fiat", "commodity") of currency asset
-     * classes that were created, updated, or deleted. May contain multiple
-     * codes for batch operations.
+     * @brief Changed monetary nature codes.
      */
     std::vector<std::string> codes;
 
@@ -65,9 +57,10 @@ namespace ores::eventing::domain {
 /**
  * @brief Event traits specialization for monetary_nature_changed_event.
  */
-template <>
+template<>
 struct event_traits<ores::refdata::eventing::monetary_nature_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.monetary_nature_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.monetary_nature_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/ois_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/ois_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_OIS_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_OIS_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that ois convention data has changed.
+ *
+ * Published when any ois convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct ois_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed ois convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for ois_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::ois_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.ois_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/overnight_index_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/overnight_index_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_OVERNIGHT_INDEX_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_OVERNIGHT_INDEX_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that overnight index convention data has changed.
+ *
+ * Published when any overnight index convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct overnight_index_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed overnight index convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for overnight_index_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::overnight_index_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.overnight_index_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_changed_event.hpp
@@ -20,23 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that party data has changed.
  *
- * This event is published when any party entity is created, updated, or
- * deleted in the database. Subscribers can use the timestamp to query for
- * changes since that point.
+ * Published when any party entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct party_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed party UUIDs (as strings).
+     */
+    std::vector<std::string> party_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -44,9 +54,13 @@ struct party_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for party_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::party_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.party_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.party_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_contact_information_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_contact_information_changed_event.hpp
@@ -20,19 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that party contact information has changed.
+ * @brief Domain event indicating that party contact information data has changed.
+ *
+ * Published when any party contact information entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct party_contact_information_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed party contact information UUIDs (as strings).
+     */
+    std::vector<std::string> party_contact_information_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -40,9 +54,13 @@ struct party_contact_information_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for party_contact_information_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::party_contact_information_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.party_contact_information_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.party_contact_information_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_id_scheme_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_id_scheme_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_PARTY_ID_SCHEME_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_PARTY_ID_SCHEME_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that party id scheme data has changed.
+ *
+ * Published when any party id scheme entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct party_id_scheme_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed party id scheme codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for party_id_scheme_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::party_id_scheme_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.party_id_scheme_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_identifier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_identifier_changed_event.hpp
@@ -20,19 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_IDENTIFIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_IDENTIFIER_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that party identifier data has changed.
+ *
+ * Published when any party identifier entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct party_identifier_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed party identifier UUIDs (as strings).
+     */
+    std::vector<std::string> party_identifier_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -40,9 +54,13 @@ struct party_identifier_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for party_identifier_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::party_identifier_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.party_identifier_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.party_identifier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_status_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_status_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_PARTY_STATUS_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_PARTY_STATUS_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that party status data has changed.
+ *
+ * Published when any party status entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct party_status_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed party status codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for party_status_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::party_status_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.party_status_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_type_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_type_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_PARTY_TYPE_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_PARTY_TYPE_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that party type data has changed.
+ *
+ * Published when any party type entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct party_type_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed party type codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for party_type_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::party_type_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.party_type_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/portfolio_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/portfolio_changed_event.hpp
@@ -20,23 +20,33 @@
 #ifndef ORES_REFDATA_API_EVENTING_PORTFOLIO_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PORTFOLIO_CHANGED_EVENT_HPP
 
-#include "ores.eventing.api/domain/event_traits.hpp"
 #include <chrono>
-#include <string>
 #include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that portfolio data has changed.
  *
- * This event is published when any portfolio entity is created, updated, or
- * deleted in the database. Subscribers can use the timestamp to query for
- * changes since that point.
+ * Published when any portfolio entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct portfolio_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
     std::chrono::system_clock::time_point timestamp;
-    std::vector<std::string> ids;
+
+    /**
+     * @brief Changed portfolio UUIDs (as strings).
+     */
+    std::vector<std::string> portfolio_ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
     std::string tenant_id;
 };
 
@@ -44,9 +54,13 @@ struct portfolio_changed_event final {
 
 namespace ores::eventing::domain {
 
-template <>
+/**
+ * @brief Event traits specialization for portfolio_changed_event.
+ */
+template<>
 struct event_traits<ores::refdata::eventing::portfolio_changed_event> {
-    static constexpr std::string_view name = "ores.refdata.portfolio_changed";
+    static constexpr std::string_view name =
+        "ores.refdata.portfolio_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/rounding_type_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/rounding_type_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_ROUNDING_TYPE_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_ROUNDING_TYPE_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that rounding type data has changed.
+ *
+ * Published when any rounding type entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct rounding_type_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed rounding type codes.
+     */
+    std::vector<std::string> codes;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for rounding_type_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::rounding_type_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.rounding_type_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/swap_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/swap_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_SWAP_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_SWAP_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that swap convention data has changed.
+ *
+ * Published when any swap convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct swap_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed swap convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for swap_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::swap_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.swap_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/zero_convention_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/zero_convention_changed_event.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_EVENTING_ZERO_CONVENTION_CHANGED_EVENT_HPP
+#define ORES_REFDATA_API_EVENTING_ZERO_CONVENTION_CHANGED_EVENT_HPP
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include "ores.eventing.api/domain/event_traits.hpp"
+
+namespace ores::refdata::eventing {
+
+/**
+ * @brief Domain event indicating that zero convention data has changed.
+ *
+ * Published when any zero convention entity is created, updated, or
+ * deleted. Subscribers use the timestamp to query for changes since that point.
+ */
+struct zero_convention_changed_event final {
+    /**
+     * @brief The timestamp of when the change occurred (in UTC).
+     */
+    std::chrono::system_clock::time_point timestamp;
+
+    /**
+     * @brief Changed zero convention codes.
+     */
+    std::vector<std::string> ids;
+
+    /**
+     * @brief The tenant that owns the changed entity.
+     */
+    std::string tenant_id;
+};
+
+}
+
+namespace ores::eventing::domain {
+
+/**
+ * @brief Event traits specialization for zero_convention_changed_event.
+ */
+template<>
+struct event_traits<ores::refdata::eventing::zero_convention_changed_event> {
+    static constexpr std::string_view name =
+        "ores.refdata.zero_convention_changed";
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/book_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/book_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_BOOK_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_BOOK_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_BOOK_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_BOOK_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/book.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/book.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_books_request {
     using response_type = struct get_books_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.books.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.books.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_books_response {
     std::vector<ores::refdata::domain::book> books;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_book_request {
     using response_type = struct save_book_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.books.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.books.save";
     ores::refdata::domain::book data;
+
+    static save_book_request from(ores::refdata::domain::book v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_book_response {
@@ -51,7 +60,8 @@ struct save_book_response {
 
 struct delete_book_request {
     using response_type = struct delete_book_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.books.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.books.delete";
     std::vector<std::string> ids;
 };
 
@@ -62,12 +72,13 @@ struct delete_book_response {
 
 struct get_book_history_request {
     using response_type = struct get_book_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.books.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.books.history";
     std::string id;
 };
 
 struct get_book_history_response {
-    std::vector<ores::refdata::domain::book> books;
+    std::vector<ores::refdata::domain::book> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/book_status_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/book_status_protocol.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_REFDATA_API_MESSAGING_BOOK_STATUS_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_BOOK_STATUS_PROTOCOL_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "ores.refdata.api/domain/book_status.hpp"
@@ -30,6 +31,8 @@ struct get_book_statuses_request {
     using response_type = struct get_book_statuses_response;
     static constexpr std::string_view nats_subject =
         "refdata.v1.book_statuses.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_book_statuses_response {
@@ -44,6 +47,10 @@ struct save_book_status_request {
     static constexpr std::string_view nats_subject =
         "refdata.v1.book_statuses.save";
     ores::refdata::domain::book_status data;
+
+    static save_book_status_request from(ores::refdata::domain::book_status v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_book_status_response {
@@ -71,7 +78,7 @@ struct get_book_status_history_request {
 };
 
 struct get_book_status_history_response {
-    std::vector<ores::refdata::domain::book_status> statuses;
+    std::vector<ores::refdata::domain::book_status> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/business_unit_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/business_unit_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_BUSINESS_UNIT_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_BUSINESS_UNIT_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/business_unit.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/business_unit.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_business_units_request {
     using response_type = struct get_business_units_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.business-units.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.business_units.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_business_units_response {
     std::vector<ores::refdata::domain::business_unit> business_units;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_business_unit_request {
     using response_type = struct save_business_unit_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.business-units.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.business_units.save";
     ores::refdata::domain::business_unit data;
+
+    static save_business_unit_request from(ores::refdata::domain::business_unit v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_business_unit_response {
@@ -51,7 +60,8 @@ struct save_business_unit_response {
 
 struct delete_business_unit_request {
     using response_type = struct delete_business_unit_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.business-units.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.business_units.delete";
     std::vector<std::string> ids;
 };
 
@@ -62,14 +72,15 @@ struct delete_business_unit_response {
 
 struct get_business_unit_history_request {
     using response_type = struct get_business_unit_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.business-units.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.business_units.history";
     std::string id;
 };
 
 struct get_business_unit_history_response {
+    std::vector<ores::refdata::domain::business_unit> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::business_unit> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/cds_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/cds_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/cds_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/cds_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_cds_conventions_request {
     using response_type = struct get_cds_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.cds_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_cds_conventions_response {
     std::vector<ores::refdata::domain::cds_convention> cds_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_cds_convention_request {
     using response_type = struct save_cds_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.cds_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.save";
     ores::refdata::domain::cds_convention data;
+
+    static save_cds_convention_request from(ores::refdata::domain::cds_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_cds_convention_response {
@@ -51,8 +60,9 @@ struct save_cds_convention_response {
 
 struct delete_cds_convention_request {
     using response_type = struct delete_cds_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.cds_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_cds_convention_response {
@@ -62,12 +72,13 @@ struct delete_cds_convention_response {
 
 struct get_cds_convention_history_request {
     using response_type = struct get_cds_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.cds_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.history";
     std::string id;
 };
 
 struct get_cds_convention_history_response {
-    std::vector<ores::refdata::domain::cds_convention> cds_conventions;
+    std::vector<ores::refdata::domain::cds_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/contact_type_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/contact_type_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_CONTACT_TYPE_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_CONTACT_TYPE_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/contact_type.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/contact_type.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_contact_types_request {
     using response_type = struct get_contact_types_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.contact-types.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.contact_types.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_contact_types_response {
-    std::vector<ores::refdata::domain::contact_type> contact_types;
+    std::vector<ores::refdata::domain::contact_type> types;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_contact_type_request {
     using response_type = struct save_contact_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.contact-types.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.contact_types.save";
     ores::refdata::domain::contact_type data;
+
+    static save_contact_type_request from(ores::refdata::domain::contact_type v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_contact_type_response {
@@ -51,8 +60,9 @@ struct save_contact_type_response {
 
 struct delete_contact_type_request {
     using response_type = struct delete_contact_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.contact-types.delete";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.contact_types.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_contact_type_response {
@@ -62,14 +72,15 @@ struct delete_contact_type_response {
 
 struct get_contact_type_history_request {
     using response_type = struct get_contact_type_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.contact-types.history";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.contact_types.history";
+    std::string code;
 };
 
 struct get_contact_type_history_response {
+    std::vector<ores::refdata::domain::contact_type> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::contact_type> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_contact_information_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_contact_information_protocol.hpp
@@ -20,26 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_COUNTERPARTY_CONTACT_INFORMATION_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_COUNTERPARTY_CONTACT_INFORMATION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/counterparty_contact_information.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/counterparty_contact_information.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_counterparty_contact_informations_request {
     using response_type = struct get_counterparty_contact_informations_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-contacts.list";
-    std::string counterparty_id;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_contact_informations.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_counterparty_contact_informations_response {
-    std::vector<ores::refdata::domain::counterparty_contact_information> contact_informations;
+    std::vector<ores::refdata::domain::counterparty_contact_information> counterparty_contact_informations;
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_counterparty_contact_information_request {
     using response_type = struct save_counterparty_contact_information_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-contacts.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_contact_informations.save";
     ores::refdata::domain::counterparty_contact_information data;
+
+    static save_counterparty_contact_information_request from(ores::refdata::domain::counterparty_contact_information v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_counterparty_contact_information_response {
@@ -49,11 +60,25 @@ struct save_counterparty_contact_information_response {
 
 struct delete_counterparty_contact_information_request {
     using response_type = struct delete_counterparty_contact_information_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-contacts.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_contact_informations.delete";
     std::vector<std::string> ids;
 };
 
 struct delete_counterparty_contact_information_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_counterparty_contact_information_history_request {
+    using response_type = struct get_counterparty_contact_information_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_contact_informations.history";
+    std::string id;
+};
+
+struct get_counterparty_contact_information_history_response {
+    std::vector<ores::refdata::domain::counterparty_contact_information> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_identifier_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_identifier_protocol.hpp
@@ -20,26 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_COUNTERPARTY_IDENTIFIER_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_COUNTERPARTY_IDENTIFIER_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/counterparty_identifier.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/counterparty_identifier.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_counterparty_identifiers_request {
     using response_type = struct get_counterparty_identifiers_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-identifiers.list";
-    std::string counterparty_id;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_identifiers.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_counterparty_identifiers_response {
-    std::vector<ores::refdata::domain::counterparty_identifier> identifiers;
+    std::vector<ores::refdata::domain::counterparty_identifier> counterparty_identifiers;
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_counterparty_identifier_request {
     using response_type = struct save_counterparty_identifier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-identifiers.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_identifiers.save";
     ores::refdata::domain::counterparty_identifier data;
+
+    static save_counterparty_identifier_request from(ores::refdata::domain::counterparty_identifier v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_counterparty_identifier_response {
@@ -49,11 +60,25 @@ struct save_counterparty_identifier_response {
 
 struct delete_counterparty_identifier_request {
     using response_type = struct delete_counterparty_identifier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparty-identifiers.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_identifiers.delete";
     std::vector<std::string> ids;
 };
 
 struct delete_counterparty_identifier_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_counterparty_identifier_history_request {
+    using response_type = struct get_counterparty_identifier_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparty_identifiers.history";
+    std::string id;
+};
+
+struct get_counterparty_identifier_history_response {
+    std::vector<ores::refdata::domain::counterparty_identifier> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/counterparty_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_COUNTERPARTY_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_COUNTERPARTY_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/counterparty.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/counterparty.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_counterparties_request {
     using response_type = struct get_counterparties_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparties.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparties.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_counterparties_response {
     std::vector<ores::refdata::domain::counterparty> counterparties;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_counterparty_request {
     using response_type = struct save_counterparty_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparties.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparties.save";
     ores::refdata::domain::counterparty data;
+
+    static save_counterparty_request from(ores::refdata::domain::counterparty v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_counterparty_response {
@@ -51,7 +60,8 @@ struct save_counterparty_response {
 
 struct delete_counterparty_request {
     using response_type = struct delete_counterparty_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparties.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparties.delete";
     std::vector<std::string> ids;
 };
 
@@ -62,14 +72,15 @@ struct delete_counterparty_response {
 
 struct get_counterparty_history_request {
     using response_type = struct get_counterparty_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.counterparties.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.counterparties.history";
     std::string id;
 };
 
 struct get_counterparty_history_response {
+    std::vector<ores::refdata::domain::counterparty> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::counterparty> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/currency_market_tier_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/currency_market_tier_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_CURRENCY_MARKET_TIER_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_CURRENCY_MARKET_TIER_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/currency_market_tier.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/currency_market_tier.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_currency_market_tiers_request {
     using response_type = struct get_currency_market_tiers_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.currency-market-tiers.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.currency_market_tiers.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_currency_market_tiers_response {
-    std::vector<ores::refdata::domain::currency_market_tier> currency_market_tiers;
+    std::vector<ores::refdata::domain::currency_market_tier> types;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_currency_market_tier_request {
     using response_type = struct save_currency_market_tier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.currency-market-tiers.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.currency_market_tiers.save";
     ores::refdata::domain::currency_market_tier data;
+
+    static save_currency_market_tier_request from(ores::refdata::domain::currency_market_tier v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_currency_market_tier_response {
@@ -51,8 +60,9 @@ struct save_currency_market_tier_response {
 
 struct delete_currency_market_tier_request {
     using response_type = struct delete_currency_market_tier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.currency-market-tiers.delete";
-    std::string tier;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.currency_market_tiers.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_currency_market_tier_response {
@@ -62,14 +72,15 @@ struct delete_currency_market_tier_response {
 
 struct get_currency_market_tier_history_request {
     using response_type = struct get_currency_market_tier_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.currency-market-tiers.history";
-    std::string tier;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.currency_market_tiers.history";
+    std::string code;
 };
 
 struct get_currency_market_tier_history_response {
+    std::vector<ores::refdata::domain::currency_market_tier> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::currency_market_tier> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/deposit_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/deposit_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/deposit_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_deposit_conventions_request {
     using response_type = struct get_deposit_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.deposit_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_deposit_conventions_response {
     std::vector<ores::refdata::domain::deposit_convention> deposit_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_deposit_convention_request {
     using response_type = struct save_deposit_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.deposit_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.save";
     ores::refdata::domain::deposit_convention data;
+
+    static save_deposit_convention_request from(ores::refdata::domain::deposit_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_deposit_convention_response {
@@ -51,8 +60,9 @@ struct save_deposit_convention_response {
 
 struct delete_deposit_convention_request {
     using response_type = struct delete_deposit_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.deposit_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_deposit_convention_response {
@@ -62,12 +72,13 @@ struct delete_deposit_convention_response {
 
 struct get_deposit_convention_history_request {
     using response_type = struct get_deposit_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.deposit_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.history";
     std::string id;
 };
 
 struct get_deposit_convention_history_response {
-    std::vector<ores::refdata::domain::deposit_convention> deposit_conventions;
+    std::vector<ores::refdata::domain::deposit_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/fra_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/fra_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/fra_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/fra_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_fra_conventions_request {
     using response_type = struct get_fra_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fra_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_fra_conventions_response {
     std::vector<ores::refdata::domain::fra_convention> fra_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_fra_convention_request {
     using response_type = struct save_fra_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fra_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.save";
     ores::refdata::domain::fra_convention data;
+
+    static save_fra_convention_request from(ores::refdata::domain::fra_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_fra_convention_response {
@@ -51,8 +60,9 @@ struct save_fra_convention_response {
 
 struct delete_fra_convention_request {
     using response_type = struct delete_fra_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fra_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_fra_convention_response {
@@ -62,12 +72,13 @@ struct delete_fra_convention_response {
 
 struct get_fra_convention_history_request {
     using response_type = struct get_fra_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fra_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.history";
     std::string id;
 };
 
 struct get_fra_convention_history_response {
-    std::vector<ores::refdata::domain::fra_convention> fra_conventions;
+    std::vector<ores::refdata::domain::fra_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/fx_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/fx_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/fx_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/fx_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_fx_conventions_request {
     using response_type = struct get_fx_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fx_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_fx_conventions_response {
     std::vector<ores::refdata::domain::fx_convention> fx_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_fx_convention_request {
     using response_type = struct save_fx_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fx_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.save";
     ores::refdata::domain::fx_convention data;
+
+    static save_fx_convention_request from(ores::refdata::domain::fx_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_fx_convention_response {
@@ -51,8 +60,9 @@ struct save_fx_convention_response {
 
 struct delete_fx_convention_request {
     using response_type = struct delete_fx_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fx_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_fx_convention_response {
@@ -62,12 +72,13 @@ struct delete_fx_convention_response {
 
 struct get_fx_convention_history_request {
     using response_type = struct get_fx_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.fx_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.history";
     std::string id;
 };
 
 struct get_fx_convention_history_response {
-    std::vector<ores::refdata::domain::fx_convention> fx_conventions;
+    std::vector<ores::refdata::domain::fx_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/ibor_index_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/ibor_index_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_ibor_index_conventions_request {
     using response_type = struct get_ibor_index_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ibor_index_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_ibor_index_conventions_response {
     std::vector<ores::refdata::domain::ibor_index_convention> ibor_index_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_ibor_index_convention_request {
     using response_type = struct save_ibor_index_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ibor_index_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.save";
     ores::refdata::domain::ibor_index_convention data;
+
+    static save_ibor_index_convention_request from(ores::refdata::domain::ibor_index_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_ibor_index_convention_response {
@@ -51,8 +60,9 @@ struct save_ibor_index_convention_response {
 
 struct delete_ibor_index_convention_request {
     using response_type = struct delete_ibor_index_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ibor_index_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_ibor_index_convention_response {
@@ -62,12 +72,13 @@ struct delete_ibor_index_convention_response {
 
 struct get_ibor_index_convention_history_request {
     using response_type = struct get_ibor_index_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ibor_index_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.history";
     std::string id;
 };
 
 struct get_ibor_index_convention_history_response {
-    std::vector<ores::refdata::domain::ibor_index_convention> ibor_index_conventions;
+    std::vector<ores::refdata::domain::ibor_index_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/monetary_nature_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/monetary_nature_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_MONETARY_NATURE_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_MONETARY_NATURE_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/monetary_nature.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/monetary_nature.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_monetary_natures_request {
     using response_type = struct get_monetary_natures_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.monetary-natures.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.monetary_natures.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_monetary_natures_response {
-    std::vector<ores::refdata::domain::monetary_nature> monetary_natures;
+    std::vector<ores::refdata::domain::monetary_nature> types;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_monetary_nature_request {
     using response_type = struct save_monetary_nature_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.monetary-natures.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.monetary_natures.save";
     ores::refdata::domain::monetary_nature data;
+
+    static save_monetary_nature_request from(ores::refdata::domain::monetary_nature v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_monetary_nature_response {
@@ -51,8 +60,9 @@ struct save_monetary_nature_response {
 
 struct delete_monetary_nature_request {
     using response_type = struct delete_monetary_nature_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.monetary-natures.delete";
-    std::string nature;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.monetary_natures.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_monetary_nature_response {
@@ -62,14 +72,15 @@ struct delete_monetary_nature_response {
 
 struct get_monetary_nature_history_request {
     using response_type = struct get_monetary_nature_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.monetary-natures.history";
-    std::string nature;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.monetary_natures.history";
+    std::string code;
 };
 
 struct get_monetary_nature_history_response {
+    std::vector<ores::refdata::domain::monetary_nature> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::monetary_nature> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/ois_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/ois_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/ois_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/ois_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_ois_conventions_request {
     using response_type = struct get_ois_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ois_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_ois_conventions_response {
     std::vector<ores::refdata::domain::ois_convention> ois_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_ois_convention_request {
     using response_type = struct save_ois_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ois_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.save";
     ores::refdata::domain::ois_convention data;
+
+    static save_ois_convention_request from(ores::refdata::domain::ois_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_ois_convention_response {
@@ -51,8 +60,9 @@ struct save_ois_convention_response {
 
 struct delete_ois_convention_request {
     using response_type = struct delete_ois_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ois_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_ois_convention_response {
@@ -62,12 +72,13 @@ struct delete_ois_convention_response {
 
 struct get_ois_convention_history_request {
     using response_type = struct get_ois_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.ois_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.history";
     std::string id;
 };
 
 struct get_ois_convention_history_response {
-    std::vector<ores::refdata::domain::ois_convention> ois_conventions;
+    std::vector<ores::refdata::domain::ois_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/overnight_index_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/overnight_index_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_overnight_index_conventions_request {
     using response_type = struct get_overnight_index_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.overnight_index_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_overnight_index_conventions_response {
     std::vector<ores::refdata::domain::overnight_index_convention> overnight_index_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_overnight_index_convention_request {
     using response_type = struct save_overnight_index_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.overnight_index_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.save";
     ores::refdata::domain::overnight_index_convention data;
+
+    static save_overnight_index_convention_request from(ores::refdata::domain::overnight_index_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_overnight_index_convention_response {
@@ -53,7 +62,7 @@ struct delete_overnight_index_convention_request {
     using response_type = struct delete_overnight_index_convention_response;
     static constexpr std::string_view nats_subject =
         "refdata.v1.overnight_index_conventions.delete";
-    std::vector<std::string> codes;
+    std::vector<std::string> ids;
 };
 
 struct delete_overnight_index_convention_response {
@@ -69,7 +78,7 @@ struct get_overnight_index_convention_history_request {
 };
 
 struct get_overnight_index_convention_history_response {
-    std::vector<ores::refdata::domain::overnight_index_convention> overnight_index_conventions;
+    std::vector<ores::refdata::domain::overnight_index_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_contact_information_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_contact_information_protocol.hpp
@@ -20,26 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_CONTACT_INFORMATION_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_CONTACT_INFORMATION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party_contact_information.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party_contact_information.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_party_contact_informations_request {
     using response_type = struct get_party_contact_informations_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-contacts.list";
-    std::string party_id;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_contact_informations.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_party_contact_informations_response {
-    std::vector<ores::refdata::domain::party_contact_information> contact_informations;
+    std::vector<ores::refdata::domain::party_contact_information> party_contact_informations;
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_contact_information_request {
     using response_type = struct save_party_contact_information_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-contacts.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_contact_informations.save";
     ores::refdata::domain::party_contact_information data;
+
+    static save_party_contact_information_request from(ores::refdata::domain::party_contact_information v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_contact_information_response {
@@ -49,11 +60,25 @@ struct save_party_contact_information_response {
 
 struct delete_party_contact_information_request {
     using response_type = struct delete_party_contact_information_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-contacts.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_contact_informations.delete";
     std::vector<std::string> ids;
 };
 
 struct delete_party_contact_information_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_party_contact_information_history_request {
+    using response_type = struct get_party_contact_information_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_contact_informations.history";
+    std::string id;
+};
+
+struct get_party_contact_information_history_response {
+    std::vector<ores::refdata::domain::party_contact_information> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_id_scheme_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_id_scheme_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_ID_SCHEME_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_ID_SCHEME_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party_id_scheme.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party_id_scheme.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_party_id_schemes_request {
     using response_type = struct get_party_id_schemes_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-id-schemes.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_id_schemes.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_party_id_schemes_response {
-    std::vector<ores::refdata::domain::party_id_scheme> party_id_schemes;
+    std::vector<ores::refdata::domain::party_id_scheme> schemes;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_id_scheme_request {
     using response_type = struct save_party_id_scheme_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-id-schemes.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_id_schemes.save";
     ores::refdata::domain::party_id_scheme data;
+
+    static save_party_id_scheme_request from(ores::refdata::domain::party_id_scheme v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_id_scheme_response {
@@ -51,8 +60,9 @@ struct save_party_id_scheme_response {
 
 struct delete_party_id_scheme_request {
     using response_type = struct delete_party_id_scheme_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-id-schemes.delete";
-    std::string scheme;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_id_schemes.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_party_id_scheme_response {
@@ -62,14 +72,15 @@ struct delete_party_id_scheme_response {
 
 struct get_party_id_scheme_history_request {
     using response_type = struct get_party_id_scheme_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-id-schemes.history";
-    std::string scheme;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_id_schemes.history";
+    std::string code;
 };
 
 struct get_party_id_scheme_history_response {
+    std::vector<ores::refdata::domain::party_id_scheme> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::party_id_scheme> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_identifier_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_identifier_protocol.hpp
@@ -20,26 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_IDENTIFIER_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_IDENTIFIER_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party_identifier.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party_identifier.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_party_identifiers_request {
     using response_type = struct get_party_identifiers_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-identifiers.list";
-    std::string party_id;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_identifiers.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_party_identifiers_response {
-    std::vector<ores::refdata::domain::party_identifier> identifiers;
+    std::vector<ores::refdata::domain::party_identifier> party_identifiers;
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_identifier_request {
     using response_type = struct save_party_identifier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-identifiers.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_identifiers.save";
     ores::refdata::domain::party_identifier data;
+
+    static save_party_identifier_request from(ores::refdata::domain::party_identifier v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_identifier_response {
@@ -49,11 +60,25 @@ struct save_party_identifier_response {
 
 struct delete_party_identifier_request {
     using response_type = struct delete_party_identifier_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-identifiers.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_identifiers.delete";
     std::vector<std::string> ids;
 };
 
 struct delete_party_identifier_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_party_identifier_history_request {
+    using response_type = struct get_party_identifier_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_identifiers.history";
+    std::string id;
+};
+
+struct get_party_identifier_history_response {
+    std::vector<ores::refdata::domain::party_identifier> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_parties_request {
     using response_type = struct get_parties_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.parties.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.parties.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_parties_response {
     std::vector<ores::refdata::domain::party> parties;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_request {
     using response_type = struct save_party_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.parties.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.parties.save";
     ores::refdata::domain::party data;
+
+    static save_party_request from(ores::refdata::domain::party v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_response {
@@ -51,7 +60,8 @@ struct save_party_response {
 
 struct delete_party_request {
     using response_type = struct delete_party_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.parties.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.parties.delete";
     std::vector<std::string> ids;
 };
 
@@ -62,32 +72,15 @@ struct delete_party_response {
 
 struct get_party_history_request {
     using response_type = struct get_party_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.parties.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.parties.history";
     std::string id;
 };
 
 struct get_party_history_response {
-    bool success = false;
-    std::string message;
     std::vector<ores::refdata::domain::party> history;
-};
-
-/**
- * @brief Reads all active parties for a tenant — used by IAM party cache.
- *
- * Returns the full, unpaginated party set for the given tenant so that
- * consumers can build an in-process cache without multiple round-trips.
- */
-struct read_parties_for_cache_request {
-    using response_type = struct read_parties_for_cache_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.parties.read";
-    std::string tenant_id;
-};
-
-struct read_parties_for_cache_response {
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::party> parties;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_status_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_status_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_STATUS_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_STATUS_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party_status.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party_status.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_party_statuses_request {
     using response_type = struct get_party_statuses_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-statuses.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_statuses.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_party_statuses_response {
-    std::vector<ores::refdata::domain::party_status> party_statuses;
+    std::vector<ores::refdata::domain::party_status> statuses;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_status_request {
     using response_type = struct save_party_status_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-statuses.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_statuses.save";
     ores::refdata::domain::party_status data;
+
+    static save_party_status_request from(ores::refdata::domain::party_status v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_status_response {
@@ -51,8 +60,9 @@ struct save_party_status_response {
 
 struct delete_party_status_request {
     using response_type = struct delete_party_status_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-statuses.delete";
-    std::string status;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_statuses.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_party_status_response {
@@ -62,14 +72,15 @@ struct delete_party_status_response {
 
 struct get_party_status_history_request {
     using response_type = struct get_party_status_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-statuses.history";
-    std::string status;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_statuses.history";
+    std::string code;
 };
 
 struct get_party_status_history_response {
+    std::vector<ores::refdata::domain::party_status> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::party_status> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_type_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/party_type_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PARTY_TYPE_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PARTY_TYPE_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/party_type.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/party_type.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_party_types_request {
     using response_type = struct get_party_types_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-types.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_types.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_party_types_response {
-    std::vector<ores::refdata::domain::party_type> party_types;
+    std::vector<ores::refdata::domain::party_type> types;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_party_type_request {
     using response_type = struct save_party_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-types.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_types.save";
     ores::refdata::domain::party_type data;
+
+    static save_party_type_request from(ores::refdata::domain::party_type v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_party_type_response {
@@ -51,8 +60,9 @@ struct save_party_type_response {
 
 struct delete_party_type_request {
     using response_type = struct delete_party_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-types.delete";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_types.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_party_type_response {
@@ -62,14 +72,15 @@ struct delete_party_type_response {
 
 struct get_party_type_history_request {
     using response_type = struct get_party_type_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.party-types.history";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.party_types.history";
+    std::string code;
 };
 
 struct get_party_type_history_response {
+    std::vector<ores::refdata::domain::party_type> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::party_type> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/portfolio_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/portfolio_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_PORTFOLIO_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_PORTFOLIO_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/portfolio.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/portfolio.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_portfolios_request {
     using response_type = struct get_portfolios_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.portfolios.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.portfolios.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_portfolios_response {
     std::vector<ores::refdata::domain::portfolio> portfolios;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_portfolio_request {
     using response_type = struct save_portfolio_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.portfolios.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.portfolios.save";
     ores::refdata::domain::portfolio data;
+
+    static save_portfolio_request from(ores::refdata::domain::portfolio v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_portfolio_response {
@@ -51,7 +60,8 @@ struct save_portfolio_response {
 
 struct delete_portfolio_request {
     using response_type = struct delete_portfolio_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.portfolios.delete";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.portfolios.delete";
     std::vector<std::string> ids;
 };
 
@@ -62,14 +72,15 @@ struct delete_portfolio_response {
 
 struct get_portfolio_history_request {
     using response_type = struct get_portfolio_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.portfolios.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.portfolios.history";
     std::string id;
 };
 
 struct get_portfolio_history_response {
+    std::vector<ores::refdata::domain::portfolio> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::portfolio> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/rounding_type_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/rounding_type_protocol.hpp
@@ -20,28 +20,37 @@
 #ifndef ORES_REFDATA_API_MESSAGING_ROUNDING_TYPE_PROTOCOL_HPP
 #define ORES_REFDATA_API_MESSAGING_ROUNDING_TYPE_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/rounding_type.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/rounding_type.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_rounding_types_request {
     using response_type = struct get_rounding_types_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.rounding-types.list";
-    int offset = 0;
-    int limit = 100;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.rounding_types.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_rounding_types_response {
-    std::vector<ores::refdata::domain::rounding_type> rounding_types;
+    std::vector<ores::refdata::domain::rounding_type> types;
     int total_available_count = 0;
+    bool success = false;
+    std::string message;
 };
 
 struct save_rounding_type_request {
     using response_type = struct save_rounding_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.rounding-types.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.rounding_types.save";
     ores::refdata::domain::rounding_type data;
+
+    static save_rounding_type_request from(ores::refdata::domain::rounding_type v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_rounding_type_response {
@@ -51,8 +60,9 @@ struct save_rounding_type_response {
 
 struct delete_rounding_type_request {
     using response_type = struct delete_rounding_type_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.rounding-types.delete";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.rounding_types.delete";
+    std::vector<std::string> codes;
 };
 
 struct delete_rounding_type_response {
@@ -62,14 +72,15 @@ struct delete_rounding_type_response {
 
 struct get_rounding_type_history_request {
     using response_type = struct get_rounding_type_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.rounding-types.history";
-    std::string type;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.rounding_types.history";
+    std::string code;
 };
 
 struct get_rounding_type_history_response {
+    std::vector<ores::refdata::domain::rounding_type> history;
     bool success = false;
     std::string message;
-    std::vector<ores::refdata::domain::rounding_type> history;
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/swap_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/swap_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/swap_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/swap_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_swap_conventions_request {
     using response_type = struct get_swap_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.swap_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_swap_conventions_response {
     std::vector<ores::refdata::domain::swap_convention> swap_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_swap_convention_request {
     using response_type = struct save_swap_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.swap_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.save";
     ores::refdata::domain::swap_convention data;
+
+    static save_swap_convention_request from(ores::refdata::domain::swap_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_swap_convention_response {
@@ -51,8 +60,9 @@ struct save_swap_convention_response {
 
 struct delete_swap_convention_request {
     using response_type = struct delete_swap_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.swap_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_swap_convention_response {
@@ -62,12 +72,13 @@ struct delete_swap_convention_response {
 
 struct get_swap_convention_history_request {
     using response_type = struct get_swap_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.swap_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.history";
     std::string id;
 };
 
 struct get_swap_convention_history_response {
-    std::vector<ores::refdata::domain::swap_convention> swap_conventions;
+    std::vector<ores::refdata::domain::swap_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/zero_convention_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/zero_convention_protocol.hpp
@@ -17,31 +17,40 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_ZERO_CONVENTION_PROTOCOL_HPP
-#define ORES_REFDATA_MESSAGING_ZERO_CONVENTION_PROTOCOL_HPP
+#ifndef ORES_REFDATA_API_MESSAGING_ZERO_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_ZERO_CONVENTION_PROTOCOL_HPP
 
-#include "ores.refdata.api/domain/zero_convention.hpp"
+#include <cstdint>
 #include <string>
 #include <vector>
+#include "ores.refdata.api/domain/zero_convention.hpp"
 
 namespace ores::refdata::messaging {
 
 struct get_zero_conventions_request {
     using response_type = struct get_zero_conventions_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.zero_conventions.list";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.zero_conventions.list";
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
 };
 
 struct get_zero_conventions_response {
     std::vector<ores::refdata::domain::zero_convention> zero_conventions;
     int total_available_count = 0;
-    bool success = true;
+    bool success = false;
     std::string message;
 };
 
 struct save_zero_convention_request {
     using response_type = struct save_zero_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.zero_conventions.save";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.zero_conventions.save";
     ores::refdata::domain::zero_convention data;
+
+    static save_zero_convention_request from(ores::refdata::domain::zero_convention v) {
+        return {.data = std::move(v)};
+    }
 };
 
 struct save_zero_convention_response {
@@ -51,8 +60,9 @@ struct save_zero_convention_response {
 
 struct delete_zero_convention_request {
     using response_type = struct delete_zero_convention_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.zero_conventions.delete";
-    std::vector<std::string> codes;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.zero_conventions.delete";
+    std::vector<std::string> ids;
 };
 
 struct delete_zero_convention_response {
@@ -62,12 +72,13 @@ struct delete_zero_convention_response {
 
 struct get_zero_convention_history_request {
     using response_type = struct get_zero_convention_history_response;
-    static constexpr std::string_view nats_subject = "refdata.v1.zero_conventions.history";
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.zero_conventions.history";
     std::string id;
 };
 
 struct get_zero_convention_history_response {
-    std::vector<ores::refdata::domain::zero_convention> zero_conventions;
+    std::vector<ores::refdata::domain::zero_convention> history;
     bool success = false;
     std::string message;
 };

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_handler.hpp
@@ -20,22 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_BOOK_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_BOOK_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/book_protocol.hpp"
-#include "ores.refdata.core/service/book_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/book_protocol.hpp"
+#include "ores.refdata.core/service/book_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& book_handler_lg() {
-    static auto instance = ores::logging::make_logger("ores.refdata.messaging.book_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.book_handler");
     return instance;
 }
 } // namespace
@@ -44,116 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for book operations.
+ */
 class book_handler {
 public:
     book_handler(ores::nats::service::client& nats,
-                 ores::database::context ctx,
-                 std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(book_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::book_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::book_service svc(req_ctx);
         get_books_response resp;
-        try {
-            resp.books = svc.list_books();
-            resp.total_available_count = static_cast<int>(resp.books.size());
-            BOOST_LOG_SEV(book_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_handler_lg(), error) << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_books_request>(msg)) {
+            try {
+                resp.books = svc.list_books(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_books());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(book_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(book_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(book_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::books:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::books:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::book_service svc(ctx);
-        auto req = decode<save_book_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_book(req->data);
-            BOOST_LOG_SEV(book_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_book_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_book_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(book_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::books:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::book_service svc(ctx);
-        auto req = decode<delete_book_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            for (const auto& id_str : req->ids)
-                svc.remove_book(id_str);
-            BOOST_LOG_SEV(book_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_book_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_book_response{.success = false, .message = e.what()});
+        service::book_service svc(req_ctx);
+        if (auto req = decode<save_book_request>(msg)) {
+            try {
+                svc.save_book(req->data);
+                BOOST_LOG_SEV(book_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_book_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_book_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(book_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::book_service svc(ctx);
-        auto req = decode<get_book_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::book_service svc(req_ctx);
+        if (auto req = decode<get_book_history_request>(msg)) {
+            try {
+                auto hist = svc.get_book_history(req->id);
+                BOOST_LOG_SEV(book_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_book_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_book_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(book_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_book_history(req->id);
-            BOOST_LOG_SEV(book_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, get_book_history_response{.books = std::move(h), .success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, get_book_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::books:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::book_service svc(req_ctx);
+        if (auto req = decode<delete_book_request>(msg)) {
+            try {
+                svc.delete_books(req->ids);
+                BOOST_LOG_SEV(book_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_book_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_book_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -164,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_status_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/book_status_handler.hpp
@@ -20,22 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_BOOK_STATUS_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_BOOK_STATUS_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/book_status_protocol.hpp"
-#include "ores.refdata.core/service/book_status_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/book_status_protocol.hpp"
+#include "ores.refdata.core/service/book_status_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& book_status_handler_lg() {
-    static auto instance = ores::logging::make_logger("ores.refdata.messaging.book_status_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.book_status_handler");
     return instance;
 }
 } // namespace
@@ -44,126 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for book status operations.
+ */
 class book_status_handler {
 public:
     book_status_handler(ores::nats::service::client& nats,
-                        ores::database::context ctx,
-                        std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(book_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::book_status_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::book_status_service svc(req_ctx);
         get_book_statuses_response resp;
-        try {
-            resp.statuses = svc.list_statuses();
-            BOOST_LOG_SEV(book_status_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_book_statuses_request>(msg)) {
+            try {
+                resp.statuses = svc.list_statuses(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_statuses());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(book_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(book_status_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(book_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::book_statuses:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::book_statuses:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::book_status_service svc(ctx);
-        auto req = decode<save_book_status_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_status(req->data);
-            BOOST_LOG_SEV(book_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_book_status_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_book_status_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(book_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::book_statuses:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::book_status_service svc(ctx);
-        auto req = decode<delete_book_status_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_statuses(req->codes);
-            BOOST_LOG_SEV(book_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_book_status_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_book_status_response{.success = false, .message = e.what()});
+        service::book_status_service svc(req_ctx);
+        if (auto req = decode<save_book_status_request>(msg)) {
+            try {
+                svc.save_status(req->data);
+                BOOST_LOG_SEV(book_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_book_status_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_book_status_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(book_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(book_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::book_status_service svc(ctx);
-        auto req = decode<get_book_status_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(book_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::book_status_service svc(req_ctx);
+        if (auto req = decode<get_book_status_history_request>(msg)) {
+            try {
+                auto hist = svc.get_status_history(req->code);
+                BOOST_LOG_SEV(book_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_book_status_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_book_status_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(book_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_status_history(req->code);
-            BOOST_LOG_SEV(book_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_book_status_history_response{.statuses = std::move(h), .success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(book_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_book_status_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::book_statuses:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::book_status_service svc(req_ctx);
+        if (auto req = decode<delete_book_status_request>(msg)) {
+            try {
+                svc.delete_statuses(req->codes);
+                BOOST_LOG_SEV(book_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_book_status_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(book_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_book_status_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(book_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -174,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/business_unit_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/business_unit_handler.hpp
@@ -20,24 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_BUSINESS_UNIT_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_BUSINESS_UNIT_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/business_unit_protocol.hpp"
-#include "ores.refdata.core/service/business_unit_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <boost/uuid/string_generator.hpp>
-#include <optional>
+#include "ores.refdata.api/messaging/business_unit_protocol.hpp"
+#include "ores.refdata.core/service/business_unit_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& business_unit_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.business_unit_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.business_unit_handler");
     return instance;
 }
 } // namespace
@@ -46,130 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for business unit operations.
+ */
 class business_unit_handler {
 public:
     business_unit_handler(ores::nats::service::client& nats,
-                          ores::database::context ctx,
-                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(business_unit_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::business_unit_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::business_unit_service svc(req_ctx);
         get_business_units_response resp;
-        try {
-            resp.business_units = svc.list_business_units();
-            resp.total_available_count = static_cast<int>(resp.business_units.size());
-            BOOST_LOG_SEV(business_unit_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_business_units_request>(msg)) {
+            try {
+                resp.business_units = svc.list_business_units(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_business_units());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(business_unit_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(business_unit_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(business_unit_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::business_units:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::business_units:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::business_unit_service svc(ctx);
-        auto req = decode<save_business_unit_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_business_unit(req->data);
-            BOOST_LOG_SEV(business_unit_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_business_unit_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_business_unit_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(business_unit_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::business_units:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::business_unit_service svc(ctx);
-        auto req = decode<delete_business_unit_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            boost::uuids::string_generator gen;
-            for (const auto& id_str : req->ids)
-                svc.remove_business_unit(gen(id_str));
-            BOOST_LOG_SEV(business_unit_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_business_unit_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_business_unit_response{.success = false, .message = e.what()});
+        service::business_unit_service svc(req_ctx);
+        if (auto req = decode<save_business_unit_request>(msg)) {
+            try {
+                svc.save_business_unit(req->data);
+                BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_business_unit_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(business_unit_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_business_unit_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(business_unit_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(business_unit_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::business_unit_service svc(ctx);
-        auto req = decode<get_business_unit_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::business_unit_service svc(req_ctx);
+        if (auto req = decode<get_business_unit_history_request>(msg)) {
+            try {
+                auto hist = svc.get_business_unit_history(req->id);
+                BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_business_unit_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(business_unit_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_business_unit_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(business_unit_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            boost::uuids::string_generator gen;
-            auto h = svc.get_business_unit_history(gen(req->id));
-            BOOST_LOG_SEV(business_unit_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_business_unit_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(business_unit_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_business_unit_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::business_units:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::business_unit_service svc(req_ctx);
+        if (auto req = decode<delete_business_unit_request>(msg)) {
+            try {
+                svc.delete_business_units(req->ids);
+                BOOST_LOG_SEV(business_unit_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_business_unit_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(business_unit_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_business_unit_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(business_unit_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -180,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/cds_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/cds_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_CDS_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_CDS_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_CDS_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_CDS_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
-#include "ores.refdata.core/service/cds_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+#include "ores.refdata.core/service/cds_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& cds_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.cds_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.cds_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class cds_convention_handler {
 public:
     cds_convention_handler(ores::nats::service::client& nats,
-                           ores::database::context ctx,
-                           std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::cds_convention_service svc(req_ctx);
         get_cds_conventions_response resp;
-        try {
-            resp.cds_conventions = svc.list_cds_conventions();
-            resp.total_available_count = static_cast<int>(resp.cds_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(cds_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_cds_conventions_request>(msg)) {
+            try {
+                resp.cds_conventions = svc.list_cds_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_cds_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(cds_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,24 +109,28 @@ public:
         if (auto req = decode<save_cds_convention_request>(msg)) {
             try {
                 svc.save_cds_convention(req->data);
-                BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_cds_convention_response{.success = true});
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_cds_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(cds_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_cds_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_cds_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(cds_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -125,52 +140,54 @@ public:
         if (auto req = decode<get_cds_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_cds_convention_history(req->id);
-                BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_cds_convention_history_response{.cds_conventions = std::move(hist),
-                                                          .success = true});
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_cds_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(cds_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_cds_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_cds_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(cds_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::cds_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::cds_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::cds_convention_service svc(req_ctx);
         if (auto req = decode<delete_cds_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_cds_convention(code);
-                BOOST_LOG_SEV(cds_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_cds_convention_response{.success = true});
+                svc.delete_cds_conventions(req->ids);
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_cds_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(cds_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_cds_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_cds_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(cds_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/contact_type_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/contact_type_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_CONTACT_TYPE_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_CONTACT_TYPE_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/contact_type_protocol.hpp"
-#include "ores.refdata.core/service/contact_type_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/contact_type_protocol.hpp"
+#include "ores.refdata.core/service/contact_type_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& contact_type_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.contact_type_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.contact_type_handler");
     return instance;
 }
 } // namespace
@@ -45,127 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for contact type operations.
+ */
 class contact_type_handler {
 public:
     contact_type_handler(ores::nats::service::client& nats,
-                         ores::database::context ctx,
-                         std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(contact_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::contact_type_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::contact_type_service svc(req_ctx);
         get_contact_types_response resp;
-        try {
-            resp.contact_types = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.contact_types.size());
-            BOOST_LOG_SEV(contact_type_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_contact_types_request>(msg)) {
+            try {
+                resp.types = svc.list_types(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_types());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(contact_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(contact_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(contact_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::contact_types:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::contact_types:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::contact_type_service svc(ctx);
-        auto req = decode<save_contact_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_type(req->data);
-            BOOST_LOG_SEV(contact_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_contact_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_contact_type_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(contact_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::contact_types:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::contact_type_service svc(ctx);
-        auto req = decode<delete_contact_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_type(req->type);
-            BOOST_LOG_SEV(contact_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_contact_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_contact_type_response{.success = false, .message = e.what()});
+        service::contact_type_service svc(req_ctx);
+        if (auto req = decode<save_contact_type_request>(msg)) {
+            try {
+                svc.save_type(req->data);
+                BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_contact_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(contact_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_contact_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(contact_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(contact_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::contact_type_service svc(ctx);
-        auto req = decode<get_contact_type_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::contact_type_service svc(req_ctx);
+        if (auto req = decode<get_contact_type_history_request>(msg)) {
+            try {
+                auto hist = svc.get_type_history(req->code);
+                BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_contact_type_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(contact_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_contact_type_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(contact_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_type_history(req->type);
-            BOOST_LOG_SEV(contact_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_contact_type_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(contact_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_contact_type_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::contact_types:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::contact_type_service svc(req_ctx);
+        if (auto req = decode<delete_contact_type_request>(msg)) {
+            try {
+                svc.delete_types(req->codes);
+                BOOST_LOG_SEV(contact_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_contact_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(contact_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_contact_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(contact_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -176,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_contact_information_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_contact_information_handler.hpp
@@ -1,0 +1,203 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_CONTACT_INFORMATION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_CONTACT_INFORMATION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/counterparty_contact_information_protocol.hpp"
+#include "ores.refdata.core/service/counterparty_contact_information_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& counterparty_contact_information_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.counterparty_contact_information_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for counterparty contact information operations.
+ */
+class counterparty_contact_information_handler {
+public:
+    counterparty_contact_information_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_contact_information_service svc(req_ctx);
+        get_counterparty_contact_informations_response resp;
+        if (auto req = decode<get_counterparty_contact_informations_request>(msg)) {
+            try {
+                resp.counterparty_contact_informations = svc.list_counterparty_contact_informations(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_counterparty_contact_informations());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
+        }
+        BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparty_contact_informations:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::counterparty_contact_information_service svc(req_ctx);
+        if (auto req = decode<save_counterparty_contact_information_request>(msg)) {
+            try {
+                svc.save_counterparty_contact_information(req->data);
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_counterparty_contact_information_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_counterparty_contact_information_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_contact_information_service svc(req_ctx);
+        if (auto req = decode<get_counterparty_contact_information_history_request>(msg)) {
+            try {
+                auto hist = svc.get_counterparty_contact_information_history(req->id);
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_counterparty_contact_information_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_counterparty_contact_information_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparty_contact_informations:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::counterparty_contact_information_service svc(req_ctx);
+        if (auto req = decode<delete_counterparty_contact_information_request>(msg)) {
+            try {
+                svc.delete_counterparty_contact_informations(req->ids);
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_counterparty_contact_information_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_counterparty_contact_information_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_handler.hpp
@@ -20,24 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/counterparty_protocol.hpp"
-#include "ores.refdata.core/service/counterparty_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <boost/uuid/string_generator.hpp>
-#include <optional>
+#include "ores.refdata.api/messaging/counterparty_protocol.hpp"
+#include "ores.refdata.core/service/counterparty_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& counterparty_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.counterparty_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.counterparty_handler");
     return instance;
 }
 } // namespace
@@ -46,137 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for counterparty operations.
+ */
 class counterparty_handler {
 public:
     counterparty_handler(ores::nats::service::client& nats,
-                         ores::database::context ctx,
-                         std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::counterparty_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_service svc(req_ctx);
         get_counterparties_response resp;
-        auto req = decode<get_counterparties_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            reply(nats_, msg, resp);
+        if (auto req = decode<get_counterparties_request>(msg)) {
+            try {
+                resp.counterparties = svc.list_counterparties(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_counterparties());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
-        try {
-            resp.counterparties = svc.list_counterparties(static_cast<std::uint32_t>(req->offset),
-                                                          static_cast<std::uint32_t>(req->limit));
-            resp.total_available_count = static_cast<int>(svc.count_counterparties());
-            BOOST_LOG_SEV(counterparty_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-        }
+        BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::counterparties:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparties:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::counterparty_service svc(ctx);
-        auto req = decode<save_counterparty_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_counterparty(req->data);
-            BOOST_LOG_SEV(counterparty_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_counterparty_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_counterparty_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::counterparties:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::counterparty_service svc(ctx);
-        auto req = decode<delete_counterparty_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            boost::uuids::string_generator gen;
-            for (const auto& id_str : req->ids)
-                svc.remove_counterparty(gen(id_str));
-            BOOST_LOG_SEV(counterparty_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_counterparty_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_counterparty_response{.success = false, .message = e.what()});
+        service::counterparty_service svc(req_ctx);
+        if (auto req = decode<save_counterparty_request>(msg)) {
+            try {
+                svc.save_counterparty(req->data);
+                BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_counterparty_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_counterparty_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::counterparty_service svc(ctx);
-        auto req = decode<get_counterparty_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_service svc(req_ctx);
+        if (auto req = decode<get_counterparty_history_request>(msg)) {
+            try {
+                auto hist = svc.get_counterparty_history(req->id);
+                BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_counterparty_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_counterparty_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            boost::uuids::string_generator gen;
-            auto h = svc.get_counterparty_history(gen(req->id));
-            BOOST_LOG_SEV(counterparty_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_counterparty_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_counterparty_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparties:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::counterparty_service svc(req_ctx);
+        if (auto req = decode<delete_counterparty_request>(msg)) {
+            try {
+                svc.delete_counterparties(req->ids);
+                BOOST_LOG_SEV(counterparty_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_counterparty_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_counterparty_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -187,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_identifier_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/counterparty_identifier_handler.hpp
@@ -20,24 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_IDENTIFIER_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_COUNTERPARTY_IDENTIFIER_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/counterparty_identifier_protocol.hpp"
-#include "ores.refdata.core/service/counterparty_identifier_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <boost/uuid/string_generator.hpp>
-#include <optional>
+#include "ores.refdata.api/messaging/counterparty_identifier_protocol.hpp"
+#include "ores.refdata.core/service/counterparty_identifier_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& counterparty_identifier_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.counterparty_identifier_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.counterparty_identifier_handler");
     return instance;
 }
 } // namespace
@@ -46,117 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for counterparty identifier operations.
+ */
 class counterparty_identifier_handler {
 public:
     counterparty_identifier_handler(ores::nats::service::client& nats,
-                                    ores::database::context ctx,
-                                    std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::counterparty_identifier_service svc(ctx);
-        auto req = decode<get_counterparty_identifiers_request>(msg);
-        if (!req) {
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_identifier_service svc(req_ctx);
+        get_counterparty_identifiers_response resp;
+        if (auto req = decode<get_counterparty_identifiers_request>(msg)) {
+            try {
+                resp.counterparty_identifiers = svc.list_counterparty_identifiers(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_counterparty_identifiers());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
             BOOST_LOG_SEV(counterparty_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
-        try {
-            boost::uuids::string_generator gen;
-            auto items =
-                svc.list_counterparty_identifiers_by_counterparty(gen(req->counterparty_id));
-            get_counterparty_identifiers_response resp;
-            resp.identifiers = std::move(items);
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
-                << "Completed " << msg.subject;
-            reply(nats_, msg, resp);
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, get_counterparty_identifiers_response{});
-        }
+        BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::counterparty_identifiers:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparty_identifiers:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::counterparty_identifier_service svc(ctx);
-        auto req = decode<save_counterparty_identifier_request>(msg);
-        if (!req) {
+        service::counterparty_identifier_service svc(req_ctx);
+        if (auto req = decode<save_counterparty_identifier_request>(msg)) {
+            try {
+                svc.save_counterparty_identifier(req->data);
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_counterparty_identifier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_counterparty_identifier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(counterparty_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            svc.save_counterparty_identifier(req->data);
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
-                << "Completed " << msg.subject;
-            reply(nats_, msg, save_counterparty_identifier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  save_counterparty_identifier_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        service::counterparty_identifier_service svc(req_ctx);
+        if (auto req = decode<get_counterparty_identifier_history_request>(msg)) {
+            try {
+                auto hist = svc.get_counterparty_identifier_history(req->id);
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_counterparty_identifier_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_counterparty_identifier_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(counterparty_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::counterparty_identifiers:delete")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::counterparty_identifiers:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::counterparty_identifier_service svc(ctx);
-        auto req = decode<delete_counterparty_identifier_request>(msg);
-        if (!req) {
+        service::counterparty_identifier_service svc(req_ctx);
+        if (auto req = decode<delete_counterparty_identifier_request>(msg)) {
+            try {
+                svc.delete_counterparty_identifiers(req->ids);
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_counterparty_identifier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_counterparty_identifier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(counterparty_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            boost::uuids::string_generator gen;
-            for (const auto& id_str : req->ids)
-                svc.remove_counterparty_identifier(gen(id_str));
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), debug)
-                << "Completed " << msg.subject;
-            reply(nats_, msg, delete_counterparty_identifier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(counterparty_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  delete_counterparty_identifier_response{.success = false, .message = e.what()});
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -167,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/currency_market_tier_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/currency_market_tier_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_CURRENCY_MARKET_TIER_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_CURRENCY_MARKET_TIER_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/currency_market_tier_protocol.hpp"
-#include "ores.refdata.core/service/currency_market_tier_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/currency_market_tier_protocol.hpp"
+#include "ores.refdata.core/service/currency_market_tier_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& currency_market_tier_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.currency_market_tier_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.currency_market_tier_handler");
     return instance;
 }
 } // namespace
@@ -45,142 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for currency market tier operations.
+ */
 class currency_market_tier_handler {
 public:
     currency_market_tier_handler(ores::nats::service::client& nats,
-                                 ores::database::context ctx,
-                                 std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(currency_market_tier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::currency_market_tier_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::currency_market_tier_service svc(req_ctx);
         get_currency_market_tiers_response resp;
-        auto req = decode<get_currency_market_tiers_request>(msg);
-        if (!req) {
+        if (auto req = decode<get_currency_market_tiers_request>(msg)) {
+            try {
+                resp.types = svc.list_types(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_types());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
             BOOST_LOG_SEV(currency_market_tier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            reply(nats_, msg, resp);
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
-        try {
-            resp.currency_market_tiers = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.currency_market_tiers.size());
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-        }
+        BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(currency_market_tier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::currency_market_tiers:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::currency_market_tiers:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::currency_market_tier_service svc(ctx);
-        auto req = decode<save_currency_market_tier_request>(msg);
-        if (!req) {
+        service::currency_market_tier_service svc(req_ctx);
+        if (auto req = decode<save_currency_market_tier_request>(msg)) {
+            try {
+                svc.save_type(req->data);
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_currency_market_tier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_currency_market_tier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(currency_market_tier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_type(req->data);
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_currency_market_tier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  save_currency_market_tier_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(currency_market_tier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::currency_market_tiers:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::currency_market_tier_service svc(ctx);
-        auto req = decode<delete_currency_market_tier_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_type(req->tier);
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_currency_market_tier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  delete_currency_market_tier_response{.success = false, .message = e.what()});
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(currency_market_tier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::currency_market_tier_service svc(ctx);
-        auto req = decode<get_currency_market_tier_history_request>(msg);
-        if (!req) {
+        const auto& req_ctx = *req_ctx_expected;
+        service::currency_market_tier_service svc(req_ctx);
+        if (auto req = decode<get_currency_market_tier_history_request>(msg)) {
+            try {
+                auto hist = svc.get_type_history(req->code);
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_currency_market_tier_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_currency_market_tier_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(currency_market_tier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_type_history(req->tier);
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_currency_market_tier_history_response{.success = true,
-                                                            .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_currency_market_tier_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::currency_market_tiers:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::currency_market_tier_service svc(req_ctx);
+        if (auto req = decode<delete_currency_market_tier_request>(msg)) {
+            try {
+                svc.delete_types(req->codes);
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_currency_market_tier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(currency_market_tier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_currency_market_tier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(currency_market_tier_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -191,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/deposit_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/deposit_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
-#include "ores.refdata.core/service/deposit_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+#include "ores.refdata.core/service/deposit_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& deposit_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.deposit_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.deposit_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class deposit_convention_handler {
 public:
     deposit_convention_handler(ores::nats::service::client& nats,
-                               ores::database::context ctx,
-                               std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::deposit_convention_service svc(req_ctx);
         get_deposit_conventions_response resp;
-        try {
-            resp.deposit_conventions = svc.list_deposit_conventions();
-            resp.total_available_count = static_cast<int>(resp.deposit_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_deposit_conventions_request>(msg)) {
+            try {
+                resp.deposit_conventions = svc.list_deposit_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_deposit_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -100,13 +111,13 @@ public:
                 svc.save_deposit_convention(req->data);
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, save_deposit_convention_response{.success = true});
+                reply(nats_, msg,
+                    save_deposit_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_deposit_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_deposit_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
@@ -116,8 +127,10 @@ public:
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -129,17 +142,13 @@ public:
                 auto hist = svc.get_deposit_convention_history(req->id);
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_deposit_convention_history_response{
-                          .deposit_conventions = std::move(hist), .success = true});
+                reply(nats_, msg, get_deposit_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(
-                    nats_,
-                    msg,
-                    get_deposit_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_deposit_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
@@ -149,31 +158,32 @@ public:
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::deposit_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::deposit_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::deposit_convention_service svc(req_ctx);
         if (auto req = decode<delete_deposit_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_deposit_convention(code);
+                svc.delete_deposit_conventions(req->ids);
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, delete_deposit_convention_response{.success = true});
+                reply(nats_, msg,
+                    delete_deposit_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_deposit_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_deposit_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/fra_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/fra_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_FRA_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_FRA_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_FRA_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_FRA_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
-#include "ores.refdata.core/service/fra_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+#include "ores.refdata.core/service/fra_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& fra_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.fra_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.fra_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class fra_convention_handler {
 public:
     fra_convention_handler(ores::nats::service::client& nats,
-                           ores::database::context ctx,
-                           std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::fra_convention_service svc(req_ctx);
         get_fra_conventions_response resp;
-        try {
-            resp.fra_conventions = svc.list_fra_conventions();
-            resp.total_available_count = static_cast<int>(resp.fra_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(fra_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_fra_conventions_request>(msg)) {
+            try {
+                resp.fra_conventions = svc.list_fra_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_fra_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fra_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,24 +109,28 @@ public:
         if (auto req = decode<save_fra_convention_request>(msg)) {
             try {
                 svc.save_fra_convention(req->data);
-                BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_fra_convention_response{.success = true});
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_fra_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fra_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_fra_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_fra_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fra_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -125,52 +140,54 @@ public:
         if (auto req = decode<get_fra_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_fra_convention_history(req->id);
-                BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_fra_convention_history_response{.fra_conventions = std::move(hist),
-                                                          .success = true});
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_fra_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fra_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_fra_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_fra_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fra_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::fra_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::fra_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::fra_convention_service svc(req_ctx);
         if (auto req = decode<delete_fra_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_fra_convention(code);
-                BOOST_LOG_SEV(fra_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_fra_convention_response{.success = true});
+                svc.delete_fra_conventions(req->ids);
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_fra_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fra_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_fra_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_fra_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fra_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/fx_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/fx_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_FX_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_FX_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_FX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_FX_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
-#include "ores.refdata.core/service/fx_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+#include "ores.refdata.core/service/fx_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& fx_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.fx_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.fx_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class fx_convention_handler {
 public:
     fx_convention_handler(ores::nats::service::client& nats,
-                          ores::database::context ctx,
-                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::fx_convention_service svc(req_ctx);
         get_fx_conventions_response resp;
-        try {
-            resp.fx_conventions = svc.list_fx_conventions();
-            resp.total_available_count = static_cast<int>(resp.fx_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(fx_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_fx_conventions_request>(msg)) {
+            try {
+                resp.fx_conventions = svc.list_fx_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_fx_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fx_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,23 +109,28 @@ public:
         if (auto req = decode<save_fx_convention_request>(msg)) {
             try {
                 svc.save_fx_convention(req->data);
-                BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_fx_convention_response{.success = true});
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_fx_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fx_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(
-                    nats_, msg, save_fx_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_fx_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fx_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -124,52 +140,54 @@ public:
         if (auto req = decode<get_fx_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_fx_convention_history(req->id);
-                BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_fx_convention_history_response{.fx_conventions = std::move(hist),
-                                                         .success = true});
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_fx_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fx_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_fx_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_fx_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fx_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::fx_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::fx_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::fx_convention_service svc(req_ctx);
         if (auto req = decode<delete_fx_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_fx_convention(code);
-                BOOST_LOG_SEV(fx_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_fx_convention_response{.success = true});
+                svc.delete_fx_conventions(req->ids);
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_fx_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(fx_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_fx_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_fx_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(fx_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/ibor_index_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/ibor_index_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
-#include "ores.refdata.core/service/ibor_index_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+#include "ores.refdata.core/service/ibor_index_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& ibor_index_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.ibor_index_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.ibor_index_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class ibor_index_convention_handler {
 public:
     ibor_index_convention_handler(ores::nats::service::client& nats,
-                                  ores::database::context ctx,
-                                  std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::ibor_index_convention_service svc(req_ctx);
         get_ibor_index_conventions_response resp;
-        try {
-            resp.ibor_index_conventions = svc.list_ibor_index_conventions();
-            resp.total_available_count = static_cast<int>(resp.ibor_index_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_ibor_index_conventions_request>(msg)) {
+            try {
+                resp.ibor_index_conventions = svc.list_ibor_index_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_ibor_index_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -100,13 +111,13 @@ public:
                 svc.save_ibor_index_convention(req->data);
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, save_ibor_index_convention_response{.success = true});
+                reply(nats_, msg,
+                    save_ibor_index_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_ibor_index_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_ibor_index_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
@@ -116,8 +127,10 @@ public:
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -129,17 +142,13 @@ public:
                 auto hist = svc.get_ibor_index_convention_history(req->id);
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_ibor_index_convention_history_response{
-                          .ibor_index_conventions = std::move(hist), .success = true});
+                reply(nats_, msg, get_ibor_index_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_ibor_index_convention_history_response{.success = false,
-                                                                 .message = e.what()});
+                reply(nats_, msg, get_ibor_index_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
@@ -149,31 +158,32 @@ public:
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::ibor_index_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::ibor_index_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::ibor_index_convention_service svc(req_ctx);
         if (auto req = decode<delete_ibor_index_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_ibor_index_convention(code);
+                svc.delete_ibor_index_conventions(req->ids);
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, delete_ibor_index_convention_response{.success = true});
+                reply(nats_, msg,
+                    delete_ibor_index_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_ibor_index_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_ibor_index_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/monetary_nature_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/monetary_nature_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_MONETARY_NATURE_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_MONETARY_NATURE_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/monetary_nature_protocol.hpp"
-#include "ores.refdata.core/service/monetary_nature_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/monetary_nature_protocol.hpp"
+#include "ores.refdata.core/service/monetary_nature_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& monetary_nature_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.monetary_nature_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.monetary_nature_handler");
     return instance;
 }
 } // namespace
@@ -45,131 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for monetary nature operations.
+ */
 class monetary_nature_handler {
 public:
     monetary_nature_handler(ores::nats::service::client& nats,
-                            ores::database::context ctx,
-                            std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(monetary_nature_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::monetary_nature_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::monetary_nature_service svc(req_ctx);
         get_monetary_natures_response resp;
-        try {
-            resp.monetary_natures = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.monetary_natures.size());
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_monetary_natures_request>(msg)) {
+            try {
+                resp.types = svc.list_types(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_types());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(monetary_nature_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(monetary_nature_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::monetary_natures:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::monetary_natures:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::monetary_nature_service svc(ctx);
-        auto req = decode<save_monetary_nature_request>(msg);
-        if (!req) {
+        service::monetary_nature_service svc(req_ctx);
+        if (auto req = decode<save_monetary_nature_request>(msg)) {
+            try {
+                svc.save_type(req->data);
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_monetary_nature_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_monetary_nature_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(monetary_nature_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_type(req->data);
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_monetary_nature_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_monetary_nature_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(monetary_nature_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::monetary_natures:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::monetary_nature_service svc(ctx);
-        auto req = decode<delete_monetary_nature_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_type(req->nature);
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_monetary_nature_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, delete_monetary_nature_response{.success = false, .message = e.what()});
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(monetary_nature_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::monetary_nature_service svc(ctx);
-        auto req = decode<get_monetary_nature_history_request>(msg);
-        if (!req) {
+        const auto& req_ctx = *req_ctx_expected;
+        service::monetary_nature_service svc(req_ctx);
+        if (auto req = decode<get_monetary_nature_history_request>(msg)) {
+            try {
+                auto hist = svc.get_type_history(req->code);
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_monetary_nature_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_monetary_nature_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(monetary_nature_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_type_history(req->nature);
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_monetary_nature_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_monetary_nature_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::monetary_natures:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::monetary_nature_service svc(req_ctx);
+        if (auto req = decode<delete_monetary_nature_request>(msg)) {
+            try {
+                svc.delete_types(req->codes);
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_monetary_nature_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(monetary_nature_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_monetary_nature_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(monetary_nature_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -180,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/ois_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/ois_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_OIS_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_OIS_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_OIS_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_OIS_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
-#include "ores.refdata.core/service/ois_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+#include "ores.refdata.core/service/ois_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& ois_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.ois_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.ois_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class ois_convention_handler {
 public:
     ois_convention_handler(ores::nats::service::client& nats,
-                           ores::database::context ctx,
-                           std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::ois_convention_service svc(req_ctx);
         get_ois_conventions_response resp;
-        try {
-            resp.ois_conventions = svc.list_ois_conventions();
-            resp.total_available_count = static_cast<int>(resp.ois_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(ois_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_ois_conventions_request>(msg)) {
+            try {
+                resp.ois_conventions = svc.list_ois_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_ois_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ois_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,24 +109,28 @@ public:
         if (auto req = decode<save_ois_convention_request>(msg)) {
             try {
                 svc.save_ois_convention(req->data);
-                BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_ois_convention_response{.success = true});
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_ois_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ois_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_ois_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_ois_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(ois_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -125,52 +140,54 @@ public:
         if (auto req = decode<get_ois_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_ois_convention_history(req->id);
-                BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_ois_convention_history_response{.ois_conventions = std::move(hist),
-                                                          .success = true});
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_ois_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ois_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_ois_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_ois_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(ois_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::ois_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::ois_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::ois_convention_service svc(req_ctx);
         if (auto req = decode<delete_ois_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_ois_convention(code);
-                BOOST_LOG_SEV(ois_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_ois_convention_response{.success = true});
+                svc.delete_ois_conventions(req->ids);
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_ois_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(ois_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_ois_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_ois_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
-            BOOST_LOG_SEV(ois_convention_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
             error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/overnight_index_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/overnight_index_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
-#include "ores.refdata.core/service/overnight_index_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+#include "ores.refdata.core/service/overnight_index_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& overnight_index_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.overnight_index_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.overnight_index_convention_handler");
     return instance;
 }
 } // namespace
@@ -52,17 +52,16 @@ using namespace ores::logging;
  */
 class overnight_index_convention_handler {
 public:
-    overnight_index_convention_handler(
-        ores::nats::service::client& nats,
+    overnight_index_convention_handler(ores::nats::service::client& nats,
         ores::database::context ctx,
         std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -70,14 +69,22 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::overnight_index_convention_service svc(req_ctx);
         get_overnight_index_conventions_response resp;
-        try {
-            resp.overnight_index_conventions = svc.list_overnight_index_conventions();
-            resp.total_available_count = static_cast<int>(resp.overnight_index_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_overnight_index_conventions_request>(msg)) {
+            try {
+                resp.overnight_index_conventions = svc.list_overnight_index_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_overnight_index_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
         BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
             << "Completed " << msg.subject;
@@ -85,8 +92,10 @@ public:
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -102,14 +111,13 @@ public:
                 svc.save_overnight_index_convention(req->data);
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, save_overnight_index_convention_response{.success = true});
+                reply(nats_, msg,
+                    save_overnight_index_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_overnight_index_convention_response{.success = false,
-                                                               .message = e.what()});
+                reply(nats_, msg, save_overnight_index_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
@@ -119,8 +127,10 @@ public:
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -132,17 +142,13 @@ public:
                 auto hist = svc.get_overnight_index_convention_history(req->id);
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_overnight_index_convention_history_response{
-                          .overnight_index_conventions = std::move(hist), .success = true});
+                reply(nats_, msg, get_overnight_index_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_overnight_index_convention_history_response{.success = false,
-                                                                      .message = e.what()});
+                reply(nats_, msg, get_overnight_index_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
@@ -152,32 +158,32 @@ public:
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::overnight_index_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::overnight_index_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::overnight_index_convention_service svc(req_ctx);
         if (auto req = decode<delete_overnight_index_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_overnight_index_convention(code);
+                svc.delete_overnight_index_conventions(req->ids);
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
                     << "Completed " << msg.subject;
-                reply(nats_, msg, delete_overnight_index_convention_response{.success = true});
+                reply(nats_, msg,
+                    delete_overnight_index_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_overnight_index_convention_response{.success = false,
-                                                                 .message = e.what()});
+                reply(nats_, msg, delete_overnight_index_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_contact_information_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_contact_information_handler.hpp
@@ -1,0 +1,203 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_CONTACT_INFORMATION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_PARTY_CONTACT_INFORMATION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/party_contact_information_protocol.hpp"
+#include "ores.refdata.core/service/party_contact_information_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& party_contact_information_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_contact_information_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for party contact information operations.
+ */
+class party_contact_information_handler {
+public:
+    party_contact_information_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_contact_information_service svc(req_ctx);
+        get_party_contact_informations_response resp;
+        if (auto req = decode<get_party_contact_informations_request>(msg)) {
+            try {
+                resp.party_contact_informations = svc.list_party_contact_informations(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_party_contact_informations());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(party_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
+        }
+        BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_contact_informations:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_contact_information_service svc(req_ctx);
+        if (auto req = decode<save_party_contact_information_request>(msg)) {
+            try {
+                svc.save_party_contact_information(req->data);
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_contact_information_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_contact_information_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_contact_information_service svc(req_ctx);
+        if (auto req = decode<get_party_contact_information_history_request>(msg)) {
+            try {
+                auto hist = svc.get_party_contact_information_history(req->id);
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_contact_information_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_contact_information_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_contact_informations:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_contact_information_service svc(req_ctx);
+        if (auto req = decode<delete_party_contact_information_request>(msg)) {
+            try {
+                svc.delete_party_contact_informations(req->ids);
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_contact_information_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_contact_information_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_contact_information_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_contact_information_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_handler.hpp
@@ -20,25 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PARTY_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
-#include "ores.database/service/tenant_context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/party_protocol.hpp"
-#include "ores.refdata.core/service/party_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
-#include "ores.service/messaging/workflow_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <boost/uuid/string_generator.hpp>
-#include <optional>
+#include "ores.refdata.api/messaging/party_protocol.hpp"
+#include "ores.refdata.core/service/party_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& party_handler_lg() {
-    static auto instance = ores::logging::make_logger("ores.refdata.messaging.party_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_handler");
     return instance;
 }
 } // namespace
@@ -47,216 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for party operations.
+ */
 class party_handler {
 public:
     party_handler(ores::nats::service::client& nats,
-                  ores::database::context ctx,
-                  std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(party_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_service svc(req_ctx);
         get_parties_response resp;
-        auto req = decode<get_parties_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            reply(nats_, msg, resp);
+        if (auto req = decode<get_parties_request>(msg)) {
+            try {
+                resp.parties = svc.list_parties(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_parties());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(party_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
-        try {
-            resp.parties = svc.list_parties(static_cast<std::uint32_t>(req->offset),
-                                            static_cast<std::uint32_t>(req->limit));
-            resp.total_available_count = static_cast<int>(svc.count_parties());
-            BOOST_LOG_SEV(party_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_handler_lg(), error) << msg.subject << " failed: " << e.what();
-        }
+        BOOST_LOG_SEV(party_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        using ores::service::messaging::is_workflow_command;
-        using ores::service::messaging::extract_workflow_header;
-        using ores::service::messaging::publish_step_completion;
-        using ores::service::messaging::check_step_idempotency;
-        using ores::service::messaging::workflow_step_id_header;
-        using ores::service::messaging::workflow_instance_id_header;
-        using ores::service::messaging::workflow_tenant_id_header;
-
-        // Workflow step command: bypass JWT auth; use X-Tenant-Id for context.
-        if (is_workflow_command(msg)) {
-            const auto step_id = extract_workflow_header(msg, workflow_step_id_header);
-            const auto inst_id = extract_workflow_header(msg, workflow_instance_id_header);
-            const auto tenant_id = extract_workflow_header(msg, workflow_tenant_id_header);
-
-            // Idempotency guard: replay cached result if this step already completed.
-            if (auto cached = check_step_idempotency(nats_, step_id)) {
-                publish_step_completion(nats_,
-                                        step_id,
-                                        inst_id,
-                                        cached->outcome,
-                                        cached->result_json,
-                                        cached->error_message,
-                                        cached->log);
-                return;
-            }
-
-            auto req = decode<save_party_request>(msg);
-            if (!req) {
-                publish_step_completion(nats_,
-                                        step_id,
-                                        inst_id,
-                                        ores::workflow::messaging::step_outcome::failed,
-                                        "",
-                                        "Failed to decode save_party_request");
-                return;
-            }
+        BOOST_LOG_SEV(party_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::parties:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_service svc(req_ctx);
+        if (auto req = decode<save_party_request>(msg)) {
             try {
-                using ores::database::service::tenant_context;
-                auto wf_ctx = tenant_context::with_tenant(ctx_, tenant_id);
-                service::party_service svc(wf_ctx);
                 svc.save_party(req->data);
                 BOOST_LOG_SEV(party_handler_lg(), debug)
-                    << "Workflow step completed: " << msg.subject;
-                publish_step_completion(nats_,
-                                        step_id,
-                                        inst_id,
-                                        ores::workflow::messaging::step_outcome::completed,
-                                        rfl::json::write(save_party_response{.success = true}),
-                                        "");
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(party_handler_lg(), error)
-                    << "Workflow step failed: " << msg.subject << " — " << e.what();
-                publish_step_completion(nats_,
-                                        step_id,
-                                        inst_id,
-                                        ores::workflow::messaging::step_outcome::failed,
-                                        "",
-                                        e.what());
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_response{
+                    .success = false, .message = e.what()});
             }
-            return;
-        }
-
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(party_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::parties:write")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::party_service svc(ctx);
-        auto req = decode<save_party_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_party(req->data);
-            BOOST_LOG_SEV(party_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_party_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_party_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(party_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::parties:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::party_service svc(ctx);
-        auto req = decode<delete_party_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            boost::uuids::string_generator gen;
-            for (const auto& id_str : req->ids)
-                svc.remove_party(gen(id_str));
-            BOOST_LOG_SEV(party_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_party_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_party_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void read_for_cache(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(party_handler_lg(), msg);
-        auto req = decode<read_parties_for_cache_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            reply(nats_,
-                  msg,
-                  read_parties_for_cache_response{.success = false,
-                                                  .message = "Failed to decode request"});
-            return;
-        }
-        try {
-            using ores::database::service::tenant_context;
-            auto tctx = tenant_context::with_tenant(ctx_, req->tenant_id);
-            service::party_service svc(tctx);
-            auto parties = svc.list_parties();
-            BOOST_LOG_SEV(party_handler_lg(), debug)
-                << "Completed " << msg.subject << " (tenant=" << req->tenant_id
-                << ", count=" << parties.size() << ")";
-            reply(nats_,
-                  msg,
-                  read_parties_for_cache_response{.success = true, .parties = std::move(parties)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, read_parties_for_cache_response{.success = false, .message = e.what()});
+        } else {
+            BOOST_LOG_SEV(party_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(party_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_service svc(ctx);
-        auto req = decode<get_party_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_service svc(req_ctx);
+        if (auto req = decode<get_party_history_request>(msg)) {
+            try {
+                auto hist = svc.get_party_history(req->id);
+                BOOST_LOG_SEV(party_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            boost::uuids::string_generator gen;
-            auto h = svc.get_party_history(gen(req->id));
-            BOOST_LOG_SEV(party_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, get_party_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, get_party_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::parties:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_service svc(req_ctx);
+        if (auto req = decode<delete_party_request>(msg)) {
+            try {
+                svc.delete_parties(req->ids);
+                BOOST_LOG_SEV(party_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -267,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_id_scheme_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_id_scheme_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_ID_SCHEME_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PARTY_ID_SCHEME_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/party_id_scheme_protocol.hpp"
-#include "ores.refdata.core/service/party_id_scheme_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/party_id_scheme_protocol.hpp"
+#include "ores.refdata.core/service/party_id_scheme_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& party_id_scheme_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.party_id_scheme_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_id_scheme_handler");
     return instance;
 }
 } // namespace
@@ -45,131 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for party ID scheme operations.
+ */
 class party_id_scheme_handler {
 public:
     party_id_scheme_handler(ores::nats::service::client& nats,
-                            ores::database::context ctx,
-                            std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_id_scheme_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_id_scheme_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_id_scheme_service svc(req_ctx);
         get_party_id_schemes_response resp;
-        try {
-            resp.party_id_schemes = svc.list_schemes();
-            resp.total_available_count = static_cast<int>(resp.party_id_schemes.size());
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_party_id_schemes_request>(msg)) {
+            try {
+                resp.schemes = svc.list_schemes(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_schemes());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(party_id_scheme_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_id_scheme_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_id_schemes:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_id_schemes:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::party_id_scheme_service svc(ctx);
-        auto req = decode<save_party_id_scheme_request>(msg);
-        if (!req) {
+        service::party_id_scheme_service svc(req_ctx);
+        if (auto req = decode<save_party_id_scheme_request>(msg)) {
+            try {
+                svc.save_scheme(req->data);
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_id_scheme_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_id_scheme_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(party_id_scheme_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_scheme(req->data);
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_party_id_scheme_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_party_id_scheme_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_id_scheme_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_id_schemes:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::party_id_scheme_service svc(ctx);
-        auto req = decode<delete_party_id_scheme_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_scheme(req->scheme);
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_party_id_scheme_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, delete_party_id_scheme_response{.success = false, .message = e.what()});
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_id_scheme_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_id_scheme_service svc(ctx);
-        auto req = decode<get_party_id_scheme_history_request>(msg);
-        if (!req) {
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_id_scheme_service svc(req_ctx);
+        if (auto req = decode<get_party_id_scheme_history_request>(msg)) {
+            try {
+                auto hist = svc.get_scheme_history(req->code);
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_id_scheme_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_id_scheme_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(party_id_scheme_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_scheme_history(req->scheme);
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_party_id_scheme_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_party_id_scheme_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_id_schemes:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_id_scheme_service svc(req_ctx);
+        if (auto req = decode<delete_party_id_scheme_request>(msg)) {
+            try {
+                svc.delete_schemes(req->codes);
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_id_scheme_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_id_scheme_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_id_scheme_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_id_scheme_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -180,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_identifier_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_identifier_handler.hpp
@@ -20,24 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_IDENTIFIER_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PARTY_IDENTIFIER_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/party_identifier_protocol.hpp"
-#include "ores.refdata.core/service/party_identifier_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <boost/uuid/string_generator.hpp>
-#include <optional>
+#include "ores.refdata.api/messaging/party_identifier_protocol.hpp"
+#include "ores.refdata.core/service/party_identifier_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& party_identifier_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.party_identifier_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_identifier_handler");
     return instance;
 }
 } // namespace
@@ -46,112 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for party identifier operations.
+ */
 class party_identifier_handler {
 public:
     party_identifier_handler(ores::nats::service::client& nats,
-                             ores::database::context ctx,
-                             std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_identifier_service svc(ctx);
-        auto req = decode<get_party_identifiers_request>(msg);
-        if (!req) {
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_identifier_service svc(req_ctx);
+        get_party_identifiers_response resp;
+        if (auto req = decode<get_party_identifiers_request>(msg)) {
+            try {
+                resp.party_identifiers = svc.list_party_identifiers(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_party_identifiers());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
             BOOST_LOG_SEV(party_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
-        try {
-            boost::uuids::string_generator gen;
-            auto items = svc.list_party_identifiers_by_party(gen(req->party_id));
-            get_party_identifiers_response resp;
-            resp.identifiers = std::move(items);
-            BOOST_LOG_SEV(party_identifier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, resp);
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, get_party_identifiers_response{});
-        }
+        BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_identifiers:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_identifiers:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::party_identifier_service svc(ctx);
-        auto req = decode<save_party_identifier_request>(msg);
-        if (!req) {
+        service::party_identifier_service svc(req_ctx);
+        if (auto req = decode<save_party_identifier_request>(msg)) {
+            try {
+                svc.save_party_identifier(req->data);
+                BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_identifier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_identifier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(party_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            svc.save_party_identifier(req->data);
-            BOOST_LOG_SEV(party_identifier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_party_identifier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, save_party_identifier_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_identifier_service svc(req_ctx);
+        if (auto req = decode<get_party_identifier_history_request>(msg)) {
+            try {
+                auto hist = svc.get_party_identifier_history(req->id);
+                BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_identifier_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_identifier_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_identifier_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_identifier_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_identifiers:delete")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_identifiers:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::party_identifier_service svc(ctx);
-        auto req = decode<delete_party_identifier_request>(msg);
-        if (!req) {
+        service::party_identifier_service svc(req_ctx);
+        if (auto req = decode<delete_party_identifier_request>(msg)) {
+            try {
+                svc.delete_party_identifiers(req->ids);
+                BOOST_LOG_SEV(party_identifier_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_identifier_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_identifier_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_identifier_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
             BOOST_LOG_SEV(party_identifier_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            boost::uuids::string_generator gen;
-            for (const auto& id_str : req->ids)
-                svc.remove_party_identifier(gen(id_str));
-            BOOST_LOG_SEV(party_identifier_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_party_identifier_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_identifier_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  delete_party_identifier_response{.success = false, .message = e.what()});
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -162,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_status_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_status_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_STATUS_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PARTY_STATUS_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/party_status_protocol.hpp"
-#include "ores.refdata.core/service/party_status_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/party_status_protocol.hpp"
+#include "ores.refdata.core/service/party_status_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& party_status_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.party_status_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_status_handler");
     return instance;
 }
 } // namespace
@@ -45,127 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for party status operations.
+ */
 class party_status_handler {
 public:
     party_status_handler(ores::nats::service::client& nats,
-                         ores::database::context ctx,
-                         std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_status_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_status_service svc(req_ctx);
         get_party_statuses_response resp;
-        try {
-            resp.party_statuses = svc.list_statuses();
-            resp.total_available_count = static_cast<int>(resp.party_statuses.size());
-            BOOST_LOG_SEV(party_status_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_party_statuses_request>(msg)) {
+            try {
+                resp.statuses = svc.list_statuses(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_statuses());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(party_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(party_status_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_statuses:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_statuses:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::party_status_service svc(ctx);
-        auto req = decode<save_party_status_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_status(req->data);
-            BOOST_LOG_SEV(party_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_party_status_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_party_status_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_statuses:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::party_status_service svc(ctx);
-        auto req = decode<delete_party_status_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_status(req->status);
-            BOOST_LOG_SEV(party_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_party_status_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_party_status_response{.success = false, .message = e.what()});
+        service::party_status_service svc(req_ctx);
+        if (auto req = decode<save_party_status_request>(msg)) {
+            try {
+                svc.save_status(req->data);
+                BOOST_LOG_SEV(party_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_status_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_status_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_status_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_status_service svc(ctx);
-        auto req = decode<get_party_status_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_status_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_status_service svc(req_ctx);
+        if (auto req = decode<get_party_status_history_request>(msg)) {
+            try {
+                auto hist = svc.get_status_history(req->code);
+                BOOST_LOG_SEV(party_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_status_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_status_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_status_history(req->status);
-            BOOST_LOG_SEV(party_status_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_party_status_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_status_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_party_status_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_statuses:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_status_service svc(req_ctx);
+        if (auto req = decode<delete_party_status_request>(msg)) {
+            try {
+                svc.delete_statuses(req->codes);
+                BOOST_LOG_SEV(party_status_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_status_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_status_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_status_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_status_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -176,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_type_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_type_handler.hpp
@@ -20,22 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PARTY_TYPE_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PARTY_TYPE_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/party_type_protocol.hpp"
-#include "ores.refdata.core/service/party_type_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/party_type_protocol.hpp"
+#include "ores.refdata.core/service/party_type_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& party_type_handler_lg() {
-    static auto instance = ores::logging::make_logger("ores.refdata.messaging.party_type_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.party_type_handler");
     return instance;
 }
 } // namespace
@@ -44,122 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for party type operations.
+ */
 class party_type_handler {
 public:
     party_type_handler(ores::nats::service::client& nats,
-                       ores::database::context ctx,
-                       std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_type_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_type_service svc(req_ctx);
         get_party_types_response resp;
-        try {
-            resp.party_types = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.party_types.size());
-            BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_type_handler_lg(), error) << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_party_types_request>(msg)) {
+            try {
+                resp.types = svc.list_types(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_types());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(party_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(party_type_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_types:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_types:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::party_type_service svc(ctx);
-        auto req = decode<save_party_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_type(req->data);
-            BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_party_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_type_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_party_type_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::party_types:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::party_type_service svc(ctx);
-        auto req = decode<delete_party_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_type(req->type);
-            BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_party_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_type_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_party_type_response{.success = false, .message = e.what()});
+        service::party_type_service svc(req_ctx);
+        if (auto req = decode<save_party_type_request>(msg)) {
+            try {
+                svc.save_type(req->data);
+                BOOST_LOG_SEV(party_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_party_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_party_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(party_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(party_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::party_type_service svc(ctx);
-        auto req = decode<get_party_type_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(party_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::party_type_service svc(req_ctx);
+        if (auto req = decode<get_party_type_history_request>(msg)) {
+            try {
+                auto hist = svc.get_type_history(req->code);
+                BOOST_LOG_SEV(party_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_party_type_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_party_type_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(party_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_type_history(req->type);
-            BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_party_type_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(party_type_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, get_party_type_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::party_types:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::party_type_service svc(req_ctx);
+        if (auto req = decode<delete_party_type_request>(msg)) {
+            try {
+                svc.delete_types(req->codes);
+                BOOST_LOG_SEV(party_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_party_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(party_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_party_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(party_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -170,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/portfolio_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/portfolio_handler.hpp
@@ -20,22 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_PORTFOLIO_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_PORTFOLIO_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/portfolio_protocol.hpp"
-#include "ores.refdata.core/service/portfolio_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/portfolio_protocol.hpp"
+#include "ores.refdata.core/service/portfolio_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& portfolio_handler_lg() {
-    static auto instance = ores::logging::make_logger("ores.refdata.messaging.portfolio_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.portfolio_handler");
     return instance;
 }
 } // namespace
@@ -44,124 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for portfolio operations.
+ */
 class portfolio_handler {
 public:
     portfolio_handler(ores::nats::service::client& nats,
-                      ores::database::context ctx,
-                      std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(portfolio_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
-            << "Listing portfolios: tenant_id=" << ctx.tenant_id().to_string()
-            << " workspace_id=" << ctx.workspace_id();
-        service::portfolio_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::portfolio_service svc(req_ctx);
         get_portfolios_response resp;
-        try {
-            resp.portfolios = svc.list_portfolios();
-            resp.total_available_count = static_cast<int>(resp.portfolios.size());
-            BOOST_LOG_SEV(portfolio_handler_lg(), debug)
-                << "Completed " << msg.subject << ": returned " << resp.total_available_count
-                << " portfolios";
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), error) << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_portfolios_request>(msg)) {
+            try {
+                resp.portfolios = svc.list_portfolios(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_portfolios());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(portfolio_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(portfolio_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(portfolio_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::portfolios:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::portfolios:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::portfolio_service svc(ctx);
-        auto req = decode<save_portfolio_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_portfolio(req->data);
-            BOOST_LOG_SEV(portfolio_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_portfolio_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_portfolio_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(portfolio_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::portfolios:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::portfolio_service svc(ctx);
-        auto req = decode<delete_portfolio_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            for (const auto& id_str : req->ids)
-                svc.remove_portfolio(id_str);
-            BOOST_LOG_SEV(portfolio_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_portfolio_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_portfolio_response{.success = false, .message = e.what()});
+        service::portfolio_service svc(req_ctx);
+        if (auto req = decode<save_portfolio_request>(msg)) {
+            try {
+                svc.save_portfolio(req->data);
+                BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_portfolio_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(portfolio_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_portfolio_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(portfolio_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id = log_handler_entry(portfolio_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::portfolio_service svc(ctx);
-        auto req = decode<get_portfolio_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::portfolio_service svc(req_ctx);
+        if (auto req = decode<get_portfolio_history_request>(msg)) {
+            try {
+                auto hist = svc.get_portfolio_history(req->id);
+                BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_portfolio_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(portfolio_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_portfolio_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(portfolio_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_portfolio_history(req->id);
-            BOOST_LOG_SEV(portfolio_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_portfolio_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(portfolio_handler_lg(), error) << msg.subject << " failed: " << e.what();
-            reply(
-                nats_, msg, get_portfolio_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::portfolios:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::portfolio_service svc(req_ctx);
+        if (auto req = decode<delete_portfolio_request>(msg)) {
+            try {
+                svc.delete_portfolios(req->ids);
+                BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_portfolio_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(portfolio_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_portfolio_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(portfolio_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -172,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/rounding_type_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/rounding_type_handler.hpp
@@ -20,23 +20,23 @@
 #ifndef ORES_REFDATA_CORE_MESSAGING_ROUNDING_TYPE_HANDLER_HPP
 #define ORES_REFDATA_CORE_MESSAGING_ROUNDING_TYPE_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/rounding_type_protocol.hpp"
-#include "ores.refdata.core/service/rounding_type_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/rounding_type_protocol.hpp"
+#include "ores.refdata.core/service/rounding_type_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& rounding_type_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.rounding_type_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.rounding_type_handler");
     return instance;
 }
 } // namespace
@@ -45,127 +45,150 @@ using ores::service::messaging::reply;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
-using ores::service::messaging::log_handler_entry;
 using namespace ores::logging;
 
+/**
+ * @brief NATS message handler for rounding type operations.
+ */
 class rounding_type_handler {
 public:
     rounding_type_handler(ores::nats::service::client& nats,
-                          ores::database::context ctx,
-                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(rounding_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::rounding_type_service svc(ctx);
+        const auto& req_ctx = *req_ctx_expected;
+        service::rounding_type_service svc(req_ctx);
         get_rounding_types_response resp;
-        try {
-            resp.rounding_types = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.rounding_types.size());
-            BOOST_LOG_SEV(rounding_type_handler_lg(), debug) << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
+        if (auto req = decode<get_rounding_types_request>(msg)) {
+            try {
+                resp.types = svc.list_types(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_types());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(rounding_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(rounding_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
+        BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(rounding_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::rounding_types:write")) {
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::rounding_types:write")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::rounding_type_service svc(ctx);
-        auto req = decode<save_rounding_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.save_type(req->data);
-            BOOST_LOG_SEV(rounding_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, save_rounding_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, save_rounding_type_response{.success = false, .message = e.what()});
-        }
-    }
-
-    void remove(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(rounding_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
-            return;
-        }
-        const auto& ctx = *ctx_expected;
-        if (!has_permission(ctx, "refdata::rounding_types:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
-        service::rounding_type_service svc(ctx);
-        auto req = decode<delete_rounding_type_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
-            return;
-        }
-        try {
-            svc.remove_type(req->type);
-            BOOST_LOG_SEV(rounding_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_, msg, delete_rounding_type_response{.success = true});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_, msg, delete_rounding_type_response{.success = false, .message = e.what()});
+        service::rounding_type_service svc(req_ctx);
+        if (auto req = decode<save_rounding_type_request>(msg)) {
+            try {
+                svc.save_type(req->data);
+                BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_rounding_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(rounding_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_rounding_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(rounding_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
     void history(ores::nats::message msg) {
-        [[maybe_unused]] const auto correlation_id =
-            log_handler_entry(rounding_type_handler_lg(), msg);
-        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!ctx_expected) {
-            error_reply(nats_, msg, ctx_expected.error());
+        BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        const auto& ctx = *ctx_expected;
-        service::rounding_type_service svc(ctx);
-        auto req = decode<get_rounding_type_history_request>(msg);
-        if (!req) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+        const auto& req_ctx = *req_ctx_expected;
+        service::rounding_type_service svc(req_ctx);
+        if (auto req = decode<get_rounding_type_history_request>(msg)) {
+            try {
+                auto hist = svc.get_type_history(req->code);
+                BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_rounding_type_history_response{
+                    .history = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(rounding_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_rounding_type_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(rounding_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
-        try {
-            auto h = svc.get_type_history(req->type);
-            BOOST_LOG_SEV(rounding_type_handler_lg(), debug) << "Completed " << msg.subject;
-            reply(nats_,
-                  msg,
-                  get_rounding_type_history_response{.success = true, .history = std::move(h)});
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(rounding_type_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            reply(nats_,
-                  msg,
-                  get_rounding_type_history_response{.success = false, .message = e.what()});
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::rounding_types:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::rounding_type_service svc(req_ctx);
+        if (auto req = decode<delete_rounding_type_request>(msg)) {
+            try {
+                svc.delete_types(req->codes);
+                BOOST_LOG_SEV(rounding_type_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_rounding_type_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(rounding_type_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_rounding_type_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(rounding_type_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
         }
     }
 
@@ -176,4 +199,5 @@ private:
 };
 
 } // namespace ores::refdata::messaging
+
 #endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/swap_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/swap_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
-#include "ores.refdata.core/service/swap_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+#include "ores.refdata.core/service/swap_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& swap_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.swap_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.swap_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class swap_convention_handler {
 public:
     swap_convention_handler(ores::nats::service::client& nats,
-                            ores::database::context ctx,
-                            std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::swap_convention_service svc(req_ctx);
         get_swap_conventions_response resp;
-        try {
-            resp.swap_conventions = svc.list_swap_conventions();
-            resp.total_available_count = static_cast<int>(resp.swap_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(swap_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_swap_conventions_request>(msg)) {
+            try {
+                resp.swap_conventions = svc.list_swap_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_swap_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(swap_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,14 +109,15 @@ public:
         if (auto req = decode<save_swap_convention_request>(msg)) {
             try {
                 svc.save_swap_convention(req->data);
-                BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_swap_convention_response{.success = true});
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_swap_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(swap_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_swap_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_swap_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
@@ -115,8 +127,10 @@ public:
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -126,17 +140,15 @@ public:
         if (auto req = decode<get_swap_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_swap_convention_history(req->id);
-                BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_swap_convention_history_response{.swap_conventions = std::move(hist),
-                                                           .success = true});
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_swap_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(swap_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_swap_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_swap_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
@@ -146,30 +158,32 @@ public:
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::swap_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::swap_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::swap_convention_service svc(req_ctx);
         if (auto req = decode<delete_swap_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_swap_convention(code);
-                BOOST_LOG_SEV(swap_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_swap_convention_response{.success = true});
+                svc.delete_swap_conventions(req->ids);
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_swap_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(swap_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_swap_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_swap_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(swap_convention_handler_lg(), warn)

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/zero_convention_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/zero_convention_handler.hpp
@@ -17,26 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_MESSAGING_ZERO_CONVENTION_HANDLER_HPP
-#define ORES_REFDATA_MESSAGING_ZERO_CONVENTION_HANDLER_HPP
+#ifndef ORES_REFDATA_CORE_MESSAGING_ZERO_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_ZERO_CONVENTION_HANDLER_HPP
 
-#include "ores.database/domain/context.hpp"
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
-#include "ores.refdata.api/messaging/zero_convention_protocol.hpp"
-#include "ores.refdata.core/service/zero_convention_service.hpp"
+#include "ores.database/domain/context.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
-#include <optional>
+#include "ores.refdata.api/messaging/zero_convention_protocol.hpp"
+#include "ores.refdata.core/service/zero_convention_service.hpp"
 
 namespace ores::refdata::messaging {
 
 namespace {
 inline auto& zero_convention_handler_lg() {
-    static auto instance =
-        ores::logging::make_logger("ores.refdata.messaging.zero_convention_handler");
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.zero_convention_handler");
     return instance;
 }
 } // namespace
@@ -53,15 +53,15 @@ using namespace ores::logging;
 class zero_convention_handler {
 public:
     zero_convention_handler(ores::nats::service::client& nats,
-                            ores::database::context ctx,
-                            std::optional<ores::security::jwt::jwt_authenticator> verifier)
-        : nats_(nats)
-        , ctx_(std::move(ctx))
-        , verifier_(std::move(verifier)) {}
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
 
     void list(ores::nats::message msg) {
-        BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -69,22 +69,33 @@ public:
         const auto& req_ctx = *req_ctx_expected;
         service::zero_convention_service svc(req_ctx);
         get_zero_conventions_response resp;
-        try {
-            resp.zero_conventions = svc.list_zero_conventions();
-            resp.total_available_count = static_cast<int>(resp.zero_conventions.size());
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(zero_convention_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.success = false;
-            resp.message = e.what();
+        if (auto req = decode<get_zero_conventions_request>(msg)) {
+            try {
+                resp.zero_conventions = svc.list_zero_conventions(req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(svc.count_zero_conventions());
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(zero_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+        } else {
+            BOOST_LOG_SEV(zero_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
         }
-        BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Completed " << msg.subject;
+        BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
         reply(nats_, msg, resp);
     }
 
     void save(ores::nats::message msg) {
-        BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -98,14 +109,15 @@ public:
         if (auto req = decode<save_zero_convention_request>(msg)) {
             try {
                 svc.save_zero_convention(req->data);
-                BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, save_zero_convention_response{.success = true});
+                BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_zero_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(zero_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      save_zero_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, save_zero_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(zero_convention_handler_lg(), warn)
@@ -115,8 +127,10 @@ public:
     }
 
     void history(ores::nats::message msg) {
-        BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
@@ -126,17 +140,15 @@ public:
         if (auto req = decode<get_zero_convention_history_request>(msg)) {
             try {
                 auto hist = svc.get_zero_convention_history(req->id);
-                BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_,
-                      msg,
-                      get_zero_convention_history_response{.zero_conventions = std::move(hist),
-                                                           .success = true});
+                BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_zero_convention_history_response{
+                    .history = std::move(hist), .success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(zero_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      get_zero_convention_history_response{.success = false, .message = e.what()});
+                reply(nats_, msg, get_zero_convention_history_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(zero_convention_handler_lg(), warn)
@@ -146,30 +158,32 @@ public:
     }
 
     void remove(ores::nats::message msg) {
-        BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Handling " << msg.subject;
-        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
         if (!req_ctx_expected) {
             error_reply(nats_, msg, req_ctx_expected.error());
             return;
         }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "refdata::zero_conventions:write")) {
+        if (!has_permission(req_ctx, "refdata::zero_conventions:delete")) {
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
         service::zero_convention_service svc(req_ctx);
         if (auto req = decode<delete_zero_convention_request>(msg)) {
             try {
-                for (const auto& code : req->codes)
-                    svc.remove_zero_convention(code);
-                BOOST_LOG_SEV(zero_convention_handler_lg(), debug) << "Completed " << msg.subject;
-                reply(nats_, msg, delete_zero_convention_response{.success = true});
+                svc.delete_zero_conventions(req->ids);
+                BOOST_LOG_SEV(zero_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_zero_convention_response{.success = true});
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(zero_convention_handler_lg(), error)
                     << msg.subject << " failed: " << e.what();
-                reply(nats_,
-                      msg,
-                      delete_zero_convention_response{.success = false, .message = e.what()});
+                reply(nats_, msg, delete_zero_convention_response{
+                    .success = false, .message = e.what()});
             }
         } else {
             BOOST_LOG_SEV(zero_convention_handler_lg(), warn)

--- a/projects/ores.refdata/modeling/ores.refdata.book_status.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book_status.org
@@ -100,8 +100,6 @@ drop function if exists ores_refdata_validate_book_status_fn;
 
 ** Flags
 :PROPERTIES:
-:component_include:  refdata.api
-:component_core:     refdata.core
 :subcomponent:       api
 :has_batch_remove:   true
 :END:


### PR DESCRIPTION
## Summary

Regenerate protocol, nats-eventing, and nats-handler headers for the full refdata entity set. Also ships the codegen model unification investigation (cross-cutting analysis, rides this PR for convenience).

## Changes

- Sync protocol, nats-eventing, and nats-handler codegen output for all refdata entities
- Normalise NATS subjects to underscores; rename list/delete/history fields to template standard
- Add missing *_changed_event.hpp files for entities that lacked them
- Fix book_status missing subcomponent flag (blocked messaging profiles)
- Add codegen model unification investigation doc (doc/analysis/)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: party_status](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_party_status/story.html) | 8B3D478B-DD68-44B7-A8BF-DB50F76C9506 |
| Task | [Sync C++ messaging codegen for party_status](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/commission_party_status/task_sync_cpp_messaging_codegen_party_status.html) | 7F64F55A-32BA-4774-8508-FF7F05FD984F |

🤖 Generated with [Claude Code](https://claude.com/claude-code)