### PR TITLE
[compass] pr create: record the environment on the PR

### DIFF
--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/story.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/story.org
@@ -21,7 +21,7 @@ Improve compass quality of life with a mix of UX enhancements and bug fixes surf
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
 | Now           | Nothing. |
 | Waiting on    | Nothing.                               |
@@ -51,6 +51,7 @@ Improve compass quality of life with a mix of UX enhancements and bug fixes surf
 | [[id:8C8A7CBE-8986-4FF3-BB47-318F9D683C71][Compass search: explicit weighted scoring model]] | DONE | | 2026-06-30 | Replace the ad-hoc core/full/body label system with a formal scoring pipeline: each signal (title-core match, title-full match, body FTS, exact phrase, type boost) is normalised to [0,1] and combined with explicit weights to produce a percentage score. Threshold filtering removes low-confidence noise. The scorer is extracted into a standalone testable function so the algorithm can be evaluated against a corpus and tuned. |
 | [[id:7110094D-20FC-473C-B0C9-DF2270D93F82][compass heading: skip stories owned by another environment]] | DONE | 2026-06-30 | 2026-06-30 | compass heading recommends tasks regardless of which environment started them. Tasks and stories are stamped with #+environment: at task start. heading should read this field and deprioritise (or skip) items whose environment differs from the current ORES_CHECKOUT_LABEL, so two environments working the same sprint do not compete for the same stories. |
 | [[id:DDAFAC96-8BA1-4CC3-91A9-3B8A905781A6][Add compass db status command]] | DONE | 2026-06-30 | 2026-06-30 | Extract the database info block from compass bearings into a standalone compass db status command that gives a full database health overview: restore date, schema version/drift, bootstrap mode, non-system tenants, party count, and anything else useful for diagnosing the DB state. |
+| [[id:841F94BF-E2AB-4CE0-86BB-60FE65A0380F][compass pr create: record the environment on the PR]] | STARTED | 2026-07-02 | | compass pr create's body has no record of which ores_dev_* environment the work was done in. Add an Environment line (from the task's #+environment: field, overridable with --environment) to the PR body. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/story.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/story.org
@@ -21,7 +21,7 @@ Improve compass quality of life with a mix of UX enhancements and bug fixes surf
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
 | Now           | Nothing. |
 | Waiting on    | Nothing.                               |
@@ -51,11 +51,17 @@ Improve compass quality of life with a mix of UX enhancements and bug fixes surf
 | [[id:8C8A7CBE-8986-4FF3-BB47-318F9D683C71][Compass search: explicit weighted scoring model]] | DONE | | 2026-06-30 | Replace the ad-hoc core/full/body label system with a formal scoring pipeline: each signal (title-core match, title-full match, body FTS, exact phrase, type boost) is normalised to [0,1] and combined with explicit weights to produce a percentage score. Threshold filtering removes low-confidence noise. The scorer is extracted into a standalone testable function so the algorithm can be evaluated against a corpus and tuned. |
 | [[id:7110094D-20FC-473C-B0C9-DF2270D93F82][compass heading: skip stories owned by another environment]] | DONE | 2026-06-30 | 2026-06-30 | compass heading recommends tasks regardless of which environment started them. Tasks and stories are stamped with #+environment: at task start. heading should read this field and deprioritise (or skip) items whose environment differs from the current ORES_CHECKOUT_LABEL, so two environments working the same sprint do not compete for the same stories. |
 | [[id:DDAFAC96-8BA1-4CC3-91A9-3B8A905781A6][Add compass db status command]] | DONE | 2026-06-30 | 2026-06-30 | Extract the database info block from compass bearings into a standalone compass db status command that gives a full database health overview: restore date, schema version/drift, bootstrap mode, non-system tenants, party count, and anything else useful for diagnosing the DB state. |
-| [[id:841F94BF-E2AB-4CE0-86BB-60FE65A0380F][compass pr create: record the environment on the PR]] | STARTED | 2026-07-02 | | compass pr create's body has no record of which ores_dev_* environment the work was done in. Add an Environment line (from the task's #+environment: field, overridable with --environment) to the PR body. |
+| [[id:841F94BF-E2AB-4CE0-86BB-60FE65A0380F][compass pr create: record the environment on the PR]] | DONE | 2026-07-02 | 2026-07-02 | compass pr create's body has no record of which ores_dev_* environment the work was done in. Add an Environment line (from the task's #+environment: field, overridable with --environment) to the PR body. |
 
 * Result
 
