### PR TITLE
[agile] Close marketdata-client-library task; record result

### DIFF
--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/story.org
@@ -50,7 +50,7 @@ Validate the approach developed in the sprint-21 analysis story by building a wo
 | [[id:6B5BB82B-0A74-464B-9382-4D3275FFD4E2][Tick loop and process factory]] | DONE | 2026-06-26 | 2026-06-26 | Implement the tick_loop with fixed-mode clock and a seeded GmmProcess; publish typed fx_spot_tick to marketdata.v1.tick.fx.rate.eur.usd (no DB write yet). Validates synthetic generation and NATS fan-out publishing in isolation — step 2 of the FX spot PoC implementation order. |
 | [[id:2F29D41D-44CC-47BF-81C2-40F216767011][DB write integration]] | DONE | 2026-06-26 | 2026-06-26 | Add a marketdata.v1.observations.save NATS request-reply call per tick in FxSpotFeed; verify observations appear in the existing MarketSeriesMdiWindow observation view. Step 3 of the FX spot PoC implementation order. |
 | [[id:E2C8F6C1-4B41-4ABB-BC40-12B8E4DE7672][Start/stop NATS handlers for FX spot feed]] | DONE | 2026-06-26 | 2026-06-26 | Add marketdata.v1.market_feed_configs.start and stop request-reply handlers to ores.synthetic.service; step 4 of the FX spot PoC implementation order. |
-| [[id:E5C1373A-01C9-43AE-BC4B-3D35A64DE24B][ores.marketdata.client library and ClientManager::nats_client()]] | STARTED | 2026-06-27 | | New ores.marketdata.client sub-component with fx_spot_subscription; add nats_client() accessor to ClientManager; validate with a logging subscriber. Step 5 of the FX spot PoC implementation order. |
+| [[id:E5C1373A-01C9-43AE-BC4B-3D35A64DE24B][ores.marketdata.client library and ClientManager::nats_client()]] | DONE | 2026-06-27 | 2026-06-27 | New ores.marketdata.client sub-component with fx_spot_subscription; add nats_client() accessor to ClientManager; validate with a logging subscriber. Step 5 of the FX spot PoC implementation order. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_marketdata-client-library.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_market_data_poc/task_marketdata-client-library.org
@@ -26,11 +26,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:8A65240D-C7A2-4F66-860F-97137B03B482][PoC: synthetic market data generation — FX spot vertical slice]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-27                               |
 
 * Acceptance
@@ -60,3 +60,9 @@ plan itself stays — it is the historical record of what we did.)
 | 3 | Missing Qt threading note for callers | =fx_spot_subscription.hpp= | Fixed | =@note= added: handler runs on NATS delivery thread; use =QMetaObject::invokeMethod= or =Qt::QueuedConnection= |
 
 * Result
+
+Delivered =ores.marketdata.client= as a new CMake sub-component under =projects/ores.marketdata/client=. The component provides =fx_spot_subscription=, a RAII class that translates an ORE key (e.g. =FX/RATE/EUR/USD=) to a canonical NATS subject (=marketdata.v1.tick.fx.rate.eur.usd=), subscribes via the =ores.nats= client, deserialises arriving messages with =rfl::json= into =fx_spot_tick= domain objects, and delivers them to a caller-supplied handler. Malformed messages are logged at =warn= severity and silently dropped. The subscription tears down automatically on destruction.
+
+Added =ClientManager::nats_client()= to =ores.qt.api=: returns the raw =ores::nats::service::client&=, guards on =is_logged_in()=, and throws =std::runtime_error= if not authenticated.
+
+Key supporting work: extracted =ore_key_to_subject= to =detail/subject_helpers.hpp= so tests exercise the real production function; added the Qt threading =@note= to the class docstring; tightened the =nats_client()= precondition guard to use =is_logged_in()= to match the documented =@pre=.


### PR DESCRIPTION
Closes the step 5 task (`E5C1373A`) for the FX spot PoC: marks it DONE, fills in the `* Result` section and the review round table.

The implementation PR (#1346) merged first; this PR carries only the bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)