### PR TITLE
[hotfix] Fix party_type_handler API mismatch with party_type_service

### DIFF
--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_type_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/party_type_handler.hpp
@@ -66,10 +66,17 @@ public:
         }
         const auto& ctx = *ctx_expected;
         service::party_type_service svc(ctx);
+        auto req = decode<get_party_types_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(party_type_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            return;
+        }
         get_party_types_response resp;
         try {
-            resp.party_types = svc.list_types();
-            resp.total_available_count = static_cast<int>(resp.party_types.size());
+            resp.party_types = svc.list_types(
+                static_cast<std::uint32_t>(req->offset),
+                static_cast<std::uint32_t>(req->limit));
+            resp.total_available_count = static_cast<int>(svc.count_types());
             BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(party_type_handler_lg(), error) << msg.subject << " failed: " << e.what();
@@ -126,7 +133,7 @@ public:
             return;
         }
         try {
-            svc.remove_type(req->type);
+            svc.delete_type(req->type);
             BOOST_LOG_SEV(party_type_handler_lg(), debug) << "Completed " << msg.subject;
             reply(nats_, msg, delete_party_type_response{.success = true});
         } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary

`party_type_service` was updated to add pagination to `list_types()` and rename `remove_type` to `delete_type`, but `party_type_handler.hpp` was not updated in sync. This left the build broken after PR #1348 restored handlers to their pre-PR state.

## Changes

- `list` handler: decode request; call `list_types(offset, limit)` with `uint32_t` casts; use `count_types()` for `total_available_count`
- `remove` handler: `remove_type(req->type)` → `delete_type(req->type)`

## Verification

Scanned all other handlers — no other `remove_*` / `list_*` mismatches found. All remaining services use no-arg `list_*()` and `remove_*()` which match their handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)