### PR TITLE
[synthetic] Config-driven multi-feed autonomous generation

### DIFF
--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
@@ -55,7 +55,7 @@ This story is Scope 2 — the proper config-driven generation backend.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:A2CEB990-7DCA-487E-A6DA-867B725AD9F3][Config-driven multi-feed generation (start a config)]] | STARTED | 2026-06-29 | | Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels. |
+| [[id:A2CEB990-7DCA-487E-A6DA-867B725AD9F3][Config-driven multi-feed generation (start a config)]] | DONE | 2026-06-29 | 2026-06-29 | Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels. |
 | [[id:645B48D0-E2DF-4ACA-AD28-526DC48AFDAD][Ornstein-Uhlenbeck (mean-reverting) process engine]] | BACKLOG | | | Add a mean-reverting Ornstein-Uhlenbeck price-process engine alongside geometric and arithmetic, selectable on the synthetic screen. |
 | [[id:F7547B82-B069-4900-B487-89AA74AAA23A][Scaffold new feed config/domain types via codegen]] | BACKLOG | | | Create any new persisted config and domain types this feed work needs (e.g. a market-data feed-config/binding entity) through the codegen full-stack pipeline rather than hand-writing them. |
 

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/story.org
@@ -8,7 +8,7 @@
 #+filetags: :synthetic:marketdata:backend:sprint_21:v0:
 #+created: 2026-06-29
 #+updated: 2026-06-29
-#+environment:
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -24,7 +24,7 @@ writing to a market series that matches its own ORE key.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:C34A07B2-6BE6-40E5-B1A5-640D5369CECD][Sprint 21]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -55,8 +55,9 @@ This story is Scope 2 — the proper config-driven generation backend.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:A2CEB990-7DCA-487E-A6DA-867B725AD9F3][Config-driven multi-feed generation (start a config)]] | BACKLOG | | | Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels. |
+| [[id:A2CEB990-7DCA-487E-A6DA-867B725AD9F3][Config-driven multi-feed generation (start a config)]] | STARTED | 2026-06-29 | | Make the synthetic service run many feeds at once and start/stop a whole config's FX rates together, publishing on producer-namespaced channels. |
 | [[id:645B48D0-E2DF-4ACA-AD28-526DC48AFDAD][Ornstein-Uhlenbeck (mean-reverting) process engine]] | BACKLOG | | | Add a mean-reverting Ornstein-Uhlenbeck price-process engine alongside geometric and arithmetic, selectable on the synthetic screen. |
+| [[id:F7547B82-B069-4900-B487-89AA74AAA23A][Scaffold new feed config/domain types via codegen]] | BACKLOG | | | Create any new persisted config and domain types this feed work needs (e.g. a market-data feed-config/binding entity) through the codegen full-stack pipeline rather than hand-writing them. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_codegen_synthetic_feed_config_types.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_codegen_synthetic_feed_config_types.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: F7547B82-B069-4900-B487-89AA74AAA23A
+:END:
+#+title: Task: Scaffold new feed config/domain types via codegen
+#+description: Create any new persisted config and domain types this feed work needs (e.g. a market-data feed-config/binding entity) through the codegen full-stack pipeline rather than hand-writing them.
+#+type: task
+#+level: s1
+#+filetags: :ores.synthetic:ores.marketdata:codegen:config_driven_generation:sprint_21:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+For every new persisted type introduced by the config-driven feed work — notably the market-data feed-config/binding entity that maps a system feed to a synthetic producer, and any auxiliary types — use the ORE Studio codegen entity pipeline (SQL, domain, JSON/table IO, repository, messaging, CLI/shell/HTTP/Qt/Wt as applicable) instead of writing layers by hand, so the new types match the currency/refdata pattern.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-29                               |
+
+* Acceptance
+
+- New config/domain types are generated via codegen profiles (codegen-add-entity and friends); no hand-rolled domain/repository/messaging boilerplate for them; generated layers build and round-trip.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
@@ -7,26 +7,34 @@
 #+level: s1
 #+filetags: :ores.synthetic:generation:nats:config_driven_generation:sprint_21:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/config-driven-multi-feed-generation
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-29
 #+updated: 2026-06-29
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-Replace the single-feed PoC with a feed_controller that holds a map of concurrently-running feeds (one thread each), and a config-level start/stop so 'start a config' launches all its enabled FX rates; raw ticks publish on producer-namespaced subjects so multiple producers for the same pair (e.g. Wiener vs GBM-drift EUR/USD) coexist.
+Make the synthetic service generate autonomously from its persisted
+configuration. On service startup it reads the enabled configs and starts
+every enabled FX rate as an independent, concurrently-running producer
+(multi-feed feed_controller, one thread each), resolving/creating a market
+series per ORE key, and publishes each on its own synthetic *producer*
+channel (deliberately separate from the official market-data channel, which
+the marketdata authority republishes onto in a later task). No manual trigger
+is required — an enabled ("auto") config generates; a manual start/stop stays
+as an override.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
@@ -35,7 +43,16 @@ Replace the single-feed PoC with a feed_controller that holds a map of concurren
 
 * Acceptance
 
-- Starting a config starts every enabled FX rate in it as an independent producer; stopping a config stops them all; two configs producing the same pair publish on distinct producer-namespaced subjects without collision; Market Simulator gains a config-level Start/Stop action.
+- On synthetic-service startup, every enabled FX rate across enabled configs is started automatically as an independent producer (no manual trigger).
+- feed_controller runs many feeds concurrently (one thread each); start/stop is keyed per feed; shutdown joins them all.
+- Each feed resolves/creates its own market series from its ORE key (no longer hard-coded to EUR/USD).
+- Each producer publishes on its own synthetic producer channel, derived so two producers for the same pair (e.g. Wiener vs GBM-drift EUR/USD) do not collide.
+- Manual start/stop remains available as an override.
+
+* Decisions
+
+- Channel layering: synthetic publishes on a *producer* channel; the marketdata authority (story F6CD8E90) republishes onto the official tenant channel; charts/grid (story DE2F85D0) read only the official channel. The live chart on the old raw subject is superseded by those tasks and is not kept alive here.
+- Two independent "auto" switches: synthetic auto-generates from enabled configs; marketdata auto-republishes from enabled feeds (the latter in F6CD8E90).
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
@@ -8,7 +8,7 @@
 #+filetags: :ores.synthetic:generation:nats:config_driven_generation:sprint_21:v0:
 #+owner: marco
 #+branch: feature/config-driven-multi-feed-generation
-#+pr:
+#+pr: 1373
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-29
@@ -66,7 +66,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1373][#1373]] | [synthetic] Config-driven multi-feed autonomous generation |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
@@ -34,11 +34,11 @@ as an override.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:E6679CB1-2246-44FD-B557-7F1791574B1B][Config-driven synthetic feed generation (per-config series, lifecycle)]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-06-29                               |
 
 * Acceptance
@@ -87,3 +87,20 @@ plan itself stays — it is the historical record of what we did.)
 | 11 | Redundant explicit shutdown() | application.cpp | Declined | Idempotent; gives explicit ordering guarantee |
 
 * Result
