### PR TITLE
[build] Bump version to 0.0.22

### DIFF
--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -300,4 +300,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/orestudio_0.0.21_amd64.deb
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/orestudio_0.0.22_amd64.deb

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -231,4 +231,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.21-Darwin.dmg
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.22-Darwin.dmg

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -250,4 +250,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.21-win64.*
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.22-win64.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ message(STATUS "CMake Version: ${CMAKE_VERSION}")
 enable_testing()
 configure_file(CTestCustom.cmake CTestCustom.cmake COPYONLY)
 
-project(OreStudio VERSION 0.0.21 LANGUAGES CXX
+project(OreStudio VERSION 0.0.22 LANGUAGES CXX
     DESCRIPTION "UI and other utilities for the Open Source Risk Engine (ORE).")
 
 # Copy all binaries into the publish directory.

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
@@ -41,7 +41,7 @@ agile index, and carry postponed sprint 21 stories forward.
 |------+-------+-------+-----+-------------|
 | [[id:2CC79A8B-86FC-4DF2-A36B-DB53034785AF][Task: Open sprint 22]] | STARTED | 2026-07-02 | | Scaffold sprint 22, wire manifest, move postponed stories. |
 | [[id:5076E124-409F-4D79-B207-3CD59968D4AA][Generate release notes for Sprint 21]] | DONE | 2026-07-02 | 2026-07-02 | Generate ORE Studio release notes from merged PRs and the closing sprint 21 backlog, tag main, and open a draft GitHub release. |
-| [[id:C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA][Bump project version to 0.0.22 for sprint 22]] | STARTED | 2026-07-02 | | Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version). |
+| [[id:C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA][Bump project version to 0.0.22 for sprint 22]] | DONE | 2026-07-02 | 2026-07-02 | Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
@@ -41,7 +41,7 @@ agile index, and carry postponed sprint 21 stories forward.
 |------+-------+-------+-----+-------------|
 | [[id:2CC79A8B-86FC-4DF2-A36B-DB53034785AF][Task: Open sprint 22]] | STARTED | 2026-07-02 | | Scaffold sprint 22, wire manifest, move postponed stories. |
 | [[id:5076E124-409F-4D79-B207-3CD59968D4AA][Generate release notes for Sprint 21]] | DONE | 2026-07-02 | 2026-07-02 | Generate ORE Studio release notes from merged PRs and the closing sprint 21 backlog, tag main, and open a draft GitHub release. |
-| [[id:C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA][Bump project version to 0.0.22 for sprint 22]] | BACKLOG | | | Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version). |
+| [[id:C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA][Bump project version to 0.0.22 for sprint 22]] | STARTED | 2026-07-02 | | Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/story.org
@@ -41,6 +41,7 @@ agile index, and carry postponed sprint 21 stories forward.
 |------+-------+-------+-----+-------------|
 | [[id:2CC79A8B-86FC-4DF2-A36B-DB53034785AF][Task: Open sprint 22]] | STARTED | 2026-07-02 | | Scaffold sprint 22, wire manifest, move postponed stories. |
 | [[id:5076E124-409F-4D79-B207-3CD59968D4AA][Generate release notes for Sprint 21]] | DONE | 2026-07-02 | 2026-07-02 | Generate ORE Studio release notes from merged PRs and the closing sprint 21 backlog, tag main, and open a draft GitHub release. |
+| [[id:C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA][Bump project version to 0.0.22 for sprint 22]] | BACKLOG | | | Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA
+:END:
+#+title: Task: Bump project version to 0.0.22 for sprint 22
+#+description: Missed as part of the sprint-opening process: bump the project version across CMakeLists.txt, vcpkg.json, and the GitHub workflow files (currently all still at 0.0.21, sprint 21's version).
+#+type: task
+#+level: s1
+#+filetags: :open_sprint_22:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Bump the project version from =0.0.21= (sprint 21's version) to
+=0.0.22= for sprint 22, following [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]].
+This is normally part of opening a sprint (see
+[[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] itself) but was missed.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- =CMakeLists.txt= =project(OreStudio VERSION 0.0.22 ...)=.
+- =vcpkg.json= =version-string= updated to =0.0.22=.
+- =.github/workflows/continuous-linux.yml=,
+  =continuous-windows.yml=, =continuous-macos.yml= package-path
+  references updated to =0.0.22=.
+- Fresh CMake configure picks up the new version with no other
+  drift.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
@@ -8,7 +8,7 @@
 #+filetags: :open_sprint_22:sprint_22:v0:
 #+owner: marco
 #+branch: feature/bump-project-version-sprint-22
-#+pr:
+#+pr: 1404
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-02
@@ -62,7 +62,7 @@ one that actually exists — v0.0.22 doesn't exist yet).
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1404][#1404]] | [build] Bump version to 0.0.22 |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
@@ -29,11 +29,11 @@ This is normally part of opening a sprint (see
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] |
-| Now          | Fix verified locally.                  |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR.                                    |
+| Next         | Nothing. |
 | Last touched | 2026-07-02                               |
 
 * Acceptance
@@ -71,3 +71,9 @@ one that actually exists — v0.0.22 doesn't exist yet).
 |   |                 |      |          |       |
 
 * Result
+
+Bumped 0.0.21 → 0.0.22 across CMakeLists.txt, vcpkg.json, the three
+CI workflow package filenames, and readme.org's four badges
+(sprint, PRs-since, commits-since, screenshot). Verified via the
+recipe's own grep check (zero stray old-version references) and
+three independent PR reviews, all LGTM.

--- a/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
+++ b/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :open_sprint_22:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/bump-project-version-sprint-22
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-02
 #+updated: 2026-07-02
-#+environment:
+#+environment: prime_origin
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -29,11 +29,11 @@ This is normally part of opening a sprint (see
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:6990C56C-106D-43BF-9FB9-46B03756F954][Open sprint 22]] |
-| Now          | Not yet started.                       |
+| Now          | Fix verified locally.                  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | PR.                                    |
 | Last touched | 2026-07-02                               |
 
 * Acceptance
