### PR TITLE
[compass] Add client start/stop subcommands

### DIFF
--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/story.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/story.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: 25A93F0B-FD5C-4EA1-9194-093073B44C44
+:END:
+#+title: Story: Add compass client start/stop subcommands
+#+description: compass client was a flat command (only launch, no way to stop via compass); every other Operate-pillar command (services, env, nats) uses start/stop/status subcommands. Add client start (existing launch behaviour) and client stop (--colour-scoped PID termination, reusing the same terminate logic as services stop).
+#+type: story
+#+level: s2
+#+filetags: :compass:cli:devx:sprint_22:v0:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-07-03                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:22B3B8D4-3937-47BB-B378-847D72F95D12][Implement compass client start/stop subcommands]] | BACKLOG | | | Rework run_client() in compass_services.py to use argparse subparsers matching compass services; rename cmd_client to cmd_client_start; extract the PID-terminate logic from cmd_stop's closure into a shared _terminate() helper and add cmd_client_stop. Update the devops-run-client skill and user-manual chapter_2_connecting references from the old flat compass client invocation. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/story.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/story.org
@@ -21,11 +21,11 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing. |
 | Last touched  | 2026-07-03                               |
 
 * Acceptance
@@ -36,7 +36,7 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:22B3B8D4-3937-47BB-B378-847D72F95D12][Implement compass client start/stop subcommands]] | BACKLOG | | | Rework run_client() in compass_services.py to use argparse subparsers matching compass services; rename cmd_client to cmd_client_start; extract the PID-terminate logic from cmd_stop's closure into a shared _terminate() helper and add cmd_client_stop. Update the devops-run-client skill and user-manual chapter_2_connecting references from the old flat compass client invocation. |
+| [[id:22B3B8D4-3937-47BB-B378-847D72F95D12][Implement compass client start/stop subcommands]] | DONE | | 2026-07-03 | Rework run_client() in compass_services.py to use argparse subparsers matching compass services; rename cmd_client to cmd_client_start; extract the PID-terminate logic from cmd_stop's closure into a shared _terminate() helper and add cmd_client_stop. Update the devops-run-client skill and user-manual chapter_2_connecting references from the old flat compass client invocation. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:cli:devx:sprint_22:v0:add_compass_client_start_stop_subcommands:
 #+owner: marco
 #+branch: feature/add-compass-client-start-stop-subcommands
-#+pr:
+#+pr: 1416
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
@@ -69,7 +69,7 @@ PID file name.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1416][#1416]] | [compass] Add client start/stop subcommands |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
@@ -75,7 +75,11 @@ PID file name.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Bare compass client bearings hint now errors (subcommand required) | compass.py:4915 | Accepted | Flagged by all 3 review passes; fixed to `compass client start` |
+| 2 | Stale start-client.sh migration comment still says "compass client" | compass_services.py:10 | Accepted | Fixed |
+| 3 | client missing from top-level --help epilog | compass.py:5912 | Accepted | Added `client: start | stop (operate)` line |
+| 4 | Duplicated "unknown colour" error string across start/stop | compass_services.py | Declined | Minor DRY nit, not worth the indirection for a 2-line string |
+| 5 | No `client status` subcommand | (n/a) | Declined | Out of scope — task's acceptance criteria only called for start/stop |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
@@ -33,9 +33,9 @@ launched and torn down consistently with the rest of compass.
 |--------------+----------------------------------------|
 | State        | DONE                              |
 | Parent story | [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] |
-| Now          | Done. Verified start/stop against a live instance.       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | N/A.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-03                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
@@ -7,41 +7,61 @@
 #+level: s1
 #+filetags: :compass:cli:devx:sprint_22:v0:add_compass_client_start_stop_subcommands:
 #+owner: marco
-#+branch:
+#+branch: feature/add-compass-client-start-stop-subcommands
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
 #+updated: 2026-07-03
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+While manually verifying party_type Qt UI, launched the client with the
+old flat =compass client --colour ...= syntax and noticed it has no
+=stop= counterpart, unlike every other Operate-pillar command
+(=services start/stop/status=, =env configure=, =nats init=). Add
+=compass client start=/=compass client stop= so the client can be
+launched and torn down consistently with the rest of compass.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] |
-| Now          | Not yet started.                       |
+| Now          | Done. Verified start/stop against a live instance.       |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | N/A.                  |
 | Last touched | 2026-07-03                               |
 
 * Acceptance
 
