### PR TITLE
[synthetic] Add market data generation config domain entities

### DIFF
--- a/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/story.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/story.org
@@ -8,7 +8,7 @@
 #+filetags: :market_data:synthetic:sprint_21:v0:
 #+created: 2026-06-28
 #+updated: 2026-06-28
-#+environment:
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -29,7 +29,7 @@ data is correctly owned and traceable.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -57,7 +57,7 @@ data is correctly owned and traceable.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:FD9977D4-B5CB-4F72-AA8E-139F34A346D1][Synthetic config entities across all layers (currency pattern)]] | STARTED | 2026-06-28 | | Hand-write the synthetic generation config domain model — synthetic_config (container), synthetic_fx_spot_config (sub-config, FK to container), synthetic_gmm_component (FK to sub-config) — across every layer, mirroring the currency reference entity (and book for FKs) so they convert to codegen types later: domain type + json_io + table_io + table, generator, repository (entity/mapper/repository), NATS protocol, SQL (create/triggers/notify), service, handler, eventing, CMake + registrar wiring. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
@@ -8,7 +8,7 @@
 #+filetags: :synthetic_generation_configuration:sprint_21:v0:
 #+owner: marco
 #+branch: feature/synthetic-config-entities
-#+pr:
+#+pr: 1362
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-28
@@ -51,7 +51,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1362][#1362]] | [synthetic] Add market data generation config domain entities |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
@@ -57,6 +57,14 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| R1 | Canary: synthetic not a registered component prefix + missing RLS policies | parser + rls | Fixed | 8d0043038 — prefix registered, 6 RLS policies added |
+| R1 | ticks_per_hour / gmm_initial_price need positive constraints | fx_spot create.sql + service | Fixed | a5547f668 — SQL CHECK + service guard |
+| R1 | ore_key needs non-empty constraint | fx_spot create.sql + service | Fixed | a5547f668 — SQL CHECK + service guard |
+| R1 | weight needs DB-level CHECK | gmm create.sql | Fixed | a5547f668 — check (weight >= 0) |
+| R1 | batch remove() missing valid_to filter (all 3 repos) | repositories | Fixed | ceb571f04 |
+| R1 | truncated GPL header in fx_spot/gmm handlers | handlers | Fixed | be461c059 |
+| R1 | no cascade soft-delete on parent removal | SQL triggers | Declined | acknowledged soft-FK limitation; separate cascade story |
+| R1 | list handler swallows errors silently | handlers | Declined | inherited from currency template; cross-cutting, fix globally |
+| R1 | informational notes (read perm, weight-sum, optional description, party-scoped source uniq) | — | Declined | intentional / matches established pattern |
 
 * Result

--- a/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
+++ b/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: FD9977D4-B5CB-4F72-AA8E-139F34A346D1
+:END:
+#+title: Task: Synthetic config entities across all layers (currency pattern)
+#+description: Hand-write the synthetic generation config domain model — synthetic_config (container), synthetic_fx_spot_config (sub-config, FK to container), synthetic_gmm_component (FK to sub-config) — across every layer, mirroring the currency reference entity (and book for FKs) so they convert to codegen types later: domain type + json_io + table_io + table, generator, repository (entity/mapper/repository), NATS protocol, SQL (create/triggers/notify), service, handler, eventing, CMake + registrar wiring.
+#+type: task
+#+level: s1
+#+filetags: :synthetic_generation_configuration:sprint_21:v0:
+#+owner: marco
+#+branch: feature/synthetic-config-entities
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-28
+#+updated: 2026-06-28
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1D7FFB95-E766-4A49-BEE6-23067B6E035B][Synthetic generation configuration and config-driven feeds]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Establish the persisted synthetic generation config data model in ores.synthetic, party/tenant-scoped, with every file matching the currency/book codegen output patterns so a future codegen pass regenerates them with zero/minimal diff.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:1D7FFB95-E766-4A49-BEE6-23067B6E035B][Synthetic generation configuration and config-driven feeds]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-28                               |
+
+* Acceptance
+
+- synthetic_config, synthetic_fx_spot_config and synthetic_gmm_component exist across all layers following the currency pattern exactly
+- Real foreign keys link sub-config -> container and component -> sub-config
+- DB recreate provisions the tables; CRUD round-trips over NATS; build is green
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.codegen/src/plantuml_er_parse_sql.py
+++ b/projects/ores.codegen/src/plantuml_er_parse_sql.py
@@ -54,6 +54,7 @@ COMPONENT_PREFIXES = {
     'ores_marketdata_': {'name': 'marketdata', 'description': 'Market Data (Quotes, Fixings, Series)', 'schema': 'public', 'color': '#E3F2FD', 'order': 18},
     'ores_controller_': {'name': 'controller', 'description': 'Service Lifecycle Controller', 'schema': 'public', 'color': '#E8EAF6', 'order': 19},
     'ores_analytics_': {'name': 'analytics', 'description': 'Analytics & Pricing Configuration', 'schema': 'public', 'color': '#E8F5E9', 'order': 20},
+    'ores_synthetic_': {'name': 'synthetic', 'description': 'Synthetic Data Generation', 'schema': 'public', 'color': '#F9FBE7', 'order': 22},
     'ores_workspaces_': {'name': 'workspace', 'description': 'Workspace — Isolated Data Contexts', 'schema': 'public', 'color': '#E8F5E9', 'order': 21},
     'ores_workspace_': {'name': 'workspace', 'description': 'Workspace — Isolated Data Contexts', 'schema': 'public', 'color': '#E8F5E9', 'order': 21},
     'ores_utility_': {'name': 'utility', 'description': 'Utility Functions', 'schema': 'public', 'color': '#ECEFF1', 'order': 15},

--- a/projects/ores.sql/create/create.sql
+++ b/projects/ores.sql/create/create.sql
@@ -57,6 +57,7 @@
 \ir ./marketdata/marketdata_create.sql
 \ir ./controller/controller_create.sql
 \ir ./analytics/analytics_create.sql
+\ir ./synthetic/synthetic_create.sql
 
 -- =============================================================================
 -- 6. Row-Level Security Policies (depend on all tables and IAM functions)

--- a/projects/ores.sql/create/rls/rls_create.sql
+++ b/projects/ores.sql/create/rls/rls_create.sql
@@ -40,3 +40,4 @@
 \ir ../reporting/reporting_rls_policies_create.sql
 \ir ../controller/controller_rls_policies_create.sql
 \ir ../analytics/analytics_rls_policies_create.sql
+\ir ../synthetic/synthetic_rls_policies_create.sql

--- a/projects/ores.sql/create/synthetic/synthetic_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_create.sql
@@ -20,3 +20,5 @@
 
 \ir ./synthetic_market_data_generation_configs_create.sql
 \ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
+\ir ./synthetic_fx_spot_generation_configs_create.sql
+\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql

--- a/projects/ores.sql/create/synthetic/synthetic_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_create.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+\ir ./synthetic_market_data_generation_configs_create.sql
+\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql

--- a/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
@@ -47,7 +47,10 @@ create table if not exists "ores_synthetic_fx_spot_generation_configs_tbl" (
         tstzrange(valid_from, valid_to) WITH &&
     ),
     check ("valid_from" < "valid_to"),
-    check ("source_name" <> '')
+    check ("source_name" <> ''),
+    check ("ore_key" <> ''),
+    check ("gmm_initial_price" > 0),
+    check ("ticks_per_hour" > 0)
 );
 
 create unique index if not exists sfsgc_version_uniq_idx