+
+Lifted the single-EUR/USD-feed PoC to autonomous, config-driven multi-feed
+generation. The synthetic service now reads enabled configs from the DB on
+startup and starts every enabled FX rate as an independent producer thread; the
+feed_controller holds a map keyed by source name, resolves/creates a market
+series per ORE key, and publishes each on its own synthetic producer channel
+(synthetic.v1.tick.<source>). Manual start/stop remains as an override.
+
+Verified end-to-end at the producer layer (no UI needed): auto-start created
+per-pair series and ran EUR/USD and GBP/USD concurrently, published typed ticks
+on distinct producer subjects (confirmed on the NATS wire), and persisted
+observations per series. The live chart/grid is intentionally deferred to the
+marketdata authority (F6CD8E90) and consumer (DE2F85D0) stories.
+
+Shipped via PR #1373 (review round 1 addressed: fixed a stop-flag race,
+moved series-resolution RPC out of the mutex, sanitised the producer subject,
+hardened malformed start/stop handling; merged with CI green).

--- a/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
+++ b/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.org
@@ -70,8 +70,20 @@ plan itself stays — it is the historical record of what we did.)
 
 * Review
 
+** Round 1 (PR #1373, 2026-06-29) — 3 bot reviewers, issue-level
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | stop_flag_.store(false) races a concurrent stop → join hangs | fx_spot_feed.cpp | Fixed | a5ac182 — removed the redundant reset (genuine bug) |
+| 2 | Blocking RPC (resolve_series) held under mu_ | feed_controller.hpp | Fixed | a5ac182 — resolve before locking |
+| 3 | Unsanitised source_name into NATS subject | feed_controller.hpp | Fixed | a5ac182 — replace non-token chars, keep '.' |
+| 4 | Malformed start → silent EUR/USD default | market_feed_config_handler.hpp | Fixed | a5ac182 — error reply + return |
+| 5 | Malformed stop → silent stop-all | market_feed_config_handler.hpp | Fixed | a5ac182 — error reply + return |
+| 6 | Stale single-feed PoC comments | handler + protocol | Fixed | a5ac182 |
+| 7 | running_count() not const | feed_controller.hpp | Fixed | a5ac182 — const + mutable mu_ |
+| 8 | GMM lookup-key asymmetry unclear | application.cpp | Fixed | a5ac182 — comment added |
+| 9 | NATS publish before DB persist | fx_spot_feed.cpp | Declined | Intentional: live broadcast must not wait on persistence (documented PoC trade-off) |
+| 10 | N serial list_series on startup | feed_controller.hpp | Deferred | Now outside lock; single-cached-list is a PoC follow-up |
+| 11 | Redundant explicit shutdown() | application.cpp | Declined | Idempotent; gives explicit ordering guarantee |
 
 * Result

--- a/doc/knowledge/architecture/market_data_architecture.org
+++ b/doc/knowledge/architecture/market_data_architecture.org
@@ -89,6 +89,29 @@ There is no per-tick request/reply and no orchestration of producers: pure
 pub/sub. Persistence policy (dedup, downsample, batch) lives here, uniformly
 across all producers.
 
+** Spot rate blending and verification
+
+A feed config binds an official series to *one* active source, but more than
+one source can legitimately be available for the same pair (two synthetic
+producers, or a vendor plus synthetic). Where the authority must reconcile
+several sources into the one official spot, that combination is *spot rate
+blending* — a weighted/consensus average, robust median, or governed waterfall
+— and is a responsibility of =ores.marketdata=, not the producers. Blending is
+*situational*, not always-on: FX spot is an observable Level 1 input, so the
+authority mostly passes a single source through and blends only at the margin
+(stale, illiquid, or disputed feeds, or where governance requires
+defensibility against more than one source). Downstream of blending sits a
+lighter-weight *spot verification* (tolerance check vs reference sources) and,
+for the EOD/IPV cuts, an *approval* step — all owned by the authority and its
+governance, not the producer. This is deliberately distinct from the
+no-arbitrage derivation in the CRM below: blending picks/combines *observed*
+rates for a pair; the CRM *computes* derived crosses from drivers.
+
+See [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][Spot rate blending]] and its cluster:
+[[id:0AABF2DE-8A65-4EF6-A9AD-FBE4AFDF2B46][blending methods]],
+[[id:936BE1EE-89F0-4F82-9064-9AB53E886299][why spot is observable]], and
+[[id:93BF1249-609F-452C-B1EC-FEB493F44273][spot rate governance]] (verification, approval, local vs global).
+
 ** Cross-rates matrix: drivers in, derived rates out
 
 The "remap" step is more than a passthrough for FX. Producers feed *driver*

--- a/doc/knowledge/domain/fx_spot_rate_blending_methods.org
+++ b/doc/knowledge/domain/fx_spot_rate_blending_methods.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 0AABF2DE-8A65-4EF6-A9AD-FBE4AFDF2B46
+:END:
+#+title: FX spot rate blending methods
+#+description: The statistical and governed methods for combining multi-source spot rates: simple/weighted average, median/trimmed mean, and waterfall selection.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:fx:spot:blending:domain:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+
+* Summary
+
+When several source feeds are available, [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][spot rate blending]] can combine them
+in several ways: a *simple average*, a *weighted average* (weights reflecting
+feed quality, latency, or liquidity relationships), a *median or trimmed mean*
+(robust to a stale or erroneous outlier), or a *waterfall / governed selection*
+(a preferred source with a fallback hierarchy). The choice is a governance
+decision owned by Finance / Market Risk, and changing it requires sign-off.
+
+* Detail
+
+** The methods
+
+- *Simple average* — arithmetic mean of all available source rates. Easiest;
+  no opinion about relative source quality.
+- *Weighted average* — sources carry weights, often reflecting feed quality,
+  latency, or the bank's own liquidity relationships; higher-quality or more
+  timely feeds get higher weights.
+- *Median / trimmed mean* — robust statistics that suppress outliers from a
+  stale or erroneous feed without manual intervention.
+- *Waterfall / governed selection* — a preferred source is used when present
+  and in tolerance; a defined fallback hierarchy is invoked otherwise.
+
+** Governance, not code
+
+The methodology is set by Finance or Market Risk and is defensible and
+auditable; method changes require approval. The same multi-source statistics
+(count, average, median, min/max, standard deviation) used for emerging-market
+broker-quote IPV on rates and vols can in principle be applied to spot, though
+spot's observability ([[id:936BE1EE-89F0-4F82-9064-9AB53E886299][Level 1]]) means it rarely needs the heavier treatment.
+
+** Industry precedent
+
+Robust, multi-source, statistically-defensible rate construction is the
+direction of travel for FX benchmarks generally — the WM/Reuters fix moved to a
+volume-weighted median over a widened fixing window precisely to resist
+manipulation and outliers (see References).
+
+* See also
+
+- [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][Spot rate blending]] — the parent concept.
+- [[id:93BF1249-609F-452C-B1EC-FEB493F44273][Spot rate governance]] — checks the blended output.
+
+* References
+
+- /FSB Foreign Exchange Benchmarks — Final Report/ (Financial Stability Board,
+  Sep 2014) — WM/Reuters reform: wider fixing window, volume-weighted median.
+  https://www.fsb.org/publications/r_140930.pdf
+- /WM/Refinitiv FX Benchmarks — Overview/ (LSEG/FTSE Russell) — current
+  volume-weighted-median methodology and treatment of illiquid pairs.
+  https://www.lseg.com/content/dam/ftse-russell/en_us/documents/factsheets/wmr-overview-and-request-for-feedback.pdf
+- /To fix or not to fix: representativeness of the WM/R methodology/ (Breedon &
+  Ranaldo, 2024, J. Int. Financial Markets) — argues for further robustness in
+  multi-source weighting.
+  https://www.sciencedirect.com/science/article/pii/S0927538X24000623
+- /Foreign Exchange Market Microstructure and the WM/Reuters 4pm Fix/ (Ito &
+  Yamada, 2015) — why fix-window methodology matters for derived spot.
+- /Fixing the Fix?/ (FCA Occasional Paper No. 46, 2018) — empirical assessment
+  of post-reform fix methodology.
+  https://www.fca.org.uk/publication/occasional-papers/occasional-paper-46.pdf