--
+- =compass client start --colour <c> --instance-name <n>= launches the
+  Qt client (unchanged behaviour from the old flat =compass client=).
+- =compass client stop --colour <c>= terminates the matching instance's
+  PID (SIGTERM, SIGKILL after a 10s grace period), scoped by =--colour=
+  the same way =start='s PID file is scoped.
+- =compass client --help= lists both subcommands.
+- Skill and manual references to the flat form are updated.
 
 * Plan
 
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+Extracted the PID-terminate logic that =cmd_stop= had inlined as a
+closure (capturing =stopped=/=gone= counters via =nonlocal=) into a
+standalone =_terminate(name, pid_file, grace)= helper returning
+=\"stopped\"=/=\"gone\"=, so both =cmd_stop= and the new
+=cmd_client_stop= share one implementation. Renamed =cmd_client= to
+=cmd_client_start= and factored colour resolution into
+=_client_colour()= so start and stop agree on how a colour maps to a
+PID file name.
 
 * Notes
 
@@ -58,3 +78,16 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+=projects/ores.compass/src/compass_services.py=: added =_terminate()=
+(shared by =cmd_stop= and the new =cmd_client_stop=), =_client_colour()=
+(shared by =cmd_client_start=/=cmd_client_stop=), renamed
+=cmd_client= → =cmd_client_start=, reworked =run_client()= to use
+=start=/=stop= subparsers like =run()= (services). Updated
+=projects/ores.compass/src/compass.py='s top-level help text, the
+=devops-run-client= skill, and =doc/manual/user_guide/chapter_2_connecting.org=.
+Verified live: =compass client start --colour green ...= launched
+=ores.qt=, =compass client stop --colour green= terminated it cleanly
+(SIGTERM, exited within grace period); =compass client stop --colour
+blue= against an already-exited instance correctly reported =gone=
+without touching an unrelated, separately-launched =ores.qt= process.

--- a/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
+++ b/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 22B3B8D4-3937-47BB-B378-847D72F95D12
+:END:
+#+title: Task: Implement compass client start/stop subcommands
+#+description: Rework run_client() in compass_services.py to use argparse subparsers matching compass services; rename cmd_client to cmd_client_start; extract the PID-terminate logic from cmd_stop's closure into a shared _terminate() helper and add cmd_client_stop. Update the devops-run-client skill and user-manual chapter_2_connecting references from the old flat compass client invocation.
+#+type: task
+#+level: s1
+#+filetags: :compass:cli:devx:sprint_22:v0:add_compass_client_start_stop_subcommands:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-03                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -113,7 +113,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 | [[id:3A9DF70D-07F7-46A7-8219-57A024707B64][compass generate catalogue]] | BACKLOG | | | Auto-regenerate catalogue/index org files by scanning tagged org files. |
 | [[id:20998FA2-2073-4956-AE46-EFDD44C0CFD1][Fix orphan documents and tag taxonomy]] | BACKLOG | | | Fix orphaned docs in org-roam graph; create tag inventory; add compass tag validation. |
 | [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] | DONE | | 2026-07-02 | Carried from sprint 21. |
-| [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] | STARTED | 2026-07-03 | | compass client was flat (launch-only); add start/stop matching the services/env/nats subcommand convention. |
+| [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] | DONE | 2026-07-03 | 2026-07-03 | compass client was flat (launch-only); add start/stop matching the services/env/nats subcommand convention. |
 | [[id:B7C756F2-985A-49FA-BE98-D50C4F418B51][Compass GitHub Actions support]] | STARTED | | | Give compass a quick overview of all GitHub Actions runs, highlight which ones are failing, and for failing runs surface the error detail via gh CLI without needing to download full logs. |
 
 ** Infrastructure

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -113,6 +113,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 | [[id:3A9DF70D-07F7-46A7-8219-57A024707B64][compass generate catalogue]] | BACKLOG | | | Auto-regenerate catalogue/index org files by scanning tagged org files. |
 | [[id:20998FA2-2073-4956-AE46-EFDD44C0CFD1][Fix orphan documents and tag taxonomy]] | BACKLOG | | | Fix orphaned docs in org-roam graph; create tag inventory; add compass tag validation. |
 | [[id:E051B3B8-3E96-437C-B1FE-7DE36D1DD4CE][Compass quality of life (Sprint 21)]] | DONE | | 2026-07-02 | Carried from sprint 21. |
