### PR TITLE
[refdata] Resync party_type codegen; fix display_order SQL default drift

### DIFF
--- a/doc/agile/versions/v0/sprint_22/commission_party_type/story.org
+++ b/doc/agile/versions/v0/sprint_22/commission_party_type/story.org
@@ -24,7 +24,7 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
 | Now           | Verify codegen done. Drift found across C++ core, messaging, Qt.       |
 | Waiting on    | Nothing.                                                               |
@@ -64,3 +64,4 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 | [[id:6682E5F1-DCE2-42E3-8FE2-E5FC89E576C1][Write party_type documentation (manual chapter, NATS reference)]] | ABANDONED | | | Add the party_type entity chapter to the user manual covering all Qt windows, shell commands, and CLI commands; document the NATS message types. |
 | [[id:E906BC3E-8BC1-411F-B8DD-EE0191DE3087][File Wt and HTTP gap captures for party_type]] | ABANDONED | | | File backlog captures for Wt widget and HTTP endpoint support for party_type, which are out of scope for this sprint per the commissioning epic. |
 | [[id:96C76FF3-0279-4E75-80A3-37248545025C][Migrate party_type to unified codegen model]] | DONE | | 2026-06-30 | Move _table.org sections (validation function, insert trigger, coding scheme, image_id, has_tenant_id) into ores.refdata.party_type.org; verify generated SQL is byte-identical to the table-pathway output; delete party_type_table.org. Blocked on codegen model unification infrastructure (steps 1-4 of D2256981). |
+| [[id:17699BFE-C676-4323-A8CD-A2F99A8D361B][Resync party_type codegen formatting and SQL default drift]] | DONE | 2026-07-02 | 2026-07-02 | Regen shows non-zero diff across nearly all party_type profiles (Qt, C++ domain/repository/messaging, generator) due to formatting/style drift since last sync (2026-06-30); also SQL display_order column loses 'default 0'. Regenerate and reconcile, or fix templates if drift is a template regression, so entity is zero-diff again. party_status shows the same drift; purpose_type is clean. |

--- a/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
+++ b/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_party_type:sprint_22:v0:codegen:
 #+owner: marco
 #+branch: feature/resync-party-type-codegen-drift
-#+pr:
+#+pr: 1407
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-02
@@ -72,7 +72,7 @@ current template.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1407][#1407]] | [refdata] Resync party_type codegen; fix display_order SQL default drift |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
+++ b/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
@@ -1,0 +1,96 @@
+:PROPERTIES:
+:ID: 17699BFE-C676-4323-A8CD-A2F99A8D361B
+:END:
+#+title: Task: Resync party_type codegen formatting and SQL default drift
+#+description: Regen shows non-zero diff across nearly all party_type profiles (Qt, C++ domain/repository/messaging, generator) due to formatting/style drift since last sync (2026-06-30); also SQL display_order column loses 'default 0'. Regenerate and reconcile, or fix templates if drift is a template regression, so entity is zero-diff again. party_status shows the same drift; purpose_type is clean.
+#+type: task
+#+level: s1
+#+filetags: :commission_party_type:sprint_22:v0:codegen:
+#+owner: marco
+#+branch: feature/resync-party-type-codegen-drift
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment: solid_dirac
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Regenerate party_type across all profiles so on-disk files match current
+codegen templates byte-for-byte, closing the zero-diff gate for the
+Commission: party_type story.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- =compass codegen entity generate party_type= run for all profiles.
+- =compass codegen entity show party_type= reports ✅ for every file.
+- =ores.refdata.core.lib=, =ores.refdata.api.lib=, =ores.qt.refdata.lib= build clean.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+Ran =compass codegen entity generate party_type --diff= for a byte-level
+compare; ran the real generate; then re-checked with =entity show= (the
+authoritative per-file check) and a direct build.
+
+* Notes
+
+The initial =--diff= report (used to file this task) over-stated the
+drift: most of the reported hunks were 4-space vs 2-space indentation and
+brace-placement differences that turned out to be an artefact of the
+=--diff= comparison path applying a different clang-format style than the
+project's =.clang-format= (verified: =clang-format --style=file:.clang-format
+--dry-run= against the on-disk files produced no output, i.e. they were
+already conformant). =compass codegen entity show party_type= — which
+compares against the project's actual style — is the more reliable
+zero-diff check going forward.
+
+The real drift was small: a missing =default 0= on the SQL
+=display_order= column, a missing IWYU include in =party_type_entity.cpp=,
+and two blank-line spacing fixes in the entity/mapper files matching the
+current template.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Regenerated party_type for all profiles (=compass codegen entity generate
+party_type=). =compass codegen entity show party_type= now reports ✅ for
+all 36 generated files. Content diff committed:
+
+- SQL: =display_order= column restored to =integer not null default 0=.
+- =party_type_entity.cpp=: added missing =ores.utility/rfl/reflectors.hpp=
+  IWYU include.
+- =party_type_entity.hpp=, =party_type_mapper.cpp=: blank-line spacing
+  around fields/assignments to match current template output.
+
+=ores.refdata.core.lib=, =ores.refdata.api.lib=, =ores.qt.refdata.lib=
+build clean with the regenerated sources.

