### PR TITLE
[marketdata] Fix uninitialized asset_class/series_subclass in market_series generator

### DIFF
--- a/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/story.org
+++ b/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/story.org
@@ -15,17 +15,20 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+Eliminate the two Valgrind uninitialized-memory defects the nightly
+=linux-gcc-debug-ninja= dynamic-analysis run flagged in
+=ores.marketdata.core.tests= so the CDash dashboard reports a clean
+run for this component.
 
 * Status
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing. |
 | Last touched  | 2026-07-03                               |
 
 * Acceptance
@@ -36,10 +39,27 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:B6BAAABC-C602-4413-A223-9AD532384934][Set asset_class/series_subclass in generate_synthetic_market_series]] | BACKLOG | | | generate_synthetic_market_series() never assigns r.asset_class/r.series_subclass, leaving both enum fields uninitialized; market_series_mapper::map() then calls rfl::enum_to_string() on the garbage value, which Valgrind flags as an uninitialized-memory conditional/read via enchantum::contains. Assign both fields deterministically from the generation index. |
+| [[id:B6BAAABC-C602-4413-A223-9AD532384934][Set asset_class/series_subclass in generate_synthetic_market_series]] | DONE | | 2026-07-03 | generate_synthetic_market_series() never assigns r.asset_class/r.series_subclass, leaving both enum fields uninitialized; market_series_mapper::map() then calls rfl::enum_to_string() on the garbage value, which Valgrind flags as an uninitialized-memory conditional/read via enchantum::contains. Assign both fields deterministically from the generation index. |
 
 * Decisions
 
+Fixed the generator (root cause) rather than the struct default — kept
+=domain::market_series= consistent with sibling domain structs, which
+also leave required enum fields without default member initializers,
+relying on the generator/mapper to always set them.
+
 * Out of scope
 
--
+- Did not audit other generators for the same missing-field pattern;
+  worth a follow-up sweep if this class of bug recurs.
+
+* Result
+
+Both Valgrind defects (Uninitialized Memory Conditional, Uninitialized
+Memory Read) from
+https://my.cdash.org/builds/3701562/dynamic_analysis/7928918 are fixed
+by [[id:B6BAAABC-C602-4413-A223-9AD532384934][the one task]] in this
+story. Verified locally: =ores.marketdata.core.tests= builds clean and
+runs 0-error under =valgrind= with the project's own
+=build/valgrind/custom.supp= suppressions and =CTest.cmake= memcheck
+flags.

