### PR TITLE
[hotfix] Revert eventing field rename from PR #1342

### DIFF
--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/book_changed_event.hpp
@@ -20,33 +20,23 @@
 #ifndef ORES_REFDATA_API_EVENTING_BOOK_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_BOOK_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that book data has changed.
  *
- * Published when any book entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any book entity is created, updated, or
+ * deleted in the database. Subscribers can use the timestamp to query for
+ * changes since that point.
  */
 struct book_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed book UUIDs (as strings).
-     */
-    std::vector<std::string> book_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +44,9 @@ struct book_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for book_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::book_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.book_changed";
+    static constexpr std::string_view name = "ores.refdata.book_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/business_unit_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/business_unit_changed_event.hpp
@@ -20,33 +20,23 @@
 #ifndef ORES_REFDATA_API_EVENTING_BUSINESS_UNIT_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_BUSINESS_UNIT_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that business unit data has changed.
  *
- * Published when any business unit entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any business unit entity is created,
+ * updated, or deleted in the database. Subscribers can use the timestamp
+ * to query for changes since that point.
  */
 struct business_unit_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed business unit UUIDs (as strings).
-     */
-    std::vector<std::string> business_unit_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +44,9 @@ struct business_unit_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for business_unit_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::business_unit_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.business_unit_changed";
+    static constexpr std::string_view name = "ores.refdata.business_unit_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_changed_event.hpp
@@ -20,33 +20,23 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that counterparty data has changed.
  *
- * Published when any counterparty entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any counterparty entity is created, updated, or
+ * deleted in the database. Subscribers can use the timestamp to query for
+ * changes since that point.
  */
 struct counterparty_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed counterparty UUIDs (as strings).
-     */
-    std::vector<std::string> counterparty_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +44,9 @@ struct counterparty_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for counterparty_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::counterparty_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.counterparty_changed";
+    static constexpr std::string_view name = "ores.refdata.counterparty_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_contact_information_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_contact_information_changed_event.hpp
@@ -20,33 +20,19 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that counterparty contact information data has changed.
- *
- * Published when any counterparty contact information entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * @brief Domain event indicating that counterparty contact information has changed.
  */
 struct counterparty_contact_information_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed counterparty contact information UUIDs (as strings).