-14 tasks delivered across PR #1375 through #1392.
+15 tasks delivered across PR #1375 through #1405.
+
+Reopened after initial close to add one follow-up:
+- =compass pr create= now records =**Environment:**= on every PR
+  body (from the task's =#+environment:= field, =--environment=
+  override), so a reviewer can tell which worktree produced a
+  change. Verified live on PR #1405 itself.
 
 UX and discoverability:
 - Bucketed search results (recipes / now / historic) with per-bucket caps

--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_quality_of_life_sprint_21:sprint_22:v0:
 #+owner: marco
 #+branch: feature/pr-create-environment-field
-#+pr:
+#+pr: 1405
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-02
@@ -60,7 +60,7 @@ Answer and Conventions sections to match.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1405][#1405]] | [compass] pr create: record the environment on the PR |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
@@ -69,3 +69,8 @@ Answer and Conventions sections to match.
 |   |                 |      |          |       |
 
 * Result
+
+Verified live: PR #1405 itself (raised with the modified
+=compass pr create=) shows =**Environment:** prime_origin= right
+after the Traceability table, sourced automatically from this task's
+=#+environment:= field.

--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 841F94BF-E2AB-4CE0-86BB-60FE65A0380F
+:END:
+#+title: Task: compass pr create: record the environment on the PR
+#+description: compass pr create's body has no record of which ores_dev_* environment the work was done in. Add an Environment line (from the task's #+environment: field, overridable with --environment) to the PR body.
+#+type: task
+#+level: s1
+#+filetags: :compass_quality_of_life_sprint_21:sprint_22:v0:
+#+owner: marco
+#+branch: feature/pr-create-environment-field
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment: prime_origin
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Multiple environments (=ores_dev_*= worktrees) work in parallel on
+this repo; the PR body currently has no record of which one produced
+a given change, making it harder to reproduce/continue work from a
+PR alone. Add an =**Environment:**= line to =compass pr create='s
+body, sourced from the task's =#+environment:= frontmatter field
+(overridable with =--environment=).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] |
+| Now          | Fix verified locally.                  |
+| Waiting on   | Nothing.                               |
+| Next         | PR.                                    |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- =compass pr create='s body has an =**Environment:**= line, placed
+  right after the Traceability table.
+- Defaults to the branch's task's =#+environment:= field; =(none)=
+  if absent; =--environment <name>= overrides.
+- Recipe [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] documents the new line and flag.
+
+* Plan
+
+Added =_org_field()= helper to =compass_pr.py= (parallel to the
+existing =_org_title=/=_org_id=), read the task's =#+environment:=,
+and inserted the line into the body right after Traceability. Added
+=--environment= as an explicit override. Updated the recipe's
+Answer and Conventions sections to match.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
+++ b/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.org
@@ -31,11 +31,11 @@ body, sourced from the task's =#+environment:= frontmatter field
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] |
-| Now          | Fix verified locally.                  |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR.                                    |
+| Next         | Nothing. |
 | Last touched | 2026-07-02                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -110,7 +110,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 |-------+-------+-------+-----+-------------|
 | [[id:3A9DF70D-07F7-46A7-8219-57A024707B64][compass generate catalogue]] | BACKLOG | | | Auto-regenerate catalogue/index org files by scanning tagged org files. |
 | [[id:20998FA2-2073-4956-AE46-EFDD44C0CFD1][Fix orphan documents and tag taxonomy]] | BACKLOG | | | Fix orphaned docs in org-roam graph; create tag inventory; add compass tag validation. |
-| [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] | BACKLOG | | | Carried from sprint 21. |
+| [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] | DONE | | 2026-07-02 | Carried from sprint 21. |
 
 ** Infrastructure
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -20,11 +20,11 @@ correctly-formatted title and a structured body?
 * Answer
 
 1. /Create the PR/ with =compass pr create=. It validates the title