--- a/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/story.org
+++ b/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/story.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: 83B12C2D-5202-4738-8147-5F28E566D997
+:END:
+#+title: Story: Fix uninitialized asset_class/series_subclass in market_series generator
+#+description: compass.sh CDash nightly Valgrind run flagged Uninitialized Memory Conditional/Read defects in market_series_mapper::map() via rfl::enum_to_string, traced to generate_synthetic_market_series() never setting asset_class/series_subclass before the mapper serializes them.
+#+type: story
+#+level: s2
+#+filetags: :marketdata:bugfix:valgrind:ci:sprint_22:v0:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-07-03                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:B6BAAABC-C602-4413-A223-9AD532384934][Set asset_class/series_subclass in generate_synthetic_market_series]] | BACKLOG | | | generate_synthetic_market_series() never assigns r.asset_class/r.series_subclass, leaving both enum fields uninitialized; market_series_mapper::map() then calls rfl::enum_to_string() on the garbage value, which Valgrind flags as an uninitialized-memory conditional/read via enchantum::contains. Assign both fields deterministically from the generation index. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
+++ b/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
@@ -7,41 +7,63 @@
 #+level: s1
 #+filetags: :marketdata:bugfix:valgrind:sprint_22:v0:fix_market_series_generator_uninitialized_enums:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-market-series-generator-uninitialized-enums
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
 #+updated: 2026-07-03
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Assign =r.asset_class= and =r.series_subclass= in
+=generate_synthetic_market_series()= so no field of the generated
+=domain::market_series= is left uninitialized, eliminating the
+Valgrind uninitialized-memory defects surfaced by the nightly
+=linux-gcc-debug-ninja= dynamic-analysis run
+(https://my.cdash.org/builds/3701562/dynamic_analysis/7928918).
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-03                               |
 
 * Acceptance
 
--
+- =r.asset_class= and =r.series_subclass= are always assigned a valid enumerator.
+- =ores.marketdata.core.tests [repository]= passes under
+  =valgrind --track-origins=yes --suppressions=build/valgrind/custom.supp=
+  with 0 errors.
 
 * Plan
 
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+Traced the CDash Valgrind report's stack trace (=enchantum::contains=
+→ =rfl::enum_to_string= → =market_series_mapper::map= →
+=market_series_repository::write=, in the
+=write_single_market_series= test) to
+=market_series_mapper.cpp:81= (=r.asset_class =
+=rfl::enum_to_string(v.asset_class)=). =v= came from
+=generate_synthetic_market_series()=, which builds every other field
+of =domain::market_series= but never touches =asset_class= or
+=series_subclass= — both plain =enum class= members with no default
+member initializer in the struct, so they held whatever garbage was on
+the stack. Fixed by cycling both fields deterministically through
+their full enumerator sets, keyed off the existing per-call =idx=
+counter (matching the file's existing pattern for other fields).
 
 * Notes
 
@@ -58,3 +80,16 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Fixed =generate_synthetic_market_series()= to assign =r.asset_class= and
+=r.series_subclass= by cycling deterministically through both enums'
+full enumerator sets using the existing =idx= counter.
+=ores.marketdata.core.tests= builds clean and
+=valgrind --error-exitcode=1 --track-origins=yes --trace-children=yes
+--tool=memcheck --leak-check=full --show-reachable=yes --num-callers=50
+--suppressions=build/valgrind/custom.supp= against the =[repository]=
+tag tests reports =0 errors from 0 contexts= (all 15 test cases pass),
+matching the project's own CTest memcheck configuration
+(=CTest.cmake=). This directly addresses both defects (Uninitialized
+Memory Conditional, Uninitialized Memory Read) from the CDash nightly
+run.

--- a/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
+++ b/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
@@ -8,7 +8,7 @@
 #+filetags: :marketdata:bugfix:valgrind:sprint_22:v0:fix_market_series_generator_uninitialized_enums:
 #+owner: marco
 #+branch: feature/fix-market-series-generator-uninitialized-enums
-#+pr:
+#+pr: 1412
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
@@ -71,7 +71,7 @@ counter (matching the file's existing pattern for other fields).
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1412][#1412]] | [marketdata] Fix uninitialized asset_class/series_subclass in market_series generator |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
+++ b/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: B6BAAABC-C602-4413-A223-9AD532384934
+:END:
+#+title: Task: Set asset_class/series_subclass in generate_synthetic_market_series
+#+description: generate_synthetic_market_series() never assigns r.asset_class/r.series_subclass, leaving both enum fields uninitialized; market_series_mapper::map() then calls rfl::enum_to_string() on the garbage value, which Valgrind flags as an uninitialized-memory conditional/read via enchantum::contains. Assign both fields deterministically from the generation index.
+#+type: task
+#+level: s1
+#+filetags: :marketdata:bugfix:valgrind:sprint_22:v0:fix_market_series_generator_uninitialized_enums:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-03                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -126,7 +126,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 | [[id:D628C0F8-C916-43CC-ADBE-FCC6758E1B88][Upgrade Qt to latest supported version to fix macOS 15 AGL removal]] | BACKLOG | | | Qt 6.8.x references -framework AGL (removed in macOS 15); the latest supported Qt drops that dependency. CI pinned to macos-14 as stopgap. |
 | [[id:3545641D-96DD-41DA-B4FF-B5FE43D56CA2][Canary CI: near-zero sccache hit rate makes every build a cold rebuild]] | STARTED | 2026-07-03 | | Cache-quota fix applied but doesn't explain the magnitude (32 files changed vs. 98.6% miss rate); running a live zero-source-diff experiment. |
 | [[id:05243CFE-F838-4759-9956-9400D6C90FDC][Fix NATS port collision with legacy env and label inconsistency]] | DONE | 2026-07-03 | 2026-07-03 | solid_dirac's NATS ports collided with a stray legacy env's server; migrate to base-port-derived NATS ports and unify the config label to underscore form. |
-| [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] | STARTED | 2026-07-03 | | Nightly Valgrind flagged uninitialized-memory defects in market_series_mapper::map(); generate_synthetic_market_series() never set the two enum fields. |
+| [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] | DONE | 2026-07-03 | 2026-07-03 | Nightly Valgrind flagged uninitialized-memory defects in market_series_mapper::map(); generate_synthetic_market_series() never set the two enum fields. |
 
 ** Documentation
 

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -126,6 +126,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 | [[id:D628C0F8-C916-43CC-ADBE-FCC6758E1B88][Upgrade Qt to latest supported version to fix macOS 15 AGL removal]] | BACKLOG | | | Qt 6.8.x references -framework AGL (removed in macOS 15); the latest supported Qt drops that dependency. CI pinned to macos-14 as stopgap. |
 | [[id:3545641D-96DD-41DA-B4FF-B5FE43D56CA2][Canary CI: near-zero sccache hit rate makes every build a cold rebuild]] | STARTED | 2026-07-03 | | Cache-quota fix applied but doesn't explain the magnitude (32 files changed vs. 98.6% miss rate); running a live zero-source-diff experiment. |
 | [[id:05243CFE-F838-4759-9956-9400D6C90FDC][Fix NATS port collision with legacy env and label inconsistency]] | DONE | 2026-07-03 | 2026-07-03 | solid_dirac's NATS ports collided with a stray legacy env's server; migrate to base-port-derived NATS ports and unify the config label to underscore form. |
+| [[id:83B12C2D-5202-4738-8147-5F28E566D997][Fix uninitialized asset_class/series_subclass in market_series generator]] | STARTED | 2026-07-03 | | Nightly Valgrind flagged uninitialized-memory defects in market_series_mapper::map(); generate_synthetic_market_series() never set the two enum fields. |
 
 ** Documentation
 

--- a/projects/ores.marketdata/api/src/generators/market_series_generator.cpp
+++ b/projects/ores.marketdata/api/src/generators/market_series_generator.cpp
@@ -20,6 +20,7 @@
 #include "ores.marketdata.api/generators/market_series_generator.hpp"
 #include "ores.utility/generation/generation_keys.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
+#include <array>
 #include <atomic>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include <string>
@@ -27,6 +28,25 @@
 namespace ores::marketdata::generators {
 
 using ores::utility::generation::generation_keys;
+
+namespace {
+
+constexpr std::array<domain::asset_class, 8> asset_classes{
+    domain::asset_class::fx,        domain::asset_class::rates,     domain::asset_class::credit,
+    domain::asset_class::equity,    domain::asset_class::commodity, domain::asset_class::inflation,
+    domain::asset_class::bond,      domain::asset_class::cross_asset};
+
+constexpr std::array<domain::series_subclass, 15> series_subclasses{
+    domain::series_subclass::spot,         domain::series_subclass::forward,
+    domain::series_subclass::volatility,   domain::series_subclass::yield,
+    domain::series_subclass::basis,        domain::series_subclass::fra,
+    domain::series_subclass::xccy,         domain::series_subclass::spread,
+    domain::series_subclass::index_credit, domain::series_subclass::recovery,
+    domain::series_subclass::swap,         domain::series_subclass::capfloor,
+    domain::series_subclass::seasonality,  domain::series_subclass::price,
+    domain::series_subclass::correlation};
+
+}
 
 domain::market_series
 generate_synthetic_market_series(utility::generation::generation_context& ctx) {
@@ -45,6 +65,9 @@ generate_synthetic_market_series(utility::generation::generation_context& ctx) {
     r.series_type = std::string(faker::word::noun()) + "-" + std::to_string(idx);
     r.metric = std::string(faker::word::noun()) + "-" + std::to_string(idx);
     r.qualifier = std::string(faker::word::noun()) + "-" + std::to_string(idx);
+    r.asset_class = asset_classes[static_cast<std::size_t>(idx) % asset_classes.size()];
+    r.series_subclass =
+        series_subclasses[static_cast<std::size_t>(idx) % series_subclasses.size()];
     r.modified_by = modified_by;
     r.performed_by = modified_by;
     r.change_reason_code = "system.test";


### PR DESCRIPTION
## Summary

Nightly Valgrind (linux-gcc-debug-ninja) flagged Uninitialized Memory Conditional/Read defects in market_series_mapper::map(); traced to generate_synthetic_market_series() never setting the two enum fields.

## Changes

- generate_synthetic_market_series() now cycles asset_class and series_subclass deterministically through their full enumerator sets, keyed off the existing per-call index counter
- Verified 0 valgrind errors on ores.marketdata.core.tests [repository] with the project's own build/valgrind/custom.supp suppressions and CTest.cmake memcheck flags

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix uninitialized asset_class/series_subclass in market_series generator](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/story.html) | 83B12C2D-5202-4738-8147-5F28E566D997 |
| Task | [Set asset_class/series_subclass in generate_synthetic_market_series](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/fix_market_series_generator_uninitialized_enums/task_fix_market_series_generator_uninitialized_enums.html) | B6BAAABC-C602-4413-A223-9AD532384934 |

**Environment:** solid_dirac

🤖 Generated with [Claude Code](https://claude.com/claude-code)