--- a/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
@@ -1,0 +1,142 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Synthetic FX spot generation configurations (typed sub-configs of a
+-- market_data_generation_config; one per FX spot rate produced)
+-- =============================================================================
+
+create table if not exists "ores_synthetic_fx_spot_generation_configs_tbl" (
+    "id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "config_id" uuid not null,
+    "version" integer not null,
+    "source_name" text not null,
+    "ore_key" text not null,
+    "gmm_initial_price" double precision not null,
+    "ticks_per_hour" integer not null,
+    "enabled" boolean not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    constraint sfsgc_temporal_excl exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("source_name" <> '')
+);
+
+create unique index if not exists sfsgc_version_uniq_idx
+on "ores_synthetic_fx_spot_generation_configs_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists sfsgc_id_uniq_idx
+on "ores_synthetic_fx_spot_generation_configs_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- A configuration's source name is unique per tenant and party.
+create unique index if not exists sfsgc_party_source_uniq_idx
+on "ores_synthetic_fx_spot_generation_configs_tbl" (tenant_id, party_id, source_name)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists sfsgc_tenant_idx
+on "ores_synthetic_fx_spot_generation_configs_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists sfsgc_config_id_idx
+on "ores_synthetic_fx_spot_generation_configs_tbl" (tenant_id, config_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_synthetic_fx_spot_generation_configs_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+
+    -- Validate change_reason_code
+    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
+
+    -- Validate config_id (soft FK to ores_synthetic_market_data_generation_configs_tbl)
+    if not exists (
+        select 1 from ores_synthetic_market_data_generation_configs_tbl
+        where tenant_id = new.tenant_id
+          and id = new.config_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid config_id: %. No active market data generation config found with this id.', new.config_id
+            using errcode = '23503';
+    end if;
+
+    select version into current_version
+    from "ores_synthetic_fx_spot_generation_configs_tbl"
+    where tenant_id = new.tenant_id
+      and id = new.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if new.version != 0 and new.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                new.version, current_version
+                using errcode = 'P0002';
+        end if;
+        new.version = current_version + 1;
+
+        update "ores_synthetic_fx_spot_generation_configs_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = new.tenant_id
+          and id = new.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        new.version = 1;
+    end if;
+
+    new.valid_from = current_timestamp;
+    new.valid_to = ores_utility_infinity_timestamp_fn();
+    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
+    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_fx_spot_generation_configs_insert_trg
+before insert on "ores_synthetic_fx_spot_generation_configs_tbl"
+for each row
+execute function ores_synthetic_fx_spot_generation_configs_insert_fn();
+
+create or replace rule ores_synthetic_fx_spot_generation_configs_delete_rule as
+on delete to "ores_synthetic_fx_spot_generation_configs_tbl"
+do instead
+  update "ores_synthetic_fx_spot_generation_configs_tbl"
+  set valid_to = current_timestamp
+  where tenant_id = old.tenant_id
+  and id = old.id
+  and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+create or replace function ores_synthetic_fx_spot_generation_configs_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.synthetic.fx_spot_generation_config';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', ores_utility_iso8601_timestamp_fn(change_timestamp),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_synthetic_fx_spot_generation_configs',
+                      notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_fx_spot_generation_configs_notify_trg
+after insert or update or delete on ores_synthetic_fx_spot_generation_configs_tbl
+for each row execute function ores_synthetic_fx_spot_generation_configs_notify_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
@@ -1,0 +1,141 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Synthetic GMM components (weighted normal distributions making up the
+-- Gaussian Mixture Model price process of an fx_spot_generation_config)
+-- =============================================================================
+
+create table if not exists "ores_synthetic_gmm_components_tbl" (
+    "id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "fx_spot_config_id" uuid not null,
+    "version" integer not null,
+    "component_index" integer not null,
+    "mean" double precision not null,
+    "stdev" double precision not null,
+    "weight" double precision not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    constraint sgmc_temporal_excl exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("stdev" > 0)
+);
+
+create unique index if not exists sgmc_version_uniq_idx
+on "ores_synthetic_gmm_components_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists sgmc_id_uniq_idx
+on "ores_synthetic_gmm_components_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- A component's position is unique within its owning FX spot config.
+create unique index if not exists sgmc_config_index_uniq_idx
+on "ores_synthetic_gmm_components_tbl" (tenant_id, fx_spot_config_id, component_index)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists sgmc_tenant_idx
+on "ores_synthetic_gmm_components_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists sgmc_fx_spot_config_id_idx
+on "ores_synthetic_gmm_components_tbl" (tenant_id, fx_spot_config_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_synthetic_gmm_components_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+
+    -- Validate change_reason_code
+    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
+
+    -- Validate fx_spot_config_id (soft FK to ores_synthetic_fx_spot_generation_configs_tbl)
+    if not exists (
+        select 1 from ores_synthetic_fx_spot_generation_configs_tbl
+        where tenant_id = new.tenant_id
+          and id = new.fx_spot_config_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid fx_spot_config_id: %. No active FX spot generation config found with this id.', new.fx_spot_config_id
+            using errcode = '23503';
+    end if;
+
+    select version into current_version
+    from "ores_synthetic_gmm_components_tbl"
+    where tenant_id = new.tenant_id
+      and id = new.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if new.version != 0 and new.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                new.version, current_version
+                using errcode = 'P0002';
+        end if;
+        new.version = current_version + 1;
+
+        update "ores_synthetic_gmm_components_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = new.tenant_id
+          and id = new.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        new.version = 1;
+    end if;
+
+    new.valid_from = current_timestamp;
+    new.valid_to = ores_utility_infinity_timestamp_fn();
+    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
+    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_gmm_components_insert_trg
+before insert on "ores_synthetic_gmm_components_tbl"
+for each row
+execute function ores_synthetic_gmm_components_insert_fn();
+
+create or replace rule ores_synthetic_gmm_components_delete_rule as
+on delete to "ores_synthetic_gmm_components_tbl"
+do instead
+  update "ores_synthetic_gmm_components_tbl"
+  set valid_to = current_timestamp
+  where tenant_id = old.tenant_id
+  and id = old.id
+  and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
@@ -46,7 +46,8 @@ create table if not exists "ores_synthetic_gmm_components_tbl" (
         tstzrange(valid_from, valid_to) WITH &&
     ),
     check ("valid_from" < "valid_to"),
-    check ("stdev" > 0)
+    check ("stdev" > 0),
+    check ("weight" >= 0)
 );
 
 create unique index if not exists sgmc_version_uniq_idx

--- a/projects/ores.sql/create/synthetic/synthetic_gmm_components_notify_trigger_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_gmm_components_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+create or replace function ores_synthetic_gmm_components_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.synthetic.gmm_component';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', ores_utility_iso8601_timestamp_fn(change_timestamp),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_synthetic_gmm_components',
+                      notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_gmm_components_notify_trg
+after insert or update or delete on ores_synthetic_gmm_components_tbl
+for each row execute function ores_synthetic_gmm_components_notify_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_market_data_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_market_data_generation_configs_create.sql
@@ -1,0 +1,123 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Synthetic market data generation configurations (named, party-scoped recipes)
+-- =============================================================================
+
+create table if not exists "ores_synthetic_market_data_generation_configs_tbl" (
+    "id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "name" text not null,
+    "description" text not null,
+    "enabled" boolean not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    constraint smdgc_temporal_excl exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("name" <> '')
+);
+
+create unique index if not exists smdgc_version_uniq_idx
+on "ores_synthetic_market_data_generation_configs_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists smdgc_id_uniq_idx
+on "ores_synthetic_market_data_generation_configs_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- A configuration's source name is unique per tenant and party.
+create unique index if not exists smdgc_party_name_uniq_idx
+on "ores_synthetic_market_data_generation_configs_tbl" (tenant_id, party_id, name)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists smdgc_tenant_idx
+on "ores_synthetic_market_data_generation_configs_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_synthetic_market_data_generation_configs_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+
+    -- Validate change_reason_code
+    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
+
+    select version into current_version
+    from "ores_synthetic_market_data_generation_configs_tbl"
+    where tenant_id = new.tenant_id
+      and id = new.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if new.version != 0 and new.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                new.version, current_version
+                using errcode = 'P0002';
+        end if;
+        new.version = current_version + 1;
+
+        update "ores_synthetic_market_data_generation_configs_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = new.tenant_id
+          and id = new.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        new.version = 1;
+    end if;
+
+    new.valid_from = current_timestamp;
+    new.valid_to = ores_utility_infinity_timestamp_fn();
+    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
+    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_market_data_generation_configs_insert_trg
+before insert on "ores_synthetic_market_data_generation_configs_tbl"
+for each row
+execute function ores_synthetic_market_data_generation_configs_insert_fn();
+
+create or replace rule ores_synthetic_market_data_generation_configs_delete_rule as
+on delete to "ores_synthetic_market_data_generation_configs_tbl"
+do instead
+  update "ores_synthetic_market_data_generation_configs_tbl"
+  set valid_to = current_timestamp
+  where tenant_id = old.tenant_id
+  and id = old.id
+  and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_market_data_generation_configs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_market_data_generation_configs_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+create or replace function ores_synthetic_market_data_generation_configs_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.synthetic.market_data_generation_config';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', ores_utility_iso8601_timestamp_fn(change_timestamp),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_synthetic_market_data_generation_configs',
+                      notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_synthetic_market_data_generation_configs_notify_trg
+after insert or update or delete on ores_synthetic_market_data_generation_configs_tbl
+for each row execute function ores_synthetic_market_data_generation_configs_notify_fn();

--- a/projects/ores.sql/create/synthetic/synthetic_rls_policies_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_rls_policies_create.sql
@@ -1,0 +1,106 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Row-Level Security Policies for Synthetic Tables
+-- =============================================================================
+-- Each synthetic generation config (and its sub-configs) is scoped to a tenant
+-- and an owning party. Tenant isolation is the standard permissive policy;
+-- party isolation is a RESTRICTIVE policy ANDed on top. When no party context
+-- is set (visible_party_ids is NULL) the party policy passes through, matching
+-- the established refdata pattern.
+
+-- -----------------------------------------------------------------------------
+-- Market data generation configs (dual RLS: tenant + party isolation)
+-- -----------------------------------------------------------------------------
+alter table ores_synthetic_market_data_generation_configs_tbl enable row level security;
+
+create policy market_data_generation_configs_tenant_isolation_policy
+on ores_synthetic_market_data_generation_configs_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy market_data_generation_configs_party_isolation_policy
+on ores_synthetic_market_data_generation_configs_tbl
+as restrictive
+for all using (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+)
+with check (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX spot generation configs (dual RLS: tenant + party isolation)
+-- -----------------------------------------------------------------------------
+alter table ores_synthetic_fx_spot_generation_configs_tbl enable row level security;
+
+create policy fx_spot_generation_configs_tenant_isolation_policy
+on ores_synthetic_fx_spot_generation_configs_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy fx_spot_generation_configs_party_isolation_policy
+on ores_synthetic_fx_spot_generation_configs_tbl
+as restrictive
+for all using (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+)
+with check (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- GMM components (dual RLS: tenant + party isolation)
+-- -----------------------------------------------------------------------------
+alter table ores_synthetic_gmm_components_tbl enable row level security;
+
+create policy gmm_components_tenant_isolation_policy
+on ores_synthetic_gmm_components_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy gmm_components_party_isolation_policy
+on ores_synthetic_gmm_components_tbl
+as restrictive
+for all using (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+)
+with check (
+    ores_iam_visible_party_ids_fn() is null
+    or party_id = ANY(ores_iam_visible_party_ids_fn())
+);

--- a/projects/ores.sql/drop/drop.sql
+++ b/projects/ores.sql/drop/drop.sql
@@ -26,6 +26,7 @@
 -- =============================================================================
 -- 2. Operational Tables (have FKs to data governance tables, must be dropped first)
 -- =============================================================================
+\ir ./synthetic/synthetic_drop.sql
 \ir ./analytics/drop_analytics.sql
 \ir ./controller/controller_drop.sql
 \ir ./marketdata/marketdata_drop.sql

--- a/projects/ores.sql/drop/synthetic/synthetic_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_drop.sql
@@ -18,6 +18,8 @@
  *
  */
 
+\ir ./synthetic_gmm_components_notify_trigger_drop.sql
+\ir ./synthetic_gmm_components_drop.sql
 \ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
 \ir ./synthetic_fx_spot_generation_configs_drop.sql
 \ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql

--- a/projects/ores.sql/drop/synthetic/synthetic_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
+\ir ./synthetic_market_data_generation_configs_drop.sql

--- a/projects/ores.sql/drop/synthetic/synthetic_fx_spot_generation_configs_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_fx_spot_generation_configs_drop.sql
@@ -18,7 +18,7 @@
  *
  */
 
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_fx_spot_generation_configs_drop.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_market_data_generation_configs_drop.sql
+drop rule if exists ores_synthetic_fx_spot_generation_configs_delete_rule on "ores_synthetic_fx_spot_generation_configs_tbl";
+drop trigger if exists ores_synthetic_fx_spot_generation_configs_insert_trg on "ores_synthetic_fx_spot_generation_configs_tbl";
+drop function if exists ores_synthetic_fx_spot_generation_configs_insert_fn;
+drop table if exists "ores_synthetic_fx_spot_generation_configs_tbl";

--- a/projects/ores.sql/drop/synthetic/synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
@@ -18,7 +18,5 @@
  *
  */
 
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_fx_spot_generation_configs_drop.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_market_data_generation_configs_drop.sql
+drop trigger if exists ores_synthetic_fx_spot_generation_configs_notify_trg on "ores_synthetic_fx_spot_generation_configs_tbl";
+drop function if exists ores_synthetic_fx_spot_generation_configs_notify_fn;

--- a/projects/ores.sql/drop/synthetic/synthetic_gmm_components_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_gmm_components_drop.sql
@@ -18,9 +18,7 @@
  *
  */
 
-\ir ./synthetic_market_data_generation_configs_create.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_fx_spot_generation_configs_create.sql
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_gmm_components_create.sql
-\ir ./synthetic_gmm_components_notify_trigger_create.sql
+drop rule if exists ores_synthetic_gmm_components_delete_rule on "ores_synthetic_gmm_components_tbl";
+drop trigger if exists ores_synthetic_gmm_components_insert_trg on "ores_synthetic_gmm_components_tbl";
+drop function if exists ores_synthetic_gmm_components_insert_fn;
+drop table if exists "ores_synthetic_gmm_components_tbl";

--- a/projects/ores.sql/drop/synthetic/synthetic_gmm_components_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_gmm_components_notify_trigger_drop.sql
@@ -18,9 +18,5 @@
  *
  */
 
-\ir ./synthetic_market_data_generation_configs_create.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_fx_spot_generation_configs_create.sql
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_gmm_components_create.sql
-\ir ./synthetic_gmm_components_notify_trigger_create.sql
+drop trigger if exists ores_synthetic_gmm_components_notify_trg on "ores_synthetic_gmm_components_tbl";
+drop function if exists ores_synthetic_gmm_components_notify_fn;

--- a/projects/ores.sql/drop/synthetic/synthetic_market_data_generation_configs_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_market_data_generation_configs_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_synthetic_market_data_generation_configs_delete_rule on "ores_synthetic_market_data_generation_configs_tbl";
+drop trigger if exists ores_synthetic_market_data_generation_configs_insert_trg on "ores_synthetic_market_data_generation_configs_tbl";
+drop function if exists ores_synthetic_market_data_generation_configs_insert_fn;
+drop table if exists "ores_synthetic_market_data_generation_configs_tbl";

--- a/projects/ores.sql/drop/synthetic/synthetic_market_data_generation_configs_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_market_data_generation_configs_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_synthetic_market_data_generation_configs_notify_trg on "ores_synthetic_market_data_generation_configs_tbl";
+drop function if exists ores_synthetic_market_data_generation_configs_notify_fn;

--- a/projects/ores.sql/drop/synthetic/synthetic_rls_policies_drop.sql
+++ b/projects/ores.sql/drop/synthetic/synthetic_rls_policies_drop.sql
@@ -19,22 +19,15 @@
  */
 
 -- =============================================================================
--- Drop Row-Level Security Policies
+-- Drop Row-Level Security Policies for Synthetic Tables
 -- =============================================================================
--- RLS policies must be dropped before the tables they reference. This
--- orchestration file includes all component RLS policy drops.
+-- Must be dropped before the corresponding tables are dropped.
 
-\ir ../synthetic/synthetic_rls_policies_drop.sql
-\ir ../controller/controller_rls_policies_drop.sql
-\ir ../marketdata/marketdata_rls_policies_drop.sql
-\ir ../workflow/workflow_rls_policies_drop.sql
-\ir ../compute/compute_rls_policies_drop.sql
-\ir ../scheduler/scheduler_rls_policies_drop.sql
-\ir ../trading/trading_rls_policies_drop.sql
-\ir ../geo/geo_rls_policies_drop.sql
-\ir ../assets/assets_rls_policies_drop.sql
-\ir ../telemetry/telemetry_rls_policies_drop.sql
-\ir ../variability/variability_rls_policies_drop.sql
-\ir ../iam/iam_rls_policies_drop.sql
-\ir ../refdata/refdata_rls_policies_drop.sql
-\ir ../dq/dq_rls_policies_drop.sql
+drop policy if exists gmm_components_party_isolation_policy on "ores_synthetic_gmm_components_tbl";
+drop policy if exists gmm_components_tenant_isolation_policy on "ores_synthetic_gmm_components_tbl";
+
+drop policy if exists fx_spot_generation_configs_party_isolation_policy on "ores_synthetic_fx_spot_generation_configs_tbl";
+drop policy if exists fx_spot_generation_configs_tenant_isolation_policy on "ores_synthetic_fx_spot_generation_configs_tbl";
+
+drop policy if exists market_data_generation_configs_party_isolation_policy on "ores_synthetic_market_data_generation_configs_tbl";
+drop policy if exists market_data_generation_configs_tenant_isolation_policy on "ores_synthetic_market_data_generation_configs_tbl";

--- a/projects/ores.sql/populate/iam/iam_permissions_populate.sql
+++ b/projects/ores.sql/populate/iam/iam_permissions_populate.sql
@@ -385,6 +385,9 @@ BEGIN
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:read',   'View market data generation configs');
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:write',  'Create and modify market data generation configs');
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:delete', 'Delete market data generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:read',   'View FX spot generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:write',  'Create and modify FX spot generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:delete', 'Delete FX spot generation configs');
 
     -- =============================================================================
     -- Workflow Component Permissions

--- a/projects/ores.sql/populate/iam/iam_permissions_populate.sql
+++ b/projects/ores.sql/populate/iam/iam_permissions_populate.sql
@@ -388,6 +388,9 @@ BEGIN
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:read',   'View FX spot generation configs');
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:write',  'Create and modify FX spot generation configs');
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::fx_spot_generation_configs:delete', 'Delete FX spot generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::gmm_components:read',   'View GMM components');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::gmm_components:write',  'Create and modify GMM components');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::gmm_components:delete', 'Delete GMM components');
 
     -- =============================================================================
     -- Workflow Component Permissions

--- a/projects/ores.sql/populate/iam/iam_permissions_populate.sql
+++ b/projects/ores.sql/populate/iam/iam_permissions_populate.sql
@@ -382,6 +382,9 @@ BEGIN
     -- =============================================================================
 
     PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::*', 'Full access to all synthetic data operations');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:read',   'View market data generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:write',  'Create and modify market data generation configs');
+    PERFORM ores_iam_permissions_upsert_fn(ores_utility_system_tenant_id_fn(), 'synthetic::market_data_generation_configs:delete', 'Delete market data generation configs');
 
     -- =============================================================================
     -- Workflow Component Permissions

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config.hpp
@@ -1,0 +1,130 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_DOMAIN_FX_SPOT_GENERATION_CONFIG_HPP
+#define ORES_SYNTHETIC_DOMAIN_FX_SPOT_GENERATION_CONFIG_HPP
+
+#include "ores.utility/uuid/tenant_id.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <chrono>
+#include <string>
+
+namespace ores::synthetic::domain {
+
+/**
+ * @brief Configuration for generating synthetic FX spot observations.
+ *
+ * A typed sub-configuration owned by a market_data_generation_config. It
+ * describes how to synthesise the tick stream for a single FX spot rate: which
+ * ORE market key it produces, the starting price, the tick cadence, and the
+ * source name carried as provenance on each generated observation.
+ *
+ * The price process is a Gaussian Mixture Model whose components are held
+ * separately as gmm_component rows that reference this configuration.
+ *
+ * Scoped to a tenant and a party so each party manages its own configurations
+ * and its own generated data.
+ */
+struct fx_spot_generation_config final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief Unique identifier for this configuration.
+     */
+    boost::uuids::uuid id{};
+
+    /**
+     * @brief Owning party; the configuration and the data it generates belong
+     * to this party within the tenant.
+     */
+    boost::uuids::uuid party_id{};
+
+    /**
+     * @brief Owning market data generation config.
+     *
+     * References the market_data_generation_configs table (soft FK).
+     */
+    boost::uuids::uuid config_id{};
+
+    /**
+     * @brief Stable source name carried as the provenance of generated
+     * observations (e.g. "synthetic.gmm123"). Unique per tenant and party.
+     */
+    std::string source_name;
+
+    /**
+     * @brief ORE market key identifying the FX spot rate produced (e.g.
+     * "FX/EUR/USD").
+     */
+    std::string ore_key;
+
+    /**
+     * @brief Initial spot price the generated process starts from.
+     */
+    double gmm_initial_price = 0.0;
+
+    /**
+     * @brief Number of synthetic ticks produced per hour.
+     */
+    int ticks_per_hour = 0;
+
+    /**
+     * @brief Whether the configuration is active and eligible for generation.
+     */
+    bool enabled = false;
+
+    /**
+     * @brief Username of the person who recorded this version in the system.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Username of the account that performed this operation.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded in the system.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config_json_io.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config_json_io.hpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,8 +17,18 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#ifndef ORES_SYNTHETIC_DOMAIN_FX_SPOT_GENERATION_CONFIG_JSON_IO_HPP
+#define ORES_SYNTHETIC_DOMAIN_FX_SPOT_GENERATION_CONFIG_JSON_IO_HPP
 
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_fx_spot_generation_configs_drop.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_market_data_generation_configs_drop.sql
+#include "ores.synthetic.api/domain/fx_spot_generation_config.hpp"
+#include "ores.synthetic.api/export.hpp"
+#include <iosfwd>
+
+namespace ores::synthetic::domain {
+
+ORES_SYNTHETIC_API_EXPORT std::ostream&
+operator<<(std::ostream& s, const fx_spot_generation_config& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component.hpp
@@ -1,0 +1,121 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_DOMAIN_GMM_COMPONENT_HPP
+#define ORES_SYNTHETIC_DOMAIN_GMM_COMPONENT_HPP
+
+#include "ores.utility/uuid/tenant_id.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <chrono>
+#include <string>
+
+namespace ores::synthetic::domain {
+
+/**
+ * @brief A single component of a Gaussian Mixture Model price process.
+ *
+ * An fx_spot_generation_config drives its synthetic price increments from a
+ * Gaussian Mixture Model: a weighted set of normal distributions. Each
+ * component is one normal distribution (mean, standard deviation) with a
+ * mixture weight; together the components define the increment distribution
+ * sampled per tick.
+ *
+ * Scoped to a tenant and a party so each party manages its own configurations
+ * and its own generated data.
+ */
+struct gmm_component final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief Unique identifier for this component.
+     */
+    boost::uuids::uuid id{};
+
+    /**
+     * @brief Owning party; the component and the data it helps generate belong
+     * to this party within the tenant.
+     */
+    boost::uuids::uuid party_id{};
+
+    /**
+     * @brief Owning FX spot generation config.
+     *
+     * References the fx_spot_generation_configs table (soft FK).
+     */
+    boost::uuids::uuid fx_spot_config_id{};
+
+    /**
+     * @brief Position of this component within its mixture (0-based ordering).
+     */
+    int component_index = 0;
+
+    /**
+     * @brief Mean of this component's normal distribution.
+     */
+    double mean = 0.0;
+
+    /**
+     * @brief Standard deviation of this component's normal distribution.
+     */
+    double stdev = 0.0;
+
+    /**
+     * @brief Mixture weight of this component (relative probability).
+     */
+    double weight = 0.0;
+
+    /**
+     * @brief Username of the person who recorded this version in the system.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Username of the account that performed this operation.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded in the system.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component_json_io.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component_json_io.hpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,10 +17,18 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#ifndef ORES_SYNTHETIC_DOMAIN_GMM_COMPONENT_JSON_IO_HPP
+#define ORES_SYNTHETIC_DOMAIN_GMM_COMPONENT_JSON_IO_HPP
 
-\ir ./synthetic_market_data_generation_configs_create.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_fx_spot_generation_configs_create.sql
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_gmm_components_create.sql
-\ir ./synthetic_gmm_components_notify_trigger_create.sql
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include "ores.synthetic.api/export.hpp"
+#include <iosfwd>
+
+namespace ores::synthetic::domain {
+
+ORES_SYNTHETIC_API_EXPORT std::ostream&
+operator<<(std::ostream& s, const gmm_component& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/market_data_generation_config.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/market_data_generation_config.hpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_DOMAIN_MARKET_DATA_GENERATION_CONFIG_HPP
+#define ORES_SYNTHETIC_DOMAIN_MARKET_DATA_GENERATION_CONFIG_HPP
+
+#include "ores.utility/uuid/tenant_id.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <chrono>
+#include <string>
+
+namespace ores::synthetic::domain {
+
+/**
+ * @brief A named configuration for generating synthetic market data.
+ *
+ * The top-level container that owns one or more typed sub-configurations (FX
+ * spot now; vol surface, interest-rate curves later). It is the recipe for how
+ * synthetic market data is produced. Scoped to a tenant and a party so each
+ * party manages its own configurations and its own generated data.
+ *
+ * Distinct from synthetic's non-market generators (e.g. organisation
+ * generation) — this type concerns market data specifically.
+ */
+struct market_data_generation_config final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief Unique identifier for this configuration.
+     */
+    boost::uuids::uuid id{};
+
+    /**
+     * @brief Owning party; the configuration and the data it generates belong
+     * to this party within the tenant.
+     */
+    boost::uuids::uuid party_id{};
+
+    /**
+     * @brief Stable source name carried as the provenance of generated
+     * observations (e.g. "synthetic.gmm123"). Unique per tenant and party.
+     */
+    std::string name;
+
+    /**
+     * @brief Free-text description of the configuration.
+     */
+    std::string description;
+
+    /**
+     * @brief Whether the configuration is active and eligible for generation.
+     */
+    bool enabled = false;
+
+    /**
+     * @brief Username of the person who recorded this version in the system.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Username of the account that performed this operation.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded in the system.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/market_data_generation_config_json_io.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/market_data_generation_config_json_io.hpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_DOMAIN_MARKET_DATA_GENERATION_CONFIG_JSON_IO_HPP
+#define ORES_SYNTHETIC_DOMAIN_MARKET_DATA_GENERATION_CONFIG_JSON_IO_HPP
+
+#include "ores.synthetic.api/domain/market_data_generation_config.hpp"
+#include "ores.synthetic.api/export.hpp"
+#include <iosfwd>
+
+namespace ores::synthetic::domain {
+
+ORES_SYNTHETIC_API_EXPORT std::ostream&
+operator<<(std::ostream& s, const market_data_generation_config& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp
@@ -1,0 +1,73 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_API_MESSAGING_FX_SPOT_GENERATION_CONFIG_PROTOCOL_HPP
+#define ORES_SYNTHETIC_API_MESSAGING_FX_SPOT_GENERATION_CONFIG_PROTOCOL_HPP
+
+#include "ores.synthetic.api/domain/fx_spot_generation_config.hpp"
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::messaging {
+
+struct get_fx_spot_generation_configs_request {
+    using response_type = struct get_fx_spot_generation_configs_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.fx_spot_generation_configs.list";
+    int offset = 0;
+    int limit = 100;
+};
+
+struct get_fx_spot_generation_configs_response {
+    std::vector<ores::synthetic::domain::fx_spot_generation_config> configs;
+    int total_available_count = 0;
+};
+
+struct save_fx_spot_generation_config_request {
+    using response_type = struct save_fx_spot_generation_config_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.fx_spot_generation_configs.save";
+    ores::synthetic::domain::fx_spot_generation_config data;
+
+    static save_fx_spot_generation_config_request
+    from(ores::synthetic::domain::fx_spot_generation_config c) {
+        return {.data = std::move(c)};
+    }
+};
+
+struct save_fx_spot_generation_config_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_fx_spot_generation_config_request {
+    using response_type = struct delete_fx_spot_generation_config_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.fx_spot_generation_configs.delete";
+    std::vector<std::string> ids;
+};
+
+struct delete_fx_spot_generation_config_response {
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/gmm_component_protocol.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/gmm_component_protocol.hpp
@@ -1,0 +1,72 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_API_MESSAGING_GMM_COMPONENT_PROTOCOL_HPP
+#define ORES_SYNTHETIC_API_MESSAGING_GMM_COMPONENT_PROTOCOL_HPP
+
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::messaging {
+
+struct get_gmm_components_request {
+    using response_type = struct get_gmm_components_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.gmm_components.list";
+    int offset = 0;
+    int limit = 100;
+};
+
+struct get_gmm_components_response {
+    std::vector<ores::synthetic::domain::gmm_component> components;
+    int total_available_count = 0;
+};
+
+struct save_gmm_component_request {
+    using response_type = struct save_gmm_component_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.gmm_components.save";
+    ores::synthetic::domain::gmm_component data;
+
+    static save_gmm_component_request from(ores::synthetic::domain::gmm_component c) {
+        return {.data = std::move(c)};
+    }
+};
+
+struct save_gmm_component_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_gmm_component_request {
+    using response_type = struct delete_gmm_component_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.gmm_components.delete";
+    std::vector<std::string> ids;
+};
+
+struct delete_gmm_component_response {
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp
@@ -1,0 +1,73 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_API_MESSAGING_MARKET_DATA_GENERATION_CONFIG_PROTOCOL_HPP
+#define ORES_SYNTHETIC_API_MESSAGING_MARKET_DATA_GENERATION_CONFIG_PROTOCOL_HPP
+
+#include "ores.synthetic.api/domain/market_data_generation_config.hpp"
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::messaging {
+
+struct get_market_data_generation_configs_request {
+    using response_type = struct get_market_data_generation_configs_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.market_data_generation_configs.list";
+    int offset = 0;
+    int limit = 100;
+};
+
+struct get_market_data_generation_configs_response {
+    std::vector<ores::synthetic::domain::market_data_generation_config> configs;
+    int total_available_count = 0;
+};
+
+struct save_market_data_generation_config_request {
+    using response_type = struct save_market_data_generation_config_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.market_data_generation_configs.save";
+    ores::synthetic::domain::market_data_generation_config data;
+
+    static save_market_data_generation_config_request
+    from(ores::synthetic::domain::market_data_generation_config c) {
+        return {.data = std::move(c)};
+    }
+};
+
+struct save_market_data_generation_config_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_market_data_generation_config_request {
+    using response_type = struct delete_market_data_generation_config_response;
+    static constexpr std::string_view nats_subject =
+        "synthetic.v1.market_data_generation_configs.delete";
+    std::vector<std::string> ids;
+};
+
+struct delete_market_data_generation_config_response {
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/src/CMakeLists.txt
+++ b/projects/ores.synthetic/api/src/CMakeLists.txt
@@ -19,16 +19,38 @@ set(name "ores.synthetic.api")
 set(lib_binary_name ${name})
 set(lib_target_name ${name}.lib)
 
-add_library(${lib_target_name} INTERFACE)
+set(files "")
+file(GLOB_RECURSE files RELATIVE
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
-target_include_directories(${lib_target_name} INTERFACE
+set(lib_files ${files})
+add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_SYNTHETIC_API_LIBRARY)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${lib_target_name} PRIVATE
+        -fvisibility=hidden -fvisibility-inlines-hidden)
+endif()
+set_target_properties(${lib_target_name} PROPERTIES
+    OUTPUT_NAME ${lib_binary_name})
+set_target_properties(${lib_target_name}
+    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+target_include_directories(${lib_target_name} PUBLIC
     ${CMAKE_SOURCE_DIR}/projects/ores.synthetic/api/include)
 
 target_link_libraries(${lib_target_name}
-    INTERFACE
+    PUBLIC
         ores.dq.api.lib
         ores.iam.api.lib
         ores.refdata.api.lib
-        ores.platform.lib)
+        ores.eventing.api.lib
+        ores.platform.lib
+    PRIVATE
+        ores.utility.lib
+        faker-cxx::faker-cxx
+        libfort::fort)
 
-install(TARGETS ${lib_target_name})
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
+
+install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.synthetic/api/src/domain/fx_spot_generation_config_json_io.cpp
+++ b/projects/ores.synthetic/api/src/domain/fx_spot_generation_config_json_io.cpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,8 +17,17 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.synthetic.api/domain/fx_spot_generation_config_json_io.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
 
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_fx_spot_generation_configs_drop.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_market_data_generation_configs_drop.sql
+namespace ores::synthetic::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_spot_generation_config& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/api/src/domain/gmm_component_json_io.cpp
+++ b/projects/ores.synthetic/api/src/domain/gmm_component_json_io.cpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,10 +17,17 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.synthetic.api/domain/gmm_component_json_io.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
 
-\ir ./synthetic_market_data_generation_configs_create.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_fx_spot_generation_configs_create.sql
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_gmm_components_create.sql
-\ir ./synthetic_gmm_components_notify_trigger_create.sql
+namespace ores::synthetic::domain {
+
+std::ostream& operator<<(std::ostream& s, const gmm_component& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/api/src/domain/market_data_generation_config_json_io.cpp
+++ b/projects/ores.synthetic/api/src/domain/market_data_generation_config_json_io.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.api/domain/market_data_generation_config_json_io.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::synthetic::domain {
+
+std::ostream& operator<<(std::ostream& s, const market_data_generation_config& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp
@@ -12,6 +12,10 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
  */
 #ifndef ORES_SYNTHETIC_CORE_MESSAGING_FX_SPOT_GENERATION_CONFIG_HANDLER_HPP
 #define ORES_SYNTHETIC_CORE_MESSAGING_FX_SPOT_GENERATION_CONFIG_HANDLER_HPP

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp
@@ -1,0 +1,164 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_MESSAGING_FX_SPOT_GENERATION_CONFIG_HANDLER_HPP
+#define ORES_SYNTHETIC_CORE_MESSAGING_FX_SPOT_GENERATION_CONFIG_HANDLER_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp"
+#include "ores.synthetic.core/service/fx_spot_generation_config_service.hpp"
+#include <optional>
+
+namespace ores::synthetic::messaging {
+
+namespace {
+inline auto& fx_spot_generation_config_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.synthetic.messaging.fx_spot_generation_config_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using ores::service::messaging::log_handler_entry;
+using namespace ores::logging;
+
+class fx_spot_generation_config_handler {
+public:
+    fx_spot_generation_config_handler(ores::nats::service::client& nats,
+                                      ores::database::context ctx,
+                                      std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats)
+        , ctx_(std::move(ctx))
+        , verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(fx_spot_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        service::fx_spot_generation_config_service svc(ctx);
+        get_fx_spot_generation_configs_response resp;
+        auto req = decode<get_fx_spot_generation_configs_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            reply(nats_, msg, resp);
+            return;
+        }
+        try {
+            resp.configs = svc.list_configs(static_cast<std::uint32_t>(req->offset),
+                                            static_cast<std::uint32_t>(req->limit));
+            resp.total_available_count = static_cast<int>(svc.count_configs());
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+        }
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(fx_spot_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::fx_spot_generation_configs:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fx_spot_generation_config_service svc(ctx);
+        auto req = decode<save_fx_spot_generation_config_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.save_config(req->data);
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, save_fx_spot_generation_config_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_,
+                  msg,
+                  save_fx_spot_generation_config_response{.success = false,
+                                                          .message = e.what()});
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(fx_spot_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::fx_spot_generation_configs:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fx_spot_generation_config_service svc(ctx);
+        auto req = decode<delete_fx_spot_generation_config_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.delete_configs(req->ids);
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, delete_fx_spot_generation_config_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(fx_spot_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_,
+                  msg,
+                  delete_fx_spot_generation_config_response{.success = false,
+                                                            .message = e.what()});
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::synthetic::messaging
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp
@@ -1,0 +1,155 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_MESSAGING_GMM_COMPONENT_HANDLER_HPP
+#define ORES_SYNTHETIC_CORE_MESSAGING_GMM_COMPONENT_HANDLER_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.synthetic.api/messaging/gmm_component_protocol.hpp"
+#include "ores.synthetic.core/service/gmm_component_service.hpp"
+#include <optional>
+
+namespace ores::synthetic::messaging {
+
+namespace {
+inline auto& gmm_component_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.synthetic.messaging.gmm_component_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using ores::service::messaging::log_handler_entry;
+using namespace ores::logging;
+
+class gmm_component_handler {
+public:
+    gmm_component_handler(ores::nats::service::client& nats,
+                          ores::database::context ctx,
+                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats)
+        , ctx_(std::move(ctx))
+        , verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(gmm_component_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        service::gmm_component_service svc(ctx);
+        get_gmm_components_response resp;
+        auto req = decode<get_gmm_components_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            reply(nats_, msg, resp);
+            return;
+        }
+        try {
+            resp.components = svc.list_components(static_cast<std::uint32_t>(req->offset),
+                                                 static_cast<std::uint32_t>(req->limit));
+            resp.total_available_count = static_cast<int>(svc.count_components());
+            BOOST_LOG_SEV(gmm_component_handler_lg(), debug) << "Completed " << msg.subject;
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+        }
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(gmm_component_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::gmm_components:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::gmm_component_service svc(ctx);
+        auto req = decode<save_gmm_component_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.save_component(req->data);
+            BOOST_LOG_SEV(gmm_component_handler_lg(), debug) << "Completed " << msg.subject;
+            reply(nats_, msg, save_gmm_component_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_, msg, save_gmm_component_response{.success = false, .message = e.what()});
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(gmm_component_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::gmm_components:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::gmm_component_service svc(ctx);
+        auto req = decode<delete_gmm_component_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.delete_components(req->ids);
+            BOOST_LOG_SEV(gmm_component_handler_lg(), debug) << "Completed " << msg.subject;
+            reply(nats_, msg, delete_gmm_component_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(gmm_component_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_, msg, delete_gmm_component_response{.success = false, .message = e.what()});
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::synthetic::messaging
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp
@@ -12,6 +12,10 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
  */
 #ifndef ORES_SYNTHETIC_CORE_MESSAGING_GMM_COMPONENT_HANDLER_HPP
 #define ORES_SYNTHETIC_CORE_MESSAGING_GMM_COMPONENT_HANDLER_HPP

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/market_data_generation_config_handler.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/messaging/market_data_generation_config_handler.hpp
@@ -1,0 +1,168 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_MESSAGING_MARKET_DATA_GENERATION_CONFIG_HANDLER_HPP
+#define ORES_SYNTHETIC_CORE_MESSAGING_MARKET_DATA_GENERATION_CONFIG_HANDLER_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp"
+#include "ores.synthetic.core/service/market_data_generation_config_service.hpp"
+#include <optional>
+
+namespace ores::synthetic::messaging {
+
+namespace {
+inline auto& market_data_generation_config_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.synthetic.messaging.market_data_generation_config_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using ores::service::messaging::log_handler_entry;
+using namespace ores::logging;
+
+class market_data_generation_config_handler {
+public:
+    market_data_generation_config_handler(ores::nats::service::client& nats,
+                                          ores::database::context ctx,
+                                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats)
+        , ctx_(std::move(ctx))
+        , verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(market_data_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        service::market_data_generation_config_service svc(ctx);
+        get_market_data_generation_configs_response resp;
+        auto req = decode<get_market_data_generation_configs_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            reply(nats_, msg, resp);
+            return;
+        }
+        try {
+            resp.configs = svc.list_configs(static_cast<std::uint32_t>(req->offset),
+                                            static_cast<std::uint32_t>(req->limit));
+            resp.total_available_count = static_cast<int>(svc.count_configs());
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+        }
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(market_data_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::market_data_generation_configs:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::market_data_generation_config_service svc(ctx);
+        auto req = decode<save_market_data_generation_config_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.save_config(req->data);
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, save_market_data_generation_config_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_,
+                  msg,
+                  save_market_data_generation_config_response{.success = false,
+                                                              .message = e.what()});
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(market_data_generation_config_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "synthetic::market_data_generation_configs:delete")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::market_data_generation_config_service svc(ctx);
+        auto req = decode<delete_market_data_generation_config_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            return;
+        }
+        try {
+            svc.delete_configs(req->ids);
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, delete_market_data_generation_config_response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(market_data_generation_config_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_,
+                  msg,
+                  delete_market_data_generation_config_response{.success = false,
+                                                                .message = e.what()});
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::synthetic::messaging
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp
@@ -1,0 +1,61 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_HPP
+
+#include "ores.database/repository/db_types.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+#include <ostream>
+#include <string>
+
+namespace ores::synthetic::repository {
+
+using db_timestamp = ores::database::repository::db_timestamp;
+
+/**
+ * @brief Represents an FX spot generation configuration in the database.
+ */
+struct fx_spot_generation_config_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_synthetic_fx_spot_generation_configs_tbl";
+
+    sqlgen::PrimaryKey<std::string> id; // UUID stored as string, converted in mapper
+    std::string tenant_id;
+    std::string party_id;  // UUID stored as string, converted in mapper
+    std::string config_id; // UUID stored as string, converted in mapper
+    int version = 0;
+    std::string source_name;
+    std::string ore_key;
+    double gmm_initial_price = 0.0;
+    int ticks_per_hour = 0;
+    bool enabled = false;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    db_timestamp valid_from = "9999-12-31 23:59:59";
+    db_timestamp valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_spot_generation_config_entity& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_mapper.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_mapper.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_MAPPER_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_MAPPER_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/fx_spot_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp"
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Maps domain model entities to data storage layer and vice-versa.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT fx_spot_generation_config_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.fx_spot_generation_config_mapper";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    static domain::fx_spot_generation_config
+    map(const fx_spot_generation_config_entity& v);
+    static fx_spot_generation_config_entity
+    map(const domain::fx_spot_generation_config& v);
+
+    static std::vector<domain::fx_spot_generation_config>
+    map(const std::vector<fx_spot_generation_config_entity>& v);
+    static std::vector<fx_spot_generation_config_entity>
+    map(const std::vector<domain::fx_spot_generation_config>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_repository.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_repository.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_REPOSITORY_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_FX_SPOT_GENERATION_CONFIG_REPOSITORY_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/fx_spot_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include <sqlgen/postgres.hpp>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Reads and writes FX spot generation configs off of data storage.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT fx_spot_generation_config_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.fx_spot_generation_config_repository";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Returns the SQL created by sqlgen to construct the table.
+     */
+    std::string sql();
+
+    /**
+     * @brief Writes configs to database. Expects unique ids.
+     */
+    /**@{*/
+    void write(context ctx, const domain::fx_spot_generation_config& config);
+    void write(context ctx, const std::vector<domain::fx_spot_generation_config>& configs);
+    /**@}*/
+
+    /**
+     * @brief Reads latest configs, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::fx_spot_generation_config> read_latest(context ctx);
+    std::vector<domain::fx_spot_generation_config>
+    read_latest(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads latest configs with pagination support.
+     */
+    std::vector<domain::fx_spot_generation_config>
+    read_latest(context ctx, std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active configs.
+     */
+    std::uint32_t get_total_config_count(context ctx);
+
+    /**
+     * @brief Reads configs at the supplied time point, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::fx_spot_generation_config>
+    read_at_timepoint(context ctx, const std::string& as_of);
+    std::vector<domain::fx_spot_generation_config>
+    read_at_timepoint(context ctx, const std::string& as_of, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads all configs, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::fx_spot_generation_config> read_all(context ctx);
+    std::vector<domain::fx_spot_generation_config>
+    read_all(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Deletes a config by closing its temporal validity.
+     */
+    void remove(context ctx, const std::string& id);
+
+    /**
+     * @brief Deletes configs by closing their temporal validity.
+     */
+    void remove(context ctx, const std::vector<std::string>& ids);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_HPP
+
+#include "ores.database/repository/db_types.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+#include <ostream>
+#include <string>
+
+namespace ores::synthetic::repository {
+
+using db_timestamp = ores::database::repository::db_timestamp;
+
+/**
+ * @brief Represents a GMM component in the database.
+ */
+struct gmm_component_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_synthetic_gmm_components_tbl";
+
+    sqlgen::PrimaryKey<std::string> id; // UUID stored as string, converted in mapper
+    std::string tenant_id;
+    std::string party_id;          // UUID stored as string, converted in mapper
+    std::string fx_spot_config_id; // UUID stored as string, converted in mapper
+    int version = 0;
+    int component_index = 0;
+    double mean = 0.0;
+    double stdev = 0.0;
+    double weight = 0.0;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    db_timestamp valid_from = "9999-12-31 23:59:59";
+    db_timestamp valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const gmm_component_entity& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_mapper.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_mapper.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_MAPPER_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_MAPPER_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/gmm_component_entity.hpp"
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Maps domain model entities to data storage layer and vice-versa.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT gmm_component_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.gmm_component_mapper";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    static domain::gmm_component map(const gmm_component_entity& v);
+    static gmm_component_entity map(const domain::gmm_component& v);
+
+    static std::vector<domain::gmm_component>
+    map(const std::vector<gmm_component_entity>& v);
+    static std::vector<gmm_component_entity>
+    map(const std::vector<domain::gmm_component>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_repository.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_repository.hpp
@@ -1,0 +1,113 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_REPOSITORY_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_GMM_COMPONENT_REPOSITORY_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include <sqlgen/postgres.hpp>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Reads and writes GMM components off of data storage.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT gmm_component_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.gmm_component_repository";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Returns the SQL created by sqlgen to construct the table.
+     */
+    std::string sql();
+
+    /**
+     * @brief Writes components to database. Expects unique ids.
+     */
+    /**@{*/
+    void write(context ctx, const domain::gmm_component& component);
+    void write(context ctx, const std::vector<domain::gmm_component>& components);
+    /**@}*/
+
+    /**
+     * @brief Reads latest components, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::gmm_component> read_latest(context ctx);
+    std::vector<domain::gmm_component> read_latest(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads latest components with pagination support.
+     */
+    std::vector<domain::gmm_component>
+    read_latest(context ctx, std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active components.
+     */
+    std::uint32_t get_total_component_count(context ctx);
+
+    /**
+     * @brief Reads components at the supplied time point, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::gmm_component>
+    read_at_timepoint(context ctx, const std::string& as_of);
+    std::vector<domain::gmm_component>
+    read_at_timepoint(context ctx, const std::string& as_of, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads all components, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::gmm_component> read_all(context ctx);
+    std::vector<domain::gmm_component> read_all(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Deletes a component by closing its temporal validity.
+     */
+    void remove(context ctx, const std::string& id);
+
+    /**
+     * @brief Deletes components by closing their temporal validity.
+     */
+    void remove(context ctx, const std::vector<std::string>& ids);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_entity.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_HPP
+
+#include "ores.database/repository/db_types.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+#include <ostream>
+#include <string>
+
+namespace ores::synthetic::repository {
+
+using db_timestamp = ores::database::repository::db_timestamp;
+
+/**
+ * @brief Represents a market data generation configuration in the database.
+ */
+struct market_data_generation_config_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_synthetic_market_data_generation_configs_tbl";
+
+    sqlgen::PrimaryKey<std::string> id; // UUID stored as string, converted in mapper
+    std::string tenant_id;
+    std::string party_id; // UUID stored as string, converted in mapper
+    int version = 0;
+    std::string name;
+    std::string description;
+    bool enabled = false;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    db_timestamp valid_from = "9999-12-31 23:59:59";
+    db_timestamp valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const market_data_generation_config_entity& v);
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_mapper.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_mapper.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_MAPPER_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_MAPPER_HPP
+
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/market_data_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/market_data_generation_config_entity.hpp"
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Maps domain model entities to data storage layer and vice-versa.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT market_data_generation_config_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.market_data_generation_config_mapper";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    static domain::market_data_generation_config
+    map(const market_data_generation_config_entity& v);
+    static market_data_generation_config_entity
+    map(const domain::market_data_generation_config& v);
+
+    static std::vector<domain::market_data_generation_config>
+    map(const std::vector<market_data_generation_config_entity>& v);
+    static std::vector<market_data_generation_config_entity>
+    map(const std::vector<domain::market_data_generation_config>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_repository.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/market_data_generation_config_repository.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_REPOSITORY_HPP
+#define ORES_SYNTHETIC_CORE_REPOSITORY_MARKET_DATA_GENERATION_CONFIG_REPOSITORY_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/market_data_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include <sqlgen/postgres.hpp>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::repository {
+
+/**
+ * @brief Reads and writes market data generation configs off of data storage.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT market_data_generation_config_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.repository.market_data_generation_config_repository";
+
+    static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Returns the SQL created by sqlgen to construct the table.
+     */
+    std::string sql();
+
+    /**
+     * @brief Writes configs to database. Expects unique ids.
+     */
+    /**@{*/
+    void write(context ctx, const domain::market_data_generation_config& config);
+    void write(context ctx, const std::vector<domain::market_data_generation_config>& configs);
+    /**@}*/
+
+    /**
+     * @brief Reads latest configs, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::market_data_generation_config> read_latest(context ctx);
+    std::vector<domain::market_data_generation_config>
+    read_latest(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads latest configs with pagination support.
+     */
+    std::vector<domain::market_data_generation_config>
+    read_latest(context ctx, std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active configs.
+     */
+    std::uint32_t get_total_config_count(context ctx);
+
+    /**
+     * @brief Reads configs at the supplied time point, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::market_data_generation_config>
+    read_at_timepoint(context ctx, const std::string& as_of);
+    std::vector<domain::market_data_generation_config>
+    read_at_timepoint(context ctx, const std::string& as_of, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Reads all configs, possibly filtered by id.
+     */
+    /**@{*/
+    std::vector<domain::market_data_generation_config> read_all(context ctx);
+    std::vector<domain::market_data_generation_config>
+    read_all(context ctx, const std::string& id);
+    /**@}*/
+
+    /**
+     * @brief Deletes a config by closing its temporal validity.
+     */
+    void remove(context ctx, const std::string& id);
+
+    /**
+     * @brief Deletes configs by closing their temporal validity.
+     */
+    void remove(context ctx, const std::vector<std::string>& ids);
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/service/fx_spot_generation_config_service.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/service/fx_spot_generation_config_service.hpp
@@ -1,0 +1,106 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_SERVICE_FX_SPOT_GENERATION_CONFIG_SERVICE_HPP
+#define ORES_SYNTHETIC_CORE_SERVICE_FX_SPOT_GENERATION_CONFIG_SERVICE_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/fx_spot_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/fx_spot_generation_config_repository.hpp"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::service {
+
+/**
+ * @brief Service for managing FX spot generation configs.
+ *
+ * Provides a higher-level interface for config operations, wrapping the
+ * underlying repository.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT fx_spot_generation_config_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.service.fx_spot_generation_config_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_spot_generation_config_service(context ctx);
+
+    /**
+     * @brief Lists configs with pagination support.
+     */
+    std::vector<domain::fx_spot_generation_config>
+    list_configs(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active configs.
+     */
+    std::uint32_t count_configs();
+
+    /**
+     * @brief Saves a config (creates or updates).
+     */
+    void save_config(const domain::fx_spot_generation_config& config);
+
+    /**
+     * @brief Saves a batch of configs atomically (all or nothing).
+     */
+    void save_configs(const std::vector<domain::fx_spot_generation_config>& configs);
+
+    /**
+     * @brief Deletes a config by its id.
+     */
+    void delete_config(const std::string& id);
+
+    /**
+     * @brief Deletes configs by their ids.
+     */
+    void delete_configs(const std::vector<std::string>& ids);
+
+    /**
+     * @brief Retrieves a single config by its id.
+     */
+    std::optional<domain::fx_spot_generation_config> get_config(const std::string& id);
+
+    /**
+     * @brief Retrieves all historical versions of a config.
+     */
+    std::vector<domain::fx_spot_generation_config>
+    get_config_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::fx_spot_generation_config_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/service/gmm_component_service.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/service/gmm_component_service.hpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_SERVICE_GMM_COMPONENT_SERVICE_HPP
+#define ORES_SYNTHETIC_CORE_SERVICE_GMM_COMPONENT_SERVICE_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/gmm_component_repository.hpp"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::service {
+
+/**
+ * @brief Service for managing GMM components.
+ *
+ * Provides a higher-level interface for component operations, wrapping the
+ * underlying repository.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT gmm_component_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.service.gmm_component_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit gmm_component_service(context ctx);
+
+    /**
+     * @brief Lists components with pagination support.
+     */
+    std::vector<domain::gmm_component>
+    list_components(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active components.
+     */
+    std::uint32_t count_components();
+
+    /**
+     * @brief Saves a component (creates or updates).
+     */
+    void save_component(const domain::gmm_component& component);
+
+    /**
+     * @brief Saves a batch of components atomically (all or nothing).
+     */
+    void save_components(const std::vector<domain::gmm_component>& components);
+
+    /**
+     * @brief Deletes a component by its id.
+     */
+    void delete_component(const std::string& id);
+
+    /**
+     * @brief Deletes components by their ids.
+     */
+    void delete_components(const std::vector<std::string>& ids);
+
+    /**
+     * @brief Retrieves a single component by its id.
+     */
+    std::optional<domain::gmm_component> get_component(const std::string& id);
+
+    /**
+     * @brief Retrieves all historical versions of a component.
+     */
+    std::vector<domain::gmm_component> get_component_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::gmm_component_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/service/market_data_generation_config_service.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/service/market_data_generation_config_service.hpp
@@ -1,0 +1,106 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_CORE_SERVICE_MARKET_DATA_GENERATION_CONFIG_SERVICE_HPP
+#define ORES_SYNTHETIC_CORE_SERVICE_MARKET_DATA_GENERATION_CONFIG_SERVICE_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/market_data_generation_config.hpp"
+#include "ores.synthetic.core/export.hpp"
+#include "ores.synthetic.core/repository/market_data_generation_config_repository.hpp"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::service {
+
+/**
+ * @brief Service for managing market data generation configs.
+ *
+ * Provides a higher-level interface for config operations, wrapping the
+ * underlying repository.
+ */
+class ORES_SYNTHETIC_CORE_EXPORT market_data_generation_config_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.synthetic.service.market_data_generation_config_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit market_data_generation_config_service(context ctx);
+
+    /**
+     * @brief Lists configs with pagination support.
+     */
+    std::vector<domain::market_data_generation_config>
+    list_configs(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active configs.
+     */
+    std::uint32_t count_configs();
+
+    /**
+     * @brief Saves a config (creates or updates).
+     */
+    void save_config(const domain::market_data_generation_config& config);
+
+    /**
+     * @brief Saves a batch of configs atomically (all or nothing).
+     */
+    void save_configs(const std::vector<domain::market_data_generation_config>& configs);
+
+    /**
+     * @brief Deletes a config by its id.
+     */
+    void delete_config(const std::string& id);
+
+    /**
+     * @brief Deletes configs by their ids.
+     */
+    void delete_configs(const std::vector<std::string>& ids);
+
+    /**
+     * @brief Retrieves a single config by its id.
+     */
+    std::optional<domain::market_data_generation_config> get_config(const std::string& id);
+
+    /**
+     * @brief Retrieves all historical versions of a config.
+     */
+    std::vector<domain::market_data_generation_config>
+    get_config_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::market_data_generation_config_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.synthetic/core/src/messaging/registrar.cpp
+++ b/projects/ores.synthetic/core/src/messaging/registrar.cpp
@@ -21,9 +21,11 @@
 #include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
 #include "ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp"
 #include "ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp"
+#include "ores.synthetic.api/messaging/gmm_component_protocol.hpp"
 #include "ores.synthetic.core/messaging/organisation_handler.hpp"
 #include "ores.synthetic.core/messaging/market_data_generation_config_handler.hpp"
 #include "ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp"
+#include "ores.synthetic.core/messaging/gmm_component_handler.hpp"
 #include <memory>
 #include <optional>
 
@@ -75,6 +77,23 @@ registrar::register_handlers(ores::nats::service::client& nats,
             [h](ores::nats::message msg) { h->save(std::move(msg)); }));
         subs.push_back(nats.queue_subscribe(
             std::string(delete_fx_spot_generation_config_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // GMM component
+    // ----------------------------------------------------------------
+    {
+        constexpr auto queue_group = "ores.synthetic.service";
+        auto h = std::make_shared<gmm_component_handler>(nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            std::string(get_gmm_components_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(save_gmm_component_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(delete_gmm_component_request::nats_subject), queue_group,
             [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
     }
 

--- a/projects/ores.synthetic/core/src/messaging/registrar.cpp
+++ b/projects/ores.synthetic/core/src/messaging/registrar.cpp
@@ -19,7 +19,9 @@
  */
 #include "ores.synthetic.core/messaging/registrar.hpp"
 #include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
+#include "ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp"
 #include "ores.synthetic.core/messaging/organisation_handler.hpp"
+#include "ores.synthetic.core/messaging/market_data_generation_config_handler.hpp"
 #include <memory>
 #include <optional>
 
@@ -39,6 +41,23 @@ registrar::register_handlers(ores::nats::service::client& nats,
         nats.queue_subscribe(generate_organisation_request::nats_subject,
                              "ores.synthetic.service",
                              [oh](ores::nats::message msg) { oh->generate(std::move(msg)); }));
+
+    // ----------------------------------------------------------------
+    // Market data generation config
+    // ----------------------------------------------------------------
+    {
+        constexpr auto queue_group = "ores.synthetic.service";
+        auto h = std::make_shared<market_data_generation_config_handler>(nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            std::string(get_market_data_generation_configs_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(save_market_data_generation_config_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(delete_market_data_generation_config_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+    }
 
     return subs;
 }

--- a/projects/ores.synthetic/core/src/messaging/registrar.cpp
+++ b/projects/ores.synthetic/core/src/messaging/registrar.cpp
@@ -20,8 +20,10 @@
 #include "ores.synthetic.core/messaging/registrar.hpp"
 #include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
 #include "ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp"
+#include "ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp"
 #include "ores.synthetic.core/messaging/organisation_handler.hpp"
 #include "ores.synthetic.core/messaging/market_data_generation_config_handler.hpp"
+#include "ores.synthetic.core/messaging/fx_spot_generation_config_handler.hpp"
 #include <memory>
 #include <optional>
 
@@ -56,6 +58,23 @@ registrar::register_handlers(ores::nats::service::client& nats,
             [h](ores::nats::message msg) { h->save(std::move(msg)); }));
         subs.push_back(nats.queue_subscribe(
             std::string(delete_market_data_generation_config_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // FX spot generation config
+    // ----------------------------------------------------------------
+    {
+        constexpr auto queue_group = "ores.synthetic.service";
+        auto h = std::make_shared<fx_spot_generation_config_handler>(nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            std::string(get_fx_spot_generation_configs_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(save_fx_spot_generation_config_request::nats_subject), queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            std::string(delete_fx_spot_generation_config_request::nats_subject), queue_group,
             [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
     }
 

--- a/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_entity.cpp
+++ b/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_entity.cpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,8 +17,15 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp"
+#include <rfl.hpp>
+#include <rfl/json.hpp>
 
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_fx_spot_generation_configs_drop.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_drop.sql
-\ir ./synthetic_market_data_generation_configs_drop.sql
+namespace ores::synthetic::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_spot_generation_config_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_mapper.cpp
+++ b/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_mapper.cpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/fx_spot_generation_config_mapper.hpp"
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.synthetic.api/domain/fx_spot_generation_config_json_io.hpp" // IWYU pragma: keep.
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_spot_generation_config
+fx_spot_generation_config_mapper::map(const fx_spot_generation_config_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_spot_generation_config r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.config_id = boost::lexical_cast<boost::uuids::uuid>(v.config_id);
+    r.source_name = v.source_name;
+    r.ore_key = v.ore_key;
+    r.gmm_initial_price = v.gmm_initial_price;
+    r.ticks_per_hour = v.ticks_per_hour;
+    r.enabled = v.enabled;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_spot_generation_config_entity
+fx_spot_generation_config_mapper::map(const domain::fx_spot_generation_config& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_spot_generation_config_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.config_id = boost::uuids::to_string(v.config_id);
+    r.version = v.version;
+    r.source_name = v.source_name;
+    r.ore_key = v.ore_key;
+    r.gmm_initial_price = v.gmm_initial_price;
+    r.ticks_per_hour = v.ticks_per_hour;
+    r.enabled = v.enabled;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    // Note: recorded_at is read-only; valid_from/valid_to are managed by database triggers
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_spot_generation_config>
+fx_spot_generation_config_mapper::map(
+    const std::vector<fx_spot_generation_config_entity>& v) {
+    return map_vector<fx_spot_generation_config_entity, domain::fx_spot_generation_config>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "db entities");
+}
+
+std::vector<fx_spot_generation_config_entity>
+fx_spot_generation_config_mapper::map(
+    const std::vector<domain::fx_spot_generation_config>& v) {
+    return map_vector<domain::fx_spot_generation_config, fx_spot_generation_config_entity>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "domain entities");
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_repository.cpp
@@ -1,0 +1,204 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/fx_spot_generation_config_repository.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.database/repository/helpers.hpp"
+#include "ores.synthetic.api/domain/fx_spot_generation_config_json_io.hpp" // IWYU pragma: keep.
+#include "ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp"
+#include "ores.synthetic.core/repository/fx_spot_generation_config_mapper.hpp"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+using fsgc_entity = fx_spot_generation_config_entity;
+using fsgc_domain = domain::fx_spot_generation_config;
+
+std::string fx_spot_generation_config_repository::sql() {
+    return generate_create_table_sql<fsgc_entity>(lg());
+}
+
+void fx_spot_generation_config_repository::write(context ctx, const fsgc_domain& config) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing config to database: " << config;
+    execute_write_query(
+        ctx, fx_spot_generation_config_mapper::map(config), lg(), "Writing config to database.");
+}
+
+void fx_spot_generation_config_repository::write(context ctx,
+                                                 const std::vector<fsgc_domain>& configs) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing configs to database. Count: " << configs.size();
+    execute_write_query(ctx,
+                        fx_spot_generation_config_mapper::map(configs),
+                        lg(),
+                        "Writing configs to database.");
+}
+
+std::vector<fsgc_domain> fx_spot_generation_config_repository::read_latest(context ctx) {
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs");
+}
+
+std::vector<fsgc_domain> fx_spot_generation_config_repository::read_latest(context ctx,
+                                                                          const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest configs. id: " << id;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> |
+                       where("id"_c == id && "valid_to"_c == max.value()) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs by id.");
+}
+
+std::vector<fsgc_domain>
+fx_spot_generation_config_repository::read_latest(context ctx,
+                                                  std::uint32_t offset,
+                                                  std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest configs with offset: " << offset
+                               << " and limit: " << limit;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc()) |
+                       sqlgen::offset(offset) | sqlgen::limit(limit);
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs with pagination.");
+}
+
+std::uint32_t fx_spot_generation_config_repository::get_total_config_count(context ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Retrieving total active config count";
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+
+    struct count_result {
+        long long count;
+    };
+
+    const auto query = sqlgen::select_from<fsgc_entity>(sqlgen::count().as<"count">()) |
+                       where("valid_to"_c == max.value()) | sqlgen::to<count_result>;
+
+    const auto r = sqlgen::session(ctx.connection_pool()).and_then(query);
+    ensure_success(r, lg());
+
+    const auto count = static_cast<std::uint32_t>(r->count);
+    BOOST_LOG_SEV(lg(), debug) << "Total active config count: " << count;
+    return count;
+}
+
+std::vector<fsgc_domain>
+fx_spot_generation_config_repository::read_at_timepoint(context ctx, const std::string& as_of) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading configs at timepoint: " << as_of;
+
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> |
+                       where("valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading configs at timepoint.");
+}
+
+std::vector<fsgc_domain>
+fx_spot_generation_config_repository::read_at_timepoint(context ctx,
+                                                        const std::string& as_of,
+                                                        const std::string& id) {
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> |
+                       where("id"_c == id && "valid_from"_c <= ts.value() &&
+                             "valid_to"_c >= ts.value());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading configs at timepoint by id.");
+}
+
+std::vector<fsgc_domain> fx_spot_generation_config_repository::read_all(context ctx) {
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> | order_by("valid_from"_c.desc());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading all configs.");
+}
+
+std::vector<fsgc_domain> fx_spot_generation_config_repository::read_all(context ctx,
+                                                                       const std::string& id) {
+    const auto query = sqlgen::read<std::vector<fsgc_entity>> | where("id"_c == id) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<fsgc_entity, fsgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return fx_spot_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading all configs by id");
+}
+
+void fx_spot_generation_config_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing config from database: " << id;
+
+    // Delete only the current record - the database trigger will close the
+    // temporal record instead of actually deleting it (sets valid_to = current_timestamp)
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<fsgc_entity> |
+                       where("id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing config from database.");
+}
+
+void fx_spot_generation_config_repository::remove(context ctx,
+                                                  const std::vector<std::string>& ids) {
+    const auto query = sqlgen::delete_from<fsgc_entity> | where("id"_c.in(ids));
+    execute_delete_query(ctx, query, lg(), "batch removing configs");
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_repository.cpp
@@ -197,7 +197,9 @@ void fx_spot_generation_config_repository::remove(context ctx, const std::string
 
 void fx_spot_generation_config_repository::remove(context ctx,
                                                   const std::vector<std::string>& ids) {
-    const auto query = sqlgen::delete_from<fsgc_entity> | where("id"_c.in(ids));
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<fsgc_entity> |
+                       where("id"_c.in(ids) && "valid_to"_c == max.value());
     execute_delete_query(ctx, query, lg(), "batch removing configs");
 }
 

--- a/projects/ores.synthetic/core/src/repository/gmm_component_entity.cpp
+++ b/projects/ores.synthetic/core/src/repository/gmm_component_entity.cpp
@@ -1,4 +1,4 @@
-/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
@@ -17,10 +17,15 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+#include "ores.synthetic.core/repository/gmm_component_entity.hpp"
+#include <rfl.hpp>
+#include <rfl/json.hpp>
 
-\ir ./synthetic_market_data_generation_configs_create.sql
-\ir ./synthetic_market_data_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_fx_spot_generation_configs_create.sql
-\ir ./synthetic_fx_spot_generation_configs_notify_trigger_create.sql
-\ir ./synthetic_gmm_components_create.sql
-\ir ./synthetic_gmm_components_notify_trigger_create.sql
+namespace ores::synthetic::repository {
+
+std::ostream& operator<<(std::ostream& s, const gmm_component_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/gmm_component_mapper.cpp
+++ b/projects/ores.synthetic/core/src/repository/gmm_component_mapper.cpp
@@ -1,0 +1,89 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/gmm_component_mapper.hpp"
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.synthetic.api/domain/gmm_component_json_io.hpp" // IWYU pragma: keep.
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::gmm_component gmm_component_mapper::map(const gmm_component_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::gmm_component r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.fx_spot_config_id = boost::lexical_cast<boost::uuids::uuid>(v.fx_spot_config_id);
+    r.component_index = v.component_index;
+    r.mean = v.mean;
+    r.stdev = v.stdev;
+    r.weight = v.weight;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+gmm_component_entity gmm_component_mapper::map(const domain::gmm_component& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    gmm_component_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.fx_spot_config_id = boost::uuids::to_string(v.fx_spot_config_id);
+    r.version = v.version;
+    r.component_index = v.component_index;
+    r.mean = v.mean;
+    r.stdev = v.stdev;
+    r.weight = v.weight;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    // Note: recorded_at is read-only; valid_from/valid_to are managed by database triggers
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::gmm_component>
+gmm_component_mapper::map(const std::vector<gmm_component_entity>& v) {
+    return map_vector<gmm_component_entity, domain::gmm_component>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "db entities");
+}
+
+std::vector<gmm_component_entity>
+gmm_component_mapper::map(const std::vector<domain::gmm_component>& v) {
+    return map_vector<domain::gmm_component, gmm_component_entity>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "domain entities");
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/gmm_component_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/gmm_component_repository.cpp
@@ -189,7 +189,9 @@ void gmm_component_repository::remove(context ctx, const std::string& id) {
 }
 
 void gmm_component_repository::remove(context ctx, const std::vector<std::string>& ids) {
-    const auto query = sqlgen::delete_from<gmmc_entity> | where("id"_c.in(ids));
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<gmmc_entity> |
+                       where("id"_c.in(ids) && "valid_to"_c == max.value());
     execute_delete_query(ctx, query, lg(), "batch removing components");
 }
 

--- a/projects/ores.synthetic/core/src/repository/gmm_component_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/gmm_component_repository.cpp
@@ -1,0 +1,196 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/gmm_component_repository.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.database/repository/helpers.hpp"
+#include "ores.synthetic.api/domain/gmm_component_json_io.hpp" // IWYU pragma: keep.
+#include "ores.synthetic.core/repository/gmm_component_entity.hpp"
+#include "ores.synthetic.core/repository/gmm_component_mapper.hpp"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+using gmmc_entity = gmm_component_entity;
+using gmmc_domain = domain::gmm_component;
+
+std::string gmm_component_repository::sql() {
+    return generate_create_table_sql<gmmc_entity>(lg());
+}
+
+void gmm_component_repository::write(context ctx, const gmmc_domain& component) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing component to database: " << component;
+    execute_write_query(
+        ctx, gmm_component_mapper::map(component), lg(), "Writing component to database.");
+}
+
+void gmm_component_repository::write(context ctx, const std::vector<gmmc_domain>& components) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing components to database. Count: " << components.size();
+    execute_write_query(
+        ctx, gmm_component_mapper::map(components), lg(), "Writing components to database.");
+}
+
+std::vector<gmmc_domain> gmm_component_repository::read_latest(context ctx) {
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading latest components");
+}
+
+std::vector<gmmc_domain> gmm_component_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest components. id: " << id;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> |
+                       where("id"_c == id && "valid_to"_c == max.value()) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading latest components by id.");
+}
+
+std::vector<gmmc_domain>
+gmm_component_repository::read_latest(context ctx, std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest components with offset: " << offset
+                               << " and limit: " << limit;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc()) |
+                       sqlgen::offset(offset) | sqlgen::limit(limit);
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading latest components with pagination.");
+}
+
+std::uint32_t gmm_component_repository::get_total_component_count(context ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Retrieving total active component count";
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+
+    struct count_result {
+        long long count;
+    };
+
+    const auto query = sqlgen::select_from<gmmc_entity>(sqlgen::count().as<"count">()) |
+                       where("valid_to"_c == max.value()) | sqlgen::to<count_result>;
+
+    const auto r = sqlgen::session(ctx.connection_pool()).and_then(query);
+    ensure_success(r, lg());
+
+    const auto count = static_cast<std::uint32_t>(r->count);
+    BOOST_LOG_SEV(lg(), debug) << "Total active component count: " << count;
+    return count;
+}
+
+std::vector<gmmc_domain>
+gmm_component_repository::read_at_timepoint(context ctx, const std::string& as_of) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading components at timepoint: " << as_of;
+
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> |
+                       where("valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading components at timepoint.");
+}
+
+std::vector<gmmc_domain>
+gmm_component_repository::read_at_timepoint(context ctx,
+                                           const std::string& as_of,
+                                           const std::string& id) {
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> |
+                       where("id"_c == id && "valid_from"_c <= ts.value() &&
+                             "valid_to"_c >= ts.value());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading components at timepoint by id.");
+}
+
+std::vector<gmmc_domain> gmm_component_repository::read_all(context ctx) {
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> | order_by("valid_from"_c.desc());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading all components.");
+}
+
+std::vector<gmmc_domain> gmm_component_repository::read_all(context ctx, const std::string& id) {
+    const auto query = sqlgen::read<std::vector<gmmc_entity>> | where("id"_c == id) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<gmmc_entity, gmmc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return gmm_component_mapper::map(entities); },
+        lg(),
+        "Reading all components by id");
+}
+
+void gmm_component_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing component from database: " << id;
+
+    // Delete only the current record - the database trigger will close the
+    // temporal record instead of actually deleting it (sets valid_to = current_timestamp)
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<gmmc_entity> |
+                       where("id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing component from database.");
+}
+
+void gmm_component_repository::remove(context ctx, const std::vector<std::string>& ids) {
+    const auto query = sqlgen::delete_from<gmmc_entity> | where("id"_c.in(ids));
+    execute_delete_query(ctx, query, lg(), "batch removing components");
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/market_data_generation_config_entity.cpp
+++ b/projects/ores.synthetic/core/src/repository/market_data_generation_config_entity.cpp
@@ -1,0 +1,31 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/market_data_generation_config_entity.hpp"
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::synthetic::repository {
+
+std::ostream& operator<<(std::ostream& s, const market_data_generation_config_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/market_data_generation_config_mapper.cpp
+++ b/projects/ores.synthetic/core/src/repository/market_data_generation_config_mapper.cpp
@@ -1,0 +1,89 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/market_data_generation_config_mapper.hpp"
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.synthetic.api/domain/market_data_generation_config_json_io.hpp" // IWYU pragma: keep.
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::market_data_generation_config
+market_data_generation_config_mapper::map(const market_data_generation_config_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::market_data_generation_config r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.name = v.name;
+    r.description = v.description;
+    r.enabled = v.enabled;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+market_data_generation_config_entity
+market_data_generation_config_mapper::map(const domain::market_data_generation_config& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    market_data_generation_config_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.version = v.version;
+    r.name = v.name;
+    r.description = v.description;
+    r.enabled = v.enabled;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    // Note: recorded_at is read-only; valid_from/valid_to are managed by database triggers
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::market_data_generation_config>
+market_data_generation_config_mapper::map(
+    const std::vector<market_data_generation_config_entity>& v) {
+    return map_vector<market_data_generation_config_entity, domain::market_data_generation_config>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "db entities");
+}
+
+std::vector<market_data_generation_config_entity>
+market_data_generation_config_mapper::map(
+    const std::vector<domain::market_data_generation_config>& v) {
+    return map_vector<domain::market_data_generation_config, market_data_generation_config_entity>(
+        v, [](const auto& ve) { return map(ve); }, lg(), "domain entities");
+}
+
+}

--- a/projects/ores.synthetic/core/src/repository/market_data_generation_config_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/market_data_generation_config_repository.cpp
@@ -197,7 +197,9 @@ void market_data_generation_config_repository::remove(context ctx, const std::st
 
 void market_data_generation_config_repository::remove(context ctx,
                                                       const std::vector<std::string>& ids) {
-    const auto query = sqlgen::delete_from<mdgc_entity> | where("id"_c.in(ids));
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<mdgc_entity> |
+                       where("id"_c.in(ids) && "valid_to"_c == max.value());
     execute_delete_query(ctx, query, lg(), "batch removing configs");
 }
 

--- a/projects/ores.synthetic/core/src/repository/market_data_generation_config_repository.cpp
+++ b/projects/ores.synthetic/core/src/repository/market_data_generation_config_repository.cpp
@@ -1,0 +1,204 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/repository/market_data_generation_config_repository.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.database/repository/helpers.hpp"
+#include "ores.synthetic.api/domain/market_data_generation_config_json_io.hpp" // IWYU pragma: keep.
+#include "ores.synthetic.core/repository/market_data_generation_config_entity.hpp"
+#include "ores.synthetic.core/repository/market_data_generation_config_mapper.hpp"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::synthetic::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+using mdgc_entity = market_data_generation_config_entity;
+using mdgc_domain = domain::market_data_generation_config;
+
+std::string market_data_generation_config_repository::sql() {
+    return generate_create_table_sql<mdgc_entity>(lg());
+}
+
+void market_data_generation_config_repository::write(context ctx, const mdgc_domain& config) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing config to database: " << config;
+    execute_write_query(
+        ctx, market_data_generation_config_mapper::map(config), lg(), "Writing config to database.");
+}
+
+void market_data_generation_config_repository::write(context ctx,
+                                                     const std::vector<mdgc_domain>& configs) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing configs to database. Count: " << configs.size();
+    execute_write_query(ctx,
+                        market_data_generation_config_mapper::map(configs),
+                        lg(),
+                        "Writing configs to database.");
+}
+
+std::vector<mdgc_domain> market_data_generation_config_repository::read_latest(context ctx) {
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs");
+}
+
+std::vector<mdgc_domain> market_data_generation_config_repository::read_latest(context ctx,
+                                                                              const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest configs. id: " << id;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> |
+                       where("id"_c == id && "valid_to"_c == max.value()) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs by id.");
+}
+
+std::vector<mdgc_domain>
+market_data_generation_config_repository::read_latest(context ctx,
+                                                      std::uint32_t offset,
+                                                      std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest configs with offset: " << offset
+                               << " and limit: " << limit;
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> |
+                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc()) |
+                       sqlgen::offset(offset) | sqlgen::limit(limit);
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading latest configs with pagination.");
+}
+
+std::uint32_t market_data_generation_config_repository::get_total_config_count(context ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Retrieving total active config count";
+
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+
+    struct count_result {
+        long long count;
+    };
+
+    const auto query = sqlgen::select_from<mdgc_entity>(sqlgen::count().as<"count">()) |
+                       where("valid_to"_c == max.value()) | sqlgen::to<count_result>;
+
+    const auto r = sqlgen::session(ctx.connection_pool()).and_then(query);
+    ensure_success(r, lg());
+
+    const auto count = static_cast<std::uint32_t>(r->count);
+    BOOST_LOG_SEV(lg(), debug) << "Total active config count: " << count;
+    return count;
+}
+
+std::vector<mdgc_domain>
+market_data_generation_config_repository::read_at_timepoint(context ctx, const std::string& as_of) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading configs at timepoint: " << as_of;
+
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> |
+                       where("valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading configs at timepoint.");
+}
+
+std::vector<mdgc_domain>
+market_data_generation_config_repository::read_at_timepoint(context ctx,
+                                                            const std::string& as_of,
+                                                            const std::string& id) {
+    const auto ts = make_timestamp(as_of, lg());
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> |
+                       where("id"_c == id && "valid_from"_c <= ts.value() &&
+                             "valid_to"_c >= ts.value());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading configs at timepoint by id.");
+}
+
+std::vector<mdgc_domain> market_data_generation_config_repository::read_all(context ctx) {
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> | order_by("valid_from"_c.desc());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading all configs.");
+}
+
+std::vector<mdgc_domain> market_data_generation_config_repository::read_all(context ctx,
+                                                                           const std::string& id) {
+    const auto query = sqlgen::read<std::vector<mdgc_entity>> | where("id"_c == id) |
+                       order_by("valid_from"_c.desc());
+
+    return execute_read_query<mdgc_entity, mdgc_domain>(
+        ctx,
+        query,
+        [](const auto& entities) { return market_data_generation_config_mapper::map(entities); },
+        lg(),
+        "Reading all configs by id");
+}
+
+void market_data_generation_config_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing config from database: " << id;
+
+    // Delete only the current record - the database trigger will close the
+    // temporal record instead of actually deleting it (sets valid_to = current_timestamp)
+    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::delete_from<mdgc_entity> |
+                       where("id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing config from database.");
+}
+
+void market_data_generation_config_repository::remove(context ctx,
+                                                      const std::vector<std::string>& ids) {
+    const auto query = sqlgen::delete_from<mdgc_entity> | where("id"_c.in(ids));
+    execute_delete_query(ctx, query, lg(), "batch removing configs");
+}
+
+}

--- a/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
@@ -1,0 +1,94 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/service/fx_spot_generation_config_service.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include <stdexcept>
+
+using ores::service::messaging::stamp;
+
+namespace ores::synthetic::service {
+
+using namespace ores::logging;
+
+fx_spot_generation_config_service::fx_spot_generation_config_service(context ctx)
+    : ctx_(std::move(ctx))
+    , repo_{} {}
+
+std::vector<domain::fx_spot_generation_config>
+fx_spot_generation_config_service::list_configs(std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Listing configs with offset=" << offset << " limit=" << limit;
+    return repo_.read_latest(ctx_, offset, limit);
+}
+
+std::uint32_t fx_spot_generation_config_service::count_configs() {
+    BOOST_LOG_SEV(lg(), debug) << "Counting configs";
+    return repo_.get_total_config_count(ctx_);
+}
+
+void fx_spot_generation_config_service::save_config(
+    const domain::fx_spot_generation_config& config) {
+    if (config.source_name.empty()) {
+        throw std::invalid_argument("FX spot generation config source name cannot be empty.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving config: " << config.source_name;
+    auto c = config;
+    stamp(c, ctx_);
+    repo_.write(ctx_, c);
+}
+
+void fx_spot_generation_config_service::save_configs(
+    const std::vector<domain::fx_spot_generation_config>& configs) {
+    for (const auto& c : configs) {
+        if (c.source_name.empty())
+            throw std::invalid_argument("FX spot generation config source name cannot be empty.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving " << configs.size() << " configs";
+    auto stamped = configs;
+    for (auto& c : stamped)
+        stamp(c, ctx_);
+    repo_.write(ctx_, stamped);
+}
+
+void fx_spot_generation_config_service::delete_config(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Deleting config: " << id;
+    repo_.remove(ctx_, id);
+}
+
+void fx_spot_generation_config_service::delete_configs(const std::vector<std::string>& ids) {
+    repo_.remove(ctx_, ids);
+}
+
+std::optional<domain::fx_spot_generation_config>
+fx_spot_generation_config_service::get_config(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting config: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::vector<domain::fx_spot_generation_config>
+fx_spot_generation_config_service::get_config_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting config history for: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
@@ -27,6 +27,21 @@ namespace ores::synthetic::service {
 
 using namespace ores::logging;
 
+namespace {
+
+void validate(const domain::fx_spot_generation_config& c) {
+    if (c.source_name.empty())
+        throw std::invalid_argument("FX spot generation config source name cannot be empty.");
+    if (c.ore_key.empty())
+        throw std::invalid_argument("FX spot generation config ORE key cannot be empty.");
+    if (c.gmm_initial_price <= 0.0)
+        throw std::invalid_argument("FX spot generation config initial price must be positive.");
+    if (c.ticks_per_hour <= 0)
+        throw std::invalid_argument("FX spot generation config ticks per hour must be positive.");
+}
+
+}
+
 fx_spot_generation_config_service::fx_spot_generation_config_service(context ctx)
     : ctx_(std::move(ctx))
     , repo_{} {}
@@ -44,9 +59,7 @@ std::uint32_t fx_spot_generation_config_service::count_configs() {
 
 void fx_spot_generation_config_service::save_config(
     const domain::fx_spot_generation_config& config) {
-    if (config.source_name.empty()) {
-        throw std::invalid_argument("FX spot generation config source name cannot be empty.");
-    }
+    validate(config);
     BOOST_LOG_SEV(lg(), debug) << "Saving config: " << config.source_name;
     auto c = config;
     stamp(c, ctx_);
@@ -55,10 +68,8 @@ void fx_spot_generation_config_service::save_config(
 
 void fx_spot_generation_config_service::save_configs(
     const std::vector<domain::fx_spot_generation_config>& configs) {
-    for (const auto& c : configs) {
-        if (c.source_name.empty())
-            throw std::invalid_argument("FX spot generation config source name cannot be empty.");
-    }
+    for (const auto& c : configs)
+        validate(c);
     BOOST_LOG_SEV(lg(), debug) << "Saving " << configs.size() << " configs";
     auto stamped = configs;
     for (auto& c : stamped)

--- a/projects/ores.synthetic/core/src/service/gmm_component_service.cpp
+++ b/projects/ores.synthetic/core/src/service/gmm_component_service.cpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/service/gmm_component_service.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include <stdexcept>
+
+using ores::service::messaging::stamp;
+
+namespace ores::synthetic::service {
+
+using namespace ores::logging;
+
+namespace {
+
+void validate(const domain::gmm_component& c) {
+    if (c.stdev <= 0.0)
+        throw std::invalid_argument("GMM component standard deviation must be positive.");
+    if (c.weight < 0.0)
+        throw std::invalid_argument("GMM component weight cannot be negative.");
+}
+
+}
+
+gmm_component_service::gmm_component_service(context ctx)
+    : ctx_(std::move(ctx))
+    , repo_{} {}
+
+std::vector<domain::gmm_component>
+gmm_component_service::list_components(std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Listing components with offset=" << offset
+                               << " limit=" << limit;
+    return repo_.read_latest(ctx_, offset, limit);
+}
+
+std::uint32_t gmm_component_service::count_components() {
+    BOOST_LOG_SEV(lg(), debug) << "Counting components";
+    return repo_.get_total_component_count(ctx_);
+}
+
+void gmm_component_service::save_component(const domain::gmm_component& component) {
+    validate(component);
+    BOOST_LOG_SEV(lg(), debug) << "Saving component: index " << component.component_index;
+    auto c = component;
+    stamp(c, ctx_);
+    repo_.write(ctx_, c);
+}
+
+void gmm_component_service::save_components(const std::vector<domain::gmm_component>& components) {
+    for (const auto& c : components)
+        validate(c);
+    BOOST_LOG_SEV(lg(), debug) << "Saving " << components.size() << " components";
+    auto stamped = components;
+    for (auto& c : stamped)
+        stamp(c, ctx_);
+    repo_.write(ctx_, stamped);
+}
+
+void gmm_component_service::delete_component(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Deleting component: " << id;
+    repo_.remove(ctx_, id);
+}
+
+void gmm_component_service::delete_components(const std::vector<std::string>& ids) {
+    repo_.remove(ctx_, ids);
+}
+
+std::optional<domain::gmm_component> gmm_component_service::get_component(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting component: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::vector<domain::gmm_component>
+gmm_component_service::get_component_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting component history for: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.synthetic/core/src/service/market_data_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/market_data_generation_config_service.cpp
@@ -1,0 +1,94 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.core/service/market_data_generation_config_service.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include <stdexcept>
+
+using ores::service::messaging::stamp;
+
+namespace ores::synthetic::service {
+
+using namespace ores::logging;
+
+market_data_generation_config_service::market_data_generation_config_service(context ctx)
+    : ctx_(std::move(ctx))
+    , repo_{} {}
+
+std::vector<domain::market_data_generation_config>
+market_data_generation_config_service::list_configs(std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Listing configs with offset=" << offset << " limit=" << limit;
+    return repo_.read_latest(ctx_, offset, limit);
+}
+
+std::uint32_t market_data_generation_config_service::count_configs() {
+    BOOST_LOG_SEV(lg(), debug) << "Counting configs";
+    return repo_.get_total_config_count(ctx_);
+}
+
+void market_data_generation_config_service::save_config(
+    const domain::market_data_generation_config& config) {
+    if (config.name.empty()) {
+        throw std::invalid_argument("Market data generation config name cannot be empty.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving config: " << config.name;
+    auto c = config;
+    stamp(c, ctx_);
+    repo_.write(ctx_, c);
+}
+
+void market_data_generation_config_service::save_configs(
+    const std::vector<domain::market_data_generation_config>& configs) {
+    for (const auto& c : configs) {
+        if (c.name.empty())
+            throw std::invalid_argument("Market data generation config name cannot be empty.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving " << configs.size() << " configs";
+    auto stamped = configs;
+    for (auto& c : stamped)
+        stamp(c, ctx_);
+    repo_.write(ctx_, stamped);
+}
+
+void market_data_generation_config_service::delete_config(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Deleting config: " << id;
+    repo_.remove(ctx_, id);
+}
+
+void market_data_generation_config_service::delete_configs(const std::vector<std::string>& ids) {
+    repo_.remove(ctx_, ids);
+}
+
+std::optional<domain::market_data_generation_config>
+market_data_generation_config_service::get_config(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting config: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::vector<domain::market_data_generation_config>
+market_data_generation_config_service::get_config_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting config history for: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}


### PR DESCRIPTION
## Summary

Adds the three domain entities for the synthetic generation configuration story (1D7FFB95): a market_data_generation_config container, its fx_spot_generation_config child, and the gmm_component grandchild. Each is hand-written across all layers to byte-for-pattern match the currency reference entity, so a future codegen pass regenerates them with minimal diff. Parent/child links use the codebase's established soft-FK pattern (UUID column validated in the insert trigger against the active parent row), as a real DB FK cannot target a bitemporal table's partial-unique key.

## Changes

- market_data_generation_config: full stack (domain/json_io/protocol, entity/mapper/repository/service/handler, temporal SQL, IAM perms)
- fx_spot_generation_config: full stack; soft-FK config_id -> container
- gmm_component: full stack; soft-FK fx_spot_config_id -> fx_spot config; component_index unique per config
- ores.synthetic.api converted from INTERFACE to a compiled library to match the refdata.api pattern
- Synthetic create/drop SQL aggregators wired into create.sql/drop.sql; 9 new synthetic IAM permission codes
- Verified: api/core/service build and link clean; db recreate provisions all three tables and permissions without error

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Synthetic generation configuration and config-driven feeds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/story.html) | 1D7FFB95-E766-4A49-BEE6-23067B6E035B |
| Task | [Synthetic config entities across all layers (currency pattern)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/synthetic_generation_configuration/task_synthetic_config_entities.html) | FD9977D4-B5CB-4F72-AA8E-139F34A346D1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)