### PR TITLE
[agile] Raise generation-side tasks across existing sprint stories

### DIFF
--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
@@ -55,7 +55,8 @@ This story is Scope 2 — the proper config-driven generation backend.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:A2CEB990-7DCA-487E-A6DA-867B725AD9F3][Config-driven multi-feed generation (start a config)]] | BACKLOG | | | Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels. |
+| [[id:645B48D0-E2DF-4ACA-AD28-526DC48AFDAD][Ornstein-Uhlenbeck (mean-reverting) process engine]] | BACKLOG | | | Add a mean-reverting Ornstein-Uhlenbeck price-process engine alongside geometric and arithmetic, selectable on the synthetic screen. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: A2CEB990-7DCA-487E-A6DA-867B725AD9F3
+:END:
+#+title: Task: Config-driven multi-feed generation (start a config)
+#+description: Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels.
+#+type: task
+#+level: s1
+#+filetags: :ores.synthetic:generation:nats:config_driven_generation:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Replace the single-feed PoC with a feed_controller that holds a map of concurrently-running feeds (one thread each), and a config-level start/stop so 'start a config' launches all its enabled FX rates; raw ticks publish on producer-namespaced subjects so multiple producers for the same pair (e.g. Wiener vs GBM-drift EUR/USD) coexist.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- Starting a config starts every enabled FX rate in it as an independent producer; stopping a config stops them all; two configs producing the same pair publish on distinct producer-namespaced subjects without collision; Market Simulator gains a config-level Start/Stop action.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_ornstein_uhlenbeck_process_engine.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_ornstein_uhlenbeck_process_engine.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 645B48D0-E2DF-4ACA-AD28-526DC48AFDAD
+:END:
+#+title: Task: Ornstein-Uhlenbeck (mean-reverting) process engine
+#+description: Add a mean-reverting Ornstein-Uhlenbeck price-process engine alongside geometric and arithmetic, selectable on the synthetic screen.
+#+type: task
+#+level: s1
+#+filetags: :ores.synthetic:quant:ui:config_driven_generation:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Implement an Ornstein-Uhlenbeck stochastic process (mean reversion to a long-run level with configurable speed and volatility) as a third engine in the synthetic generator, wire it through process_factory and the process_type enum/DB constraint, and expose it as an Engine choice in the Price-behaviour tab.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- OU engine is selectable in the FX spot rate editor; simulate and live generation produce mean-reverting paths; process_type persists and is accepted by the DB check constraint; existing geometric/arithmetic engines unaffected.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/marketdata_feed_binding_and_ingestion/story.org
+++ b/doc/agile/versions/v0/sprint_21/marketdata_feed_binding_and_ingestion/story.org
@@ -51,7 +51,7 @@ source) and *remaps* them to the official tenant-scoped stream consumers use.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:D8008A82-67BA-4FE4-A835-D8A58C0BE539][Marketdata system-feed to producer mapping and republish]] | BACKLOG | | | A persisted marketdata feed-config that binds a system feed to one chosen raw synthetic producer; the marketdata service subscribes it and republishes on the official tenant-scoped stream. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/marketdata_feed_binding_and_ingestion/task_marketdata_system_feed_to_producer_mapping.org
+++ b/doc/agile/versions/v0/sprint_21/marketdata_feed_binding_and_ingestion/task_marketdata_system_feed_to_producer_mapping.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: D8008A82-67BA-4FE4-A835-D8A58C0BE539
+:END:
+#+title: Task: Marketdata system-feed to producer mapping and republish
+#+description: A persisted marketdata feed-config that binds a system feed to one chosen raw synthetic producer; the marketdata service subscribes it and republishes on the official tenant-scoped stream.
+#+type: task
+#+level: s1
+#+filetags: :ores.marketdata:generation:nats:marketdata_feed_binding_and_ingestion:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F6CD8E90-6EE2-4B4F-A4EC-C173C906222A][Market data feed binding, ingestion and official stream]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Introduce the marketdata-authority binding: a persisted feed-config mapping a system feed (tenant-scoped ore_key) to one chosen raw producer source; the marketdata service subscribes the bound producer, persists per-series observations, and republishes onto the official tenant stream.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:F6CD8E90-6EE2-4B4F-A4EC-C173C906222A][Market data feed binding, ingestion and official stream]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- A system feed can be bound to exactly one raw producer; the marketdata service republishes the bound producer's ticks on the official tenant subject and persists them under the correct per-ore_key series; rebinding switches the source without restarting producers.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/story.org
+++ b/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/story.org
@@ -48,7 +48,8 @@ contract, with no knowledge of what produces each feed.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| [[id:8432FFB1-A084-4B39-8EBF-998521BBAF66][Qt UI to map system feeds to raw producers]] | BACKLOG | | | A Qt screen to view system market-data feeds and choose which raw synthetic producer each is bound to. |
+| [[id:C98C8C6C-5CF8-4A36-9D5B-A394A62CB942][Qt FX spot grid for live system feeds]] | BACKLOG | | | A one-row-per-system-feed grid showing live mid, change and status, flashing green/red on each tick. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/task_qt_fx_spot_grid.org
+++ b/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/task_qt_fx_spot_grid.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: C98C8C6C-5CF8-4A36-9D5B-A394A62CB942
+:END:
+#+title: Task: Qt FX spot grid for live system feeds
+#+description: A one-row-per-system-feed grid showing live mid, change and status, flashing green/red on each tick.
+#+type: task
+#+level: s1
+#+filetags: :ores.qt:marketdata:ui:source_agnostic_control_panel:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:DE2F85D0-9238-41EA-9C2F-A42D37AEEB3D][Source-agnostic market data control panel]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add an FX spot grid (named per trading-system conventions) listing all system feeds: currency pair, mid, change (24h) and status (LIVE/STALE/DISCONNECTED), with a per-cell flash on each tick and optional sparkline; subscribes to the official tenant tick streams.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:DE2F85D0-9238-41EA-9C2F-A42D37AEEB3D][Source-agnostic market data control panel]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- Grid shows one row per system feed with live mid; the cell flashes up-green/down-red as the mid moves; status reflects tick recency (LIVE/STALE) and connectivity; rows update independently across many pairs.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/task_qt_system_feed_mapping_ui.org
+++ b/doc/agile/versions/v0/sprint_21/source_agnostic_control_panel/task_qt_system_feed_mapping_ui.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 8432FFB1-A084-4B39-8EBF-998521BBAF66
+:END:
+#+title: Task: Qt UI to map system feeds to raw producers
+#+description: A Qt screen to view system market-data feeds and choose which raw synthetic producer each is bound to.
+#+type: task
+#+level: s1
+#+filetags: :ores.qt:marketdata:ui:source_agnostic_control_panel:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:DE2F85D0-9238-41EA-9C2F-A42D37AEEB3D][Source-agnostic market data control panel]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a Qt UI that lists system feeds and lets the user bind each to one of the available raw synthetic producers (the mapping persisted via the marketdata feed-config).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:DE2F85D0-9238-41EA-9C2F-A42D37AEEB3D][Source-agnostic market data control panel]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- User can see each system feed and its current source, pick a different available producer, and persist the change; the grid/live view then reflects the newly-bound source.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
Planning only (docs). Breaks the synthetic→marketdata feed pipeline into tasks under the stories the sprint already defined for it, rather than creating a new overlapping story.

## Tasks added
- **Config-driven synthetic feed generation** (`E6679CB1`):
  - Config-driven multi-feed generation (start a config)
  - Ornstein–Uhlenbeck (mean-reverting) process engine
- **Market data feed binding and ingestion** (`F6CD8E90`):
  - Marketdata system-feed → producer mapping and republish
- **Source-agnostic market data control panel** (`DE2F85D0`):
  - Qt UI to map system feeds to raw producers
  - Qt FX spot grid for live system feeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)