+| [[id:25A93F0B-FD5C-4EA1-9194-093073B44C44][Add compass client start/stop subcommands]] | STARTED | 2026-07-03 | | compass client was flat (launch-only); add start/stop matching the services/env/nats subcommand convention. |
 | [[id:B7C756F2-985A-49FA-BE98-D50C4F418B51][Compass GitHub Actions support]] | STARTED | | | Give compass a quick overview of all GitHub Actions runs, highlight which ones are failing, and for failing runs surface the error detail via gh CLI without needing to download full logs. |
 
 ** Infrastructure

--- a/doc/llm/skills/devops-run-client/SKILL.org
+++ b/doc/llm/skills/devops-run-client/SKILL.org
@@ -27,9 +27,14 @@ Launching the Qt client, detached so the terminal stays free; colour and instanc
 1. /Launch/:
 
    #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh client --colour <colour> --instance-name <name>
+   ./projects/ores.compass/compass.sh client start --colour <colour> --instance-name <name>
    #+end_src
 
+2. /Stop/ (pass the same =--colour= the instance was started with):
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh client stop --colour <colour>
+   #+end_src
 
 * Recipes
 

--- a/doc/manual/user_guide/chapter_2_connecting.org
+++ b/doc/manual/user_guide/chapter_2_connecting.org
@@ -380,7 +380,7 @@ should connect to =local1=, not to staging or production. Rather than pick
 the label by hand each time, set it when you launch the client — the
 =--instance-name= command-line option (see [[*Telling windows apart (instance colour and name)][Telling windows apart]]) opens
 the client with the /Label/ already set, so Quick Connect is pre-filtered
-to that environment. The =compass client= command does this
+to that environment. The =compass client start= command does this
 for you, taking the label from =ORES_CHECKOUT_LABEL= in your =.env=.
 
 *** When the connection fails
@@ -543,7 +543,7 @@ ores --instance-name "Local dev" --instance-color 2196F3
 
 The colour and the name are independent: the colour is only a visual
 marker, and the name is what identifies the instance. If you launch via
-=compass client=, its =--colour red|green|blue|<hex>=
+=compass client start=, its =--colour red|green|blue|<hex>=
 sets the marker colour and =--name= sets the instance name; when you omit
 =--name=, the name comes from =ORES_CHECKOUT_LABEL= in your =.env= — never
 from the colour.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4912,7 +4912,7 @@ def cmd_bearings(argv):
                 print(f"  Client   : {_C_GREEN}running{_C_RESET}  ({_desc})")
             else:
                 print(f"  Client   : not running  "
-                      f"({_ycmd('compass client')})")
+                      f"({_ycmd('compass client start')})")
         except SystemExit:
             print("  Services : (no preset in .env — compass env configure)")
         # ── Genesis env check (when .env exists) ────────────────────────────
@@ -5910,6 +5910,7 @@ def main():
         "  db:       recreate | setup | drop | sql | reset-system | reset-tenant (provision)\n"
         "  sql:      alias for db sql — run SQL in the environment\n"
         "  services: start | stop | status | clear-logs (operate)\n"
+        "  client:   start | stop (operate)\n"
     )
     parser = argparse.ArgumentParser(
         description="Compass: developer toolkit for ORE Studio — orient, scaffold, capture, and search.",

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -5995,8 +5995,8 @@ def main():
                           help="Operate: service lifecycle — start, stop, "
                                "status, clear-logs")
     subparsers.add_parser("client",
-                          help="Operate: launch the Qt client (detached; "
-                               "--colour/--instance-name for parallel runs)")
+                          help="Operate: Qt client lifecycle — start (detached; "
+                               "--colour/--instance-name for parallel runs), stop")
     subparsers.add_parser("test",
                           help="Test: 'test results' shows last run overview; "
                                "'test logging on|off|status' toggles test logging; 'test --help'")