--- a/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
+++ b/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.org
@@ -78,7 +78,9 @@ current template.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | claude-review: fix correct, no issues found | (all) | Accepted | 3 independent bot passes, all issue-level (no line comments); CI green |
+| 2 | party_status/contact_type have the same unaddressed blank-line drift | party_type_entity.hpp, party_type_mapper.cpp | Declined (out of scope) | Already tracked — this task's Notes flag party_status explicitly; contact_type not yet tracked, left as-is |
+| 3 | reflectors.hpp IWYU include missing repo-wide (~143/148 *_entity.cpp files), not just party_type/party_status | party_type_entity.cpp | Declined (out of scope) | Filed as backlog capture doc/agile/product_backlog/inbox/sweep_missing_rfl_reflectors_include.org for a dedicated sweep |
 
 * Result
 

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/party_type_entity.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/party_type_entity.hpp
@@ -40,7 +40,9 @@ struct party_type_entity {
     sqlgen::PrimaryKey<std::string> code;
     std::string tenant_id;
     int version = 0;
+
     std::string name;
+
     std::string description;
     int display_order = 0;
     std::string modified_by;

--- a/projects/ores.refdata/core/src/repository/party_type_entity.cpp
+++ b/projects/ores.refdata/core/src/repository/party_type_entity.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.refdata.core/repository/party_type_entity.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <ostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>

--- a/projects/ores.refdata/core/src/repository/party_type_mapper.cpp
+++ b/projects/ores.refdata/core/src/repository/party_type_mapper.cpp
@@ -33,7 +33,9 @@ domain::party_type party_type_mapper::map(const party_type_entity& v) {
     r.version = v.version;
     r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.code = v.code.value();
+
     r.name = v.name;
+
     r.description = v.description;
     r.display_order = v.display_order;
     r.modified_by = v.modified_by;
@@ -53,7 +55,9 @@ party_type_entity party_type_mapper::map(const domain::party_type& v) {
     r.code = v.code;
     r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
+
     r.name = v.name;
+
     r.description = v.description;
     r.display_order = v.display_order;
     r.modified_by = v.modified_by;

--- a/projects/ores.sql/create/refdata/refdata_party_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_types_create.sql
@@ -37,7 +37,7 @@ create table if not exists "ores_refdata_party_types_tbl" (
     "version" integer not null,
     "name" text not null,
     "description" text not null,
-    "display_order" integer not null,
+    "display_order" integer not null default 0,
     "modified_by" text not null,
     "performed_by" text not null,
     "change_reason_code" text not null,


### PR DESCRIPTION
## Summary

Regenerate party_type across all profiles to close the zero-diff gate for the Commission: party_type story.

## Changes

- SQL display_order column restored to 'integer not null default 0'
- Added missing IWYU include in party_type_entity.cpp
- Blank-line spacing fixes in entity/mapper matching current template
- Confirmed compass codegen entity show party_type reports zero-diff across all 36 files; build green

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: party_type](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_party_type/story.html) | 59583AFF-7657-4F79-BB7E-2086BCA04A91 |
| Task | [Resync party_type codegen formatting and SQL default drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_party_type/task_resync_party_type_codegen_drift.html) | 17699BFE-C676-4323-A8CD-A2F99A8D361B |

**Environment:** solid_dirac

🤖 Generated with [Claude Code](https://claude.com/claude-code)