--- a/doc/knowledge/domain/fx_spot_rate_governance.org
+++ b/doc/knowledge/domain/fx_spot_rate_governance.org
@@ -28,12 +28,23 @@ right one.
   spot — spot is largely observable (some blending aside) and expected to be
   close to market.
 - *Spot verification*: a lighter check that rates are not too far from market
-  (liquidity-driven), focused on the main currencies ([[id:46224A12-6BE5-413E-A2B0-08B7308E786C][G11]]).
+  (liquidity-driven), focused on the main currencies ([[id:46224A12-6BE5-413E-A2B0-08B7308E786C][G11]]). In practice a
+  *Spot Reconciliation Report* compares each system spot against reference
+  sources (Reuters, Bloomberg) with colour-coded tolerances: within tolerance →
+  green; outside → flagged, and Finance either amends the rate or documents a
+  justification. Any amendment must be *captured, commented, reviewed, and
+  approved* before it feeds official valuations.
 - *Finance approval*: once Finance is satisfied and forward curves are closed,
-  spot rates are *approved*. Multiple approved sets may exist for different
-  purposes; valuation must select the correct set.
+  spot rates are *approved*. The approved rates override the market-data cut,
+  are used by all downstream systems and reports, and are the base for the *IPV
+  cut* (which may override rates and vols with independently sourced data, but
+  typically not spot, given observability). Multiple approved sets may exist for
+  different purposes (intraday risk, official EOD, IPV); valuation must select
+  the correct set.
 
 * See also
 
 - [[id:48F6FD8D-56C7-4FF7-A369-CD13D08A6057][Cross-rates matrix (CRM)]] — the hub.
 - [[id:46224A12-6BE5-413E-A2B0-08B7308E786C][FX currency conventions]] — verification focuses on G11.
+- [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][Spot rate blending]] — combining sources into the rate this governs.
+- [[id:936BE1EE-89F0-4F82-9064-9AB53E886299][Why FX spot rates are observable Level 1 inputs]] — why spot has no full IPV.

--- a/doc/knowledge/domain/fx_spot_rate_observability.org
+++ b/doc/knowledge/domain/fx_spot_rate_observability.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 936BE1EE-89F0-4F82-9064-9AB53E886299
+:END:
+#+title: Why FX spot rates are observable Level 1 inputs
+#+description: Spot rates are continuously quoted, tight-consensus Level 1 inputs, so they need lighter verification than trader-marked vols and curves.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:fx:spot:ipv:domain:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+
+* Summary
+
+FX spot rates for major pairs are canonical *Level 1* fair-value inputs:
+quoted continuously in active, liquid markets by dealers, EBS/Reuters matching
+platforms, and data vendors, with tiny bid/offer spreads and tight cross-source
+consensus. Unlike implied-volatility surfaces and interest-rate curves — which
+carry significant model risk and are often trader-marked — spot carries little
+valuation uncertainty, so it is not subject to a full Independent Price
+Verification (IPV) process. Instead it gets a lighter-weight verification step.
+
+* Detail
+
+** The contrast with vols and curves
+
+Volatility surfaces and rate curves require a mandatory IPV process because
+they embed model risk and trader marks. Spot does not have this character:
+
+- Continuously quoted by multiple independent venues and vendors.
+- For major pairs (the [[id:46224A12-6BE5-413E-A2B0-08B7308E786C][G11]]) the spread is tiny and consensus is tight.
+- Cross-source discrepancies almost always reflect *timing* (stale feed,
+  different snapshot time), not genuine disagreement about value.
+
+** Consequence
+
+The full IPV process is replaced by a lighter [[id:93BF1249-609F-452C-B1EC-FEB493F44273][spot verification]] step — a
+tolerance check against reference sources. This same observability is *why*
+[[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][spot rate blending]] stays simple relative to vol IPV: there is rarely a deep
+valuation question to resolve, only a robustness/timeliness one.
+
+** Accounting basis
+
+IFRS 13 Fair Value Measurement defines the three-level hierarchy (Level 1
+quoted prices in active markets, Level 2 observable inputs, Level 3
+unobservable) and mandates maximising the use of observable inputs. FX spot
+for major pairs is the canonical Level 1 input — the conceptual foundation for
+keeping spot handling light.
+
+* See also
+
+- [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][Spot rate blending]] — the situational combination practice this enables.
+- [[id:93BF1249-609F-452C-B1EC-FEB493F44273][Spot rate governance]] — the lighter check that replaces full IPV.
+
+* References
+
+- /IFRS 13 Fair Value Measurement/ (IASB, effective 2013) — the three-level
+  fair-value hierarchy; FX spot for major pairs is a Level 1 input.
+  https://www.iasplus.com/en/standards/ifrs/ifrs13

--- a/doc/knowledge/domain/spot_rate_blending.org
+++ b/doc/knowledge/domain/spot_rate_blending.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: 4B7E9471-F9A8-461E-B50C-C7B9A57C6D04
+:END:
+#+title: Spot rate blending
+#+description: Combining spot FX rates from multiple external sources into one official rate, and why the practice is limited and situational.
+#+type: knowledge
+#+level: cross
+#+filetags: :marketdata:fx:spot:blending:domain:
+#+created: 2026-06-29
+#+updated: 2026-06-29
+
+* Summary
+
+/Spot rate blending/ is the practice of combining spot FX rates from
+multiple external market-data sources — rather than taking any single feed
+verbatim — to produce the rate that enters the system as the official spot
+for a currency pair. The blended rate is typically a weighted or consensus
+average, or a governed selection, across providers such as Reuters and
+Bloomberg. The need is *limited and situational*: because spot is largely
+observable, the main spot is expected to be close to market at all times, and
+blending matters chiefly at the margin — when a feed is stale, illiquid, or
+disputed, or when governance requires the rate to be defensible against more
+than one source.
+
+* Detail
+
+** What blending produces
+
+A single official spot per currency pair, derived from one-or-more source
+feeds. When only one source is available the "blend" degenerates to passing
+that source through; the value of blending appears once two or more sources
+disagree.
+
+** Why it is situational, not pervasive
+
+Spot rates are [[id:936BE1EE-89F0-4F82-9064-9AB53E886299][observable Level 1 inputs]]: continuously quoted, tight-
+consensus, and rarely in genuine valuation dispute. Discrepancies between
+sources almost always reflect *timing* (a stale snapshot) rather than
+uncertainty about the true rate. So blending is not a heavyweight,
+always-on process — it is a robustness mechanism that earns its keep at the
+margin and feeds the lighter-weight spot verification step (see
+[[id:93BF1249-609F-452C-B1EC-FEB493F44273][spot rate governance]]).
+
+** Who decides the method
+
+The combination method is a governance decision (Finance / Market Risk),
+not a per-trade choice. The available [[id:0AABF2DE-8A65-4EF6-A9AD-FBE4AFDF2B46][blending methods]] range from a simple
+average to a governed waterfall; changes to the methodology require sign-off.
+
+* See also
+
+- [[id:0AABF2DE-8A65-4EF6-A9AD-FBE4AFDF2B46][FX spot rate blending methods]] — how sources are combined.
+- [[id:936BE1EE-89F0-4F82-9064-9AB53E886299][Why FX spot rates are observable Level 1 inputs]] — why blending stays light.
+- [[id:93BF1249-609F-452C-B1EC-FEB493F44273][Spot rate governance]] — the verification, approval and local/global rules the blended rate feeds.
+- [[id:DF2B616F-E112-4C57-A73B-69F85BE96EF4][Market Data Architecture]] — where blending sits in ores.marketdata.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -91,6 +91,12 @@ Finance concepts the codebase relies on.
   - [[id:6F7DFFDF-9E22-4870-916C-7680DE1EB065][Spot rate derivation mechanics]] — covered interest parity, forward points,
     discount factors, pips/mfactor.
   - [[id:93BF1249-609F-452C-B1EC-FEB493F44273][Spot rate governance]] — local/global, spot verification, finance approval.
