### PR TITLE
[ci] Trigger canary run for sccache zero-diff experiment

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -36,7 +36,8 @@ jobs:
     environment: CI
     env:
       # Temporary: diagnosing near-zero sccache hit rate (story
-      # canary_ctest_ignores_cancellation). Remove once resolved.
+      # canary_ctest_ignores_cancellation, task
+      # analyze_sccache_zero_diff_experiment). Remove once resolved.
       SCCACHE_LOG: sccache=debug
       SCCACHE_ERROR_LOG: /tmp/sccache_debug.log
     steps:


### PR DESCRIPTION
## Summary
- Tiny trigger PR: touches canary-linux.yml (comment only) to get a fresh canary run with the SCCACHE_LOG=debug instrumentation landed in #1414, so the zero-source-diff experiment (task analyze_sccache_zero_diff_experiment) has a "run 1" to rerun for "run 2".

## Test plan
- [ ] Canary run 1 (this PR) completes
- [ ] `gh run rerun` on the same run for zero-diff run 2
- [ ] Compare sccache hit rates