-     */
-    std::vector<std::string> counterparty_contact_information_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,10 +40,7 @@ struct counterparty_contact_information_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for counterparty_contact_information_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::counterparty_contact_information_changed_event> {
     static constexpr std::string_view name =
         "ores.refdata.counterparty_contact_information_changed";

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_identifier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/counterparty_identifier_changed_event.hpp
@@ -20,33 +20,19 @@
 #ifndef ORES_REFDATA_API_EVENTING_COUNTERPARTY_IDENTIFIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_COUNTERPARTY_IDENTIFIER_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that counterparty identifier data has changed.
- *
- * Published when any counterparty identifier entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct counterparty_identifier_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed counterparty identifier UUIDs (as strings).
-     */
-    std::vector<std::string> counterparty_identifier_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +40,9 @@ struct counterparty_identifier_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for counterparty_identifier_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::counterparty_identifier_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.counterparty_identifier_changed";
+    static constexpr std::string_view name = "ores.refdata.counterparty_identifier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/currency_market_tier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/currency_market_tier_changed_event.hpp
@@ -20,27 +20,35 @@
 #ifndef ORES_REFDATA_API_EVENTING_CURRENCY_MARKET_TIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_CURRENCY_MARKET_TIER_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that currency market tier data has changed.
  *
- * Published when any currency market tier entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any currency market tier entity is created,
+ * updated, or deleted in the database. Subscribers can use the timestamp
+ * to query for changes since that point.
  */
 struct currency_market_tier_changed_event final {
     /**
      * @brief The timestamp of when the change occurred (in UTC).
+     *
+     * Clients can use this timestamp to query the database for entities
+     * that have changed since this point.
      */
     std::chrono::system_clock::time_point timestamp;
 
     /**
-     * @brief Changed currency market tier codes.
+     * @brief Codes of currency market tiers that changed.
+     *
+     * Contains the codes (e.g., "g10", "emerging") of currency market
+     * tiers that were created, updated, or deleted. May contain multiple
+     * codes for batch operations.
      */
     std::vector<std::string> codes;
 
@@ -57,10 +65,9 @@ namespace ores::eventing::domain {
 /**
  * @brief Event traits specialization for currency_market_tier_changed_event.
  */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::currency_market_tier_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.currency_market_tier_changed";
+    static constexpr std::string_view name = "ores.refdata.currency_market_tier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/monetary_nature_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/monetary_nature_changed_event.hpp
@@ -20,27 +20,35 @@
 #ifndef ORES_REFDATA_API_EVENTING_MONETARY_NATURE_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_MONETARY_NATURE_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that monetary nature data has changed.
+ * @brief Domain event indicating that currency asset class data has changed.
  *
- * Published when any monetary nature entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any currency asset class entity is created,
+ * updated, or deleted in the database. Subscribers can use the timestamp
+ * to query for changes since that point.
  */
 struct monetary_nature_changed_event final {
     /**
      * @brief The timestamp of when the change occurred (in UTC).
+     *
+     * Clients can use this timestamp to query the database for entities
+     * that have changed since this point.
      */
     std::chrono::system_clock::time_point timestamp;
 
     /**
-     * @brief Changed monetary nature codes.
+     * @brief Codes of currency asset classes that changed.
+     *
+     * Contains the codes (e.g., "fiat", "commodity") of currency asset
+     * classes that were created, updated, or deleted. May contain multiple
+     * codes for batch operations.
      */
     std::vector<std::string> codes;
 
@@ -57,10 +65,9 @@ namespace ores::eventing::domain {
 /**
  * @brief Event traits specialization for monetary_nature_changed_event.
  */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::monetary_nature_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.monetary_nature_changed";
+    static constexpr std::string_view name = "ores.refdata.monetary_nature_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_changed_event.hpp
@@ -20,33 +20,23 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that party data has changed.
  *
- * Published when any party entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any party entity is created, updated, or
+ * deleted in the database. Subscribers can use the timestamp to query for
+ * changes since that point.
  */
 struct party_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed party UUIDs (as strings).
-     */
-    std::vector<std::string> party_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +44,9 @@ struct party_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for party_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::party_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.party_changed";
+    static constexpr std::string_view name = "ores.refdata.party_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_contact_information_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_contact_information_changed_event.hpp
@@ -20,33 +20,19 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_CONTACT_INFORMATION_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
- * @brief Domain event indicating that party contact information data has changed.
- *
- * Published when any party contact information entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * @brief Domain event indicating that party contact information has changed.
  */
 struct party_contact_information_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed party contact information UUIDs (as strings).
-     */
-    std::vector<std::string> party_contact_information_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +40,9 @@ struct party_contact_information_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for party_contact_information_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::party_contact_information_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.party_contact_information_changed";
+    static constexpr std::string_view name = "ores.refdata.party_contact_information_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_identifier_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/party_identifier_changed_event.hpp
@@ -20,33 +20,19 @@
 #ifndef ORES_REFDATA_API_EVENTING_PARTY_IDENTIFIER_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PARTY_IDENTIFIER_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that party identifier data has changed.
- *
- * Published when any party identifier entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
  */
 struct party_identifier_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed party identifier UUIDs (as strings).
-     */
-    std::vector<std::string> party_identifier_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +40,9 @@ struct party_identifier_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for party_identifier_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::party_identifier_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.party_identifier_changed";
+    static constexpr std::string_view name = "ores.refdata.party_identifier_changed";
 };
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/eventing/portfolio_changed_event.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/eventing/portfolio_changed_event.hpp
@@ -20,33 +20,23 @@
 #ifndef ORES_REFDATA_API_EVENTING_PORTFOLIO_CHANGED_EVENT_HPP
 #define ORES_REFDATA_API_EVENTING_PORTFOLIO_CHANGED_EVENT_HPP
 
-#include <chrono>
-#include <vector>
-#include <string>
 #include "ores.eventing.api/domain/event_traits.hpp"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace ores::refdata::eventing {
 
 /**
  * @brief Domain event indicating that portfolio data has changed.
  *
- * Published when any portfolio entity is created, updated, or
- * deleted. Subscribers use the timestamp to query for changes since that point.
+ * This event is published when any portfolio entity is created, updated, or
+ * deleted in the database. Subscribers can use the timestamp to query for
+ * changes since that point.
  */
 struct portfolio_changed_event final {
-    /**
-     * @brief The timestamp of when the change occurred (in UTC).
-     */
     std::chrono::system_clock::time_point timestamp;
-
-    /**
-     * @brief Changed portfolio UUIDs (as strings).
-     */
-    std::vector<std::string> portfolio_ids;
-
-    /**
-     * @brief The tenant that owns the changed entity.
-     */
+    std::vector<std::string> ids;
     std::string tenant_id;
 };
 
@@ -54,13 +44,9 @@ struct portfolio_changed_event final {
 
 namespace ores::eventing::domain {
 
-/**
- * @brief Event traits specialization for portfolio_changed_event.
- */
-template<>
+template <>
 struct event_traits<ores::refdata::eventing::portfolio_changed_event> {
-    static constexpr std::string_view name =
-        "ores.refdata.portfolio_changed";
+    static constexpr std::string_view name = "ores.refdata.portfolio_changed";
 };
 
 }


### PR DESCRIPTION
## Summary

PR #1342 renamed the \`ids\` field in changed_event headers to entity-specific names (\`book_ids\`, \`business_unit_ids\`, \`counterparty_ids\`, etc.). These headers were retained in PR #1348 as "additive", but the rename is a breaking change — \`application.cpp\` accesses \`.ids\` on all of them.

## Changes

Revert 11 modified eventing files to their pre-PR state (\`ids\` field). New eventing files added by PR #1342 (\`book_status_changed_event\`, \`cds_convention_changed_event\`, etc.) are left in place — they are not yet referenced by \`application.cpp\` so cause no build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)