### PR TITLE
[ci] Save build caches on test failure, shrink Windows sccache cap

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -202,7 +202,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete cmake cache entry
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -211,14 +211,14 @@ jobs:
             || true
 
       - name: Save cmake build cache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: build/output/linux-gcc-debug-ninja/projects
           key: cmake-build-linux-gcc-debug-ninja
 
       - name: Delete sccache entry
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -227,7 +227,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -202,7 +202,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete cmake cache entry
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -211,14 +211,14 @@ jobs:
             || true
 
       - name: Save cmake build cache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: build/output/linux-gcc-debug-ninja/projects
           key: cmake-build-linux-gcc-debug-ninja
 
       - name: Delete sccache entry
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -227,7 +227,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -261,7 +261,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete cmake cache entry
-        if: success() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
+        if: always() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -270,14 +270,14 @@ jobs:
             || true
 
       - name: Save cmake build cache
-        if: success() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
+        if: always() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
         uses: actions/cache/save@v6
         with:
           path: build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/projects
           key: cmake-build-${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
 
       - name: Delete sccache entry
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -286,7 +286,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -261,7 +261,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete cmake cache entry
-        if: always() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
+        if: ${{ !cancelled() }} && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -270,14 +270,14 @@ jobs:
             || true
 
       - name: Save cmake build cache
-        if: always() && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
+        if: ${{ !cancelled() }} && matrix.compiler == 'gcc' && matrix.buildtype == 'debug'
         uses: actions/cache/save@v6
         with:
           path: build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/projects
           key: cmake-build-${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
 
       - name: Delete sccache entry
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -286,7 +286,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -208,7 +208,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete sccache entry
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -217,7 +217,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -208,7 +208,7 @@ jobs:
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete sccache entry
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -217,7 +217,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -218,7 +218,7 @@ jobs:
           ctest -VV --preset $preset --script "CTest.cmake,$cmake_args"
 
       - name: Delete sccache entry
-        if: always()
+        if: ${{ !cancelled() }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -228,7 +228,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           variant: sccache
           key: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          max-size: 2000M
+          max-size: 1000M
           save: false
 
       - name: Install Clang
@@ -218,7 +218,7 @@ jobs:
           ctest -VV --preset $preset --script "CTest.cmake,$cmake_args"
 
       - name: Delete sccache entry
-        if: success()
+        if: always()
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -228,7 +228,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -221,7 +221,7 @@ jobs:
           ctest -VV --timeout 12000 --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete sccache entry
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -230,7 +230,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -221,7 +221,7 @@ jobs:
           ctest -VV --timeout 12000 --preset ${preset} --script "CTest.cmake,${cmake_args}"
 
       - name: Delete sccache entry
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -230,7 +230,7 @@ jobs:
             || true
 
       - name: Save sccache
-        if: success()
+        if: always()
         uses: actions/cache/save@v6
         with:
           path: ${{ env.SCCACHE_DIR }}


### PR DESCRIPTION
## Summary
- Cache-save steps (`Save sccache`, `Save cmake build cache`) were gated on `if: success()` in all continuous/nightly/canary workflows. Any test failure discarded a fully-compiled sccache/cmake-build cache even though compilation itself succeeded, forcing the next run to compile from cold cache.
- Repo Actions cache usage was at 10.74GB, over GitHub's 10GB per-repo LRU eviction limit, so infrequently-touched Linux caches were evicted in favour of larger/more active Windows sccache caches — meaning even successful saves weren't reliably reused.
- Diagnosed via run https://github.com/OreStudio/OreStudio/actions/runs/28571609315: sccache reported 2433 compile requests, 0 cache hits (0.00%), and the compile phase alone took ~2h20m before failing on unrelated schema-drift test failures.

## Changes
- `if: success()` → `if: always()` on cache delete/save steps in `continuous-linux.yml`, `continuous-windows.yml`, `continuous-macos.yml`, `canary-linux.yml`, `nightly-linux.yml`.
- Lowered Windows sccache `max-size` from 2000M to 1000M per build-type variant (4 variants totalled ~6.4GB, the largest share of cache usage).
- Cleaned up existing cache bloat directly via the Actions cache API: deleted 7 PR-branch-scoped duplicate caches (~540MB) and the 4 oversized Windows sccache entries (~6.4GB) so they regenerate at the new smaller cap. Repo cache usage dropped from 10.74GB to 3.83GB.

## Test plan
- [ ] Watch the next scheduled Linux/Windows/macOS CI runs to confirm `Restore sccache` reports non-zero cache hits after this lands
- [ ] Confirm cache-save steps run (not skipped) even on a run where tests fail
- [ ] Confirm `gh api repos/OreStudio/OreStudio/actions/caches` stays comfortably under the 10GB limit over the next few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)