### PR TITLE
[ci] Install Emacs via apt instead of purcell/setup-emacs Nix action

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Emacs
-        uses: purcell/setup-emacs@v8.0
-        with:
-          version: 29.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y emacs-nox
       - name: Build site
         run: |
           emacs -Q --script projects/ores.lisp/src/ores-build-site.el

--- a/.github/workflows/shell-script-drift.yml
+++ b/.github/workflows/shell-script-drift.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Emacs
-        uses: purcell/setup-emacs@v8.0
-        with:
-          version: 29.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y emacs-nox
       - name: Tangle shell scripts from recipes
         run: |
           emacs -Q --script projects/ores.lisp/src/ores-build-recipe-scripts.el

--- a/.github/workflows/site-cdash.yml
+++ b/.github/workflows/site-cdash.yml
@@ -99,9 +99,9 @@ jobs:
         run: sudo apt-get install -y graphviz doxygen fonts-firacode fonts-freefont-ttf
 
       - name: Setup Emacs
-        uses: purcell/setup-emacs@v8.0
-        with:
-          version: 29.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y emacs-nox
 
       - name: Init environment
         env:

--- a/.github/workflows/template-drift.yml
+++ b/.github/workflows/template-drift.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Emacs
-        uses: purcell/setup-emacs@v8.0
-        with:
-          version: 29.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y emacs-nox
       - name: Tangle templates
         run: |
           emacs -Q --script projects/ores.lisp/src/ores-build-codegen-templates.el


### PR DESCRIPTION
## Summary
The `purcell/setup-emacs@v8.0` action bootstraps a full **Nix** install (downloading from `releases.nixos.org`) before fetching Emacs 29.1 from a Nix channel. That network bootstrap is the flaky step that intermittently fails **Setup Emacs** and reds the Emacs-based jobs (`template-drift`, `build-site`, `site-cdash`, `shell-script-drift`) even when nothing is actually wrong.

## Change
Replace the action in all four workflows with a plain apt install:
```yaml
- name: Setup Emacs
  run: |
    sudo apt-get update
    sudo apt-get install -y emacs-nox
```
Ubuntu 24.04 (the runner) ships Emacs 29.3, and these jobs only need `emacs -Q --script` with bundled org-mode. This matches how the same workflows already install graphviz/doxygen/clang-format. Faster, and no Nix dependency or flake.

## Note
Drops the pinned 29.1 for distro-tracked 29.3; org tangling and site export are stable across 29.x (verified: local tangle is a no-op / zero drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)