### PR TITLE
[synthetic] GMM improvements: chart axes, per-component PDFs, Ornstein-Uhlenbeck

### DIFF
--- a/doc/agile/product_backlog/inbox/codegen_sql_validation_fn_drift_synthetic.org
+++ b/doc/agile/product_backlog/inbox/codegen_sql_validation_fn_drift_synthetic.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: D583B57B-B896-48A6-AD66-1F01FAE3FA3D
+:END:
+#+title: Reconcile SQL codegen template drift on synthetic validation fn
+#+description: Regenerating the fx_spot_generation_config SQL layer drops the tracked system-tenant fallback logic from its validation function, indicating the template has drifted from the checked-in output.
+#+type: capture
+#+level: cross
+#+filetags: :codegen:sql:synthetic:drift:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Regenerating =projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org=
+via =compass codegen generate --model ... --profile sql= (done to add
+=ou= to the =process_type= check constraint for the GMM-improvements
+story) produced a diff that, besides the intended check-constraint
+change, also silently dropped custom validation logic from the
+tracked =ores_synthetic_validate_fx_spot_generation_config_fn()=
+function in
+=projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql=:
+the "system tenant canonical set" pass-through/fallback branch (the
+block starting "Allow pass-through if neither this tenant nor the
+system tenant has seeded active fx_spot_generation_configs yet...")
+was replaced by a simpler null-check-only body. Either the
+=sql_schema_domain_entity_create.mustache= template (or the model's
+=* Validation function= section) has drifted behind manual edits
+previously made to the generated file, or the template itself
+regressed. The regeneration was reverted; only the single
+check-constraint line was hand-edited instead, to avoid losing the
+validation logic.
+
+* Why
+
+Someone should compare the template output against the tracked file
+for this entity (and possibly others sharing the same template) and
+reconcile — either port the system-tenant fallback logic into the
+model/template properly, or determine it was an unintentional manual
+patch that should be redone as a template change. Left as-is, any
+future full regeneration of this entity's SQL layer will silently
+regress tenant validation behaviour.
+
+* References
+
+- =projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql=
+- =projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org=
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/custom_jump_distributions_and_cross_rate_correlation.org
+++ b/doc/agile/product_backlog/inbox/custom_jump_distributions_and_cross_rate_correlation.org
@@ -1,0 +1,42 @@
+:PROPERTIES:
+:ID: 62E7C0B3-02C8-4DFE-9C56-6FB36CB5121B
+:END:
+#+title: Custom jump distributions and cross-rate correlation matrices
+#+description: Configurable jump-size distributions and cross-rate correlation for multi-asset synthetic FX scenarios.
+#+type: capture
+#+level: cross
+#+filetags: :synthetic:gmm:process:backlog:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Two related but distinct capabilities, both currently listed as
+placeholders in the FxSpotRateEditor "Component Tools" disclosure
+panel: (1) custom/configurable jump-size distributions — beyond a
+default distribution once jump/Poisson processes exist (depends on
+[[id:84635A47-0E1A-4B67-A775-15F256D54A2D][Implement jump/Poisson stochastic process component]]); (2)
+cross-rate correlation matrices, so multiple synthetic FX pairs
+generated concurrently can be driven by correlated shocks rather than
+independent RNG streams per pair, for more realistic multi-asset
+synthetic scenarios.
+
+* Why
+
+Currently listed as "Planned — not yet available" placeholders with
+no implementation
+(=projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp=,
+=buildAdvancedControls()=, the futureBox/futureText widget). Reviewed
+during
+[[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]]'s
+process-tools inventory task and explicitly scoped out.
+
+* References
+
+- =projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp= (Component Tools panel)
+
+* See also
+
+- [[id:84635A47-0E1A-4B67-A775-15F256D54A2D][Implement jump/Poisson stochastic process component]]

--- a/doc/agile/product_backlog/inbox/enforce_process_parameter_validation_server_side.org
+++ b/doc/agile/product_backlog/inbox/enforce_process_parameter_validation_server_side.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: FDEAC2F6-A87F-4281-82CC-437B06D5B02F
+:END:
+#+title: Enforce process parameter validation at save/feed-start time
+#+description: validate_process_parameters exists but isn't called by gmm_component_handler::save or feed_controller::start, so bad configs can still be persisted or crash a feed thread.
+#+type: capture
+#+level: cross
+#+filetags: :synthetic:validation:backlog:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+[[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]]
+added =ores::synthetic::domain::validate_process_parameters()=
+(=projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp=)
+as the shared source of truth for whether a (means, stdevs, weights,
+initial_price) tuple is valid for a given =process_type=, and wired it
+into =process_factory::make_process()=
+(=projects/ores.synthetic/service/src/process_factory.cpp=) and the Qt
+client (=FxSpotRateEditor::onSaveClicked()=). It is *not* yet called
+by:
+- =gmm_component_handler::save()=
+  (=projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp=)
+  — persists whatever weight/stdev the client sends, with no
+  validation beyond ID-nil checks in
+  =gmm_component_service::save_gmm_component=.
+- =feed_controller::start()=
+  (=projects/ores.synthetic/service/src/feed_controller.hpp=) — calls
+  =process_factory::make_process()= with no surrounding =try/catch=, so
+  an invalid persisted config could throw uncaught inside the feed
+  thread rather than being rejected up front.
+
+Wire =validate_process_parameters()= into both: reject invalid
+=gmm_component= saves with a clear error before persisting, and guard
+=feed_controller::start()= so a bad config can't start (or crash) a
+feed thread.
+
+* Why
+
+=gmm_component= and =fx_spot_generation_config= (which carries
+=process_type=) are saved via two separate requests (not atomic — see
+also the pre-existing =atomic_batch_save_fx_spot_config= backlog
+item), so cross-entity validation at save time needs some thought
+about when both pieces are actually known together. Scoped out of the
+GMM improvements story to avoid rushing a fix into the persistence
+layer; the client-side and =process_factory=-side validation already
+close the most common path (the Qt editor), but a config written via
+any other path (API script, future admin tool, a bug) is still
+unguarded server-side.
+
+* References
+
+- =projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp=
+- =projects/ores.synthetic/core/include/ores.synthetic.core/messaging/gmm_component_handler.hpp=
+- =projects/ores.synthetic/service/src/feed_controller.hpp=
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/hoist_chart_theme_colours_helper.org
+++ b/doc/agile/product_backlog/inbox/hoist_chart_theme_colours_helper.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: 4EE11531-E6AB-4094-8297-F0E7DB12EC39
+:END:
+#+title: Hoist duplicated Qt chart theme colours into a shared helper
+#+description: Chart text/grid colour constants (0xCBD5E1 text, 0xFFFFFF12-ish grid) are copy-pasted across five call sites and can drift out of sync.
+#+type: capture
+#+level: cross
+#+filetags: :qt:synthetic:charts:tech-debt:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+=QColor(0xCB, 0xD5, 0xE1)= (chart text) and the near-transparent white
+grid colour are hardcoded independently in at least five places:
+=ReturnDistributionChart.cpp=, =SamplePricePathsChart.cpp=,
+=FxSpotChartWindow.cpp=, and =MarketSimulatorWindow.cpp= (two spots).
+This exists because the app's dark theme is applied via QSS only
+(never =QApplication::setPalette=), so =QWidget::palette()= can't be
+used to derive chart colours reliably — see
+[[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]]'s
+chart-axes task for the investigation. Hoist these literals into a
+small shared helper (e.g. a =ChartTheme= namespace/struct in
+=ores.qt= common code) so all QtCharts call sites read from one place.
+
+* Why
+
+Five independent copies of the same colour literals can silently
+drift out of sync as the theme evolves, and any future dark/light
+theme toggle would need to touch all five sites individually. Flagged
+during PR #1409 review as a non-blocking follow-up.
+
+* References
+
+- =projects/ores.qt/synthetic/src/ReturnDistributionChart.cpp=
+- =projects/ores.qt/synthetic/src/SamplePricePathsChart.cpp=
+- =projects/ores.qt/mktdata/src/FxSpotChartWindow.cpp=
+- =projects/ores.qt/synthetic/src/MarketSimulatorWindow.cpp=
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/implement_jump_poisson_process.org
+++ b/doc/agile/product_backlog/inbox/implement_jump_poisson_process.org
@@ -1,0 +1,47 @@
+:PROPERTIES:
+:ID: 84635A47-0E1A-4B67-A775-15F256D54A2D
+:END:
+#+title: Implement jump/Poisson stochastic process component
+#+description: Add a jump/Poisson process type as a selectable synthetic FX spot price-process engine.
+#+type: capture
+#+level: cross
+#+filetags: :synthetic:gmm:process:backlog:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Add a jump/Poisson process type as a synthetic FX spot price-process
+engine, alongside the existing geometric/arithmetic GMM engines and
+the Ornstein-Uhlenbeck engine added by
+[[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]].
+Should support configurable jump intensity (Poisson rate) and a
+jump-size distribution, wired the same way OU was: a new process
+class implementing =IStochasticProcess=
+(=projects/ores.marketdata/api/include/ores.marketdata.api/domain/i_stochastic_process.hpp=),
+a new branch in
+=process_factory::make_process()=
+(=projects/ores.synthetic/service/src/process_factory.cpp/.hpp=), and
+UI exposure in =FxSpotRateEditor=.
+
+* Why
+
+Currently listed as a placeholder ("Planned — not yet available") in
+the FxSpotRateEditor "Component Tools" disclosure panel
+(=projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp=,
+=buildAdvancedControls()=); no implementation exists anywhere under
+=projects/=. Reviewed during the GMM improvements story's
+process-tools inventory task and explicitly scoped out to keep that
+story focused on Ornstein-Uhlenbeck.
+
+* References
+
+- =projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp= (Component Tools panel)
+- =projects/ores.synthetic/service/src/process_factory.cpp/.hpp=
+- =projects/ores.synthetic/service/src/processes/ou_process.hpp= (pattern to follow)
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
@@ -26,12 +26,12 @@ Ornstein-Uhlenbeck in particular.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Working task: Review stochastic process component tools; implement Ornstein-Uhlenbeck. |
+| Now           | Done — all three tasks closed.         |
 | Waiting on    | Nothing.                               |
-| Next          | Work remaining tasks in order.         |
-| Last touched  | 2026-07-02                               |
+| Next          | Raise a PR.                            |
+| Last touched  | 2026-07-03                               |
 
 * Acceptance
 
@@ -56,10 +56,27 @@ Ornstein-Uhlenbeck in particular.
 |------+-------+-------+-----+-------------|
 | [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | DONE | 2026-07-02 | 2026-07-02 | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
 | [[id:553D514F-EB3E-4FF0-9CD8-A847C3B88A11][Display per-component and combined GMM PDFs]] | DONE | 2026-07-02 | 2026-07-02 | Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour. |
-| [[id:402BDE9B-A604-4D5F-A6F3-B8F8D3165994][Review stochastic process component tools; implement Ornstein-Uhlenbeck]] | BACKLOG | | | Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process. |
+| [[id:402BDE9B-A604-4D5F-A6F3-B8F8D3165994][Review stochastic process component tools; implement Ornstein-Uhlenbeck]] | DONE | | 2026-07-03 | Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process. |
 
 * Decisions
 
+- Ornstein-Uhlenbeck reuses the existing GMM component fields
+  (weight = κ, volatility σ field = σ, initial price = θ) rather than
+  adding new persisted columns or protocol fields, since OU is a
+  single-regime process (3 scalars) rather than a K-component mixture.
+  This follows the same precedent already set by the "arithmetic"
+  engine, which reuses the same %-suffixed μ/σ fields for absolute
+  price increments via a warning banner rather than relabelling
+  fields.
+- Jump/Poisson processes and cross-rate correlation matrices were
+  reviewed and left explicitly out of scope for this story — both are
+  already flagged to users as "planned, not wired to anything" in the
+  FxSpotRateEditor "Component Tools" disclosure panel, so the gap was
+  visible, not silently dropped.
+
 * Out of scope
 
--
+- New persisted schema/protocol fields dedicated to Ornstein-Uhlenbeck
+  parameters (see Decisions — reused existing GMM fields instead).
+- Jump/Poisson processes and cross-rate correlation matrices (already
+  tracked as planned in the "Component Tools" panel).

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
@@ -26,11 +26,11 @@ Ornstein-Uhlenbeck in particular.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Not yet started.                       |
+| Now           | Working task: Add X/Y axis labels to GMM preview charts. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Work remaining tasks in order.         |
 | Last touched  | 2026-07-02                               |
 
 * Acceptance
@@ -54,7 +54,7 @@ Ornstein-Uhlenbeck in particular.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | BACKLOG | | | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
+| [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | STARTED | 2026-07-02 | | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
 | [[id:553D514F-EB3E-4FF0-9CD8-A847C3B88A11][Display per-component and combined GMM PDFs]] | BACKLOG | | | Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour. |
 | [[id:402BDE9B-A604-4D5F-A6F3-B8F8D3165994][Review stochastic process component tools; implement Ornstein-Uhlenbeck]] | BACKLOG | | | Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process. |
 

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
@@ -28,7 +28,7 @@ Ornstein-Uhlenbeck in particular.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Working task: Add X/Y axis labels to GMM preview charts. |
+| Now           | Working task: Review stochastic process component tools; implement Ornstein-Uhlenbeck. |
 | Waiting on    | Nothing.                               |
 | Next          | Work remaining tasks in order.         |
 | Last touched  | 2026-07-02                               |
@@ -54,8 +54,8 @@ Ornstein-Uhlenbeck in particular.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | STARTED | 2026-07-02 | | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
-| [[id:553D514F-EB3E-4FF0-9CD8-A847C3B88A11][Display per-component and combined GMM PDFs]] | BACKLOG | | | Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour. |
+| [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | DONE | 2026-07-02 | 2026-07-02 | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
+| [[id:553D514F-EB3E-4FF0-9CD8-A847C3B88A11][Display per-component and combined GMM PDFs]] | DONE | 2026-07-02 | 2026-07-02 | Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour. |
 | [[id:402BDE9B-A604-4D5F-A6F3-B8F8D3165994][Review stochastic process component tools; implement Ornstein-Uhlenbeck]] | BACKLOG | | | Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: F4604E72-EF59-4894-A6D4-A68971C793EB
+:END:
+#+title: Story: GMM improvements: tidy up synthetic data generation loose ends
+#+description: Tidy up loose ends from the GMM-based synthetic market data generation work: chart axes, per-component PDF display, and stochastic process component gaps (incl. Ornstein-Uhlenbeck).
+#+type: story
+#+level: s2
+#+filetags: :market_data:synthetic:gmm:sprint_22:v0:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Tidy up loose ends left over from the GMM-based synthetic market data
+generation work (FX spot PoC and its config UI): give the preview
+charts readable axes, make each GMM component's PDF visible alongside
+the combined mixture PDF, and close the gap on stochastic process
+"component tools" that were designed but never implemented —
+Ornstein-Uhlenbeck in particular.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-07-02                               |
+
+* Acceptance
+
+- Live Return Distribution Preview and Live Sample Price Paths Preview
+  charts (FX Rate → Price behaviour tab) have labelled X and Y axes.
+- The Live Return Distribution Preview renders each GMM component's
+  individual PDF plus the combined mixture PDF, with the combined
+  curve in a visually distinct colour.
+- The other stochastic process types catalogued in
+  [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] are reviewed against what is
+  actually implemented; gaps are either implemented or explicitly
+  scoped out with rationale.
+- Ornstein-Uhlenbeck (mean-reverting) is implemented as a synthetic
+  process, matching the design already recorded in
+  [[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] and
+  [[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] (=synthetic_ou=), or the
+  decision to defer it is recorded with rationale.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:7CB8B816-BE19-4E02-B0C0-7A800EAD6344][Add X/Y axis labels to GMM preview charts]] | BACKLOG | | | Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab. |
+| [[id:553D514F-EB3E-4FF0-9CD8-A847C3B88A11][Display per-component and combined GMM PDFs]] | BACKLOG | | | Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour. |
+| [[id:402BDE9B-A604-4D5F-A6F3-B8F8D3165994][Review stochastic process component tools; implement Ornstein-Uhlenbeck]] | BACKLOG | | | Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :gmm-improvements:sprint_22:v0:
 #+owner: marco
-#+branch: feature/gmm-chart-axes
+#+branch: story/gmm-improvements
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -30,11 +30,11 @@ charts.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
-| Now          | Not yet started.                       |
+| Now          | Locating and instrumenting the GMM preview chart widgets.  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Add axis labels/ticks to both charts.  |
 | Last touched | 2026-07-02                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :gmm-improvements:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/gmm-chart-axes
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
@@ -8,7 +8,7 @@
 #+filetags: :gmm-improvements:sprint_22:v0:
 #+owner: marco
 #+branch: story/gmm-improvements
-#+pr:
+#+pr: 1409
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-02
@@ -71,7 +71,7 @@ axis colours rather than reading =palette()=.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1409][#1409]] | [synthetic] GMM improvements: chart axes, per-component PDFs, Ornstein-Uhlenbeck |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
@@ -30,11 +30,11 @@ charts.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
-| Now          | Locating and instrumenting the GMM preview chart widgets.  |
+| Now          | Done.                                   |
 | Waiting on   | Nothing.                               |
-| Next         | Add axis labels/ticks to both charts.  |
+| Next         | Move to the next task.                 |
 | Last touched | 2026-07-02                               |
 
 * Acceptance
@@ -46,11 +46,26 @@ charts.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Both charts (=ReturnDistributionChart=, =SamplePricePathsChart= in
+=projects/ores.qt/synthetic/=) already configured =QValueAxis= titles,
+ranges and grid/label colours in their constructors — the axes were
+never actually missing. The bug: both called
+=palette().color(QPalette::WindowText)= to pick text/grid colours, but
+the app's dark theme is applied purely via a QSS stylesheet
+(=main.cpp=, =:/TradingStyle.qss=), never via =QApplication::setPalette=,
+so =QWidget::palette()= on a freshly-constructed, unparented widget
+returns Qt's default light-mode colours — near-black text on
+=QChart::ChartThemeDark='s near-black background, effectively
+invisible. Fixed by switching both charts to the same explicit
+theme-colour constants =FxSpotChartWindow= already uses
+(=QColor(0xCB, 0xD5, 0xE1)= text, =QColor(255, 255, 255, 18)= grid)
+instead of reading =palette()=.
 
 * Notes
+
+Root cause confirmed by comparing against the working
+=FxSpotChartWindow= (=projects/ores.qt/mktdata/=), which hardcodes its
+axis colours rather than reading =palette()=.
 
 * PRs
 
@@ -65,3 +80,10 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Fixed both =ReturnDistributionChart= and =SamplePricePathsChart= to use
+explicit theme colours instead of =QWidget::palette()=, which was
+returning invisible near-black text/gridlines against the dark chart
+background. Axis titles, ranges and ticks were already correctly
+configured; only the colour was wrong. Built
+=ores.qt.synthetic.lib= clean (clang debug/make).

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 7CB8B816-BE19-4E02-B0C0-7A800EAD6344
+:END:
+#+title: Task: Add X/Y axis labels to GMM preview charts
+#+description: Add labelled X and Y axes to the Live Return Distribution Preview and Live Sample Price Paths Preview charts on the FX Rate Price behaviour tab.
+#+type: task
+#+level: s1
+#+filetags: :gmm-improvements:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The Live Return Distribution Preview and Live Sample Price Paths
+Preview charts on the FX Rate → Price behaviour tab render without
+numeric axis labels/ticks, making them hard to read (see reference
+screenshot attached to the story). Add labelled X and Y axes to both
+charts.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- Live Return Distribution Preview shows a labelled X axis ("Return
+  per Update %") and Y axis ("Probability") with numeric ticks.
+- Live Sample Price Paths Preview shows a labelled X axis ("Update
+  Steps") and Y axis ("Price") with numeric ticks.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-component-pdfs.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-component-pdfs.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 553D514F-EB3E-4FF0-9CD8-A847C3B88A11
+:END:
+#+title: Task: Display per-component and combined GMM PDFs
+#+description: Render each GMM component's own PDF curve on the Live Return Distribution Preview, plus the combined mixture PDF in a distinct colour.
+#+type: task
+#+level: s1
+#+filetags: :gmm-improvements:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The Live Return Distribution Preview currently does not distinguish
+individual GMM components from the overall mixture. Render each
+configured component's own PDF curve, plus the combined/mixture GMM
+PDF in a distinct colour, so users can see how components contribute
+to the mixture while tuning parameters.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- Each configured GMM component renders its own PDF curve on the
+  Live Return Distribution Preview.
+- The combined mixture PDF renders in a colour visually distinct
+  from the per-component curves.
+- Legend or labelling makes clear which curve is which.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-component-pdfs.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-component-pdfs.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :gmm-improvements:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: story/gmm-improvements
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -30,11 +30,11 @@ to the mixture while tuning parameters.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
-| Now          | Not yet started.                       |
+| Now          | Done.                                   |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Move to the next task.                 |
 | Last touched | 2026-07-02                               |
 
 * Acceptance
@@ -47,9 +47,24 @@ to the mixture while tuning parameters.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Added =ReturnDistributionChart::componentColor(int index)= — a static
+helper cycling through a 7-colour qualitative palette (coral, amber,
+mint, violet, lime, pink, grey), deliberately excluding the steel-blue
+used for the mixture curve. =setComponents()= now computes each
+component's weighted contribution (=weight × N(x; μ, σ)=) alongside the
+combined sum, normalises both to the mixture's peak, and draws each
+component's contribution as its own =QLineSeries= in its colour, drawn
+on top of the existing filled mixture area.
+
+On the editor side (=FxSpotRateEditor=), added a new leading "Colour"
+column (=ColColor=) to the Advanced-mode component table, with a small
+16×16 swatch per row painted via =ReturnDistributionChart::componentColor(row)=
+— row index doubles as colour index, matching the chart. Added
+=updateComponentColors()= to repaint all swatches after a row is
+removed, since removal shifts every subsequent row's index (and
+therefore its colour) down by one; =addTableRow= already assigns the
+right colour on insertion (append and full rebuild both add rows in
+final order).
 
 * Notes
 
@@ -66,3 +81,12 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Each GMM component now renders its own weighted-contribution PDF
+curve on the Live Return Distribution Preview, coloured to match a
+new colour swatch on its row in the Advanced-mode component table;
+the combined mixture stays the existing steel-blue filled area,
+excluded from the component palette so it is always visually
+distinct. Colour indices track table row position and are repainted
+on row removal. Built =ores.qt.synthetic.lib= clean (clang
+debug/make).

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-07-02
 #+updated: 2026-07-02
-#+environment:
+#+environment: merry_newton
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -36,11 +36,11 @@ Ornstein-Uhlenbeck.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
-| Now          | Inventorying implemented vs designed-only process types.  |
+| Now          | Done.                                   |
 | Waiting on   | Nothing.                               |
-| Next         | Implement Ornstein-Uhlenbeck end-to-end.  |
+| Next         | Close the story (last open task).      |
 | Last touched | 2026-07-03                               |
 
 * Acceptance
@@ -55,11 +55,70 @@ Ornstein-Uhlenbeck.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+*Inventory.* Process types catalogued in
+[[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]] /
+[[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]] vs implemented under
+=projects/ores.synthetic/service/src/processes/=: GBM/geometric
+(=gmm_process=) — implemented; arithmetic Brownian
+(=arithmetic_gmm_process=) — implemented; Ornstein-Uhlenbeck
+(=synthetic_ou=) — designed, not implemented (confirmed by grep — this
+task's reason for existing). Jump/Poisson processes and cross-rate
+correlation matrices are also designed-only, already tracked as
+"planned, not wired to anything" in the FxSpotRateEditor "Component
+Tools" disclosure panel — left as-is (out of scope; not silently
+dropped, already visibly flagged to users).
+
+*Implementation — Ornstein-Uhlenbeck.* Added =ou_process=
+(=IStochasticProcess=) implementing the exact per-tick OU
+discretisation: =X_{t+1} = θ + (X_t - θ)e^{-κ} + σ√((1-e^{-2κ})/(2κ))·Z=,
+with κ≤0 degenerating to a driftless random walk. Wired a new ="ou"=
+branch in =process_factory::make_process()=.
+
+OU is a single-regime process (3 scalars: κ, θ, σ), not a K-component
+mixture, so rather than adding new persisted columns/protocol fields
+it reuses the existing GMM-component channels: =weights[0] = κ=,
+=stdevs[0] = σ=, and =initial_price= doubles as =θ= (reverts toward its
+own starting level by default). This is the same pattern already
+established for the "arithmetic" engine, which reuses the %-suffixed
+μ/σ fields for absolute price increments via a warning banner rather
+than relabelling fields.
+
+UI (=FxSpotRateEditor=): added "Ornstein-Uhlenbeck (mean-reverting)" to
+the engine combo; added =updateEngineUi()= to swap the inline warning
+banner text and disable "Add process" (OU has one regime, not a
+mixture) while selected; switching to OU collapses the Advanced table
+to its first row; the weight-sum label becomes a "κ = ..." echo
+instead of "Weight Sum = ..." for OU. =refreshCharts()= skips
+normalisation for OU (κ/σ are scalars, not mixture shares) and clears
+the Return Distribution Preview (the increment-mixture PDF doesn't
+apply to a mean-reverting *level* process) — Sample Price Paths still
+renders correctly since it plots whatever the server returns
+regardless of engine. =onSaveClicked()= skips the "all weights zero"
+guard (κ=0 is a valid OU parameter) and the weight-normalise-to-1 step
+for OU, so κ persists as entered rather than being silently
+overwritten to 1.0.
+
+SQL: extended the =process_type= check constraint
+(=ores.synthetic.fx_spot_generation_config.org= model) to allow ='ou'=.
+Regenerating via =compass codegen generate= dropped unrelated
+hand-patched validation-function logic (template/output drift,
+unrelated to this change) — reverted the full regen and hand-edited
+just the one constraint line; filed
+[[id:D583B57B-B896-48A6-AD66-1F01FAE3FA3D][a capture]] for the drift itself.
 
 * Notes
+
+Known, deliberate limitation: the Volatility (σ) field keeps its "%"
+suffix and the value is still divided by 100 internally for OU, same
+as the pre-existing "arithmetic" engine's reuse of that field for
+absolute (non-%) units — cosmetically imprecise but functionally
+consistent with the established pattern, not fixed here to avoid
+widening this task's footprint.
+
+No dedicated unit test was added for =ou_process=, matching the
+existing =gmm_process=/=arithmetic_gmm_process= (neither has one
+either) — no established Catch2 convention exists yet for this
+directory.
 
 * PRs
 
@@ -74,3 +133,19 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Ornstein-Uhlenbeck is implemented end-to-end: =ou_process= (core
+numerics), =process_factory= dispatch, SQL constraint, and UI (engine
+selector, reused parameter fields, adjusted validation/save/preview
+paths for its single-regime shape). Other designed-only process types
+(jump/Poisson, correlation matrices) reviewed and left explicitly
+scoped out — already flagged to users in the existing "Component
+Tools" panel, not silently dropped. Built =ores.qt.synthetic.lib=,
+=ores.synthetic.service.lib= and =ores.marketdata.service.lib= clean
+(clang debug/make). Also fixed, on user report during this task:
+hardcoded change-reason-code string literals replaced with
+=ores.dq.api= constants across =FeedDialog.cpp=,
+=MarketSimulatorWindow.cpp=, =FxSpotRateEditor.cpp=; and synthetic
+market observations were missing =source=/=point_id= (tenor) —
+=feed_ingest_loop.cpp= now captures =source_name= and sets
+=point_id = "SPOT"= for scalar FX spot series.

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -130,7 +130,13 @@ directory.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | OU silently invalid when Simple mode stays selected — kappa derived from unrelated Drift/Vol/Jump sliders, jump component silently dropped | FxSpotRateEditor.cpp | Fixed | 1d07dae74 — onEngineChanged forces Advanced mode + locks Simple toggle for non-mixing engines |
+| 2 | UI hardcodes engine-specific isOuEngine() checks throughout (raised directly by user, not the bot review) | FxSpotRateEditor.cpp | Fixed | 1d07dae74 — data-driven EngineInfo table (code/label/supportsMixing) replaces scattered checks |
+| 3 | Switching to OU silently truncates mixture components | FxSpotRateEditor.cpp | Fixed (as a side effect of #1) | Advanced mode is now forced open when the collapse happens, so it's visible/editable, not silent |
+| 4 | Duplicated chart theme colour constants across 5 call sites | ReturnDistributionChart.cpp, SamplePricePathsChart.cpp | Declined (follow-up) | Captured: 4EE11531-E6AB-4094-8297-F0E7DB12EC39 |
+| 5 | Weight/Volatility column headers and tooltips still say generic text for OU | FxSpotRateEditor.cpp | Declined | Inline warning banner already documents the remapping, matching the existing "arithmetic" engine precedent |
+| 6 | Per-component QLineSeries::setName() calls are effectively dead code (legend hidden) | ReturnDistributionChart.cpp | Fixed | 1d07dae74 — one-line comment clarifying the swatch column is the intended indicator |
+| 7 | No unit tests for ou_process | ou_process.hpp/.cpp | Declined | Matches untested gmm_process/arithmetic_gmm_process; no Catch2 convention yet for this directory |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -139,6 +139,7 @@ directory.
 | 7 | No unit tests for ou_process | ou_process.hpp/.cpp | Declined | Matches untested gmm_process/arithmetic_gmm_process; no Catch2 convention yet for this directory |
 | 8 | Validation logic ("are these parameters good?") hardcoded in the UI instead of the engine (raised directly by user, not the bot review) | FxSpotRateEditor.cpp, process_factory.cpp | Fixed | c314e99cd — new ores.synthetic.api::domain::validate_process_parameters(), shared by process_factory and the Qt client; server-side enforcement at save/feed-start time not yet wired up, captured: FDEAC2F6-A87F-4281-82CC-437B06D5B02F |
 | 9 | Advanced component table headers too verbose, dialog congested (raised directly by user, not the bot review) | FxSpotRateEditor.cpp | Fixed | c314e99cd — headers shortened to symbols (μ/σ/w); explanations moved to per-header tooltips, updated per engine by updateEngineUi() |
+| 10 | Opening an existing "ou" record defaults to Simple mode (construction-time gap: engineCombo_->setCurrentIndex() runs before the currentIndexChanged connection, so onEngineChanged() never fires); Save without touching anything silently overwrites the persisted kappa with 1.0. Reported across three consecutive re-review rounds after #1's fix only covered the live combo-switch path | FxSpotRateEditor.cpp | Fixed | 247eccda3 — moved the forcing logic from onEngineChanged() into updateEngineUi(), which runs both on every engine change and once at construction time |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: 402BDE9B-A604-4D5F-A6F3-B8F8D3165994
+:END:
+#+title: Task: Review stochastic process component tools; implement Ornstein-Uhlenbeck
+#+description: Review catalogued vs implemented stochastic process types and close the gap, prioritising the designed-but-unimplemented Ornstein-Uhlenbeck (mean-reverting) process.
+#+type: task
+#+level: s1
+#+filetags: :gmm-improvements:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-02
+#+updated: 2026-07-02
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The synthetic market data generator design
+([[id:C6F45530-4B5D-4C03-95DF-65D13F7A4142][Synthetic market data generators]],
+[[id:29573D59-1BA2-4DBB-A12B-8EAC7F7CC4AB][FX spot synthetic data PoC: architecture]]) catalogues several
+stochastic process types as component tools — GBM, Brownian/Wiener,
+jump, regime-mix, Ornstein-Uhlenbeck (=synthetic_ou=, mean-reverting)
+among them. Ornstein-Uhlenbeck in particular is documented but not
+implemented anywhere under =projects/= (confirmed via grep and
+compass search; no separate open capture/task exists for it — this
+task is its home). Review which catalogued process types are
+implemented vs designed-only, and close the gaps, prioritising
+Ornstein-Uhlenbeck.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-02                               |
+
+* Acceptance
+
+- Inventory of catalogued vs implemented stochastic process types is
+  documented.
+- Ornstein-Uhlenbeck is implemented as a selectable process type with
+  parameters (kappa, theta/mean level, sigma) exposed in the config
+  UI, or its deferral is explicitly recorded with rationale.
+- Any other implementation gaps found are implemented or explicitly
+  scoped out with rationale.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -134,9 +134,11 @@ directory.
 | 2 | UI hardcodes engine-specific isOuEngine() checks throughout (raised directly by user, not the bot review) | FxSpotRateEditor.cpp | Fixed | 1d07dae74 — data-driven EngineInfo table (code/label/supportsMixing) replaces scattered checks |
 | 3 | Switching to OU silently truncates mixture components | FxSpotRateEditor.cpp | Fixed (as a side effect of #1) | Advanced mode is now forced open when the collapse happens, so it's visible/editable, not silent |
 | 4 | Duplicated chart theme colour constants across 5 call sites | ReturnDistributionChart.cpp, SamplePricePathsChart.cpp | Declined (follow-up) | Captured: 4EE11531-E6AB-4094-8297-F0E7DB12EC39 |
-| 5 | Weight/Volatility column headers and tooltips still say generic text for OU | FxSpotRateEditor.cpp | Declined | Inline warning banner already documents the remapping, matching the existing "arithmetic" engine precedent |
+| 5 | Weight/Volatility column headers and tooltips still say generic text for OU | FxSpotRateEditor.cpp | Fixed (superseded) | c314e99cd — see #9; headers shortened and tooltips now update per engine |
 | 6 | Per-component QLineSeries::setName() calls are effectively dead code (legend hidden) | ReturnDistributionChart.cpp | Fixed | 1d07dae74 — one-line comment clarifying the swatch column is the intended indicator |
 | 7 | No unit tests for ou_process | ou_process.hpp/.cpp | Declined | Matches untested gmm_process/arithmetic_gmm_process; no Catch2 convention yet for this directory |
+| 8 | Validation logic ("are these parameters good?") hardcoded in the UI instead of the engine (raised directly by user, not the bot review) | FxSpotRateEditor.cpp, process_factory.cpp | Fixed | c314e99cd — new ores.synthetic.api::domain::validate_process_parameters(), shared by process_factory and the Qt client; server-side enforcement at save/feed-start time not yet wired up, captured: FDEAC2F6-A87F-4281-82CC-437B06D5B02F |
+| 9 | Advanced component table headers too verbose, dialog congested (raised directly by user, not the bot review) | FxSpotRateEditor.cpp | Fixed | c314e99cd — headers shortened to symbols (μ/σ/w); explanations moved to per-header tooltips, updated per engine by updateEngineUi() |
 
 * Result
 
@@ -155,3 +157,15 @@ hardcoded change-reason-code string literals replaced with
 market observations were missing =source=/=point_id= (tenor) —
 =feed_ingest_loop.cpp= now captures =source_name= and sets
 =point_id = "SPOT"= for scalar FX spot series.
+
+PR #1409 review round 1 addressed: forced Advanced mode for
+non-mixing engines (closing a real correctness gap — Simple mode
+could previously save a meaningless κ and silently drop jump
+components); replaced scattered =isOuEngine()= checks with a
+data-driven =EngineInfo= table so future single-regime engines (rate
+processes) are a table row, not more special-cased UI logic; moved
+parameter validation out of the UI into a shared
+=ores.synthetic.api::domain::validate_process_parameters()= used by
+both =process_factory= and the Qt client; and shortened the Advanced
+table's headers to symbols with per-engine tooltips instead of
+permanent verbose text, addressing dialog congestion.

--- a/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
+++ b/doc/agile/versions/v0/sprint_22/gmm-improvements/task_review-process-component-tools.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :gmm-improvements:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: story/gmm-improvements
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -36,12 +36,12 @@ Ornstein-Uhlenbeck.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] |
-| Now          | Not yet started.                       |
+| Now          | Inventorying implemented vs designed-only process types.  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-02                               |
+| Next         | Implement Ornstein-Uhlenbeck end-to-end.  |
+| Last touched | 2026-07-03                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -82,6 +82,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity. Carried fr
 | [[id:0C3A6ED5-C585-4C8F-BA83-1F0C2CB5BC78][Codegen SQL variability for hypertable, bi-temporal and GIST patterns; model ores.marketdata entities]] | BACKLOG | | | SQL template variability (hypertable, soft-update/soft-delete triggers, GIST exclusion) + .org models for market_series, market_observation, market_fixing; prerequisite for full-stack codegen of ores.marketdata. |
 | [[id:D6C90C13-555C-471F-B494-CAF6A7902519][Market data cleanup: retire dead duplicate tables and preserve hand-written overrides]] | BACKLOG | | | Drop legacy pre-codegen ores_marketdata_series/observations/fixings_tbl (superseded, zero C++ references); remove their stale validation_ignore.txt entries; preserve market_observation's hand-written repository/service overrides against codegen regeneration. |
 | [[id:6C515A93-C7D9-4B6C-B7B2-7AD433BACE44][Configurable feed status indicator in the FX spot grid]] | DONE | 2026-07-02 | 2026-07-03 | FX spot grid status pips use hardcoded CSS colours; replace with a configurable indicator once the right UX (badge vs. compact status dot) is settled. |
+| [[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]] | DONE | 2026-07-02 | 2026-07-03 | Chart axis labels, per-component + combined PDF display, and stochastic process component gaps (incl. Ornstein-Uhlenbeck). |
 
 ** Tooling
 

--- a/projects/ores.marketdata/service/src/app/feed_ingest_loop.cpp
+++ b/projects/ores.marketdata/service/src/app/feed_ingest_loop.cpp
@@ -159,6 +159,7 @@ void feed_ingest_loop::subscribe_binding_locked(const std::string& ore_key,
         [this,
          ore_key_copy,
          publish_subject,
+         source_name,
          uuid_gen,
          st,
          party_uuid,
@@ -225,6 +226,8 @@ void feed_ingest_loop::subscribe_binding_locked(const std::string& ore_key,
                 obs.series_id = existing.front().id;
                 obs.observation_datetime = tick->datetime;
                 obs.value = std::to_string(tick->mid);
+                obs.source = source_name;
+                obs.point_id = "SPOT"; // scalar FX spot series has no tenor/surface coordinate
 
                 repository::market_observations_repository obs_repo;
                 obs_repo.write(tenant_ctx, obs);

--- a/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
@@ -38,6 +38,7 @@
 #include <vector>
 
 class QButtonGroup;
+class QPushButton;
 class QSlider;
 class QStackedWidget;
 class QTableWidget;
@@ -150,6 +151,7 @@ private:
     void rebuildModelFromSimple();   // sliders -> model
     void rebuildModelFromAdvanced(); // table -> model
     void refreshCharts();            // model -> both charts + weight-sum label
+    void updateWeightSumLabel();     // weight-sum label text (or κ echo for "ou")
 
     // Advanced table row construction; returns nothing, appends to table.
     void addTableRow(const ModelComponent& c);
@@ -160,7 +162,9 @@ private:
     void updateComponentColors();
 
     void onEngineChanged();
-    [[nodiscard]] std::string currentEngine() const; // "geometric" / "arithmetic"
+    void updateEngineUi(); // relabel headers/tooltips/warning and gate Add for "ou"
+    [[nodiscard]] std::string currentEngine() const; // "geometric" / "arithmetic" / "ou"
+    [[nodiscard]] bool isOuEngine() const;
     [[nodiscard]] QString incrementNoun() const;     // label noun for the active engine
 
     [[nodiscard]] QString defaultSourceName() const;
@@ -217,6 +221,7 @@ private:
 
     // Behaviour tab — Advanced page.
     QTableWidget* componentTable_;
+    QPushButton* addComponentBtn_; // disabled for the single-regime "ou" engine
     QLabel* weightSumLabel_;
 
     std::vector<std::string> knownCodes_;

--- a/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
@@ -155,6 +155,9 @@ private:
     void addTableRow(const ModelComponent& c);
     void applyProfileToRow(int row, const QString& profile); // fills σ
     void updateRemoveButtonsEnabled(); // disable Remove when only one row remains
+    // Re-paint each row's colour swatch to match its current row index (colour
+    // indices shift when a row is removed from the middle of the table).
+    void updateComponentColors();
 
     void onEngineChanged();
     [[nodiscard]] std::string currentEngine() const; // "geometric" / "arithmetic"

--- a/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/FxSpotRateEditor.hpp
@@ -164,7 +164,7 @@ private:
     void onEngineChanged();
     void updateEngineUi(); // relabel headers/tooltips/warning and gate Add for "ou"
     [[nodiscard]] std::string currentEngine() const; // "geometric" / "arithmetic" / "ou"
-    [[nodiscard]] bool isOuEngine() const;
+    [[nodiscard]] bool currentEngineSupportsMixing() const;
     [[nodiscard]] QString incrementNoun() const;     // label noun for the active engine
 
     [[nodiscard]] QString defaultSourceName() const;

--- a/projects/ores.qt/synthetic/include/ores.qt/ReturnDistributionChart.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/ReturnDistributionChart.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_QT_RETURN_DISTRIBUTION_CHART_HPP
 #define ORES_QT_RETURN_DISTRIBUTION_CHART_HPP
 
+#include <QColor>
 #include <QWidget>
 #include <vector>
 
@@ -52,6 +53,13 @@ public:
 
     /** @brief Recompute and redraw the mixture density. */
     void setComponents(const std::vector<Component>& components);
+
+    /**
+     * @brief Colour assigned to the component at @p index (cycles through a
+     * fixed qualitative palette). Shared with FxSpotRateEditor's component
+     * table so each row's colour indicator matches its PDF curve here.
+     */
+    static QColor componentColor(int index);
 
 private:
     QChart* chart_;

--- a/projects/ores.qt/synthetic/src/FeedDialog.cpp
+++ b/projects/ores.qt/synthetic/src/FeedDialog.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/FeedDialog.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.synthetic.api/messaging/market_data_generation_config_protocol.hpp"
 #include <QDialogButtonBox>
 #include <QFormLayout>
@@ -108,7 +109,9 @@ void FeedDialog::onSave() {
     feed.description = descEdit_->toPlainText().toStdString();
     feed.enabled = enabledCheck_->isChecked();
     feed.modified_by = username_.toStdString();
-    feed.change_reason_code = isNew_ ? "system.new_record" : "common.non_material_update";
+    namespace reason = ores::dq::domain::change_reason_constants::codes;
+    feed.change_reason_code =
+        isNew_ ? std::string(reason::new_record) : std::string(reason::non_material_update);
     feed.change_commentary = "Authored via Market Simulator";
     feed.version = 0;
 

--- a/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
+++ b/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
@@ -77,7 +77,15 @@ constexpr double kJumpMin = 0.0;     // weight of the jump component
 constexpr double kJumpMax = 0.5;     // up to 50% mixture share
 
 // Advanced table columns (no per-component Type — engine is config-level now).
-enum Col { ColName = 0, ColProfile = 1, ColMean = 2, ColStdev = 3, ColWeight = 4, ColActions = 5 };
+enum Col {
+    ColColor = 0,
+    ColName = 1,
+    ColProfile = 2,
+    ColMean = 3,
+    ColStdev = 4,
+    ColWeight = 5,
+    ColActions = 6
+};
 
 double sliderToValue(int slider, double lo, double hi) {
     return lo + (hi - lo) * (slider / 100.0);
@@ -528,8 +536,9 @@ QWidget* FxSpotRateEditor::buildAdvancedControls() {
     compLayout->setContentsMargins(12, 12, 12, 12);
     compLayout->setSpacing(8);
 
-    componentTable_ = new QTableWidget(0, 6, compBox);
-    componentTable_->setHorizontalHeaderLabels({tr("Component Name"),
+    componentTable_ = new QTableWidget(0, 7, compBox);
+    componentTable_->setHorizontalHeaderLabels({tr("Colour"),
+                                                tr("Component Name"),
                                                 tr("Profile"),
                                                 tr("Drift (μ %)"),
                                                 tr("Volatility (σ %)"),
@@ -546,7 +555,7 @@ QWidget* FxSpotRateEditor::buildAdvancedControls() {
         auto* hdr = componentTable_->horizontalHeader();
         hdr->setStretchLastSection(false);
         hdr->setSectionResizeMode(ColName, QHeaderView::Stretch);
-        for (int col : {ColProfile, ColMean, ColStdev, ColWeight, ColActions})
+        for (int col : {ColColor, ColProfile, ColMean, ColStdev, ColWeight, ColActions})
             hdr->setSectionResizeMode(col, QHeaderView::ResizeToContents);
     }
     compLayout->addWidget(componentTable_);
@@ -720,6 +729,19 @@ void FxSpotRateEditor::addTableRow(const ModelComponent& c) {
     const int row = componentTable_->rowCount();
     componentTable_->insertRow(row);
 
+    // Colour indicator, matching the row's PDF curve colour on the Live Return
+    // Distribution Preview chart (ReturnDistributionChart::componentColor()).
+    auto* colorSwatch = new QLabel(componentTable_);
+    colorSwatch->setFixedSize(16, 16);
+    colorSwatch->setStyleSheet(
+        QStringLiteral("background-color: %1; border-radius: 3px;")
+            .arg(ReturnDistributionChart::componentColor(row).name()));
+    auto* colorCell = new QWidget(componentTable_);
+    auto* colorLayout = new QHBoxLayout(colorCell);
+    colorLayout->setContentsMargins(4, 2, 4, 2);
+    colorLayout->addWidget(colorSwatch, 0, Qt::AlignCenter);
+    componentTable_->setCellWidget(row, ColColor, colorCell);
+
     // A flat, frameless look so the inner widgets don't draw a heavy border
     // inside the cell grid (avoids the "box in box" effect).
     const QString flatEdit = QStringLiteral("border: none; background: transparent;");
@@ -843,6 +865,7 @@ void FxSpotRateEditor::addTableRow(const ModelComponent& c) {
         }
         rebuildModelFromAdvanced();
         updateRemoveButtonsEnabled();
+        updateComponentColors(); // remaining rows shifted up — repaint swatches
         refreshCharts();
     });
 
@@ -891,6 +914,16 @@ void FxSpotRateEditor::updateRemoveButtonsEnabled() {
         if (auto* cell = componentTable_->cellWidget(r, ColActions)) {
             if (auto* btn = cell->findChild<QPushButton*>())
                 btn->setEnabled(canRemove);
+        }
+    }
+}
+
+void FxSpotRateEditor::updateComponentColors() {
+    for (int r = 0; r < componentTable_->rowCount(); ++r) {
+        if (auto* cell = componentTable_->cellWidget(r, ColColor)) {
+            if (auto* swatch = cell->findChild<QLabel*>())
+                swatch->setStyleSheet(QStringLiteral("background-color: %1; border-radius: 3px;")
+                                           .arg(ReturnDistributionChart::componentColor(r).name()));
         }
     }
 }

--- a/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
+++ b/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/FxSpotRateEditor.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.qt/ChangeReasonDialog.hpp"
 #include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/IconUtils.hpp"
@@ -342,9 +343,12 @@ void FxSpotRateEditor::buildBehaviourTab() {
     engineCombo_ = new QComboBox(tab);
     engineCombo_->addItem(tr("Geometric Brownian Motion"), QStringLiteral("geometric"));
     engineCombo_->addItem(tr("Arithmetic Brownian Motion"), QStringLiteral("arithmetic"));
+    engineCombo_->addItem(tr("Ornstein-Uhlenbeck (mean-reverting)"), QStringLiteral("ou"));
     engineCombo_->setToolTip(
         tr("The price-process engine. Geometric uses log-returns (stays positive); "
-           "arithmetic uses absolute price changes (symmetric, may go negative)."));
+           "arithmetic uses absolute price changes (symmetric, may go negative); "
+           "Ornstein-Uhlenbeck reverts toward a long-run level (a single regime, not a "
+           "mixture)."));
     {
         const int idx = engineCombo_->findData(QString::fromStdString(fx_.process_type));
         engineCombo_->setCurrentIndex(idx >= 0 ? idx : 0);
@@ -408,14 +412,9 @@ void FxSpotRateEditor::buildBehaviourTab() {
     layout->addLayout(headerRow);
 
     // Inline, non-blocking warning shown only for the arithmetic engine (full width).
-    engineWarningLabel_ =
-        new QLabel(tr("⚠ Arithmetic engine: μ and σ are absolute price increments (not "
-                      "%/log-returns), and the price can go negative or zero — unrealistic for an "
-                      "FX rate. Intended for testing the process abstraction."),
-                   tab);
+    engineWarningLabel_ = new QLabel(tab);
     engineWarningLabel_->setWordWrap(true);
     engineWarningLabel_->setStyleSheet("color:#d08020;");
-    engineWarningLabel_->setVisible(currentEngine() == "arithmetic");
     layout->addWidget(engineWarningLabel_);
 
     connect(
@@ -459,6 +458,8 @@ void FxSpotRateEditor::buildBehaviourTab() {
     layout->addWidget(pathsBox, 1);
 
     connect(modeGroup_, &QButtonGroup::idClicked, this, [this](int) { onModeChanged(); });
+
+    updateEngineUi(); // initial header/tooltip/warning sync for the starting engine
 
     tabWidget_->addTab(tab, tr("Price behaviour"));
 }
@@ -561,10 +562,11 @@ QWidget* FxSpotRateEditor::buildAdvancedControls() {
     compLayout->addWidget(componentTable_);
 
     auto* compButtons = new QHBoxLayout();
-    auto* addBtn = new QPushButton(tr("Add process"), compBox);
-    addBtn->setToolTip(tr("Add another process — two or more processes form a regime mix."));
-    connect(addBtn, &QPushButton::clicked, this, &FxSpotRateEditor::onAddComponentRow);
-    compButtons->addWidget(addBtn);
+    addComponentBtn_ = new QPushButton(tr("Add process"), compBox);
+    addComponentBtn_->setToolTip(
+        tr("Add another process — two or more processes form a regime mix."));
+    connect(addComponentBtn_, &QPushButton::clicked, this, &FxSpotRateEditor::onAddComponentRow);
+    compButtons->addWidget(addComponentBtn_);
     auto* resetAdvBtn = new QPushButton(tr("Reset"), compBox);
     resetAdvBtn->setToolTip(tr("Restore a single Normal-profile component."));
     connect(resetAdvBtn, &QPushButton::clicked, this, &FxSpotRateEditor::onResetAdvanced);
@@ -887,6 +889,10 @@ std::string FxSpotRateEditor::currentEngine() const {
     return engineCombo_ ? engineCombo_->currentData().toString().toStdString() : "geometric";
 }
 
+bool FxSpotRateEditor::isOuEngine() const {
+    return currentEngine() == "ou";
+}
+
 QString FxSpotRateEditor::incrementNoun() const {
     return currentEngine() == "arithmetic" ? tr("price change") : tr("log-return");
 }
@@ -894,10 +900,42 @@ QString FxSpotRateEditor::incrementNoun() const {
 void FxSpotRateEditor::onEngineChanged() {
     if (engineCombo_)
         fx_.process_type = currentEngine();
-    if (engineWarningLabel_)
-        engineWarningLabel_->setVisible(currentEngine() == "arithmetic");
+    updateEngineUi();
+    if (isOuEngine() && componentTable_ && componentTable_->rowCount() > 1) {
+        // OU is a single-regime process — collapse to the first row so the
+        // reused Volatility (σ) / Weight (κ) fields have one unambiguous value.
+        components_.resize(1);
+        syncing_ = true;
+        syncAdvancedFromModel();
+        syncing_ = false;
+        updateComponentColors();
+    }
     // Engine only affects the path simulation, not the increment PDF.
     refreshCharts();
+}
+
+void FxSpotRateEditor::updateEngineUi() {
+    const bool ou = isOuEngine();
+    const bool arithmetic = currentEngine() == "arithmetic";
+
+    if (engineWarningLabel_) {
+        if (ou) {
+            engineWarningLabel_->setText(
+                tr("⚠ Ornstein-Uhlenbeck engine: a single regime, not a mixture. Reuses this "
+                   "editor's fields as: κ (reversion speed) = Weight, σ (volatility) = "
+                   "Volatility (σ), and θ (long-run mean) = Initial Price. Drift (μ) is "
+                   "unused. \"Add process\" is disabled while this engine is selected."));
+        } else if (arithmetic) {
+            engineWarningLabel_->setText(
+                tr("⚠ Arithmetic engine: μ and σ are absolute price increments (not "
+                   "%/log-returns), and the price can go negative or zero — unrealistic for an "
+                   "FX rate. Intended for testing the process abstraction."));
+        }
+        engineWarningLabel_->setVisible(ou || arithmetic);
+    }
+
+    if (addComponentBtn_)
+        addComponentBtn_->setEnabled(!ou);
 }
 
 void FxSpotRateEditor::onAddComponentRow() {
@@ -957,11 +995,7 @@ void FxSpotRateEditor::syncAdvancedFromModel() {
     for (const auto& c : components_)
         addTableRow(c);
     updateRemoveButtonsEnabled();
-    // Refresh weight-sum label.
-    double sum = 0.0;
-    for (const auto& c : components_)
-        sum += c.weight;
-    weightSumLabel_->setText(tr("Weight Sum = %1 (normalised on save)").arg(sum, 0, 'f', 3));
+    updateWeightSumLabel();
 }
 
 void FxSpotRateEditor::rebuildModelFromAdvanced() {
@@ -982,7 +1016,15 @@ void FxSpotRateEditor::rebuildModelFromAdvanced() {
         next.push_back(c);
     }
     components_ = std::move(next);
+    updateWeightSumLabel();
+}
 
+void FxSpotRateEditor::updateWeightSumLabel() {
+    if (isOuEngine()) {
+        const double kappa = components_.empty() ? 0.0 : components_.front().weight;
+        weightSumLabel_->setText(tr("κ (reversion speed) = %1").arg(kappa, 0, 'f', 3));
+        return;
+    }
     double sum = 0.0;
     for (const auto& c : components_)
         sum += c.weight;
@@ -1068,20 +1110,28 @@ void FxSpotRateEditor::rebuildModelFromSimple() {
 void FxSpotRateEditor::refreshCharts() {
     std::vector<ReturnDistributionChart::Component> distComps;
     std::vector<SamplePricePathsChart::Component> pathComps;
-    double sum = 0.0;
-    for (const auto& c : components_)
-        sum += c.weight;
-    for (const auto& c : components_) {
-        const double w = sum > 0.0 ? c.weight / sum : c.weight;
-        distComps.push_back({c.mean, c.stdev, w});
-        pathComps.push_back({c.mean, c.stdev, w});
+    const std::string engine = currentEngine();
+    const double price = priceSpin_ ? priceSpin_->value() : fx_.gmm_initial_price;
+
+    if (engine == "ou") {
+        // Single regime, scalar params (κ, σ) reused from Weight/Volatility — not a
+        // mixture, so no normalisation. θ (long-run mean) is the Initial Price, sent
+        // separately below; the increment PDF chart doesn't apply to a level process.
+        if (!components_.empty())
+            pathComps.push_back({0.0, components_.front().stdev, components_.front().weight});
+    } else {
+        double sum = 0.0;
+        for (const auto& c : components_)
+            sum += c.weight;
+        for (const auto& c : components_) {
+            const double w = sum > 0.0 ? c.weight / sum : c.weight;
+            distComps.push_back({c.mean, c.stdev, w});
+            pathComps.push_back({c.mean, c.stdev, w});
+        }
     }
 
-    const double price = priceSpin_ ? priceSpin_->value() : fx_.gmm_initial_price;
-    const std::string engine = currentEngine();
-
     if (distChart_)
-        distChart_->setComponents(distComps); // PDF is engine-independent (increment dist)
+        distChart_->setComponents(distComps); // empty for "ou" — PDF n/a to a level process
     if (pathsChart_) {
         pathsChart_->setComponents(pathComps);
         pathsChart_->setInitialPrice(price);
@@ -1147,8 +1197,10 @@ void FxSpotRateEditor::onSaveClicked() {
         rebuildModelFromSimple();
 
     // Reject an all-zero weight set: the server builds a std::discrete_distribution
-    // from the weights, which is undefined behaviour when they sum to zero.
-    {
+    // from the weights, which is undefined behaviour when they sum to zero. Doesn't
+    // apply to "ou": κ = 0 is a valid parameter (driftless random walk), and there's
+    // no discrete_distribution over regimes since it's a single process.
+    if (!isOuEngine()) {
         double weightSum = 0.0;
         for (const auto& mc : components_)
             weightSum += mc.weight;
@@ -1181,7 +1233,9 @@ void FxSpotRateEditor::onSaveClicked() {
         crSel->commentary.empty() ? "Authored via Market Simulator" : crSel->commentary;
     fx.version = 0;
 
-    // Build the component stack, normalising weights to sum 1.
+    // Build the component stack, normalising weights to sum 1. Not for "ou": its one
+    // row's weight is κ (reversion speed), a scalar parameter, not a mixture share.
+    const bool ou = isOuEngine();
     double total = 0.0;
     for (const auto& mc : components_)
         total += mc.weight;
@@ -1206,9 +1260,11 @@ void FxSpotRateEditor::onSaveClicked() {
         c.description = mc.description;
         c.mean = mc.mean;
         c.stdev = mc.stdev;
-        c.weight = total > 0.0 ? mc.weight / total : mc.weight;
+        c.weight = (!ou && total > 0.0) ? mc.weight / total : mc.weight;
         c.modified_by = username_.toStdString();
-        c.change_reason_code = rowIsNew ? "system.new_record" : "common.non_material_update";
+        namespace reason = ores::dq::domain::change_reason_constants::codes;
+        c.change_reason_code =
+            rowIsNew ? std::string(reason::new_record) : std::string(reason::non_material_update);
         c.change_commentary = "Authored via Market Simulator";
         c.version = 0;
         comps.push_back(c);

--- a/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
+++ b/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
@@ -77,6 +77,40 @@ constexpr double kVolMax = 0.02;     // 2% per update
 constexpr double kJumpMin = 0.0;     // weight of the jump component
 constexpr double kJumpMax = 0.5;     // up to 50% mixture share
 
+/**
+ * @brief Price-process engine metadata: the single source of truth for what
+ * appears in the engine combo and how the editor's generic gating (Add
+ * process / Simple mode / weight normalisation / the all-zero-weight guard)
+ * behaves per engine — the UI asks "does this engine support mixing?"
+ * rather than hardcoding "is this the ou engine?" throughout. More single-
+ * regime engines (e.g. Vasicek/CIR/Hull-White for rates) are expected to
+ * follow the same shape: add a row here, not new special-cases in the UI.
+ */
+struct EngineInfo {
+    const char* code;  // matches process_type / process_factory's dispatch key
+    const char* label; // combo box display text (wrapped in tr() at use site)
+    // False for single-regime processes (e.g. mean-reverting): the Advanced
+    // component table collapses to one row, "Add process" is disabled, the
+    // all-zero-weight guard and weight-sum-to-1 normalisation are skipped
+    // (that row's Weight field is repurposed as a scalar parameter, not a
+    // mixture share). Per-engine field remapping/wording stays engine-
+    // specific — a boolean can't express what a field means, only whether
+    // there can be more than one of them.
+    bool supportsMixing;
+};
+constexpr EngineInfo kEngines[] = {
+    {"geometric", QT_TR_NOOP("Geometric Brownian Motion"), true},
+    {"arithmetic", QT_TR_NOOP("Arithmetic Brownian Motion"), true},
+    {"ou", QT_TR_NOOP("Ornstein-Uhlenbeck (mean-reverting)"), false},
+};
+
+const EngineInfo* find_engine(const std::string& code) {
+    for (const auto& e : kEngines)
+        if (code == e.code)
+            return &e;
+    return nullptr;
+}
+
 // Advanced table columns (no per-component Type — engine is config-level now).
 enum Col {
     ColColor = 0,
@@ -341,9 +375,8 @@ void FxSpotRateEditor::buildBehaviourTab() {
     auto* headerRow = new QHBoxLayout();
     headerRow->addWidget(new QLabel(tr("Engine:"), tab));
     engineCombo_ = new QComboBox(tab);
-    engineCombo_->addItem(tr("Geometric Brownian Motion"), QStringLiteral("geometric"));
-    engineCombo_->addItem(tr("Arithmetic Brownian Motion"), QStringLiteral("arithmetic"));
-    engineCombo_->addItem(tr("Ornstein-Uhlenbeck (mean-reverting)"), QStringLiteral("ou"));
+    for (const auto& e : kEngines)
+        engineCombo_->addItem(tr(e.label), QString::fromLatin1(e.code));
     engineCombo_->setToolTip(
         tr("The price-process engine. Geometric uses log-returns (stays positive); "
            "arithmetic uses absolute price changes (symmetric, may go negative); "
@@ -889,8 +922,9 @@ std::string FxSpotRateEditor::currentEngine() const {
     return engineCombo_ ? engineCombo_->currentData().toString().toStdString() : "geometric";
 }
 
-bool FxSpotRateEditor::isOuEngine() const {
-    return currentEngine() == "ou";
+bool FxSpotRateEditor::currentEngineSupportsMixing() const {
+    const auto* info = find_engine(currentEngine());
+    return info ? info->supportsMixing : true; // unknown engine: don't block on it
 }
 
 QString FxSpotRateEditor::incrementNoun() const {
@@ -901,30 +935,50 @@ void FxSpotRateEditor::onEngineChanged() {
     if (engineCombo_)
         fx_.process_type = currentEngine();
     updateEngineUi();
-    if (isOuEngine() && componentTable_ && componentTable_->rowCount() > 1) {
-        // OU is a single-regime process — collapse to the first row so the
-        // reused Volatility (σ) / Weight (κ) fields have one unambiguous value.
-        components_.resize(1);
-        syncing_ = true;
-        syncAdvancedFromModel();
-        syncing_ = false;
-        updateComponentColors();
+    if (!currentEngineSupportsMixing()) {
+        // A single-regime engine has no defined Simple-mode mapping (the sliders
+        // drive drift/vol/jump-fraction, which don't correspond to a single
+        // process's parameters), so force Advanced mode — the only surface where
+        // those parameters are directly editable.
+        if (modeGroup_ && modeGroup_->checkedId() != 1) {
+            if (auto* advancedBtn = modeGroup_->button(1))
+                advancedBtn->setChecked(true);
+            onModeChanged();
+        }
+        if (componentTable_ && componentTable_->rowCount() > 1) {
+            // Single-regime process — collapse to the first row so its reused
+            // fields have one unambiguous value.
+            components_.resize(1);
+            syncing_ = true;
+            syncAdvancedFromModel();
+            syncing_ = false;
+            updateComponentColors();
+        }
     }
-    // Engine only affects the path simulation, not the increment PDF.
+    // Engine also determines whether the Return Distribution PDF chart applies
+    // (it doesn't for "ou", a level process rather than an increment mixture).
     refreshCharts();
 }
 
 void FxSpotRateEditor::updateEngineUi() {
-    const bool ou = isOuEngine();
-    const bool arithmetic = currentEngine() == "arithmetic";
+    // Generic, capability-driven gating (any engine with supportsMixing = false
+    // behaves this way, not just "ou" specifically).
+    const bool mixing = currentEngineSupportsMixing();
+    // The warning banner's wording is inherently engine-specific — a boolean
+    // can't express *how* a single-regime engine's fields are repurposed, so
+    // this part stays keyed on the engine code, unlike the gating above.
+    const auto engine = currentEngine();
+    const bool ou = engine == "ou";
+    const bool arithmetic = engine == "arithmetic";
 
     if (engineWarningLabel_) {
         if (ou) {
             engineWarningLabel_->setText(
-                tr("⚠ Ornstein-Uhlenbeck engine: a single regime, not a mixture. Reuses this "
-                   "editor's fields as: κ (reversion speed) = Weight, σ (volatility) = "
-                   "Volatility (σ), and θ (long-run mean) = Initial Price. Drift (μ) is "
-                   "unused. \"Add process\" is disabled while this engine is selected."));
+                tr("⚠ Ornstein-Uhlenbeck engine: a single regime, not a mixture. Simple mode is "
+                   "disabled — Advanced mode's fields are reused as: κ (reversion speed) = "
+                   "Weight, σ (volatility) = Volatility (σ), and θ (long-run mean) = Initial "
+                   "Price. Drift (μ) is unused. \"Add process\" is disabled while this engine is "
+                   "selected."));
         } else if (arithmetic) {
             engineWarningLabel_->setText(
                 tr("⚠ Arithmetic engine: μ and σ are absolute price increments (not "
@@ -935,7 +989,12 @@ void FxSpotRateEditor::updateEngineUi() {
     }
 
     if (addComponentBtn_)
-        addComponentBtn_->setEnabled(!ou);
+        addComponentBtn_->setEnabled(mixing);
+
+    if (modeGroup_) {
+        if (auto* simpleBtn = modeGroup_->button(0))
+            simpleBtn->setEnabled(mixing);
+    }
 }
 
 void FxSpotRateEditor::onAddComponentRow() {
@@ -1020,7 +1079,9 @@ void FxSpotRateEditor::rebuildModelFromAdvanced() {
 }
 
 void FxSpotRateEditor::updateWeightSumLabel() {
-    if (isOuEngine()) {
+    if (!currentEngineSupportsMixing()) {
+        // Wording is OU-specific for now (the only non-mixing engine); a future
+        // second one will need its own case here, same as the warning banner.
         const double kappa = components_.empty() ? 0.0 : components_.front().weight;
         weightSumLabel_->setText(tr("κ (reversion speed) = %1").arg(kappa, 0, 'f', 3));
         return;
@@ -1113,10 +1174,12 @@ void FxSpotRateEditor::refreshCharts() {
     const std::string engine = currentEngine();
     const double price = priceSpin_ ? priceSpin_->value() : fx_.gmm_initial_price;
 
-    if (engine == "ou") {
-        // Single regime, scalar params (κ, σ) reused from Weight/Volatility — not a
-        // mixture, so no normalisation. θ (long-run mean) is the Initial Price, sent
-        // separately below; the increment PDF chart doesn't apply to a level process.
+    if (!currentEngineSupportsMixing()) {
+        // Single-regime path — wording/remapping below is OU-specific for now (the
+        // only such engine); a future second one will need its own case here.
+        // Scalar params (κ, σ) reused from Weight/Volatility — not a mixture, so no
+        // normalisation. θ (long-run mean) is the Initial Price, sent separately
+        // below; the increment PDF chart doesn't apply to a level process.
         if (!components_.empty())
             pathComps.push_back({0.0, components_.front().stdev, components_.front().weight});
     } else {
@@ -1198,9 +1261,10 @@ void FxSpotRateEditor::onSaveClicked() {
 
     // Reject an all-zero weight set: the server builds a std::discrete_distribution
     // from the weights, which is undefined behaviour when they sum to zero. Doesn't
-    // apply to "ou": κ = 0 is a valid parameter (driftless random walk), and there's
-    // no discrete_distribution over regimes since it's a single process.
-    if (!isOuEngine()) {
+    // apply to single-regime engines (e.g. "ou", where κ = 0 is a valid parameter —
+    // a driftless random walk): there's no discrete_distribution over regimes since
+    // there's only one process, not a mixture.
+    if (currentEngineSupportsMixing()) {
         double weightSum = 0.0;
         for (const auto& mc : components_)
             weightSum += mc.weight;
@@ -1233,9 +1297,10 @@ void FxSpotRateEditor::onSaveClicked() {
         crSel->commentary.empty() ? "Authored via Market Simulator" : crSel->commentary;
     fx.version = 0;
 
-    // Build the component stack, normalising weights to sum 1. Not for "ou": its one
-    // row's weight is κ (reversion speed), a scalar parameter, not a mixture share.
-    const bool ou = isOuEngine();
+    // Build the component stack, normalising weights to sum 1. Skipped for
+    // single-regime engines (e.g. "ou"): their one row's Weight field is a
+    // scalar parameter (κ), not a mixture share.
+    const bool mixing = currentEngineSupportsMixing();
     double total = 0.0;
     for (const auto& mc : components_)
         total += mc.weight;
@@ -1260,7 +1325,7 @@ void FxSpotRateEditor::onSaveClicked() {
         c.description = mc.description;
         c.mean = mc.mean;
         c.stdev = mc.stdev;
-        c.weight = (!ou && total > 0.0) ? mc.weight / total : mc.weight;
+        c.weight = (mixing && total > 0.0) ? mc.weight / total : mc.weight;
         c.modified_by = username_.toStdString();
         namespace reason = ores::dq::domain::change_reason_constants::codes;
         c.change_reason_code =

--- a/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
+++ b/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
@@ -27,6 +27,7 @@
 #include "ores.qt/ProvenanceWidget.hpp"
 #include "ores.qt/ReturnDistributionChart.hpp"
 #include "ores.qt/SamplePricePathsChart.hpp"
+#include "ores.synthetic.api/domain/process_parameter_validation.hpp"
 #include "ores.synthetic.api/messaging/fx_spot_generation_config_protocol.hpp"
 #include "ores.synthetic.api/messaging/gmm_component_protocol.hpp"
 #include <QAbstractItemView>
@@ -570,16 +571,21 @@ QWidget* FxSpotRateEditor::buildAdvancedControls() {
     compLayout->setContentsMargins(12, 12, 12, 12);
     compLayout->setSpacing(8);
 
+    // Short header labels — full explanations live in per-header tooltips
+    // (updated per engine by updateEngineUi()) rather than permanent header
+    // text, to keep this table from growing wider than the dialog can spare.
     componentTable_ = new QTableWidget(0, 7, compBox);
-    componentTable_->setHorizontalHeaderLabels({tr("Colour"),
-                                                tr("Component Name"),
-                                                tr("Profile"),
-                                                tr("Drift (μ %)"),
-                                                tr("Volatility (σ %)"),
-                                                tr("Weight"),
-                                                tr("Actions")});
+    componentTable_->setHorizontalHeaderLabels(
+        {tr(""), tr("Name"), tr("Profile"), tr("μ"), tr("σ"), tr("w"), tr("")});
+    if (auto* hdr = componentTable_->horizontalHeaderItem(ColColor))
+        hdr->setToolTip(tr("Colour — matches this component's curve on the Return "
+                           "distribution chart."));
+    if (auto* hdr = componentTable_->horizontalHeaderItem(ColProfile))
+        hdr->setToolTip(tr("A preset that fills in Volatility (σ)."));
+    if (auto* hdr = componentTable_->horizontalHeaderItem(ColActions))
+        hdr->setToolTip(tr("Remove this process."));
     // (A "Jump (planned)" column is intentionally omitted — not backed.)
-    componentTable_->setMinimumWidth(560);
+    componentTable_->setMinimumWidth(480);
     componentTable_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     componentTable_->setShowGrid(false); // avoid cell-border + inner-widget "box in box"
     componentTable_->verticalHeader()->setVisible(false);
@@ -808,7 +814,8 @@ void FxSpotRateEditor::addTableRow(const ModelComponent& c) {
     meanSpin->setValue(c.mean * 100.0);
     meanSpin->setFrame(false);
     meanSpin->setStyleSheet(flatEdit);
-    meanSpin->setToolTip(tr("Average %1 per update (%); 0 = no drift.").arg(incrementNoun()));
+    // Explanation lives on the column header tooltip (ColMean), which updates per
+    // engine — a per-row static tooltip here would go stale for e.g. "ou".
 
     auto* stdevSpin = new QDoubleSpinBox(componentTable_);
     stdevSpin->setRange(0.0, 100.0);
@@ -816,17 +823,14 @@ void FxSpotRateEditor::addTableRow(const ModelComponent& c) {
     stdevSpin->setSuffix(tr(" %"));
     stdevSpin->setValue(c.stdev * 100.0);
     stdevSpin->setFrame(false);
-    stdevSpin->setStyleSheet(flatEdit);
-    stdevSpin->setToolTip(
-        tr("Volatility of the %1 per update (%); 0 = constant.").arg(incrementNoun()));
+    stdevSpin->setStyleSheet(flatEdit); // see ColStdev header tooltip
 
     auto* weightSpin = new QDoubleSpinBox(componentTable_);
     weightSpin->setRange(0.0, 1e6);
     weightSpin->setDecimals(3);
     weightSpin->setValue(c.weight);
     weightSpin->setFrame(false);
-    weightSpin->setStyleSheet(flatEdit);
-    weightSpin->setToolTip(tr("Relative share when blending processes (normalised on save)."));
+    weightSpin->setStyleSheet(flatEdit); // see ColWeight header tooltip
 
     // Icon-only trash button, centred in the Actions cell via a small container.
     auto* removeBtn = new QPushButton(componentTable_);
@@ -994,6 +998,21 @@ void FxSpotRateEditor::updateEngineUi() {
     if (modeGroup_) {
         if (auto* simpleBtn = modeGroup_->button(0))
             simpleBtn->setEnabled(mixing);
+    }
+
+    if (componentTable_) {
+        if (auto* meanHdr = componentTable_->horizontalHeaderItem(ColMean))
+            meanHdr->setToolTip(ou ? tr("Unused by Ornstein-Uhlenbeck.") :
+                                     tr("Drift (μ) — average %1 per update (%).")
+                                         .arg(incrementNoun()));
+        if (auto* stdevHdr = componentTable_->horizontalHeaderItem(ColStdev))
+            stdevHdr->setToolTip(ou ? tr("σ — Ornstein-Uhlenbeck volatility.") :
+                                      tr("Volatility (σ) of the %1 per update (%).")
+                                          .arg(incrementNoun()));
+        if (auto* weightHdr = componentTable_->horizontalHeaderItem(ColWeight))
+            weightHdr->setToolTip(
+                ou ? tr("κ — Ornstein-Uhlenbeck reversion speed (0 = driftless random walk).") :
+                     tr("Relative share when blending processes (normalised on save)."));
     }
 }
 
@@ -1259,20 +1278,21 @@ void FxSpotRateEditor::onSaveClicked() {
     else
         rebuildModelFromSimple();
 
-    // Reject an all-zero weight set: the server builds a std::discrete_distribution
-    // from the weights, which is undefined behaviour when they sum to zero. Doesn't
-    // apply to single-regime engines (e.g. "ou", where κ = 0 is a valid parameter —
-    // a driftless random walk): there's no discrete_distribution over regimes since
-    // there's only one process, not a mixture.
-    if (currentEngineSupportsMixing()) {
-        double weightSum = 0.0;
-        for (const auto& mc : components_)
-            weightSum += mc.weight;
-        if (weightSum <= 0.0) {
-            QMessageBox::warning(this,
-                                 tr("Invalid weights"),
-                                 tr("All component weights are zero. At least one component must "
-                                    "have a positive weight."));
+    // Ask the engine itself whether these parameters are valid — the same rules
+    // process_factory enforces server-side (ores.synthetic.api::domain, shared,
+    // not duplicated UI-side logic).
+    {
+        std::vector<double> means, stdevs, weights;
+        for (const auto& mc : components_) {
+            means.push_back(mc.mean);
+            stdevs.push_back(mc.stdev);
+            weights.push_back(mc.weight);
+        }
+        const auto validation = synthetic::domain::validate_process_parameters(
+            currentEngine(), means, stdevs, weights, priceSpin_->value());
+        if (!validation.valid) {
+            QMessageBox::warning(
+                this, tr("Invalid parameters"), QString::fromStdString(validation.message));
             return;
         }
     }

--- a/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
+++ b/projects/ores.qt/synthetic/src/FxSpotRateEditor.cpp
@@ -939,11 +939,24 @@ void FxSpotRateEditor::onEngineChanged() {
     if (engineCombo_)
         fx_.process_type = currentEngine();
     updateEngineUi();
-    if (!currentEngineSupportsMixing()) {
-        // A single-regime engine has no defined Simple-mode mapping (the sliders
-        // drive drift/vol/jump-fraction, which don't correspond to a single
-        // process's parameters), so force Advanced mode — the only surface where
-        // those parameters are directly editable.
+    // Engine also determines whether the Return Distribution PDF chart applies
+    // (it doesn't for "ou", a level process rather than an increment mixture).
+    refreshCharts();
+}
+
+void FxSpotRateEditor::updateEngineUi() {
+    // Generic, capability-driven gating (any engine with supportsMixing = false
+    // behaves this way, not just "ou" specifically). Called both on every engine
+    // change AND once at the end of buildBehaviourTab() during construction — the
+    // latter matters when opening an *existing* single-regime record, since
+    // engineCombo_->setCurrentIndex() runs before its currentIndexChanged signal
+    // is connected, so onEngineChanged() never fires for the initial value. If
+    // this forcing lived only in onEngineChanged() (as it used to), an existing
+    // "ou" record would silently open on the Simple page; clicking Save without
+    // touching anything would then overwrite its real κ with a Simple-mode-
+    // derived value that has no defined meaning for a single-regime process.
+    const bool mixing = currentEngineSupportsMixing();
+    if (!mixing) {
         if (modeGroup_ && modeGroup_->checkedId() != 1) {
             if (auto* advancedBtn = modeGroup_->button(1))
                 advancedBtn->setChecked(true);
@@ -959,15 +972,6 @@ void FxSpotRateEditor::onEngineChanged() {
             updateComponentColors();
         }
     }
-    // Engine also determines whether the Return Distribution PDF chart applies
-    // (it doesn't for "ou", a level process rather than an increment mixture).
-    refreshCharts();
-}
-
-void FxSpotRateEditor::updateEngineUi() {
-    // Generic, capability-driven gating (any engine with supportsMixing = false
-    // behaves this way, not just "ou" specifically).
-    const bool mixing = currentEngineSupportsMixing();
     // The warning banner's wording is inherently engine-specific — a boolean
     // can't express *how* a single-regime engine's fields are repurposed, so
     // this part stays keyed on the engine code, unlike the gating above.

--- a/projects/ores.qt/synthetic/src/MarketSimulatorWindow.cpp
+++ b/projects/ores.qt/synthetic/src/MarketSimulatorWindow.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.qt/MarketSimulatorWindow.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.marketdata.api/domain/feed_binding.hpp"
 #include "ores.marketdata.api/domain/fx_spot_tick.hpp"
 #include "ores.marketdata.api/messaging/feed_binding_protocol.hpp"
@@ -1384,7 +1385,8 @@ void MarketSimulatorWindow::startPairsAsync(
             b.party_id = partyId;
             b.enabled = true;
             b.performed_by = username;
-            b.change_reason_code = "system.new_record";
+            b.change_reason_code =
+                std::string(ores::dq::domain::change_reason_constants::codes::new_record);
             b.change_commentary = "Auto-created by Market Simulator on feed start";
             auto bind_req =
                 ores::marketdata::messaging::save_feed_binding_request::from(std::move(b));

--- a/projects/ores.qt/synthetic/src/ReturnDistributionChart.cpp
+++ b/projects/ores.qt/synthetic/src/ReturnDistributionChart.cpp
@@ -201,6 +201,9 @@ void ReturnDistributionChart::setComponents(const std::vector<Component>& compon
         QPen compPen(componentColor(static_cast<int>(ci)));
         compPen.setWidth(2);
         compLine->setPen(compPen);
+        // Named for potential tooling/debugging use, but the chart's own legend is
+        // hidden (compact layout) — the colour-to-component mapping is conveyed via
+        // FxSpotRateEditor's component-table swatch column, not an in-chart legend.
         compLine->setName(tr("Component %1").arg(ci + 1));
         chart_->addSeries(compLine);
         compLine->attachAxis(axisX_);

--- a/projects/ores.qt/synthetic/src/ReturnDistributionChart.cpp
+++ b/projects/ores.qt/synthetic/src/ReturnDistributionChart.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "ores.qt/ReturnDistributionChart.hpp"
-#include <QPalette>
 #include <QVBoxLayout>
 #include <QtCharts/QAreaSeries>
 #include <QtCharts/QChart>
@@ -46,6 +45,26 @@ double gaussian(double x, double mean, double stdev) {
     return std::exp(-0.5 * z * z) / (s * std::sqrt(2.0 * pi));
 }
 
+// Qualitative palette for per-component curves; deliberately excludes steel
+// blue (the fixed combined-mixture colour, below) so components are always
+// visually distinct from the mixture.
+const QColor componentPalette[] = {
+    QColor(0xFF, 0x6B, 0x6B), // coral
+    QColor(0xFF, 0xB6, 0x27), // amber
+    QColor(0x4E, 0xCD, 0xC4), // mint
+    QColor(0xB3, 0x8D, 0xF5), // violet
+    QColor(0xA8, 0xD8, 0x5A), // lime
+    QColor(0xF7, 0x81, 0xBF), // pink
+    QColor(0xC9, 0xC9, 0xC9), // grey
+};
+constexpr int componentPaletteSize =
+    static_cast<int>(sizeof(componentPalette) / sizeof(componentPalette[0]));
+
+}
+
+QColor ReturnDistributionChart::componentColor(int index) {
+    const int i = ((index % componentPaletteSize) + componentPaletteSize) % componentPaletteSize;
+    return componentPalette[i];
 }
 
 ReturnDistributionChart::ReturnDistributionChart(QWidget* parent)
@@ -63,8 +82,11 @@ ReturnDistributionChart::ReturnDistributionChart(QWidget* parent)
     chart_->legend()->setVisible(false);
     chart_->setMargins(QMargins(4, 4, 4, 4));
 
-    const QColor textColor = palette().color(QPalette::WindowText);
-    const QColor gridColor(textColor.red(), textColor.green(), textColor.blue(), 40);
+    // The app's dark theme is applied via QSS only, so QWidget::palette() still
+    // returns Qt's default (light-mode) colours here — use explicit theme
+    // colours instead, matching FxSpotChartWindow's chart styling.
+    const QColor textColor(0xCB, 0xD5, 0xE1);
+    const QColor gridColor(255, 255, 255, 18);
     chart_->setTitleBrush(textColor);
 
     axisX_->setTitleText(tr("Return per Update (%)"));
@@ -124,23 +146,31 @@ void ReturnDistributionChart::setComponents(const std::vector<Component>& compon
     const double xMax = maxMean + span;
 
     constexpr int samples = 256;
-    // Compute the raw mixture density, then normalise to a peak of 1 so the
+    // Compute each component's weighted contribution alongside the raw mixture
+    // density, then normalise everything to the mixture's peak of 1 so the
     // chart shows the distribution SHAPE on a clean 0..1 "relative likelihood"
     // scale, rather than raw density values (which can be huge for a narrow
     // distribution and read confusingly as a probability > 1).
     std::vector<std::pair<double, double>> pts;
     pts.reserve(samples + 1);
+    std::vector<std::vector<double>> componentYs(
+        components.size(), std::vector<double>(samples + 1, 0.0));
     double yMax = 0.0;
     for (int i = 0; i <= samples; ++i) {
         const double x = xMin + (xMax - xMin) * i / samples;
         double y = 0.0;
-        for (const auto& c : components)
-            y += c.weight * gaussian(x, c.mean * 100.0, c.stdev * 100.0);
+        for (std::size_t ci = 0; ci < components.size(); ++ci) {
+            const auto& c = components[ci];
+            const double yi = c.weight * gaussian(x, c.mean * 100.0, c.stdev * 100.0);
+            componentYs[ci][i] = yi;
+            y += yi;
+        }
         pts.emplace_back(x, y);
         yMax = std::max(yMax, y);
     }
-    auto* line = new QLineSeries(this);
     const double norm = yMax > 0.0 ? yMax : 1.0;
+
+    auto* line = new QLineSeries(this);
     for (const auto& [x, y] : pts)
         line->append(x, y / norm);
 
@@ -159,6 +189,23 @@ void ReturnDistributionChart::setComponents(const std::vector<Component>& compon
     chart_->addSeries(area);
     area->attachAxis(axisX_);
     area->attachAxis(axisY_);
+
+    // Per-component contribution curves, drawn on top of the mixture fill in
+    // colours matching the component table's colour indicator (componentColor()).
+    for (std::size_t ci = 0; ci < components.size(); ++ci) {
+        auto* compLine = new QLineSeries(this);
+        for (int i = 0; i <= samples; ++i) {
+            const double x = xMin + (xMax - xMin) * i / samples;
+            compLine->append(x, componentYs[ci][i] / norm);
+        }
+        QPen compPen(componentColor(static_cast<int>(ci)));
+        compPen.setWidth(2);
+        compLine->setPen(compPen);
+        compLine->setName(tr("Component %1").arg(ci + 1));
+        chart_->addSeries(compLine);
+        compLine->attachAxis(axisX_);
+        compLine->attachAxis(axisY_);
+    }
 
     axisX_->setRange(xMin, xMax);
     axisY_->setRange(0.0, 1.05);

--- a/projects/ores.qt/synthetic/src/SamplePricePathsChart.cpp
+++ b/projects/ores.qt/synthetic/src/SamplePricePathsChart.cpp
@@ -23,7 +23,6 @@
 #include <QFutureWatcher>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QPalette>
 #include <QPointer>
 #include <QPushButton>
 #include <QSpinBox>
@@ -61,8 +60,11 @@ SamplePricePathsChart::SamplePricePathsChart(ClientManager* cm, QWidget* parent)
     chart_->legend()->setVisible(false);
     chart_->setMargins(QMargins(4, 4, 4, 4));
 
-    const QColor textColor = palette().color(QPalette::WindowText);
-    const QColor gridColor(textColor.red(), textColor.green(), textColor.blue(), 40);
+    // The app's dark theme is applied via QSS only, so QWidget::palette() still
+    // returns Qt's default (light-mode) colours here — use explicit theme
+    // colours instead, matching FxSpotChartWindow's chart styling.
+    const QColor textColor(0xCB, 0xD5, 0xE1);
+    const QColor gridColor(255, 255, 255, 18);
     chart_->setTitleBrush(textColor);
 
     axisX_->setTitleText(tr("Update Steps"));

--- a/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_fx_spot_generation_configs_create.sql
@@ -66,7 +66,7 @@ create table if not exists "ores_synthetic_fx_spot_generation_configs_tbl" (
     check ("ore_key" <> ''),
     check ("gmm_initial_price" > 0),
     check ("ticks_per_hour" > 0),
-    check ("process_type" in ('geometric', 'arithmetic'))
+    check ("process_type" in ('geometric', 'arithmetic', 'ou'))
 );
 
 -- Composite natural key: unique combination for active records

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_SYNTHETIC_API_DOMAIN_PROCESS_PARAMETER_VALIDATION_HPP
 #define ORES_SYNTHETIC_API_DOMAIN_PROCESS_PARAMETER_VALIDATION_HPP
 
+#include "ores.synthetic.api/export.hpp"
 #include <string>
 #include <vector>
 
@@ -58,7 +59,7 @@ struct process_parameter_validation_result final {
  *
  * initial_price must be strictly positive for every engine.
  */
-process_parameter_validation_result validate_process_parameters(
+ORES_SYNTHETIC_API_EXPORT process_parameter_validation_result validate_process_parameters(
     const std::string& process_type,
     const std::vector<double>& means,
     const std::vector<double>& stdevs,

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/process_parameter_validation.hpp
@@ -1,0 +1,70 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_API_DOMAIN_PROCESS_PARAMETER_VALIDATION_HPP
+#define ORES_SYNTHETIC_API_DOMAIN_PROCESS_PARAMETER_VALIDATION_HPP
+
+#include <string>
+#include <vector>
+
+namespace ores::synthetic::domain {
+
+/**
+ * @brief Result of validating a price-process engine's raw parameters.
+ */
+struct process_parameter_validation_result final {
+    bool valid = true;
+    std::string message; // empty when valid
+};
+
+/**
+ * @brief Validate the raw (means, stdevs, weights, initial_price) tuple for the
+ * given process_type ("geometric", "arithmetic", "ou", ...), independent of
+ * both the UI and the process-construction machinery.
+ *
+ * This is the single source of truth for "are these parameters good?" — the
+ * process classes in ores.synthetic.service (gmm_process, ou_process, ...)
+ * still validate defensively in their constructors, but callers that want a
+ * friendly ok/error-message pair *before* attempting to build or persist a
+ * process should call this instead of duplicating the rules. Lives in
+ * ores.synthetic.api (not .service/.core) so it's usable from the Qt client,
+ * which cannot link the heavier service-layer libraries.
+ *
+ * For a mixing engine (geometric/arithmetic): means, stdevs and weights must
+ * have equal, non-empty size, every stdev must be non-negative, and the
+ * weights must sum to a positive number (the server builds a
+ * std::discrete_distribution from them, which is undefined behaviour over an
+ * all-zero or empty set).
+ *
+ * For "ou" (single-regime, not a mixture): only stdevs.front() (sigma) and
+ * weights.front() (kappa) are used; sigma must be non-negative. kappa has no
+ * required sign — kappa <= 0 is a valid, if degenerate, driftless random walk.
+ *
+ * initial_price must be strictly positive for every engine.
+ */
+process_parameter_validation_result validate_process_parameters(
+    const std::string& process_type,
+    const std::vector<double>& means,
+    const std::vector<double>& stdevs,
+    const std::vector<double>& weights,
+    double initial_price);
+
+}
+
+#endif

--- a/projects/ores.synthetic/api/src/domain/process_parameter_validation.cpp
+++ b/projects/ores.synthetic/api/src/domain/process_parameter_validation.cpp
@@ -1,0 +1,79 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.synthetic.api/domain/process_parameter_validation.hpp"
+
+namespace ores::synthetic::domain {
+
+namespace {
+
+process_parameter_validation_result invalid(std::string message) {
+    return {false, std::move(message)};
+}
+
+process_parameter_validation_result validate_mixing(const std::vector<double>& means,
+                                                     const std::vector<double>& stdevs,
+                                                     const std::vector<double>& weights) {
+    if (means.empty() || stdevs.empty() || weights.empty())
+        return invalid("At least one component is required.");
+    if (means.size() != stdevs.size() || means.size() != weights.size())
+        return invalid("Component mean/volatility/weight counts must match.");
+    for (double s : stdevs)
+        if (s < 0.0)
+            return invalid("Volatility (σ) cannot be negative.");
+    double weightSum = 0.0;
+    for (double w : weights)
+        weightSum += w;
+    if (weightSum <= 0.0)
+        return invalid(
+            "All component weights are zero. At least one component must have a positive "
+            "weight.");
+    return {};
+}
+
+process_parameter_validation_result validate_ou(const std::vector<double>& stdevs,
+                                                 const std::vector<double>& weights) {
+    if (stdevs.empty() || weights.empty())
+        return invalid("Ornstein-Uhlenbeck requires κ (Weight) and σ (Volatility).");
+    if (stdevs.front() < 0.0)
+        return invalid("Volatility (σ) cannot be negative.");
+    return {};
+}
+
+}
+
+process_parameter_validation_result validate_process_parameters(
+    const std::string& process_type,
+    const std::vector<double>& means,
+    const std::vector<double>& stdevs,
+    const std::vector<double>& weights,
+    double initial_price) {
+
+    if (initial_price <= 0.0)
+        return invalid("Initial price must be positive.");
+
+    if (process_type == "ou")
+        return validate_ou(stdevs, weights);
+
+    // "geometric", "arithmetic", and any unrecognised value all use the mixing
+    // rule — matches process_factory::make_process's fallback-to-geometric.
+    return validate_mixing(means, stdevs, weights);
+}
+
+}

--- a/projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org
+++ b/projects/ores.synthetic/modeling/ores.synthetic.fx_spot_generation_config.org
@@ -151,7 +151,8 @@ faker::number::integer(1, 3600)
 :default_value: "geometric"
 :END:
 
-Price-process engine: "geometric" (multiplicative) or "arithmetic" (additive).
+Price-process engine: "geometric" (multiplicative), "arithmetic"
+(additive), or "ou" (Ornstein-Uhlenbeck, mean-reverting).
 
 #+begin_src cpp :name generator
 std::string("geometric")
@@ -188,7 +189,7 @@ faker::datatype::boolean()
 | "ore_key" <> ''                                       |
 | "gmm_initial_price" > 0                               |
 | "ticks_per_hour" > 0                                  |
-| "process_type" in ('geometric', 'arithmetic')         |
+| "process_type" in ('geometric', 'arithmetic', 'ou')   |
 
 ** Soft FK validations
 
@@ -278,7 +279,7 @@ faker::datatype::boolean()
 | quote_currency_code | Quote Currency      | quoteCurrencyEdit    | line_edit |        | true        | Enter quote currency code       |
 | gmm_initial_price   | Initial Price       | gmmInitialPriceEdit  | line_edit |        | true        | Enter initial price             |
 | ticks_per_hour      | Ticks per Hour      | ticksPerHourEdit     | spin_box  |        | true        |                                 |
-| process_type        | Process Type        | processTypeEdit      | line_edit |        | true        | geometric or arithmetic         |
+| process_type        | Process Type        | processTypeEdit      | line_edit |        | true        | geometric, arithmetic, or ou    |
 | enabled             | Enabled             | enabledCheck         | check_box |        |             |                                 |
 
 *** Columns (Qt model)

--- a/projects/ores.synthetic/service/src/process_factory.cpp
+++ b/projects/ores.synthetic/service/src/process_factory.cpp
@@ -21,6 +21,8 @@
 #include "ores.logging/make_logger.hpp"
 #include "processes/arithmetic_gmm_process.hpp"
 #include "processes/gmm_process.hpp"
+#include "processes/ou_process.hpp"
+#include <stdexcept>
 
 namespace ores::synthetic::service {
 
@@ -41,6 +43,15 @@ process_factory::make_process(const std::string& process_type,
     if (process_type == "arithmetic")
         return std::make_unique<arithmetic_gmm_process>(
             std::move(means), std::move(stdevs), std::move(weights), initial_price, seed);
+    if (process_type == "ou") {
+        if (stdevs.empty() || weights.empty())
+            throw std::invalid_argument(
+                "ou process requires at least one component (weights[0] = kappa, "
+                "stdevs[0] = sigma)");
+        const double kappa = weights.front();
+        const double sigma = stdevs.front();
+        return std::make_unique<ou_process>(kappa, initial_price, sigma, initial_price, seed);
+    }
     if (process_type != "geometric") {
         using namespace ores::logging;
         BOOST_LOG_SEV(lg(), warn) << "Unknown process_type '" << process_type

--- a/projects/ores.synthetic/service/src/process_factory.cpp
+++ b/projects/ores.synthetic/service/src/process_factory.cpp
@@ -19,6 +19,7 @@
  */
 #include "process_factory.hpp"
 #include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.api/domain/process_parameter_validation.hpp"
 #include "processes/arithmetic_gmm_process.hpp"
 #include "processes/gmm_process.hpp"
 #include "processes/ou_process.hpp"
@@ -40,14 +41,19 @@ process_factory::make_process(const std::string& process_type,
                               std::vector<double> weights,
                               double initial_price,
                               std::uint32_t seed) {
+    // Single source of truth for "are these parameters good?" — shared with the
+    // Qt client (ores.synthetic.api::domain::validate_process_parameters), so
+    // both surfaces enforce identical rules without duplicating them.
+    const auto validation =
+        ores::synthetic::domain::validate_process_parameters(
+            process_type, means, stdevs, weights, initial_price);
+    if (!validation.valid)
+        throw std::invalid_argument(validation.message);
+
     if (process_type == "arithmetic")
         return std::make_unique<arithmetic_gmm_process>(
             std::move(means), std::move(stdevs), std::move(weights), initial_price, seed);
     if (process_type == "ou") {
-        if (stdevs.empty() || weights.empty())
-            throw std::invalid_argument(
-                "ou process requires at least one component (weights[0] = kappa, "
-                "stdevs[0] = sigma)");
         const double kappa = weights.front();
         const double sigma = stdevs.front();
         return std::make_unique<ou_process>(kappa, initial_price, sigma, initial_price, seed);

--- a/projects/ores.synthetic/service/src/process_factory.hpp
+++ b/projects/ores.synthetic/service/src/process_factory.hpp
@@ -39,8 +39,16 @@ public:
     /**
      * @brief Build the price process for the given engine.
      *
-     * @param process_type "geometric" (GBM) or "arithmetic" (additive). Any
-     *        unrecognised value falls back to geometric.
+     * @param process_type "geometric" (GBM), "arithmetic" (additive), or "ou"
+     *        (Ornstein-Uhlenbeck, mean-reverting). Any unrecognised value
+     *        falls back to geometric.
+     *
+     * For "ou" the GMM component channels are repurposed as scalar
+     * parameters rather than a mixture (OU is a single-regime process, not a
+     * mixture): weights[0] = kappa (reversion speed), stdevs[0] = sigma
+     * (volatility), and initial_price doubles as theta (long-run mean) — the
+     * process reverts toward its own starting level by default. means is
+     * unused for "ou".
      */
     static std::unique_ptr<ores::marketdata::domain::IStochasticProcess>
     make_process(const std::string& process_type,

--- a/projects/ores.synthetic/service/src/processes/ou_process.cpp
+++ b/projects/ores.synthetic/service/src/processes/ou_process.cpp
@@ -1,0 +1,62 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ou_process.hpp"
+#include <cmath>
+#include <stdexcept>
+
+namespace ores::synthetic::service {
+
+ou_process::ou_process(double kappa,
+                       double theta,
+                       double sigma,
+                       double initial_price,
+                       std::uint32_t seed)
+    : kappa_(kappa)
+    , theta_(theta)
+    , sigma_(sigma)
+    , price_(initial_price)
+    , rng_(seed)
+    , normal_(0.0, 1.0) {
+
+    if (sigma_ < 0.0)
+        throw std::invalid_argument("ou_process: sigma must be non-negative");
+    if (initial_price <= 0.0)
+        throw std::invalid_argument("ou_process: initial_price must be positive");
+}
+
+double ou_process::next() {
+    const double z = normal_(rng_);
+    if (kappa_ > 0.0) {
+        const double decay = std::exp(-kappa_);
+        const double var = (1.0 - decay * decay) / (2.0 * kappa_);
+        price_ = theta_ + (price_ - theta_) * decay + sigma_ * std::sqrt(var) * z;
+    } else {
+        // kappa <= 0: no mean reversion — the kappa -> 0 limit of the exact
+        // discretisation above is a driftless random walk.
+        price_ += sigma_ * z;
+    }
+    return price_;
+}
+
+double ou_process::current() const {
+    return price_;
+}
+
+}

--- a/projects/ores.synthetic/service/src/processes/ou_process.hpp
+++ b/projects/ores.synthetic/service/src/processes/ou_process.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_SERVICE_PROCESSES_OU_PROCESS_HPP
+#define ORES_SYNTHETIC_SERVICE_PROCESSES_OU_PROCESS_HPP
+
+#include "ores.marketdata.api/domain/i_stochastic_process.hpp"
+#include <cstdint>
+#include <random>
+
+namespace ores::synthetic::service {
+
+/**
+ * @brief Ornstein-Uhlenbeck (mean-reverting) price process.
+ *
+ * dX = kappa * (theta - X) * dt + sigma * dW
+ *
+ * Advances using the exact per-tick discretisation (dt = 1 tick, matching the
+ * per-update convention the GMM engines use for their increments):
+ *   X_{t+1} = theta + (X_t - theta) * e^{-kappa} +
+ *             sigma * sqrt((1 - e^{-2*kappa}) / (2*kappa)) * Z,  Z ~ N(0, 1)
+ *
+ * kappa <= 0 degenerates to a driftless random walk (sigma * Z per tick),
+ * the kappa -> 0 limit of the variance term above.
+ */
+class ou_process final : public ores::marketdata::domain::IStochasticProcess {
+public:
+    ou_process(double kappa,
+              double theta,
+              double sigma,
+              double initial_price,
+              std::uint32_t seed = 42);
+
+    double next() override;
+    double current() const override;
+
+private:
+    double kappa_;
+    double theta_;
+    double sigma_;
+    double price_;
+    std::mt19937 rng_;
+    std::normal_distribution<double> normal_;
+};
+
+}
+
+#endif


### PR DESCRIPTION
## Summary

Tidy up loose ends from the GMM-based synthetic market data generation work: readable chart axes, per-component PDF display, and a new Ornstein-Uhlenbeck process engine.

## Changes

- Fix invisible axis labels on the GMM preview charts (dark-theme QWidget::palette() bug — app theme is QSS-only, never QApplication::setPalette)
- Render each GMM component's own PDF curve with a matching colour-swatch indicator, alongside the combined mixture PDF in a distinct colour
- Implement Ornstein-Uhlenbeck as a new synthetic price-process engine end-to-end (ou_process, process_factory dispatch, SQL constraint, UI)
- Fix change-reason-code string literals to use existing ores.dq.api constants (reported during the session)
- Set source/point_id (tenor) on synthetic market observations, previously left empty (reported during the session)
- File backlog captures for out-of-scope process types (jump/Poisson, cross-rate correlation) and an unrelated SQL-codegen template drift

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [GMM improvements: tidy up synthetic data generation loose ends](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/gmm-improvements/story.html) | F4604E72-EF59-4894-A6D4-A68971C793EB |
| Task | [Add X/Y axis labels to GMM preview charts](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/gmm-improvements/task_gmm-chart-axes.html) | 7CB8B816-BE19-4E02-B0C0-7A800EAD6344 |

**Environment:** #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED

🤖 Generated with [Claude Code](https://claude.com/claude-code)