--- a/projects/ores.compass/src/compass_services.py
+++ b/projects/ores.compass/src/compass_services.py
@@ -7,7 +7,7 @@ Native port of the build/scripts service-lifecycle scripts:
     stop-services.sh    ->  compass services stop
     status-services.sh  ->  compass services status
     clear-logs.sh       ->  compass services clear-logs
-    start-client.sh     ->  compass client
+    start-client.sh     ->  compass client start
 
 The controller spawns IAM and every domain service; this module only
 manages nats-server, the controller, and the Qt client, plus PID-file

--- a/projects/ores.compass/src/compass_services.py
+++ b/projects/ores.compass/src/compass_services.py
@@ -303,36 +303,46 @@ def cmd_start(ctx, args):
     return 0 if ok else 1
 
 
+def _terminate(name, pid_file, grace) -> str:
+    """SIGTERM (then SIGKILL after `grace` seconds) the PID in `pid_file`.
+
+    Returns "stopped", "gone" (already dead / no PID file), for callers that
+    tally results across several processes.
+    """
+    pid = _read_pid(pid_file)
+    if pid is None:
+        print(f"  skip    {name} (no PID file — already stopped)")
+        return "gone"
+    pid_file.unlink(missing_ok=True)
+    if not _pid_alive(pid):
+        print(f"  gone    {name:<38} PID {pid}")
+        return "gone"
+    os.kill(pid, signal.SIGTERM)
+    print(f"  stop    {name:<38} PID {pid}")
+    print(f"Waiting for {name} to exit...", end="", flush=True)
+    for _ in range(grace * 2):
+        if not _pid_alive(pid):
+            break
+        time.sleep(0.5)
+        print(".", end="", flush=True)
+    print(" done")
+    if _pid_alive(pid):
+        os.kill(pid, signal.SIGKILL)
+        print(f"  killed  PID {pid} (did not exit within grace period)")
+    print()
+    return "stopped"
+
+
 def cmd_stop(ctx, args):
     print(f"Stopping ORE Studio services ({ctx.preset})\n")
     stopped = gone = 0
 
     def _term(name, pid_file, grace):
         nonlocal stopped, gone
-        pid = _read_pid(pid_file)
-        if pid is None:
-            print(f"  skip    {name} (no PID file — already stopped)")
+        if _terminate(name, pid_file, grace) == "stopped":
+            stopped += 1
+        else:
             gone += 1
-            return
-        pid_file.unlink(missing_ok=True)
-        if not _pid_alive(pid):
-            print(f"  gone    {name:<38} PID {pid}")
-            gone += 1
-            return
-        os.kill(pid, signal.SIGTERM)
-        print(f"  stop    {name:<38} PID {pid}")
-        stopped += 1
-        print(f"Waiting for {name} to exit...", end="", flush=True)
-        for _ in range(grace * 2):
-            if not _pid_alive(pid):
-                break
-            time.sleep(0.5)
-            print(".", end="", flush=True)
-        print(" done")
-        if _pid_alive(pid):
-            os.kill(pid, signal.SIGKILL)
-            print(f"  killed  PID {pid} (did not exit within grace period)")
-        print()
 
     print("[Controller]")
     # The controller must stop all its children before it exits: 30 s grace.
@@ -430,24 +440,32 @@ def cmd_clear_logs(ctx, args):
     return 0
 
 
-def cmd_client(ctx, args):
+def _client_colour(colour_arg):
+    """Resolve --colour to (hex, tag), or ("", "") if unset. Returns None on
+    an invalid value (caller prints the error and exits)."""
+    if not colour_arg:
+        return "", ""
+    c = colour_arg.lower()
+    if c in CLIENT_COLOURS:
+        return CLIENT_COLOURS[c], c
+    if len(c) == 6 and all(ch in "0123456789abcdef" for ch in c):
+        return c.upper(), c
+    return None
+
+
+def cmd_client_start(ctx, args):
     if not (ctx.bin_dir / "ores.qt").exists():
         print(f"error: ores.qt not found in {ctx.bin_dir}", file=sys.stderr)
         print(f"       cmake --build --preset {ctx.preset}", file=sys.stderr)
         return 1
     ctx.run_dir.mkdir(parents=True, exist_ok=True)
 