-   convention, assembles the body (Summary, Changes, and the
+   convention, assembles the body (Summary, Changes, the
    =## Traceability= table derived from the branch's task and story
-   docs), pushes the branch, opens the PR, records it on the task
-   (=#+pr:= and the =* PRs= table), commits and pushes that record,
-   and stamps the session journal:
+   docs, and an =**Environment:**= line), pushes the branch, opens
+   the PR, records it on the task (=#+pr:= and the =* PRs= table),
+   commits and pushes that record, and stamps the session journal:
 
    #+begin_src sh :results verbatim
    ./compass.sh pr create --title "[component] One-line description" \
@@ -32,8 +32,11 @@ correctly-formatted title and a structured body?
      --change "First change" --change "Second change"
    #+end_src
 
-   Use =--draft= for a draft PR and =--task <uuid-or-slug>= when the
-   branch carries more than one task.
+   Use =--draft= for a draft PR, =--task <uuid-or-slug>= when the
+   branch carries more than one task, and =--environment <name>= to
+   override the environment shown (default: the task's
+   =#+environment:= frontmatter field, e.g. =prime_origin=; falls
+   back to =(none)= if the task doesn't record one).
 
 2. /Confirm the PR URL/ it prints. There is nothing else to do — the
    task-doc record is already committed and pushed.
@@ -69,6 +72,12 @@ correctly-formatted title and a structured body?
   - Task:  =doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/task_<TASK_SLUG>=
 - /Traceability is forward-only/: add it to new PRs; do not back-fill
   old ones.
+- /Environment line/ goes right after Traceability, always:
+  =**Environment:** <name>=. It records which =ores_dev_*= worktree
+  environment the work was done in (read from the task's
+  =#+environment:= field), so a reviewer or a later session can tell
+  where to reproduce/continue the work. =(none)= if the task doesn't
+  record one.
 
 * Script
 

--- a/projects/ores.compass/src/compass_pr.py
+++ b/projects/ores.compass/src/compass_pr.py
@@ -158,6 +158,12 @@ def _org_id(text):
     return m.group(1) if m else ""
 
 
+def _org_field(text, field):
+    """#+<field>: value from an org file's frontmatter, or "" if absent/blank."""
+    m = re.search(rf"^#\+{field}:\s*(.*)$", text, re.M | re.I)
+    return m.group(1).strip() if m else ""
+
+
 def _site_url(rel_path):
     return _SITE_BASE + str(rel_path).removesuffix(".org") + ".html"
 
@@ -209,6 +215,7 @@ def _cmd_create(args, project_root):
 
     summary = args.summary or "(Fill in: what changes, why.)"
     changes = "\n".join(f"- {c}" for c in (args.change or ["(Fill in.)"]))
+    environment = args.environment or _org_field(task_text, "environment") or "(none)"
     body = (
         f"## Summary\n\n{summary}\n\n"
         f"## Changes\n\n{changes}\n\n"
@@ -217,6 +224,7 @@ def _cmd_create(args, project_root):
         "|----------|------|----|\n"
         f"| Story | [{story_title}]({_site_url(story_rel)}) | {story_id} |\n"
         f"| Task | [{task_title}]({_site_url(task_rel)}) | {task_id} |\n\n"
+        f"**Environment:** {environment}\n\n"
         "🤖 Generated with [Claude Code](https://claude.com/claude-code)")
 
     # Ensure the branch exists on the remote under its own name — a
@@ -539,6 +547,9 @@ def run(argv, project_root):
     cr.add_argument("--task", default="",
                     help="Task UUID or slug (default: match #+branch: "
                          "against the current branch)")
+    cr.add_argument("--environment", default="",
+                    help="Environment the work was done in, e.g. "
+                         "prime_origin (default: the task's #+environment:)")
     cr.add_argument("--draft", action="store_true",
                     help="Open as a draft PR")
 


### PR DESCRIPTION
## Summary

The PR body had no record of which ores_dev_* environment produced a given change. Add an Environment line right after Traceability, sourced from the task's #+environment: field.

## Changes

- compass_pr.py: new _org_field() helper; Environment line in the body; --environment override flag
- Recipe how_do_i_create_a_pr.org updated to document the new line and flag

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality of life (Sprint 21)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/story.html) | E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE |
| Task | [compass pr create: record the environment on the PR](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/compass_quality_of_life_sprint_21/task_pr_create_environment_field.html) | 841F94BF-E2AB-4CE0-86BB-60FE65A0380F |

**Environment:** prime_origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)