+  - [[id:4B7E9471-F9A8-461E-B50C-C7B9A57C6D04][Spot rate blending]] — combining multiple source feeds into the official spot;
+    why the practice is limited and situational.
+  - [[id:0AABF2DE-8A65-4EF6-A9AD-FBE4AFDF2B46][FX spot rate blending methods]] — simple/weighted average, median/trimmed mean,
+    waterfall selection; a governed methodology.
+  - [[id:936BE1EE-89F0-4F82-9064-9AB53E886299][Why FX spot rates are observable Level 1 inputs]] — IFRS 13 Level 1; why spot
+    needs lighter verification than vols and curves.
   - [[id:0C37CE80-6795-4DEB-A318-975C53A21A0C][Volatility surface driving]] — the driver/derived pattern applied to vol
     surfaces (correlation vs basis proxying).
   - [[id:C39E7B78-B305-4E14-A46B-29EF85BFCBCC][Correlation management]] — discrete per-tenor correlations that drive cross

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/messaging/market_feed_config_protocol.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/messaging/market_feed_config_protocol.hpp
@@ -42,6 +42,10 @@ struct start_market_feed_config_request {
     static constexpr std::string_view nats_subject = "marketdata.v1.market_feed_configs.start";
 
     std::string ore_key = "FX/RATE/EUR/USD";
+    // Unique producer identity; the feed is keyed by this and publishes on
+    // "synthetic.v1.tick.<source_name>". Lets two producers for the same pair
+    // coexist. Defaults to ore_key when empty.
+    std::string source_name;
     std::vector<double> gmm_means = {-0.0001, 0.0, 0.0001};
     std::vector<double> gmm_stdevs = {0.0010, 0.0005, 0.0010};
     std::vector<double> gmm_weights = {0.2, 0.6, 0.2};
@@ -56,16 +60,16 @@ struct start_market_feed_config_response {
 };
 
 /**
- * @brief Request to stop a running synthetic market data feed.
+ * @brief Request to stop running synthetic market data feed(s).
  *
- * PoC scope: ore_key is informational; the handler stops whatever feed
- * is currently running regardless of the supplied key.
+ * Stops the feed identified by source_name; if source_name is empty, stops
+ * all running feeds.
  */
 struct stop_market_feed_config_request {
     using response_type = struct stop_market_feed_config_response;
     static constexpr std::string_view nats_subject = "marketdata.v1.market_feed_configs.stop";
 
-    std::string ore_key; // empty = stop all running feeds
+    std::string source_name; // empty = stop all running feeds
 };
 
 struct stop_market_feed_config_response {

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/messaging/market_feed_config_protocol.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/messaging/market_feed_config_protocol.hpp
@@ -29,13 +29,10 @@ namespace ores::marketdata::messaging {
 /**
  * @brief Request to start a synthetic market data feed.
  *
- * Fields carry the full GMM process configuration so the caller controls
- * the feed parameters. All fields carry PoC defaults matching the
- * hard-coded EUR/USD values used in the initial implementation.
- *
- * PoC scope: only a single EUR/USD GMM feed is supported. ore_key is
- * informational; the handler ignores it and always uses the pre-resolved
- * series_id from the service context.
+ * Fields carry the full GMM process configuration so the caller controls the
+ * feed parameters; the defaults are a convenience for ad-hoc EUR/USD starts.
+ * The feed is keyed by source_name and its market series is resolved per feed
+ * from ore_key, so many feeds (including two for the same pair) run at once.
  */
 struct start_market_feed_config_request {
     using response_type = struct start_market_feed_config_response;

--- a/projects/ores.qt/synthetic/src/MarketSimulatorWindow.cpp
+++ b/projects/ores.qt/synthetic/src/MarketSimulatorWindow.cpp
@@ -876,6 +876,7 @@ void MarketSimulatorWindow::onStartFeedClicked() {
 
     ores::marketdata::messaging::start_market_feed_config_request req;
     req.ore_key = fx.ore_key;
+    req.source_name = fx.source_name;
     req.gmm_means.clear();
     req.gmm_stdevs.clear();
     req.gmm_weights.clear();
@@ -940,7 +941,7 @@ void MarketSimulatorWindow::onStopFeedClicked() {
     const auto fx = it->second;
 
     ores::marketdata::messaging::stop_market_feed_config_request req;
-    req.ore_key = fx.ore_key;
+    req.source_name = fx.source_name;
 
     const std::string oreKey = fx.ore_key;
     BOOST_LOG_SEV(lg(), info) << "Stopping feed " << oreKey << ".";

--- a/projects/ores.synthetic/service/src/app/application.cpp
+++ b/projects/ores.synthetic/service/src/app/application.cpp
@@ -78,6 +78,8 @@ void auto_start_enabled_feeds(feed_controller& ctrl, const ores::database::conte
         if (f.enabled)
             enabled_feeds.insert(f.id);
 
+    // Group components by their parent FX config id; note the field asymmetry —
+    // gmm_component::fx_spot_config_id keys against fx_spot_generation_config::id.
     std::map<boost::uuids::uuid, std::vector<ores::synthetic::domain::gmm_component>> by_fx;
     for (const auto& c : comps)
         by_fx[c.fx_spot_config_id].push_back(c);

--- a/projects/ores.synthetic/service/src/app/application.cpp
+++ b/projects/ores.synthetic/service/src/app/application.cpp
@@ -29,6 +29,9 @@
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
 #include "ores.synthetic.core/messaging/registrar.hpp"
+#include "ores.synthetic.core/repository/fx_spot_generation_config_repository.hpp"
+#include "ores.synthetic.core/repository/gmm_component_repository.hpp"
+#include "ores.synthetic.core/repository/market_data_generation_config_repository.hpp"
 #include "ores.synthetic.service/app/application_exception.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.utility/version/version.hpp"
@@ -37,9 +40,13 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include "ores.synthetic.api/domain/gmm_component.hpp"
+#include <map>
 #include <memory>
 #include <rfl/json.hpp>
+#include <set>
 #include <span>
+#include <vector>
 
 namespace ores::synthetic::service::app {
 
@@ -48,6 +55,56 @@ using namespace ores::logging;
 namespace {
 constexpr std::string_view service_name = "ores.synthetic.service";
 constexpr std::string_view service_version = ORES_VERSION;
+
+// Start every enabled FX rate across enabled feed configs as a producer.
+auto& auto_start_lg() {
+    static auto instance = ores::logging::make_logger("ores.synthetic.service.app.auto_start");
+    return instance;
+}
+
+void auto_start_enabled_feeds(feed_controller& ctrl, const ores::database::context& ctx) {
+    namespace repo = ores::synthetic::repository;
+
+    repo::market_data_generation_config_repository feed_repo;
+    repo::fx_spot_generation_config_repository fx_repo;
+    repo::gmm_component_repository comp_repo;
+
+    const auto feeds = feed_repo.read_latest(ctx);
+    const auto fxs = fx_repo.read_latest(ctx);
+    const auto comps = comp_repo.read_latest(ctx);
+
+    std::set<boost::uuids::uuid> enabled_feeds;
+    for (const auto& f : feeds)
+        if (f.enabled)
+            enabled_feeds.insert(f.id);
+
+    std::map<boost::uuids::uuid, std::vector<ores::synthetic::domain::gmm_component>> by_fx;
+    for (const auto& c : comps)
+        by_fx[c.fx_spot_config_id].push_back(c);
+
+    int started = 0;
+    for (const auto& fx : fxs) {
+        if (!fx.enabled || !enabled_feeds.contains(fx.config_id))
+            continue;
+        const auto it = by_fx.find(fx.id);
+        if (it == by_fx.end() || it->second.empty()) {
+            BOOST_LOG_SEV(auto_start_lg(), warn)
+                << "Skipping enabled FX rate " << fx.ore_key << " — no GMM components.";
+            continue;
+        }
+        std::vector<double> means, stdevs, weights;
+        for (const auto& c : it->second) {
+            means.push_back(c.mean);
+            stdevs.push_back(c.stdev);
+            weights.push_back(c.weight);
+        }
+        if (ctrl.start(fx.ore_key, fx.source_name, std::move(means), std::move(stdevs),
+                       std::move(weights), fx.gmm_initial_price,
+                       static_cast<double>(fx.ticks_per_hour), fx.process_type))
+            ++started;
+    }
+    BOOST_LOG_SEV(auto_start_lg(), info) << "Auto-started " << started << " enabled feed(s).";
+}
 }
 
 ores::database::context application::make_context(const ores::database::database_options& db_opts) {
@@ -86,58 +143,17 @@ boost::asio::awaitable<void> application::run(boost::asio::io_context& io_ctx,
         nats,
         ores::iam::client::make_service_token_provider(
             nats, cfg.database.user, cfg.database.password()));
-    ores::marketdata::client::market_data_client md_client(svc_nats);
 
     auto db_ctx = make_context(cfg.database);
 
-    // Look up or create the EUR/USD market series; the resolved series_id is
-    // passed into the feed_controller and stamped on every market_observation.
-    boost::uuids::uuid series_id{};
-    {
-        using namespace ores::marketdata::domain;
+    auto ctrl = std::make_shared<feed_controller>(nats, svc_nats, db_ctx.tenant_id());
 
-        auto existing = md_client.list_series("FX");
-        if (!existing)
-            throw application_exception("Failed to list FX market series: " + existing.error());
-
-        for (const auto& s : *existing) {
-            if (s.metric == "RATE" && s.qualifier == "EUR/USD") {
-                series_id = s.id;
-                BOOST_LOG_SEV(lg(), info)
-                    << "Found existing EUR/USD series: " << boost::uuids::to_string(series_id);
-                break;
-            }
-        }
-
-        if (series_id.is_nil()) {
-            boost::uuids::random_generator gen;
-            series_id = gen();
-
-            market_series s;
-            s.id = series_id;
-            s.tenant_id = db_ctx.tenant_id();
-            s.series_type = "FX";
-            s.metric = "RATE";
-            s.qualifier = "EUR/USD";
-            s.asset_class = asset_class::fx;
-            s.subclass = series_subclass::spot;
-            s.is_scalar = true;
-            s.modified_by = "ores.synthetic.service";
-            s.performed_by = "ores.synthetic.service";
-            s.change_reason_code = "system.initial_load";
-            s.change_commentary = "EUR/USD FX spot synthetic feed initialisation";
-
-            const auto saved = md_client.save_series({s});
-            if (!saved)
-                throw application_exception("Failed to create EUR/USD market series: " +
-                                            saved.error());
-            BOOST_LOG_SEV(lg(), info)
-                << "Created EUR/USD market series: " << boost::uuids::to_string(series_id);
-        }
-    }
-
-    auto ctrl = std::make_shared<feed_controller>(nats, svc_nats, series_id, db_ctx.tenant_id());
-    BOOST_LOG_SEV(lg(), info) << "Feed controller ready — waiting for start signal";
+    // Autonomous, config-driven generation: start every enabled FX rate across
+    // enabled configs. Each feed resolves its own series and publishes on its
+    // synthetic producer channel.
+    auto_start_enabled_feeds(*ctrl, db_ctx);
+    BOOST_LOG_SEV(lg(), info) << "Feed controller ready — " << ctrl->running_count()
+                              << " feed(s) auto-started; waiting for control signals";
 
     co_await ores::service::service::run(
         io_ctx,

--- a/projects/ores.synthetic/service/src/feed_controller.hpp
+++ b/projects/ores.synthetic/service/src/feed_controller.hpp
@@ -30,6 +30,7 @@
 #include "process_factory.hpp"
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <cctype>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -94,13 +95,17 @@ public:
                double initial_price,
                double ticks_per_hour,
                const std::string& process_type = "geometric") {
+        // Resolve the series BEFORE locking — it makes blocking NATS RPCs, and we
+        // must not hold mu_ (which stop()/shutdown() also take) across network I/O.
+        // resolve_series is find-or-create, so a concurrent duplicate start costs
+        // at worst one extra lookup, not a corrupt state.
+        boost::uuids::uuid series_id{};
+        if (!resolve_series(ore_key, series_id))
+            return false;
+
         std::lock_guard lock(mu_);
         const std::string key = source_name.empty() ? ore_key : source_name;
         if (feeds_.contains(key))
-            return false;
-
-        boost::uuids::uuid series_id{};
-        if (!resolve_series(ore_key, series_id))
             return false;
 
         auto process = process_factory::make_process(
@@ -152,7 +157,7 @@ public:
     }
 
     /** @brief Number of feeds currently running. */
-    std::size_t running_count() {
+    std::size_t running_count() const {
         std::lock_guard lock(mu_);
         return feeds_.size();
     }
@@ -163,8 +168,19 @@ private:
         std::thread thread;
     };
 
+    // Build the producer subject from source_name. '.' is kept (it is the NATS
+    // hierarchy separator and source names are dotted), but any character that
+    // is not a safe subject token — whitespace, wildcards ('*', '>'), or
+    // non-alphanumerics other than '.', '_', '-' — is replaced with '_' so a
+    // stray value cannot produce surprise routing or a publish error.
     static std::string producer_subject(const std::string& source_name) {
-        return "synthetic.v1.tick." + source_name;
+        std::string token;
+        token.reserve(source_name.size());
+        for (unsigned char c : source_name) {
+            const bool safe = std::isalnum(c) || c == '.' || c == '_' || c == '-';
+            token += safe ? static_cast<char>(c) : '_';
+        }
+        return "synthetic.v1.tick." + token;
     }
 
     static void join_and_clear(running_feed& rf) {
@@ -238,7 +254,7 @@ private:
     ores::utility::uuid::tenant_id tenant_id_;
     boost::uuids::random_generator uuid_gen_;
 
-    std::mutex mu_;
+    mutable std::mutex mu_;
     std::map<std::string, running_feed> feeds_;
 };
 

--- a/projects/ores.synthetic/service/src/feed_controller.hpp
+++ b/projects/ores.synthetic/service/src/feed_controller.hpp
@@ -21,41 +21,57 @@
 #define ORES_SYNTHETIC_SERVICE_FEED_CONTROLLER_HPP
 
 #include "fx_spot_feed.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.marketdata.api/domain/asset_class.hpp"
+#include "ores.marketdata.api/domain/market_series.hpp"
+#include "ores.marketdata.api/domain/series_subclass.hpp"
+#include "ores.marketdata.client/market_data_client.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
 #include "process_factory.hpp"
+#include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
-#include <atomic>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <sstream>
+#include <string>
 #include <thread>
 #include <vector>
 
 namespace ores::synthetic::service {
 
 /**
- * @brief Shared mutable state for the start/stop NATS handlers.
+ * @brief Runs the synthetic producer feeds; one tick thread per feed.
  *
  * Owned by application::run() as a shared_ptr and passed to the
- * market_feed_config_handler lambdas in the registrar. Owns the running
- * fx_spot_feed and its tick thread.
+ * market_feed_config_handler lambdas in the registrar, and driven on startup
+ * by the autonomous config-driven auto-starter. Holds a map of running feeds
+ * keyed by source name (a producer's unique identity), so several producers —
+ * including two for the same pair (e.g. Wiener vs GBM-drift EUR/USD) — run
+ * concurrently and publish on distinct subjects.
  *
- * Threading: start() and stop_signal() are called from NATS I/O callbacks
- * and are protected by a mutex. shutdown() is called from the application
- * coroutine after the NATS I/O loop has stopped, so it does not race with
- * handler callbacks.
+ * Each feed resolves/creates its own market series from its ORE key and
+ * publishes on its synthetic producer channel: "synthetic.v1.tick.<source>".
  *
- * PoC limitation: supports a single active feed. A second start() while
- * one is running returns false.
+ * Threading: start() and stop() are called from NATS I/O callbacks and the
+ * startup path; both are protected by a mutex. shutdown() is called from the
+ * application coroutine after the NATS I/O loop has stopped.
  */
 class feed_controller {
+private:
+    static auto& lg() {
+        static auto instance =
+            ores::logging::make_logger("ores.synthetic.service.feed_controller");
+        return instance;
+    }
+
 public:
     feed_controller(ores::nats::service::client& nats,
                     ores::nats::service::nats_client& auth_nats,
-                    boost::uuids::uuid series_id,
                     ores::utility::uuid::tenant_id tenant_id)
         : nats_(nats)
         , auth_nats_(auth_nats)
-        , series_id_(series_id)
+        , md_client_(auth_nats)
         , tenant_id_(std::move(tenant_id)) {}
 
     ~feed_controller() {
@@ -63,12 +79,15 @@ public:
     }
 
     /**
-     * @brief Start the feed from the supplied GMM parameters.
+     * @brief Start one producer feed. Keyed by source_name (unique per producer).
      *
-     * Joins any previously stopped (but not yet joined) thread before
-     * constructing the new feed. Returns false if a feed is already running.
+     * Resolves/creates the market series for ore_key, derives the producer
+     * subject from source_name, builds the process and spawns its tick thread.
+     * Returns false if a feed with this source_name is already running or the
+     * series could not be resolved.
      */
     bool start(const std::string& ore_key,
+               const std::string& source_name,
                std::vector<double> means,
                std::vector<double> stdevs,
                std::vector<double> weights,
@@ -76,74 +95,151 @@ public:
                double ticks_per_hour,
                const std::string& process_type = "geometric") {
         std::lock_guard lock(mu_);
-        if (running_.load(std::memory_order_relaxed))
+        const std::string key = source_name.empty() ? ore_key : source_name;
+        if (feeds_.contains(key))
             return false;
-        // Join a previously stopped thread before replacing it.
-        if (thread_.joinable())
-            thread_.join();
+
+        boost::uuids::uuid series_id{};
+        if (!resolve_series(ore_key, series_id))
+            return false;
+
         auto process = process_factory::make_process(
             process_type, std::move(means), std::move(stdevs), std::move(weights), initial_price);
-        feed_ = std::make_shared<fx_spot_feed>(
-            nats_, auth_nats_, ore_key, std::move(process), ticks_per_hour, series_id_, tenant_id_);
-        thread_ = std::thread([feed = feed_]() { feed->start([](const auto& /*tick*/) {}); });
-        running_.store(true, std::memory_order_relaxed);
+        auto feed = std::make_shared<fx_spot_feed>(nats_, auth_nats_, ore_key,
+                                                   producer_subject(key), std::move(process),
+                                                   ticks_per_hour, series_id, tenant_id_);
+        running_feed rf;
+        rf.feed = feed;
+        rf.thread = std::thread([feed]() { feed->start([](const auto& /*tick*/) {}); });
+        feeds_.emplace(key, std::move(rf));
+        BOOST_LOG_SEV(lg(), ores::logging::info)
+            << "Started feed '" << key << "' (" << ore_key << "), now " << feeds_.size()
+            << " running.";
         return true;
     }
 
     /**
-     * @brief Signal the running feed to stop. Non-blocking.
+     * @brief Stop one feed by key (source_name), or all feeds if key is empty.
      *
-     * The feed's tick thread will exit after completing its current iteration.
-     * The thread is NOT joined here; join happens in shutdown() or the next
-     * start() call. Returns false if no feed is running.
+     * Signals the tick thread(s) to stop, joins, and removes them. Returns the
+     * number of feeds stopped.
      */
-    bool stop_signal() {
+    std::size_t stop(const std::string& key = {}) {
         std::lock_guard lock(mu_);
-        if (!running_.load(std::memory_order_relaxed))
-            return false;
-        feed_->stop();
-        running_.store(false, std::memory_order_relaxed);
-        return true;
+        if (key.empty()) {
+            const auto n = feeds_.size();
+            for (auto& [_, rf] : feeds_)
+                join_and_clear(rf);
+            feeds_.clear();
+            return n;
+        }
+        auto it = feeds_.find(key);
+        if (it == feeds_.end())
+            return 0;
+        join_and_clear(it->second);
+        feeds_.erase(it);
+        return 1;
     }
 
     /**
-     * @brief Stop the feed and join its thread. Safe to call even if not running.
+     * @brief Stop and join every feed. Safe to call even with none running.
      *
-     * Intended for orderly application shutdown. Must only be called after the
+     * Intended for orderly application shutdown; must only be called after the
      * NATS I/O loop has stopped (no concurrent handler callbacks).
      */
     void shutdown() {
-        {
-            std::lock_guard lock(mu_);
-            if (feed_ && running_.load(std::memory_order_relaxed))
-                feed_->stop();
-            running_.store(false, std::memory_order_relaxed);
-        }
-        if (thread_.joinable())
-            thread_.join();
+        stop();
     }
 
-    /**
-     * @brief True if a start() was called and stop_signal() has not yet been called.
-     *
-     * Does NOT mean the tick thread has exited. The flag is written under mu_ but
-     * read here lock-free — use only for informational polling, not for
-     * synchronisation.
-     */
-    bool is_running() const noexcept {
-        return running_.load(std::memory_order_relaxed);
+    /** @brief Number of feeds currently running. */
+    std::size_t running_count() {
+        std::lock_guard lock(mu_);
+        return feeds_.size();
     }
 
 private:
+    struct running_feed {
+        std::shared_ptr<fx_spot_feed> feed;
+        std::thread thread;
+    };
+
+    static std::string producer_subject(const std::string& source_name) {
+        return "synthetic.v1.tick." + source_name;
+    }
+
+    static void join_and_clear(running_feed& rf) {
+        if (rf.feed)
+            rf.feed->stop();
+        if (rf.thread.joinable())
+            rf.thread.join();
+    }
+
+    // Find-or-create the FX spot market series for an ORE key like
+    // "FX/RATE/EUR/USD" → series_type "FX", metric "RATE", qualifier "EUR/USD".
+    bool resolve_series(const std::string& ore_key, boost::uuids::uuid& out) {
+        using namespace ores::marketdata::domain;
+
+        std::vector<std::string> parts;
+        std::stringstream ss(ore_key);
+        std::string tok;
+        while (std::getline(ss, tok, '/'))
+            parts.push_back(tok);
+        if (parts.size() < 3) {
+            BOOST_LOG_SEV(lg(), ores::logging::warn) << "Cannot parse ORE key '" << ore_key << "'.";
+            return false;
+        }
+        const std::string series_type = parts[0];
+        const std::string metric = parts[1];
+        std::string qualifier = parts[2];
+        for (std::size_t i = 3; i < parts.size(); ++i)
+            qualifier += "/" + parts[i];
+
+        auto existing = md_client_.list_series(series_type);
+        if (!existing) {
+            BOOST_LOG_SEV(lg(), ores::logging::warn)
+                << "Failed to list series for '" << series_type << "': " << existing.error();
+            return false;
+        }
+        for (const auto& s : *existing) {
+            if (s.metric == metric && s.qualifier == qualifier) {
+                out = s.id;
+                return true;
+            }
+        }
+
+        market_series s;
+        s.id = uuid_gen_();
+        s.tenant_id = tenant_id_;
+        s.series_type = series_type;
+        s.metric = metric;
+        s.qualifier = qualifier;
+        s.asset_class = asset_class::fx;
+        s.subclass = series_subclass::spot;
+        s.is_scalar = true;
+        s.modified_by = "ores.synthetic.service";
+        s.performed_by = "ores.synthetic.service";
+        s.change_reason_code = "system.initial_load";
+        s.change_commentary = ore_key + " synthetic feed initialisation";
+
+        const auto saved = md_client_.save_series({s});
+        if (!saved) {
+            BOOST_LOG_SEV(lg(), ores::logging::warn)
+                << "Failed to create series for '" << ore_key << "': " << saved.error();
+            return false;
+        }
+        BOOST_LOG_SEV(lg(), ores::logging::info) << "Created series for " << ore_key << ".";
+        out = s.id;
+        return true;
+    }
+
     ores::nats::service::client& nats_;
     ores::nats::service::nats_client& auth_nats_;
-    boost::uuids::uuid series_id_;
+    ores::marketdata::client::market_data_client md_client_;
     ores::utility::uuid::tenant_id tenant_id_;
+    boost::uuids::random_generator uuid_gen_;
 
     std::mutex mu_;
-    std::shared_ptr<fx_spot_feed> feed_;
-    std::thread thread_;
-    std::atomic<bool> running_{false};
+    std::map<std::string, running_feed> feeds_;
 };
 
 }

--- a/projects/ores.synthetic/service/src/fx_spot_feed.cpp
+++ b/projects/ores.synthetic/service/src/fx_spot_feed.cpp
@@ -79,7 +79,9 @@ void fx_spot_feed::start(handler on_tick) {
     const auto period_us =
         duration_cast<microseconds>(hours(1)) / static_cast<long long>(ticks_per_hour_);
 
-    stop_flag_.store(false, std::memory_order_relaxed);
+    // Note: stop_flag_ is already false from the member initialiser. We must NOT
+    // reset it here — a stop() that arrives between thread spawn and this point
+    // would be clobbered, and the loop (and join()) would hang forever.
 
     // Sleep the tick period in small slices so stop() is observed promptly
     // (the period can be minutes; we must not block stop()/join() that long).

--- a/projects/ores.synthetic/service/src/fx_spot_feed.cpp
+++ b/projects/ores.synthetic/service/src/fx_spot_feed.cpp
@@ -43,24 +43,12 @@ auto& lg() {
     return instance;
 }
 
-std::string to_nats_subject(const std::string& ore_key) {
-    // "FX/RATE/EUR/USD" → "marketdata.v1.tick.fx.rate.eur.usd"
-    std::string s = "marketdata.v1.tick.";
-    s.reserve(s.size() + ore_key.size());
-    for (char c : ore_key) {
-        if (c == '/')
-            s += '.';
-        else
-            s += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    }
-    return s;
-}
-
 } // namespace
 
 fx_spot_feed::fx_spot_feed(ores::nats::service::client& nats,
                            ores::nats::service::nats_client& auth_nats,
                            std::string ore_key,
+                           std::string nats_subject,
                            std::unique_ptr<ores::marketdata::domain::IStochasticProcess> process,
                            double ticks_per_hour,
                            boost::uuids::uuid series_id,
@@ -71,7 +59,7 @@ fx_spot_feed::fx_spot_feed(ores::nats::service::client& nats,
     , ore_key_(std::move(ore_key))
     , process_(std::move(process))
     , ticks_per_hour_(ticks_per_hour)
-    , nats_subject_(to_nats_subject(ore_key_))
+    , nats_subject_(std::move(nats_subject))
     , series_id_(series_id)
     , tenant_id_(std::move(tenant_id)) {
 
@@ -93,8 +81,17 @@ void fx_spot_feed::start(handler on_tick) {
 
     stop_flag_.store(false, std::memory_order_relaxed);
 
+    // Sleep the tick period in small slices so stop() is observed promptly
+    // (the period can be minutes; we must not block stop()/join() that long).
+    constexpr auto slice = milliseconds(100);
+
     while (!stop_flag_.load(std::memory_order_relaxed)) {
-        std::this_thread::sleep_for(period_us);
+        auto remaining = duration_cast<microseconds>(period_us);
+        while (remaining.count() > 0 && !stop_flag_.load(std::memory_order_relaxed)) {
+            const auto nap = remaining < slice ? remaining : duration_cast<microseconds>(slice);
+            std::this_thread::sleep_for(nap);
+            remaining -= nap;
+        }
 
         if (stop_flag_.load(std::memory_order_relaxed))
             break;
@@ -129,10 +126,6 @@ void fx_spot_feed::start(handler on_tick) {
 
 void fx_spot_feed::stop() {
     stop_flag_.store(true, std::memory_order_relaxed);
-}
-
-std::string fx_spot_feed::derive_nats_subject(const std::string& ore_key) {
-    return to_nats_subject(ore_key);
 }
 
 }

--- a/projects/ores.synthetic/service/src/fx_spot_feed.hpp
+++ b/projects/ores.synthetic/service/src/fx_spot_feed.hpp
@@ -45,9 +45,9 @@ namespace ores::synthetic::service {
  *   4. Publishes the tick JSON to the NATS fan-out subject.
  *   5. Saves a market_observation to the DB via NATS request_sync (step 3).
  *
- * The NATS subject is derived from the ORE key: lowercase, '/' → '.',
- * prefixed with "marketdata.v1.tick.", e.g. "FX/RATE/EUR/USD" →
- * "marketdata.v1.tick.fx.rate.eur.usd".
+ * The NATS publish subject is supplied by the caller (the synthetic producer
+ * channel, derived per-producer from its source name) so that multiple
+ * producers for the same ORE key publish on distinct subjects.
  *
  * Threading: see IFxSpotFeed class-level doc.
  *
@@ -63,6 +63,7 @@ public:
     fx_spot_feed(ores::nats::service::client& nats,
                  ores::nats::service::nats_client& auth_nats,
                  std::string ore_key,
+                 std::string nats_subject,
                  std::unique_ptr<ores::marketdata::domain::IStochasticProcess> process,
                  double ticks_per_hour,
                  boost::uuids::uuid series_id,
@@ -73,8 +74,6 @@ public:
     void stop() override;
 
 private:
-    static std::string derive_nats_subject(const std::string& ore_key);
-
     ores::nats::service::client& nats_;
     ores::nats::service::nats_client& auth_nats_;
     ores::marketdata::client::market_data_client md_client_; // constructed once, not per tick

--- a/projects/ores.synthetic/service/src/market_feed_config_handler.hpp
+++ b/projects/ores.synthetic/service/src/market_feed_config_handler.hpp
@@ -74,6 +74,7 @@ public:
 
         start_market_feed_config_response resp;
         const bool started = ctrl_->start(req->ore_key,
+                                          req->source_name,
                                           req->gmm_means,
                                           req->gmm_stdevs,
                                           req->gmm_weights,
@@ -81,17 +82,18 @@ public:
                                           req->ticks_per_hour,
                                           req->process_type);
 
+        const std::string id = req->source_name.empty() ? req->ore_key : req->source_name;
         if (started) {
             resp.success = true;
-            resp.message = "Feed started: " + req->ore_key;
+            resp.message = "Feed started: " + id;
             BOOST_LOG_SEV(market_feed_config_handler_lg(), info)
-                << msg.subject << " — feed started: " << req->ore_key
+                << msg.subject << " — feed started: " << id
                 << "  ticks/h=" << req->ticks_per_hour;
         } else {
             resp.success = false;
-            resp.message = "Feed already running: " + req->ore_key;
+            resp.message = "Feed already running or series unresolved: " + id;
             BOOST_LOG_SEV(market_feed_config_handler_lg(), warn)
-                << msg.subject << " — feed already running: " << req->ore_key;
+                << msg.subject << " — feed not started: " << id;
         }
         reply(nats_, msg, resp);
     }
@@ -100,20 +102,16 @@ public:
         using namespace ores::marketdata::messaging;
         [[maybe_unused]] const auto cid = log_handler_entry(market_feed_config_handler_lg(), msg);
 
-        stop_market_feed_config_response resp;
-        const bool stopped = ctrl_->stop_signal();
+        auto req = decode<stop_market_feed_config_request>(msg);
+        const std::string key = req ? req->source_name : std::string{};
 
-        if (stopped) {
-            resp.success = true;
-            resp.message = "Feed stop signalled";
-            BOOST_LOG_SEV(market_feed_config_handler_lg(), info)
-                << msg.subject << " — feed stop signalled";
-        } else {
-            resp.success = false;
-            resp.message = "No feed is running";
-            BOOST_LOG_SEV(market_feed_config_handler_lg(), warn)
-                << msg.subject << " — stop requested but no feed is running";
-        }
+        stop_market_feed_config_response resp;
+        const auto stopped = ctrl_->stop(key);
+
+        resp.success = stopped > 0;
+        resp.message = std::to_string(stopped) + " feed(s) stopped";
+        BOOST_LOG_SEV(market_feed_config_handler_lg(), info)
+            << msg.subject << " — " << resp.message << (key.empty() ? " (all)" : " (" + key + ")");
         reply(nats_, msg, resp);
     }
 

--- a/projects/ores.synthetic/service/src/market_feed_config_handler.hpp
+++ b/projects/ores.synthetic/service/src/market_feed_config_handler.hpp
@@ -47,11 +47,9 @@ using namespace ores::logging;
  * @brief NATS handler for market feed config start/stop control messages.
  *
  * These are internal control-plane messages: no JWT auth or DB context is
- * required. The handler delegates to feed_controller for the actual
- * feed lifecycle management.
- *
- * PoC scope: a single EUR/USD GMM feed. The ore_key in the request is
- * informational; the handler uses the series_id pre-resolved at startup.
+ * required. The handler delegates the full multi-feed lifecycle to
+ * feed_controller — keyed by source_name, with the market series resolved
+ * per feed inside the controller (not pre-resolved at startup).
  */
 class market_feed_config_handler {
 public:
@@ -64,12 +62,15 @@ public:
         using namespace ores::marketdata::messaging;
         [[maybe_unused]] const auto cid = log_handler_entry(market_feed_config_handler_lg(), msg);
 
-        // Decode the request; fall back to defaults if body is empty or malformed.
+        // Reject a malformed body rather than silently starting a default feed.
         auto req = decode<start_market_feed_config_request>(msg);
         if (!req) {
             BOOST_LOG_SEV(market_feed_config_handler_lg(), warn)
-                << msg.subject << " — empty or malformed body; using defaults";
-            req = start_market_feed_config_request{};
+                << msg.subject << " — empty or malformed start body; rejecting";
+            reply(nats_, msg,
+                  start_market_feed_config_response{.success = false,
+                                                    .message = "Malformed start request"});
+            return;
         }
 
         start_market_feed_config_response resp;
@@ -102,8 +103,17 @@ public:
         using namespace ores::marketdata::messaging;
         [[maybe_unused]] const auto cid = log_handler_entry(market_feed_config_handler_lg(), msg);
 
+        // Reject a malformed body rather than treating it as "stop all".
         auto req = decode<stop_market_feed_config_request>(msg);
-        const std::string key = req ? req->source_name : std::string{};
+        if (!req) {
+            BOOST_LOG_SEV(market_feed_config_handler_lg(), warn)
+                << msg.subject << " — empty or malformed stop body; rejecting";
+            reply(nats_, msg,
+                  stop_market_feed_config_response{.success = false,
+                                                   .message = "Malformed stop request"});
+            return;
+        }
+        const std::string key = req->source_name;
 
         stop_market_feed_config_response resp;
         const auto stopped = ctrl_->stop(key);


### PR DESCRIPTION
## Summary

Lift the single-EUR/USD-feed PoC to autonomous, config-driven generation: on startup the synthetic service reads enabled configs from the DB and starts every enabled FX rate as a concurrent producer, resolving a market series per ORE key and publishing on its own synthetic producer channel. Also splits the spot-rate-blending summary into atomic knowledge notes. Verified end-to-end at the producer layer (DB + NATS); the live chart/grid awaits the marketdata authority and consumer stories.

## Changes

- feed_controller: map of concurrent feeds keyed by source name; per-feed start/stop or stop-all; shutdown joins all; resolves/creates a series per ORE key; publishes on synthetic.v1.tick.<source>
- application: auto-start enabled configs on startup (read from DB); drop hard-coded EUR/USD series pre-resolution
- fx_spot_feed: explicit publish subject; responsive stop (sleep in 100ms slices)
- protocol/handler/UI: carry source_name so manual start/stop works as an override
- knowledge: split spot rate blending into atomic cross-linked notes; enrich existing governance note; add blurb to Market Data Architecture; add codegen task

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Config-driven synthetic feed generation (per-config series, lifecycle)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/config_driven_generation/story.html) | E6679CB1-2246-44FD-B557-7F1791574B1B |
| Task | [Config-driven multi-feed generation (start a config)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/config_driven_generation/task_config_driven_multi_feed_generation.html) | A2CEB990-7DCA-487E-A6DA-867B725AD9F3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)