-    colour_hex = colour_tag = ""
-    if args.colour:
-        c = args.colour.lower()
-        if c in CLIENT_COLOURS:
-            colour_hex, colour_tag = CLIENT_COLOURS[c], c
-        elif len(c) == 6 and all(ch in "0123456789abcdef" for ch in c):
-            colour_hex, colour_tag = c.upper(), c
-        else:
-            print(f"error: unknown colour '{args.colour}' — use red, green, "
-                  f"blue, or a 6-digit hex value", file=sys.stderr)
-            return 1
+    resolved = _client_colour(args.colour)
+    if resolved is None:
+        print(f"error: unknown colour '{args.colour}' — use red, green, "
+              f"blue, or a 6-digit hex value", file=sys.stderr)
+        return 1
+    colour_hex, colour_tag = resolved
 
     pid_name = f"ores.qt.{colour_tag}" if colour_tag else "ores.qt"
     log_file = f"{pid_name}.log"
@@ -464,6 +482,19 @@ def cmd_client(ctx, args):
 
     _launch(ctx, pid_name, "ores.qt", client_args)
     print(f"\nLogs : {ctx.log_dir / log_file}")
+    return 0
+
+
+def cmd_client_stop(ctx, args):
+    resolved = _client_colour(args.colour)
+    if resolved is None:
+        print(f"error: unknown colour '{args.colour}' — use red, green, "
+              f"blue, or a 6-digit hex value", file=sys.stderr)
+        return 1
+    _, colour_tag = resolved
+    pid_name = f"ores.qt.{colour_tag}" if colour_tag else "ores.qt"
+    print(f"Stopping {pid_name} ({ctx.preset})\n")
+    _terminate(pid_name, ctx.run_dir / f"{pid_name}.pid", grace=10)
     return 0
 
 
@@ -510,14 +541,24 @@ def run(argv, project_root: Path) -> int:
 def run_client(argv, project_root: Path) -> int:
     ap = argparse.ArgumentParser(
         prog="compass client",
-        description="Operate pillar: launch the Qt client detached.")
-    _common(ap)
-    ap.add_argument("--colour", "--color", default=None,
+        description="Operate pillar: launch/stop the Qt client, detached.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+
+    st = sub.add_parser("start", help="Launch the Qt client detached")
+    _common(st)
+    st.add_argument("--colour", "--color", default=None,
                     help="red, green, blue, or 6-digit hex — instance accent")
-    ap.add_argument("--instance-name", default=None)
-    ap.add_argument("--log-level", default="debug")
+    st.add_argument("--instance-name", default=None)
+    st.add_argument("--log-level", default="debug")
+
+    sp = sub.add_parser("stop", help="Stop a running Qt client instance")
+    _common(sp)
+    sp.add_argument("--colour", "--color", default=None,
+                    help="Must match the --colour the instance was started "
+                         "with (default: the uncoloured instance)")
+
     args = ap.parse_args(argv)
     env = load_env(project_root)
     validate_env_version(project_root, env)
     ctx = Ctx(project_root, env, args.preset)
-    return cmd_client(ctx, args)
+    return {"start": cmd_client_start, "stop": cmd_client_stop}[args.subcmd](ctx, args)


### PR DESCRIPTION
## Summary

compass client was flat (launch-only), unlike services/env/nats which all use start/stop/status subcommands. Add client start/client stop matching that convention, with --colour support on both.

## Changes

- Renamed cmd_client to cmd_client_start; added cmd_client_stop, --colour-scoped PID termination
- Extracted shared _terminate() helper from cmd_stop's closure so both services stop and client stop reuse the same SIGTERM/SIGKILL-with-grace logic
- Updated devops-run-client skill and user-manual chapter_2_connecting references

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add compass client start/stop subcommands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/story.html) | 25A93F0B-FD5C-4EA1-9194-093073B44C44 |
| Task | [Implement compass client start/stop subcommands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/add_compass_client_start_stop_subcommands/task_add_compass_client_start_stop_subcommands.html) | 22B3B8D4-3937-47BB-B378-847D72F95D12 |

**Environment:** solid_dirac

🤖 Generated with [Claude Code](https://claude.com/claude-code)