### PR TITLE
Fix duplicate natural key fields and codegen generator template gaps

### DIFF
--- a/projects/ores.codegen/library/templates/cpp_domain_type_class.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_class.hpp.mustache
@@ -66,7 +66,7 @@ struct {{entity_singular}} final {
      * {{{detail}}}
 {{/detail}}
      */
-    {{{cpp_type}}} {{column}};
+    {{{cpp_type}}} {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 
 {{/natural_keys}}
 {{/has_identity_group}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
@@ -31,10 +31,10 @@ struct {{entity_singular}}_entity {
     int version = 0;
 {{#natural_keys}}
 {{#is_uuid}}
-    std::string {{column}};
+    std::string {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 {{/is_uuid}}
 {{^is_uuid}}
-    {{{cpp_type}}} {{column}};
+    {{{cpp_type}}} {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 {{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
@@ -30,7 +30,12 @@ struct {{entity_singular}}_entity {
 {{/has_workspace_id}}
     int version = 0;
 {{#natural_keys}}
+{{#is_uuid}}
     std::string {{column}};
+{{/is_uuid}}
+{{^is_uuid}}
+    {{{cpp_type}}} {{column}};
+{{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}
 {{#is_optional_uuid}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
@@ -41,12 +41,24 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
 {{/primary_key.is_text}}
 {{#primary_key.is_uuid}}
     r.{{primary_key.column}} = ctx.generate_uuid();
+{{#has_text_natural_keys}}
+    const auto idx = counter.fetch_add(1, std::memory_order_relaxed);
+{{/has_text_natural_keys}}
 {{/primary_key.is_uuid}}
 {{#natural_keys}}
 {{#is_uuid}}
     r.{{column}} = ctx.generate_uuid();
 {{/is_uuid}}
+{{#is_int}}
+{{#generator_expr}}
+    r.{{column}} = {{{generator_expr}}};
+{{/generator_expr}}
+{{^generator_expr}}
+    r.{{column}} = 0;
+{{/generator_expr}}
+{{/is_int}}
 {{^is_uuid}}
+{{^is_int}}
 {{#generator_expr}}
     r.{{column}} = {{{generator_expr}}} + "-"
         + std::to_string(idx);
@@ -55,6 +67,7 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     r.{{column}} = std::string(faker::word::noun()) + "-"
         + std::to_string(idx);
 {{/generator_expr}}
+{{/is_int}}
 {{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
@@ -17,7 +17,9 @@ using ores::utility::generation::generation_keys;
 
 domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     utility::generation::generation_context& ctx) {
+{{#needs_counter}}
     static std::atomic<int> counter{0};
+{{/needs_counter}}
     const auto modified_by = ctx.env().get_or(
         std::string(generation_keys::modified_by), "system");
 {{#has_tenant_id}}

--- a/projects/ores.codegen/library/templates/ores.cpp.domain.class_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.domain.class_header.org
@@ -91,7 +91,7 @@ struct {{entity_singular}} final {
      * {{{detail}}}
 {{/detail}}
      */
-    {{{cpp_type}}} {{column}};
+    {{{cpp_type}}} {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 
 {{/natural_keys}}
 {{/has_identity_group}}

--- a/projects/ores.codegen/library/templates/ores.cpp.generator.generator_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.generator.generator_impl.org
@@ -66,12 +66,24 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
 {{/primary_key.is_text}}
 {{#primary_key.is_uuid}}
     r.{{primary_key.column}} = ctx.generate_uuid();
+{{#has_text_natural_keys}}
+    const auto idx = counter.fetch_add(1, std::memory_order_relaxed);
+{{/has_text_natural_keys}}
 {{/primary_key.is_uuid}}
 {{#natural_keys}}
 {{#is_uuid}}
     r.{{column}} = ctx.generate_uuid();
 {{/is_uuid}}
+{{#is_int}}
+{{#generator_expr}}
+    r.{{column}} = {{{generator_expr}}};
+{{/generator_expr}}
+{{^generator_expr}}
+    r.{{column}} = 0;
+{{/generator_expr}}
+{{/is_int}}
 {{^is_uuid}}
+{{^is_int}}
 {{#generator_expr}}
     r.{{column}} = {{{generator_expr}}} + "-"
         + std::to_string(idx);
@@ -80,6 +92,7 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     r.{{column}} = std::string(faker::word::noun()) + "-"
         + std::to_string(idx);
 {{/generator_expr}}
+{{/is_int}}
 {{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}

--- a/projects/ores.codegen/library/templates/ores.cpp.generator.generator_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.generator.generator_impl.org
@@ -42,7 +42,9 @@ using ores::utility::generation::generation_keys;
 
 domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     utility::generation::generation_context& ctx) {
+{{#needs_counter}}
     static std::atomic<int> counter{0};
+{{/needs_counter}}
     const auto modified_by = ctx.env().get_or(
         std::string(generation_keys::modified_by), "system");
 {{#has_tenant_id}}

--- a/projects/ores.codegen/library/templates/ores.cpp.repository.entity_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.repository.entity_header.org
@@ -56,10 +56,10 @@ struct {{entity_singular}}_entity {
     int version = 0;
 {{#natural_keys}}
 {{#is_uuid}}
-    std::string {{column}};
+    std::string {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 {{/is_uuid}}
 {{^is_uuid}}
-    {{{cpp_type}}} {{column}};
+    {{{cpp_type}}} {{column}}{{#default_value}} = {{{default_value}}}{{/default_value}};
 {{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}

--- a/projects/ores.codegen/library/templates/ores.cpp.repository.entity_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.repository.entity_header.org
@@ -55,7 +55,12 @@ struct {{entity_singular}}_entity {
 {{/has_workspace_id}}
     int version = 0;
 {{#natural_keys}}
+{{#is_uuid}}
     std::string {{column}};
+{{/is_uuid}}
+{{^is_uuid}}
+    {{{cpp_type}}} {{column}};
+{{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}
 {{#is_optional_uuid}}

--- a/projects/ores.codegen/src/codegen/core.py
+++ b/projects/ores.codegen/src/codegen/core.py
@@ -1761,12 +1761,17 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             includes_dict['domain'] = sorted(injected) + existing_domain
         if 'natural_keys' in domain_entity:
             _mark_last_item(domain_entity['natural_keys'])
-            # Add iterator_var and is_uuid to natural_keys for protocol serialization
+            # Add iterator_var and is_uuid/is_int to natural_keys for protocol serialization
             for key in domain_entity['natural_keys']:
                 key['iter_var'] = iter_var
                 key['is_uuid'] = key.get('type') == 'uuid' or 'boost::uuids::uuid' in key.get('cpp_type', '')
+                key['is_int'] = key.get('cpp_type', '') in ('int', 'long', 'std::size_t') or key.get('type', '') == 'integer'
             nks = domain_entity['natural_keys']
             domain_entity['has_multiple_natural_keys'] = len(nks) > 1
+            # Flag: UUID-PK entities with text natural keys need an idx counter in the generator
+            domain_entity['has_text_natural_keys'] = any(
+                not k.get('is_uuid') and not k.get('is_int') for k in nks
+            )
             if len(nks) > 1:
                 domain_entity['natural_keys_composite_columns'] = ', '.join(nk['column'] for nk in nks)
                 if 'natural_keys_composite_name' not in domain_entity:

--- a/projects/ores.codegen/src/codegen/core.py
+++ b/projects/ores.codegen/src/codegen/core.py
@@ -1772,6 +1772,10 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             domain_entity['has_text_natural_keys'] = any(
                 not k.get('is_uuid') and not k.get('is_int') for k in nks
             )
+            domain_entity['needs_counter'] = (
+                domain_entity.get('primary_key', {}).get('is_text', False)
+                or domain_entity['has_text_natural_keys']
+            )
             if len(nks) > 1:
                 domain_entity['natural_keys_composite_columns'] = ', '.join(nk['column'] for nk in nks)
                 if 'natural_keys_composite_name' not in domain_entity:

--- a/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
@@ -39,8 +39,6 @@ create table if not exists "ores_synthetic_fx_spot_generation_configs_tbl" (
     "config_id" uuid not null,
     "base_currency_code" text not null,
     "quote_currency_code" text not null,
-    "base_currency_code" text not null,
-    "quote_currency_code" text not null,
     "source_name" text not null,
     "ore_key" text not null,
     "gmm_initial_price" double precision not null,

--- a/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_gmm_components_create.sql
@@ -37,7 +37,6 @@ create table if not exists "ores_synthetic_gmm_components_tbl" (
     "party_id" uuid not null,
     "fx_spot_config_id" uuid not null,
     "component_index" integer not null,
-    "component_index" integer not null,
     "description" text not null,
     "mean" double precision not null,
     "stdev" double precision not null,

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/fx_spot_generation_config.hpp
@@ -73,16 +73,6 @@ struct fx_spot_generation_config final {
     std::string quote_currency_code;
 
     /**
-     * @brief Base currency ISO code of the FX spot pair (soft FK to currencies).
-     */
-    std::string base_currency_code;
-
-    /**
-     * @brief Quote currency ISO code of the FX spot pair (soft FK to currencies).
-     */
-    std::string quote_currency_code;
-
-    /**
      * @brief Stable source name carried as provenance of generated observations (e.g.
      * "synthetic.eurusd"). Derived from the currency pair; unique per tenant and party.
      */

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/gmm_component.hpp
@@ -64,11 +64,6 @@ struct gmm_component final {
     /**
      * @brief Zero-based ordinal of this component within its parent's mixture.
      */
-    int component_index;
-
-    /**
-     * @brief Zero-based ordinal of this component within its parent's mixture.
-     */
     int component_index = 0;
 
     /**

--- a/projects/ores.synthetic/api/src/generators/fx_spot_generation_config_generator.cpp
+++ b/projects/ores.synthetic/api/src/generators/fx_spot_generation_config_generator.cpp
@@ -40,12 +40,11 @@ generate_synthetic_fx_spot_generation_config(utility::generation::generation_con
     r.tenant_id =
         utility::uuid::tenant_id::from_string(tid_str).value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
+    const auto idx = counter.fetch_add(1, std::memory_order_relaxed);
     r.party_id = ctx.generate_uuid();
     r.config_id = ctx.generate_uuid();
     r.base_currency_code = std::string("EUR") + "-" + std::to_string(idx);
     r.quote_currency_code = std::string("USD") + "-" + std::to_string(idx);
-    r.base_currency_code = std::string(faker::finance::currencyCode());
-    r.quote_currency_code = std::string(faker::finance::currencyCode());
     r.source_name = std::string("synthetic.") + std::string(faker::finance::currencyCode());
     r.ore_key = std::string("FX/RATE/EUR/USD");
     r.gmm_initial_price = faker::number::decimal(0.5, 2.0);

--- a/projects/ores.synthetic/api/src/generators/gmm_component_generator.cpp
+++ b/projects/ores.synthetic/api/src/generators/gmm_component_generator.cpp
@@ -30,7 +30,6 @@ using ores::utility::generation::generation_keys;
 
 domain::gmm_component
 generate_synthetic_gmm_component(utility::generation::generation_context& ctx) {
-    static std::atomic<int> counter{0};
     const auto modified_by = ctx.env().get_or(std::string(generation_keys::modified_by), "system");
     const auto tid_str =
         ctx.env().get_or(std::string(generation_keys::tenant_id), std::string("system"));

--- a/projects/ores.synthetic/api/src/generators/gmm_component_generator.cpp
+++ b/projects/ores.synthetic/api/src/generators/gmm_component_generator.cpp
@@ -42,7 +42,6 @@ generate_synthetic_gmm_component(utility::generation::generation_context& ctx) {
     r.id = ctx.generate_uuid();
     r.party_id = ctx.generate_uuid();
     r.fx_spot_config_id = ctx.generate_uuid();
-    r.component_index = faker::number::integer(0, 4) + "-" + std::to_string(idx);
     r.component_index = faker::number::integer(0, 4);
     r.description = std::string(faker::word::adjective());
     r.mean = faker::number::decimal(-0.001, 0.001);

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/fx_spot_generation_config_entity.hpp
@@ -44,8 +44,6 @@ struct fx_spot_generation_config_entity {
     std::string config_id;
     std::string base_currency_code;
     std::string quote_currency_code;
-    std::string base_currency_code;
-    std::string quote_currency_code;
     std::string source_name;
     std::string ore_key;
     double gmm_initial_price = 0.0;

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
@@ -42,7 +42,7 @@ struct gmm_component_entity {
     int version = 0;
     std::string party_id;
     std::string fx_spot_config_id;
-    int component_index;
+    int component_index = 0;
     std::string description;
     double mean = 0.0;
     double stdev = 0.0;

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
@@ -42,7 +42,7 @@ struct gmm_component_entity {
     int version = 0;
     std::string party_id;
     std::string fx_spot_config_id;
-    std::string component_index;
+    int component_index;
     std::string description;
     double mean = 0.0;
     double stdev = 0.0;

--- a/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
+++ b/projects/ores.synthetic/core/include/ores.synthetic.core/repository/gmm_component_entity.hpp
@@ -43,7 +43,6 @@ struct gmm_component_entity {
     std::string party_id;
     std::string fx_spot_config_id;
     std::string component_index;
-    int component_index = 0;
     std::string description;
     double mean = 0.0;
     double stdev = 0.0;

--- a/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_mapper.cpp
+++ b/projects/ores.synthetic/core/src/repository/fx_spot_generation_config_mapper.cpp
@@ -40,8 +40,6 @@ fx_spot_generation_config_mapper::map(const fx_spot_generation_config_entity& v)
     r.config_id = boost::lexical_cast<boost::uuids::uuid>(v.config_id);
     r.base_currency_code = v.base_currency_code;
     r.quote_currency_code = v.quote_currency_code;
-    r.base_currency_code = v.base_currency_code;
-    r.quote_currency_code = v.quote_currency_code;
     r.source_name = v.source_name;
     r.ore_key = v.ore_key;
     r.gmm_initial_price = v.gmm_initial_price;
@@ -68,8 +66,6 @@ fx_spot_generation_config_mapper::map(const domain::fx_spot_generation_config& v
     r.version = v.version;
     r.party_id = boost::uuids::to_string(v.party_id);
     r.config_id = boost::uuids::to_string(v.config_id);
-    r.base_currency_code = v.base_currency_code;
-    r.quote_currency_code = v.quote_currency_code;
     r.base_currency_code = v.base_currency_code;
     r.quote_currency_code = v.quote_currency_code;
     r.source_name = v.source_name;

--- a/projects/ores.synthetic/core/src/repository/gmm_component_mapper.cpp
+++ b/projects/ores.synthetic/core/src/repository/gmm_component_mapper.cpp
@@ -38,7 +38,6 @@ domain::gmm_component gmm_component_mapper::map(const gmm_component_entity& v) {
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
     r.fx_spot_config_id = boost::lexical_cast<boost::uuids::uuid>(v.fx_spot_config_id);
     r.component_index = v.component_index;
-    r.component_index = v.component_index;
     r.description = v.description;
     r.mean = v.mean;
     r.stdev = v.stdev;
@@ -62,7 +61,6 @@ gmm_component_entity gmm_component_mapper::map(const domain::gmm_component& v) {
     r.version = v.version;
     r.party_id = boost::uuids::to_string(v.party_id);
     r.fx_spot_config_id = boost::uuids::to_string(v.fx_spot_config_id);
-    r.component_index = v.component_index;
     r.component_index = v.component_index;
     r.description = v.description;
     r.mean = v.mean;

--- a/projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org
+++ b/projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org
@@ -88,32 +88,6 @@ std::string("USD")
 
 * Columns
 
-** base_currency_code
-:PROPERTIES:
-:type:     text
-:cpp_type: std::string
-:nullable: false
-:END:
-
-Base currency ISO code of the FX spot pair (soft FK to currencies).
-
-#+begin_src cpp :name generator
-std::string(faker::finance::currencyCode())
-#+end_src
-
-** quote_currency_code
-:PROPERTIES:
-:type:     text
-:cpp_type: std::string
-:nullable: false
-:END:
-
-Quote currency ISO code of the FX spot pair (soft FK to currencies).
-
-#+begin_src cpp :name generator
-std::string(faker::finance::currencyCode())
-#+end_src
-
 ** source_name
 :PROPERTIES:
 :type:     text

--- a/projects/ores.synthetic/modeling/ores.synthetic.gmm_component.org
+++ b/projects/ores.synthetic/modeling/ores.synthetic.gmm_component.org
@@ -63,8 +63,9 @@ uuid_gen()
 
 ** component_index
 :PROPERTIES:
-:type:     integer
-:cpp_type: int
+:type:          integer
+:cpp_type:      int
+:default_value: 0
 :END:
 
 Zero-based ordinal of this component within its parent's mixture.
@@ -74,19 +75,6 @@ faker::number::integer(0, 4)
 #+end_src
 
 * Columns
-
-** component_index
-:PROPERTIES:
-:type:     integer
-:cpp_type: int
-:nullable: false
-:END:
-
-Zero-based ordinal of this component within its parent's mixture.
-
-#+begin_src cpp :name generator
-faker::number::integer(0, 4)
-#+end_src
 
 ** description
 :PROPERTIES:


### PR DESCRIPTION
## Summary

Fixes three bugs introduced in PR #1376 when promoting fields to natural keys:

- **Duplicate struct members**: `base_currency_code`/`quote_currency_code` in `fx_spot_generation_config` and `component_index` in `gmm_component` were present in both the Natural keys and Columns sections of their org models, generating duplicate C++ struct members and causing `rfl` static assertion failures at compile time. Removed the Columns duplicates.
- **Generator template `idx` undeclared**: The generator template appended `std::to_string(idx)` for all non-UUID natural keys but only declared `idx` for text-PK entities. Added a `has_text_natural_keys` flag in `core.py` and conditionally declare `idx` for UUID-PK entities that need it.
- **Generator template int + string concatenation**: Integer natural keys (`component_index`) used the string-append pattern, which is a type error. Added `is_int` detection to natural key processing in `core.py` and a dedicated template branch that emits just the generator expression.
- **Domain header missing `default_value` for natural keys**: The natural key section of the domain class header template didn't support `{{#default_value}}`; added the same branch used for columns so `component_index = 0` is emitted.

## Test plan

- [ ] Build `ores.synthetic` cleanly — no duplicate member errors, no `rfl` static assertions
- [ ] `gmm_component` generator produces structs with `component_index = 0` default
- [ ] `fx_spot_generation_config` generator produces unique `base_currency_code`/`quote_currency_code` values per instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)