@@ -48,9 +48,13 @@ This is normally part of opening a sprint (see
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Followed [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]] exactly: CMakeLists.txt,
+vcpkg.json, the three GitHub workflow package filenames, and
+readme.org's four badges (sprint, PRs-since, commits-since,
+screenshot). New sprint (22) started 2026-07-02, so PRs-since moved
+to that date with label v0.0.22; commits-since moved to v0.0.21 (the
+just-bumped-from version); screenshot pointed at v0.0.21 (the latest
+one that actually exists — v0.0.22 doesn't exist yet).
 
 * Notes
 

--- a/readme.org
+++ b/readme.org
@@ -22,7 +22,7 @@
 #+html: <a href="https://visualstudio.microsoft.com/vs/whatsnew/"><img alt="MSVC Version" src="https://img.shields.io/badge/MSVC-2022-blue.svg"/></a>
 #+html: <a href="https://doc.qt.io/qt-6/"><img alt="Qt6" src="https://img.shields.io/badge/Qt-6-blue"/></a>
 #+html: <a href="https://orestudio.github.io/OreStudio/doxygen/html/index.html"><img alt="Doxygen" src="https://raw.githubusercontent.com/OreStudio/OreStudio/main/assets/images/doxygen_badge.svg"/></a>
-#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_21/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-21-blue.svg"/></a>
+#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-22-blue.svg"/></a>
 #+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://img.shields.io/static/v1?logo=gnuemacs&logoColor=fafafa&label=Made%20with&message=GNU%20Emacs&color=7F5AB6&style=flat"/></a>
 #+html: <a href="https://discord.gg/ztAaxmsnUJ"><img alt="Discord" src="https://img.shields.io/discord/1254062142626332732?color=5865F2&amp;logo=discord&amp;logoColor=white"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/pulse"><img alt="Commit Activity" src="https://img.shields.io/github/commit-activity/m/OreStudio/OreStudio"/></a>
@@ -40,8 +40,8 @@
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml"><img alt="Continuous Windows" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml"><img alt="Continuous MacOS.yml" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml"><img alt="Nightly Linux" src="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml/badge.svg"/></a>
-#+html: <a href="https://github.com/OreStudio/OreStudio/pulls?q=is%3Apr+is%3Amerged+merged%3A%3E%3D2026-06-12"><img alt="PRs since v0.0.20" src="https://img.shields.io/badge/PRs%20since%20v0.0.20-GitHub%20search-blue"/></a>
-#+html: <a href="https://github.com/OreStudio/OreStudio/commits/main"><img alt="Commits" src= "https://img.shields.io/github/commits-since/OreStudio/OreStudio/v0.0.20.svg"/></a>
+#+html: <a href="https://github.com/OreStudio/OreStudio/pulls?q=is%3Apr+is%3Amerged+merged%3A%3E%3D2026-07-02"><img alt="PRs since v0.0.22" src="https://img.shields.io/badge/PRs%20since%20v0.0.22-GitHub%20search-blue"/></a>
+#+html: <a href="https://github.com/OreStudio/OreStudio/commits/main"><img alt="Commits" src= "https://img.shields.io/github/commits-since/OreStudio/OreStudio/v0.0.21.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/OreStudio/OreStudio/total.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Releases" src="https://img.shields.io/github/release/OreStudio/OreStudio.svg"/></a>
 #+html: <a href="https://deepwiki.com/OreStudio/OreStudio"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"/></a>
@@ -55,7 +55,7 @@ running ORE — persistent storage for inputs and outputs, CRUD management, and 
 simple three-layer architecture (client / service / [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL]]) designed to be
 easy to understand and extend. ORE Studio was started by [[https://mcraveiro.github.io/][Marco Craveiro]].
 
-[[./assets/images/ore_studio-v0.0.20.png]]
+[[./assets/images/ore_studio-v0.0.21.png]]
 
 The project is built for people who want to *learn quantitative finance by
 building*. All the heavy mathematical lifting stays in ORE and QuantLib; ORE

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "ores",
     "description": "GUI for Open Source Risk Engine (ORE)",
-    "version-string": "0.0.21",
+    "version-string": "0.0.22",
     "dependencies": [
         "openssl",
         {


### PR DESCRIPTION
## Summary

Missed as part of sprint 22's opening (PR #1399 scaffolded the sprint but skipped the version bump). Bumps to 0.0.22 across CMakeLists.txt, vcpkg.json, workflow package filenames, and readme.org badges.

## Changes

- CMakeLists.txt / vcpkg.json version bump to 0.0.22
- GitHub workflow package filenames updated (linux/windows/macos)
- readme.org: sprint badge, PRs-since, commits-since, screenshot badges updated

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Open sprint 22](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/open_sprint_22/story.html) | 6990C56C-106D-43BF-9FB9-46B03756F954 |
| Task | [Bump project version to 0.0.22 for sprint 22](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/open_sprint_22/task_bump_project_version_sprint_22.html) | C653D61E-A2A6-47B4-96A2-7B1FC1A7EDAA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)