### PR TITLE
[refdata] Sync C++ core codegen for currency

### DIFF
--- a/doc/agile/versions/v0/sprint_22/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/story.org
@@ -27,7 +27,7 @@ same checklist applies.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
+| State         | STARTED                                |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
 | Now           | Auxiliary codegen synced. Currency-entity codegen sync (C++ core, messaging, Qt) and Wt/HTTP captures remain. |
 | Waiting on    | Nothing.                               |
@@ -86,7 +86,7 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 | [[id:00B62E70-D961-4DFA-BAB4-BB3488B31C86][Sync C++ messaging codegen for currency auxiliaries]] | DONE | 2026-06-25 | 2026-06-26 | Re-run protocol, nats-eventing, and nats-handler profiles for rounding_type, monetary_nature, currency_market_tier; diff against repo; fix templates to match code. |
 | [[id:10B1976B-A785-44B0-8DFA-F315ADFD4B8B][Sync Qt codegen for currency auxiliaries]] | DONE | 2026-06-25 | 2026-06-26 | Re-run Qt profile for rounding_type, monetary_nature, currency_market_tier; diff against repo; fix templates to match code. |
 | [[id:84522F09-7044-4343-92E5-80588C2D325F][Define and implement entity view document type]] | DONE | | 2026-06-12 | Create entity view docs listing all artefacts per entity across every projection and component, with proj: links to artefacts and codegen archetypes; implement currency as the first example. |
-| [[id:8A84D304-431A-45CF-9E3C-6AC649F6A62F][Sync C++ core codegen for currency]] | BACKLOG | | | Re-run domain, repository, service, and generator profiles for currency; diff against repo; fix templates or code per drift classification. |
+| [[id:8A84D304-431A-45CF-9E3C-6AC649F6A62F][Sync C++ core codegen for currency]] | STARTED | 2026-07-02 | | Re-run domain, repository, service, and generator profiles for currency; diff against repo; fix templates or code per drift classification. |
 | [[id:8B15EE84-1727-43B5-85E4-96E58F1BE03B][Sync C++ messaging codegen for currency]] | BACKLOG | | | Re-run protocol, nats-eventing, and nats-handler profiles for currency; diff against repo; fix templates or code per drift classification. |
 | [[id:EA647CBC-18C7-4555-9A49-FBF55BC192FD][Sync Qt codegen for currency]] | BACKLOG | | | Re-run the qt profile for currency; diff the 12 output files against the repo; fix templates or code per drift classification. |
 | [[id:3CE7779C-7D20-4203-A4E9-1FBDBFAEF537][File Wt and HTTP gap captures for currency]] | BACKLOG | | | Identify Wt UI and HTTP handler gaps for currency discovered during commissioning and file them as backlog captures for future work. |

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
@@ -104,6 +104,10 @@ suite) — out of scope for this task.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =read_all_currencies= called =read_latest= instead of =read_all=, leaving =read_all(ctx)= uncovered (raised independently by all 3 review passes) | =repository_currency_repository_tests.cpp= | Accepted | Fixed in a6fe483e7 |
+| 2 | Missing explicit =#include <unordered_set>= after generator rewrite | =currency_generator.cpp= | Accepted | Fixed in a6fe483e7 |
+| 3 | Doxygen =/**@{*/= grouping lost when =read_all(ctx)= split out and moved | =currency_repository.hpp= | Declined | Cosmetic; matches modeling org layout |
+| 4 | Batch =remove(ctx, iso_codes)= behavior change: now scopes by =valid_to == max= | =currency_repository.cpp= | Declined (intentional) | Old code had no =valid_to= filter, so the delete-via-update rule would close every historical version instead of just the current one; now matches single-=remove= semantics and the org doc |
+| 5 | Task notes describe fixing a hardcoded =r.version = 1=, not found in the pre-PR base commit | task notes | Declined (clarified) | =r.version = 1= was present in the working tree at session start (introduced by a prior crashed agent run before this PR's base commit was captured), not in committed history; the fix itself is correct and verified against the insert trigger's optimistic-concurrency check |
 
 * Result

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/sync-cpp-core-codegen-currency
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-26
 #+updated: 2026-06-26
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ Ensure the C++ core codegen profiles (domain, repository, service, generator) pr
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-26
-#+updated: 2026-06-26
+#+updated: 2026-07-03
 #+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -28,10 +28,10 @@ Ensure the C++ core codegen profiles (domain, repository, service, generator) pr
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Not yet started.                       |
+| Now          | Codegen drift fixed for all four profiles; api/core build clean; currency tests green. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-26                               |
+| Next         | Raise PR.                              |
+| Last touched | 2026-07-03                               |
 
 * Acceptance
 
@@ -42,6 +42,55 @@ Ensure the C++ core codegen profiles (domain, repository, service, generator) pr
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+Re-ran the domain, repository, generator profiles against the currency
+entity and reconciled drift between codegen output and the checked-in
+code across api and core. Repository methods were updated to be
+tenant-aware (=tenant_id= now filters every query); pagination,
+=get_total_currency_count=, filtered =read_all=, and batch =remove= are
+now covered natively by the base =repository= template, so the modeling
+doc no longer pastes them as custom overrides — only the two
+=read_at_timepoint= overloads and the unfiltered =read_all=/=read_all=
+by iso_code remain hand-written (no native equivalent, needed by the
+CLI's =export --all-versions=/=export --as-of=).
+
+Also fixed the codegen diff tool itself
+(=compass_codegen_entity.py=): =_diff_entity= runs clang-format inside a
+bare =tempfile.TemporaryDirectory()=, which has no =.clang-format=
+ancestor to discover, so clang-format silently fell back to LLVM's
+2-space default style instead of the repo's 4-space style — every diff
+run showed spurious whole-file re-indentation noise on top of any real
+drift. Seeded the tempdir root with a copy of the repo's
+=.clang-format= to fix this for all future entity diffs, not just
+currency.
+
+During verification found and fixed two real bugs introduced by the
+in-flight generator rewrite:
+- =generate_synthetic_currency= assigned =r.symbol =
+  std::string(faker::finance::currencySymbol());= directly;
+  faker-cxx's currency data set includes some real-world currencies
+  with an empty symbol, so ~generate_single_currency~ failed
+  intermittently (confirmed via 20x stress run before/after). Fixed
+  with a fallback to =\"$\"= when faker returns empty.
+- =generate_synthetic_currency= hardcoded =r.version = 1;=, but the
+  domain type's =version= field defaults to 0, which the insert
+  trigger (=ores_refdata_currencies_insert_fn=) treats as "don't
+  care" for optimistic concurrency. Hardcoding 1 broke any test that
+  writes the same currency object multiple times without bumping
+  =.version= (e.g. =build_versions_from_repository_history=), which
+  surfaced as an intermittent "Version conflict: expected version 1,
+  but current version is 2" once the row's real version advanced past
+  1. Removed the hardcoded assignment so it defaults to 0.
+
+Verified: =ores.refdata.api.lib=, =ores.refdata.core.lib=,
+=ores.refdata.api.tests=, =ores.refdata.core.tests= all build clean.
+=ores.refdata.api.tests= full suite green (412 assertions/71 cases).
+Currency-scoped tests in both suites green, repeatedly. Noted but did
+not chase: an unrelated, pre-existing hang in
+=ores.refdata.core.tests= (reproduces on unmodified =main=, unrelated
+to currency — hits different party/counterparty tests depending on
+random seed, looks like a leaked DB connection/lock under the full
+suite) — out of scope for this task.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
 #+branch: feature/sync-cpp-core-codegen-currency
-#+pr:
+#+pr: 1419
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-26
@@ -98,7 +98,7 @@ suite) — out of scope for this task.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1419][#1419]] | [refdata] Sync C++ core codegen for currency |
 
 * Review
 

--- a/projects/ores.compass/src/compass_codegen_entity.py
+++ b/projects/ores.compass/src/compass_codegen_entity.py
@@ -182,6 +182,14 @@ def _diff_entity(model_path: Path, base_dir: Path, project_root: Path,
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_root = Path(tmpdir)
+        # clang-format only discovers .clang-format by walking up from the
+        # formatted file; a bare tempdir has no such ancestor, so it silently
+        # falls back to LLVM's default style (2-space indent) instead of the
+        # repo's 4-space style. Seed the tempdir root with a copy so the
+        # diff reflects real drift, not this formatting artefact.
+        repo_clang_format = project_root / ".clang-format"
+        if repo_clang_format.exists():
+            (tmp_root / ".clang-format").write_bytes(repo_clang_format.read_bytes())
         logging.disable(logging.CRITICAL)
         try:
             for unit in units:

--- a/projects/ores.refdata/api/include/ores.refdata.api/domain/currency.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/domain/currency.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -29,7 +29,11 @@
 namespace ores::refdata::domain {
 
 /**
- * @brief Represents a currency with its metadata and formatting rules.
+ * @brief ISO 4217 currency definitions.
+ *
+ * ISO 4217 currency definitions used for reference data.
+ * Currencies are managed per-tenant and drive financial calculations,
+ * rounding, and display formatting across the system.
  */
 struct currency final {
     /**
@@ -43,67 +47,82 @@ struct currency final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief ISO 4217 alphabetic code (e.g., "USD").
+     * @brief ISO 4217 alpha-3 code (e.g., "USD", "EUR", "GBP").
+     *
+     * No :name generator block is defined for this primary key. The synthetic
+     * generate_synthetic_currency function produces counter-based codes; the fictional generator
+     * (generate_fictional_currencies, injected via custom generator sections below) is the
+     * authoritative test-data source and does not rely on the template-generated synthetic path.
      */
     std::string iso_code;
 
     /**
-     * @brief Full name of the currency (e.g., "United States Dollar").
+     * @brief Human-readable currency name (e.g., "US Dollar", "Euro").
      */
     std::string name;
 
     /**
-     * @brief ISO 4217 numeric code (e.g., "840").
+     * @brief ISO 4217 numeric code (e.g., "840", "978").
      */
     std::string numeric_code;
+
     /**
-     * @brief Currency symbol (e.g., "$").
+     * @brief Currency symbol displayed in the UI (e.g., "$", "€", "£").
      */
     std::string symbol;
+
     /**
-     * @brief Symbol for fractional unit (e.g., "cent").
+     * @brief Symbol for the fractional unit (e.g., "¢" for cents, "p" for pence).
      */
     std::string fraction_symbol;
 
     /**
-     * @brief Number of fractional units per whole unit (e.g., 100 for cents).
+     * @brief Number of fractional units per whole unit (e.g., 100 for centesimal, 0 for
+     * zero-decimal).
      */
-    int fractions_per_unit;
+    int fractions_per_unit = 0;
 
     /**
-     * @brief Rounding method for fractional amounts.
+     * @brief Rounding method code; soft FK to ores_refdata_rounding_types_tbl.
      */
     std::string rounding_type;
 
     /**
-     * @brief Decimal places to round to during formatting.
+     * @brief Number of decimal places for rounding (e.g., 2 for centesimal currencies).
      */
-    int rounding_precision;
+    int rounding_precision = 0;
 
     /**
-     * @brief Format string for display.
+     * @brief Boost.Format pattern for displaying amounts (e.g., "%3% %1$.2f").
      */
     std::string format;
 
     /**
-     * @brief Monetary nature (e.g., fiat, commodity, synthetic, supranational).
+     * @brief Nature classification; soft FK to ores_refdata_monetary_natures_tbl (e.g., "fiat",
+     * "commodity").
      */
     std::string monetary_nature;
 
     /**
-     * @brief Market tier classification (e.g., g10, emerging, exotic, frontier, historical).
+     * @brief Market tier classification; soft FK to ores_refdata_currency_market_tiers_tbl (e.g.,
+     * "g10", "emerging").
      */
     std::string market_tier;
 
     /**
-     * @brief Optional reference to a flag image in the images table.
+     * @brief Optional reference to a flag or logo image in the images table.
      */
     std::optional<boost::uuids::uuid> image_id;
 
     /**
-     * @brief Username of the person who recorded this version in the system.
+     * @brief Username of the person who last modified this currency.
      */
     std::string modified_by;
+
+    /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
 
     /**
      * @brief Code identifying the reason for the change.
@@ -118,12 +137,7 @@ struct currency final {
     std::string change_commentary;
 
     /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
-
-    /**
-     * @brief Timestamp when this version of the record was recorded in the system.
+     * @brief Timestamp when this version of the record was recorded.
      */
     std::chrono::system_clock::time_point recorded_at;
 };

--- a/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_json_io.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_json_io.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -26,6 +26,9 @@
 
 namespace ores::refdata::domain {
 
+/**
+ * @brief Dumps the currency to a stream in JSON format.
+ */
 ORES_REFDATA_API_EXPORT std::ostream& operator<<(std::ostream& s, const currency& v);
 
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_table.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_table.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -28,12 +28,7 @@
 namespace ores::refdata::domain {
 
 /**
- * @brief Converts a single currency to table format string.
- */
-ORES_REFDATA_API_EXPORT std::string convert_to_table(const currency& c);
-
-/**
- * @brief Converts a vector of currencies to table format string.
+ * @brief Converts currencies to the table format.
  */
 ORES_REFDATA_API_EXPORT std::string convert_to_table(const std::vector<currency>& v);
 

--- a/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_table_io.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/domain/currency_table_io.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -28,12 +28,7 @@
 namespace ores::refdata::domain {
 
 /**
- * @brief Prints currencies to a stream in table format.
- */
-ORES_REFDATA_API_EXPORT void print_currency_table(std::ostream& s, const std::vector<currency>& v);
-
-/**
- * @brief Dumps the currency object to a stream in table format.
+ * @brief Dumps the currency objects to a stream in table format.
  */
 ORES_REFDATA_API_EXPORT std::ostream& operator<<(std::ostream& s, const std::vector<currency>& v);
 

--- a/projects/ores.refdata/api/include/ores.refdata.api/generators/currency_generator.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/generators/currency_generator.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_DOMAIN_CURRENCY_GENERATORHPP
-#define ORES_REFDATA_DOMAIN_CURRENCY_GENERATORHPP
+#ifndef ORES_REFDATA_API_GENERATORS_CURRENCY_GENERATOR_HPP
+#define ORES_REFDATA_API_GENERATORS_CURRENCY_GENERATOR_HPP
 
 #include "ores.refdata.api/domain/currency.hpp"
 #include "ores.refdata.api/export.hpp"
@@ -34,23 +34,21 @@ ORES_REFDATA_API_EXPORT domain::currency
 generate_synthetic_currency(utility::generation::generation_context& ctx);
 
 /**
- * @brief Generates a synthetic currency from the unicode set.
- */
-ORES_REFDATA_API_EXPORT std::vector<domain::currency>
-generate_synthetic_unicode_currencies(utility::generation::generation_context& ctx);
-
-/**
- * @brief Generates N synthetic currencies. May contain duplicates.
- *
- * @note c++ 23 generators are not supported on all compilers.
+ * @brief Generates N synthetic currencies.
  */
 ORES_REFDATA_API_EXPORT std::vector<domain::currency>
 generate_synthetic_currencies(std::size_t n, utility::generation::generation_context& ctx);
 
 /**
- * @brief Generates N synthetic currencies. Does not contain duplicates.
+ * @brief Generates a set of currencies using Unicode symbols.
  *
- * @note c++ 23 generators are not supported on all compilers.
+ * Used for testing internationalisation and symbol rendering.
+ */
+ORES_REFDATA_API_EXPORT std::vector<domain::currency>
+generate_synthetic_unicode_currencies(utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic currencies with unique ISO codes.
  */
 ORES_REFDATA_API_EXPORT std::vector<domain::currency>
 generate_unique_synthetic_currencies(std::size_t n, utility::generation::generation_context& ctx);
@@ -58,7 +56,7 @@ generate_unique_synthetic_currencies(std::size_t n, utility::generation::generat
 /**
  * @brief Generates a set of fictional currencies.
  *
- * These are intentionally fake currencies with made-up codes that do not
+ * These are intentionally fake currencies with made-up ISO codes that do not
  * correspond to any real ISO 4217 codes. Useful for testing and demo
  * purposes where real currency data should not be used.
  *
@@ -67,7 +65,6 @@ generate_unique_synthetic_currencies(std::size_t n, utility::generation::generat
  */
 ORES_REFDATA_API_EXPORT std::vector<domain::currency>
 generate_fictional_currencies(std::size_t n, utility::generation::generation_context& ctx);
-
 }
 
 #endif

--- a/projects/ores.refdata/api/src/domain/currency_json_io.cpp
+++ b/projects/ores.refdata/api/src/domain/currency_json_io.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/projects/ores.refdata/api/src/domain/currency_table.cpp
+++ b/projects/ores.refdata/api/src/domain/currency_table.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,45 +18,26 @@
  *
  */
 #include "ores.refdata.api/domain/currency_table.hpp"
+#include <boost/uuid/uuid_io.hpp>
 #include <fort.hpp>
-#include <sstream>
 
 namespace ores::refdata::domain {
 
-std::string convert_to_table(const currency& c) {
-    fort::char_table table;
-    table.set_border_style(FT_BASIC_STYLE);
-
-    table << fort::header << "ISO Code" << "Version" << "Name" << "Symbol" << "Asset Class"
-          << "Market Tier" << "Fractions/Unit" << "Precision" << "Change Reason" << "Modified By"
-          << "Recorded At" << fort::endr;
-
-    table << c.iso_code << c.version << c.name << c.symbol << c.monetary_nature << c.market_tier
-          << c.fractions_per_unit << c.rounding_precision << c.change_reason_code << c.modified_by
-          << c.recorded_at << fort::endr;
-
-    std::ostringstream ss;
-    ss << std::endl << table.to_string() << std::endl;
-    return ss.str();
-}
 
 std::string convert_to_table(const std::vector<currency>& v) {
     fort::char_table table;
     table.set_border_style(FT_BASIC_STYLE);
 
-    table << fort::header << "ISO Code" << "Version" << "Name" << "Symbol" << "Asset Class"
-          << "Market Tier" << "Fractions/Unit" << "Precision" << "Change Reason" << "Modified By"
-          << "Recorded At" << fort::endr;
+    table << fort::header << "Code" << "Currency Name" << "Numeric Code" << "Symbol" << "Fraction"
+          << "Per Unit" << "Rounding Type" << "Precision" << "Format" << "Monetary Nature"
+          << "Market Tier" << "Modified By" << "Version" << fort::endr;
 
     for (const auto& c : v) {
-        table << c.iso_code << c.version << c.name << c.symbol << c.monetary_nature << c.market_tier
-              << c.fractions_per_unit << c.rounding_precision << c.change_reason_code
-              << c.modified_by << c.recorded_at << fort::endr;
+        table << c.iso_code << c.name << c.numeric_code << c.symbol << c.fraction_symbol
+              << c.fractions_per_unit << c.rounding_type << c.rounding_precision << c.format
+              << c.monetary_nature << c.market_tier << c.modified_by << c.version << fort::endr;
     }
-
-    std::ostringstream ss;
-    ss << std::endl << table.to_string() << std::endl;
-    return ss.str();
+    return table.to_string();
 }
 
 }

--- a/projects/ores.refdata/api/src/domain/currency_table_io.cpp
+++ b/projects/ores.refdata/api/src/domain/currency_table_io.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -23,8 +23,12 @@
 
 namespace ores::refdata::domain {
 
+namespace {
+
 void print_currency_table(std::ostream& s, const std::vector<currency>& v) {
     s << std::endl << convert_to_table(v) << std::endl;
+}
+
 }
 
 std::ostream& operator<<(std::ostream& s, const std::vector<currency>& v) {

--- a/projects/ores.refdata/api/src/generators/currency_generator.cpp
+++ b/projects/ores.refdata/api/src/generators/currency_generator.cpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include <string>
+#include <unordered_set>
 
 namespace ores::refdata::generators {
 

--- a/projects/ores.refdata/api/src/generators/currency_generator.cpp
+++ b/projects/ores.refdata/api/src/generators/currency_generator.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -22,41 +22,53 @@
 #include "ores.utility/uuid/tenant_id.hpp"
 #include <atomic>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
-#include <faker-cxx/finance.h>
-#include <unordered_set>
+#include <string>
 
 namespace ores::refdata::generators {
 
 using ores::utility::generation::generation_keys;
 
 domain::currency generate_synthetic_currency(utility::generation::generation_context& ctx) {
-    const auto modified_by = ctx.env().get_or(generation_keys::modified_by, "system");
-    const auto tid = ctx.env().get_or(generation_keys::tenant_id, "system");
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(std::string(generation_keys::modified_by), "system");
+    const auto tid_str =
+        ctx.env().get_or(std::string(generation_keys::tenant_id), std::string("system"));
 
     domain::currency r;
-
-    const auto parsed_tid = utility::uuid::tenant_id::from_string(tid);
-    r.tenant_id = parsed_tid.has_value() ? parsed_tid.value() : utility::uuid::tenant_id::system();
-
-    // Use fictional currency with unique code to avoid conflicts across tests
-    static std::atomic<std::size_t> counter{0};
-    const auto suffix = ++counter;
-    r.iso_code = "X" + std::to_string(suffix % 100).substr(0, 2) + std::to_string(suffix);
-    r.name = "Test Currency " + std::to_string(suffix);
-    r.numeric_code = std::to_string(10000 + suffix);
-    r.symbol = "T" + std::to_string(suffix % 10);
-    r.fraction_symbol = "";
+    r.tenant_id =
+        utility::uuid::tenant_id::from_string(tid_str).value_or(utility::uuid::tenant_id::system());
+    const auto idx = counter.fetch_add(1, std::memory_order_relaxed);
+    r.iso_code = "X" + std::to_string(idx);
+    r.name = "Test Currency " + std::to_string(faker::number::integer(1000, 9999)) + "-" +
+             std::to_string(idx);
+    r.numeric_code = std::to_string(faker::number::integer(10001, 99999));
+    // faker::finance::currencySymbol() can return an empty string for some
+    // real-world currencies in its data set; fall back to a deterministic
+    // symbol so generated test data always has a non-empty symbol.
+    const auto sym = faker::finance::currencySymbol();
+    r.symbol = sym.empty() ? "$" : std::string(sym);
+    r.fraction_symbol = std::string("c");
     r.fractions_per_unit = 100;
-    r.rounding_type = "Closest";
+    r.rounding_type = std::string("Closest");
     r.rounding_precision = 2;
-    r.format = "%3% %1$.2f";
-    r.monetary_nature = "fiat";
-    r.market_tier = "g10";
+    r.format = std::string("%3% %1$.2f");
+    r.monetary_nature = std::string("fiat");
+    r.market_tier = std::string("g10");
+    r.image_id = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
     r.change_reason_code = "system.test";
     r.change_commentary = "Synthetic test data";
-    r.modified_by = modified_by;
     r.recorded_at = ctx.past_timepoint();
+    return r;
+}
 
+std::vector<domain::currency>
+generate_synthetic_currencies(std::size_t n, utility::generation::generation_context& ctx) {
+    std::vector<domain::currency> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_currency(ctx));
     return r;
 }
 
@@ -68,7 +80,6 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
     const auto tenant_id =
         parsed_tid.has_value() ? parsed_tid.value() : utility::uuid::tenant_id::system();
 
-    // Use fictional ISO codes with unique suffix to avoid conflicts across tests
     static std::atomic<std::size_t> batch{0};
     const auto b = ++batch;
     const auto suffix = "_" + std::to_string(b);
@@ -76,7 +87,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
 
     std::vector<domain::currency> r;
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XU" + std::to_string(b), // Fictional USD-like
+                 .iso_code = "XU" + std::to_string(b),
                  .name = "Test Dollar" + suffix,
                  .numeric_code = "90001",
                  .symbol = "$",
@@ -93,7 +104,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XE" + std::to_string(b), // Fictional EUR-like
+                 .iso_code = "XE" + std::to_string(b),
                  .name = "Test Euro" + suffix,
                  .numeric_code = "90002",
                  .symbol = "\xE2\x82\xAC",
@@ -110,7 +121,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XG" + std::to_string(b), // Fictional GBP-like
+                 .iso_code = "XG" + std::to_string(b),
                  .name = "Test Pound" + suffix,
                  .numeric_code = "90003",
                  .symbol = "\xC2\xA3",
@@ -127,10 +138,11 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XJ" + std::to_string(b), // Fictional JPY-like (no fractions)
+                 .iso_code = "XJ" + std::to_string(b),
                  .name = "Test Yen" + suffix,
                  .numeric_code = "90004",
                  .symbol = "\xC2\xA5",
+                 .fraction_symbol = "",
                  .fractions_per_unit = 0,
                  .rounding_type = "Closest",
                  .rounding_precision = 0,
@@ -143,7 +155,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XI" + std::to_string(b), // Fictional INR-like
+                 .iso_code = "XI" + std::to_string(b),
                  .name = "Test Rupee" + suffix,
                  .numeric_code = "90005",
                  .symbol = "\xE2\x82\xB9",
@@ -160,7 +172,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XB" + std::to_string(b), // Fictional BTC-like
+                 .iso_code = "XB" + std::to_string(b),
                  .name = "Test Crypto" + suffix,
                  .numeric_code = "90006",
                  .symbol = "\xE2\x82\xBF",
@@ -177,7 +189,7 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
                  .recorded_at = now});
 
     r.push_back({.tenant_id = tenant_id,
-                 .iso_code = "XR" + std::to_string(b), // Fictional RUB-like
+                 .iso_code = "XR" + std::to_string(b),
                  .name = "Test Ruble" + suffix,
                  .numeric_code = "90007",
                  .symbol = "\xE2\x82\xBD",
@@ -196,16 +208,6 @@ generate_synthetic_unicode_currencies(utility::generation::generation_context& c
 }
 
 std::vector<domain::currency>
-generate_synthetic_currencies(std::size_t n, utility::generation::generation_context& ctx) {
-    std::vector<domain::currency> r;
-    r.reserve(n);
-    while (r.size() < n)
-        r.push_back(generate_synthetic_currency(ctx));
-
-    return r;
-}
-
-std::vector<domain::currency>
 generate_unique_synthetic_currencies(std::size_t n, utility::generation::generation_context& ctx) {
     std::unordered_set<std::string> seen;
     seen.reserve(n);
@@ -216,7 +218,6 @@ generate_unique_synthetic_currencies(std::size_t n, utility::generation::generat
     std::size_t suffix = 0;
     while (r.size() < n) {
         auto currency = generate_synthetic_currency(ctx);
-        // Loop until we find a unique key
         if (!seen.insert(currency.iso_code).second) {
             auto base_code = currency.iso_code;
             do {
@@ -240,6 +241,9 @@ generate_fictional_currencies(std::size_t n, utility::generation::generation_con
     std::vector<domain::currency> all;
     all.reserve(50);
 
+    // Fictional currencies intentionally omit fraction_symbol. These are
+    // synthetic test data; no real sub-unit symbol is needed, and
+    // fractions_per_unit controls numeric precision in calculations only.
     all.push_back({.tenant_id = tenant_id,
                    .iso_code = "XAE",
                    .name = "Aerilonian Dollar",
@@ -996,5 +1000,4 @@ generate_fictional_currencies(std::size_t n, utility::generation::generation_con
 
     return std::vector<domain::currency>(all.begin(), all.begin() + n);
 }
-
 }

--- a/projects/ores.refdata/api/tests/domain_currency_tests.cpp
+++ b/projects/ores.refdata/api/tests/domain_currency_tests.cpp
@@ -256,7 +256,7 @@ TEST_CASE("currency_convert_single_to_table", tags) {
     ccy.modified_by = "admin";
     ccy.recorded_at = datetime::make_timepoint(2025, 1, 1);
 
-    auto table = convert_to_table(ccy);
+    auto table = convert_to_table(std::vector<currency>{ccy});
 
     BOOST_LOG_SEV(lg, debug) << "Table output:" << table;
 

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_entity.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_entity.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2024 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,12 +17,13 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_CORE_REPOSITORY_CURRENCY_HPP
-#define ORES_REFDATA_CORE_REPOSITORY_CURRENCY_HPP
+#ifndef ORES_REFDATA_CORE_REPOSITORY_CURRENCY_ENTITY_HPP
+#define ORES_REFDATA_CORE_REPOSITORY_CURRENCY_ENTITY_HPP
 
 #include "ores.database/repository/db_types.hpp"
 #include "sqlgen/PrimaryKey.hpp"
 #include <optional>
+#include <ostream>
 #include <string>
 
 namespace ores::refdata::repository {
@@ -39,17 +40,19 @@ struct currency_entity {
     sqlgen::PrimaryKey<std::string> iso_code;
     std::string tenant_id;
     int version = 0;
+
     std::string name;
+
     std::string numeric_code;
     std::string symbol;
     std::string fraction_symbol;
-    int fractions_per_unit;
+    int fractions_per_unit = 0;
     std::string rounding_type;
-    int rounding_precision;
+    int rounding_precision = 0;
     std::string format;
     std::string monetary_nature;
     std::string market_tier;
-    std::optional<std::string> image_id; // UUID stored as string, converted in mapper
+    std::optional<std::string> image_id;
     std::string modified_by;
     std::string performed_by;
     std::string change_reason_code;

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_mapper.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_mapper.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_CORE_REPOSITORY_CURRENCY_MAPPERP_HPP
-#define ORES_REFDATA_CORE_REPOSITORY_CURRENCY_MAPPERP_HPP
+#ifndef ORES_REFDATA_CORE_REPOSITORY_CURRENCY_MAPPER_HPP
+#define ORES_REFDATA_CORE_REPOSITORY_CURRENCY_MAPPER_HPP
 
 #include "ores.logging/make_logger.hpp"
 #include "ores.refdata.api/domain/currency.hpp"
@@ -28,13 +28,13 @@
 namespace ores::refdata::repository {
 
 /**
- * @brief Maps domain model entities to data storage layer and vice-versa.
+ * @brief Maps currency domain entities to data storage layer and vice-versa.
  */
 class ORES_REFDATA_CORE_EXPORT currency_mapper {
 private:
     inline static std::string_view logger_name = "ores.refdata.repository.currency_mapper";
 
-    static auto& lg() {
+    [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
         static auto instance = make_logger(logger_name);
         return instance;

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_repository.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/currency_repository.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -24,6 +24,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.refdata.api/domain/currency.hpp"
 #include "ores.refdata.core/export.hpp"
+#include <cstdint>
 #include <sqlgen/postgres.hpp>
 #include <string>
 #include <vector>
@@ -31,13 +32,13 @@
 namespace ores::refdata::repository {
 
 /**
- * @brief Reads and writes currencies off of data storage.
+ * @brief Reads and writes currencies to data storage.
  */
 class ORES_REFDATA_CORE_EXPORT currency_repository {
 private:
     inline static std::string_view logger_name = "ores.refdata.repository.currency_repository";
 
-    static auto& lg() {
+    [[nodiscard]] static auto& lg() {
         using namespace ores::logging;
         static auto instance = make_logger(logger_name);
         return instance;
@@ -52,16 +53,15 @@ public:
     std::string sql();
 
     /**
-     * @brief Writes currencies to database. Expects the currency set to have
-     * unique ISO codes.
+     * @brief Writes currencies to database.
      */
     /**@{*/
-    void write(context ctx, const domain::currency& currencies);
-    void write(context ctx, const std::vector<domain::currency>& currencies);
+    void write(context ctx, const domain::currency& v);
+    void write(context ctx, const std::vector<domain::currency>& v);
     /**@}*/
 
     /**
-     * @brief Reads latest currencies, possibly filtered by ISO code.
+     * @brief Reads latest currencies, possibly filtered by iso_code.
      */
     /**@{*/
     std::vector<domain::currency> read_latest(context ctx);
@@ -69,11 +69,15 @@ public:
     /**@}*/
 
     /**
+     * @brief Reads all currencies, possibly filtered by iso_code.
+     */
+    std::vector<domain::currency> read_all(context ctx, const std::string& iso_code);
+
+    /**
      * @brief Reads latest currencies with pagination support.
      * @param ctx Repository context with database connection
      * @param offset Number of records to skip
      * @param limit Maximum number of records to return
-     * @return Vector of currencies within the specified range
      */
     std::vector<domain::currency>
     read_latest(context ctx, std::uint32_t offset, std::uint32_t limit);
@@ -81,13 +85,23 @@ public:
     /**
      * @brief Gets the total count of active currencies.
      * @param ctx Repository context with database connection
-     * @return Total number of currencies with valid_to == max_timestamp
+     * @return Total number of active currencies
      */
     std::uint32_t get_total_currency_count(context ctx);
 
     /**
-     * @brief Reads currencies at the supplied time point, possibly filtered by
-     * ISO code.
+     * @brief Deletes a currency by closing its temporal validity.
+     */
+    void remove(context ctx, const std::string& iso_code);
+
+    /**
+     * @brief Deletes currencies by closing their temporal validity.
+     */
+    void remove(context ctx, const std::vector<std::string>& iso_codes);
+
+    /**
+     * @brief Reads currencies at the supplied time point, possibly filtered
+     * by iso_code.
      */
     /**@{*/
     std::vector<domain::currency> read_at_timepoint(context ctx, const std::string& as_of);
@@ -96,25 +110,9 @@ public:
     /**@}*/
 
     /**
-     * @brief Reads all currencies, possibly filtered by ISO code.
+     * @brief Reads all currencies (all versions), unfiltered.
      */
-    /**@{*/
     std::vector<domain::currency> read_all(context ctx);
-    std::vector<domain::currency> read_all(context ctx, const std::string& iso_code);
-    /**@}*/
-
-    /**
-     * @brief Deletes a currency by closing its temporal validity.
-     *
-     * Sets the valid_to timestamp to now, effectively "deleting" the currency
-     * from the current point in time onwards while preserving history.
-     */
-    void remove(context ctx, const std::string& iso_code);
-
-    /**
-     * @brief Deletes currencies by closing their temporal validity.
-     */
-    void remove(context ctx, const std::vector<std::string>& iso_codes);
 };
 
 }

--- a/projects/ores.refdata/core/src/repository/currency_entity.cpp
+++ b/projects/ores.refdata/core/src/repository/currency_entity.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2024 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.refdata.core/repository/currency_entity.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <ostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>

--- a/projects/ores.refdata/core/src/repository/currency_mapper.cpp
+++ b/projects/ores.refdata/core/src/repository/currency_mapper.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -34,10 +34,10 @@ domain::currency currency_mapper::map(const currency_entity& v) {
     domain::currency r;
     r.version = v.version;
     r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    BOOST_LOG_SEV(lg(), trace) << "Mapped version: entity.version=" << v.version
-                               << " -> domain.version=" << r.version;
     r.iso_code = v.iso_code.value();
+
     r.name = v.name;
+
     r.numeric_code = v.numeric_code;
     r.symbol = v.symbol;
     r.fraction_symbol = v.fraction_symbol;
@@ -47,9 +47,9 @@ domain::currency currency_mapper::map(const currency_entity& v) {
     r.format = v.format;
     r.monetary_nature = v.monetary_nature;
     r.market_tier = v.market_tier;
-    if (v.image_id) {
-        r.image_id = boost::lexical_cast<boost::uuids::uuid>(*v.image_id);
-    }
+    r.image_id = v.image_id.has_value() ?
+                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.image_id)) :
+                     std::nullopt;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;
     r.change_reason_code = v.change_reason_code;
@@ -59,6 +59,7 @@ domain::currency currency_mapper::map(const currency_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
 }
+
 currency_entity currency_mapper::map(const domain::currency& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
@@ -66,7 +67,9 @@ currency_entity currency_mapper::map(const domain::currency& v) {
     r.iso_code = v.iso_code;
     r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
+
     r.name = v.name;
+
     r.numeric_code = v.numeric_code;
     r.symbol = v.symbol;
     r.fraction_symbol = v.fraction_symbol;
@@ -76,14 +79,12 @@ currency_entity currency_mapper::map(const domain::currency& v) {
     r.format = v.format;
     r.monetary_nature = v.monetary_nature;
     r.market_tier = v.market_tier;
-    if (v.image_id) {
-        r.image_id = boost::uuids::to_string(*v.image_id);
-    }
+    r.image_id =
+        v.image_id.has_value() ? std::optional(boost::uuids::to_string(*v.image_id)) : std::nullopt;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;
     r.change_reason_code = v.change_reason_code;
     r.change_commentary = v.change_commentary;
-    // Note: recorded_at is read-only; valid_from/valid_to are managed by database triggers
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.refdata/core/src/repository/currency_repository.cpp
+++ b/projects/ores.refdata/core/src/repository/currency_repository.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -23,9 +23,8 @@
 #include "ores.refdata.api/domain/currency_json_io.hpp" // IWYU pragma: keep.
 #include "ores.refdata.core/repository/currency_entity.hpp"
 #include "ores.refdata.core/repository/currency_mapper.hpp"
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <rfl.hpp>
-#include <rfl/json.hpp>
+#include <sqlgen/postgres.hpp>
+
 
 namespace ores::refdata::repository {
 
@@ -38,27 +37,22 @@ std::string currency_repository::sql() {
     return generate_create_table_sql<currency_entity>(lg());
 }
 
-void currency_repository::write(context ctx, const domain::currency& currency) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing currency to database: " << currency;
-
-    execute_write_query(ctx, currency_mapper::map(currency), lg(), "Writing currency to database.");
+void currency_repository::write(context ctx, const domain::currency& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing currency: " << v.iso_code;
+    execute_write_query(ctx, currency_mapper::map(v), lg(), "Writing currency to database.");
 }
 
-void currency_repository::write(context ctx, const std::vector<domain::currency>& currencies) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing currencies to database. Count: " << currencies.size();
-
-    execute_write_query(
-        ctx, currency_mapper::map(currencies), lg(), "Writing currencies to database.");
+void currency_repository::write(context ctx, const std::vector<domain::currency>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing currencies. Count: " << v.size();
+    execute_write_query(ctx, currency_mapper::map(v), lg(), "Writing currencies to database.");
 }
-
 
 std::vector<domain::currency> currency_repository::read_latest(context ctx) {
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc());
-
-    const auto sql = postgres::to_sql(query);
-    BOOST_LOG_SEV(lg(), debug) << "Query: " << sql;
+                       where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+                       order_by("iso_code"_c);
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
@@ -70,30 +64,57 @@ std::vector<domain::currency> currency_repository::read_latest(context ctx) {
 
 std::vector<domain::currency> currency_repository::read_latest(context ctx,
                                                                const std::string& iso_code) {
-    BOOST_LOG_SEV(lg(), debug) << "Reading latest currencies. ISO code: " << iso_code;
-
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("iso_code"_c == iso_code && "valid_to"_c == max.value()) |
-                       order_by("valid_from"_c.desc());
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest currency. iso_code: " << iso_code;
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query =
+        sqlgen::read<std::vector<currency_entity>> |
+        where("tenant_id"_c == tid && "iso_code"_c == iso_code && "valid_to"_c == max.value());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
         query,
         [](const auto& entities) { return currency_mapper::map(entities); },
         lg(),
-        "Reading latest currencies by ISO code.");
+        "Reading latest currency by iso_code.");
+}
+
+std::vector<domain::currency> currency_repository::read_all(context ctx,
+                                                            const std::string& iso_code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all currency versions. iso_code: " << iso_code;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<currency_entity>> |
+                       where("tenant_id"_c == tid && "iso_code"_c == iso_code) |
+                       order_by("version"_c.desc());
+
+    return execute_read_query<currency_entity, domain::currency>(
+        ctx,
+        query,
+        [](const auto& entities) { return currency_mapper::map(entities); },
+        lg(),
+        "Reading all currency versions by iso_code.");
+}
+
+void currency_repository::remove(context ctx, const std::string& iso_code) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing currency: " << iso_code;
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query =
+        sqlgen::delete_from<currency_entity> |
+        where("tenant_id"_c == tid && "iso_code"_c == iso_code && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing currency from database.");
 }
 
 std::vector<domain::currency>
 currency_repository::read_latest(context ctx, std::uint32_t offset, std::uint32_t limit) {
     BOOST_LOG_SEV(lg(), debug) << "Reading latest currencies with offset: " << offset
                                << " and limit: " << limit;
-
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc()) |
-                       sqlgen::offset(offset) | sqlgen::limit(limit);
+                       where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+                       order_by("iso_code"_c) | sqlgen::offset(offset) | sqlgen::limit(limit);
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
@@ -105,15 +126,16 @@ currency_repository::read_latest(context ctx, std::uint32_t offset, std::uint32_
 
 std::uint32_t currency_repository::get_total_currency_count(context ctx) {
     BOOST_LOG_SEV(lg(), debug) << "Retrieving total active currency count";
-
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
 
     struct count_result {
         long long count;
     };
 
+    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::select_from<currency_entity>(sqlgen::count().as<"count">()) |
-                       where("valid_to"_c == max.value()) | sqlgen::to<count_result>;
+                       where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+                       sqlgen::to<count_result>;
 
     const auto r = sqlgen::session(ctx.connection_pool()).and_then(query);
     ensure_success(r, lg());
@@ -123,13 +145,24 @@ std::uint32_t currency_repository::get_total_currency_count(context ctx) {
     return count;
 }
 
+void currency_repository::remove(context ctx, const std::vector<std::string>& iso_codes) {
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query =
+        sqlgen::delete_from<currency_entity> |
+        where("tenant_id"_c == tid && "iso_code"_c.in(iso_codes) && "valid_to"_c == max.value());
+    execute_delete_query(ctx, query, lg(), "Batch removing currencies.");
+}
+
+
 std::vector<domain::currency> currency_repository::read_at_timepoint(context ctx,
                                                                      const std::string& as_of) {
     BOOST_LOG_SEV(lg(), debug) << "Reading currencies at timepoint: " << as_of;
-
+    const auto tid = ctx.tenant_id().to_string();
     const auto ts = make_timestamp(as_of, lg());
-    const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
+    const auto query =
+        sqlgen::read<std::vector<currency_entity>> |
+        where("tenant_id"_c == tid && "valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
@@ -142,11 +175,11 @@ std::vector<domain::currency> currency_repository::read_at_timepoint(context ctx
 std::vector<domain::currency> currency_repository::read_at_timepoint(context ctx,
                                                                      const std::string& as_of,
                                                                      const std::string& iso_code) {
-
+    const auto tid = ctx.tenant_id().to_string();
     const auto ts = make_timestamp(as_of, lg());
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("iso_code"_c == iso_code && "valid_from"_c <= ts.value() &&
-                             "valid_to"_c >= ts.value());
+                       where("tenant_id"_c == tid && "iso_code"_c == iso_code &&
+                             "valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
@@ -157,7 +190,9 @@ std::vector<domain::currency> currency_repository::read_at_timepoint(context ctx
 }
 
 std::vector<domain::currency> currency_repository::read_all(context ctx) {
-    const auto query = sqlgen::read<std::vector<currency_entity>> | order_by("valid_from"_c.desc());
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<currency_entity>> | where("tenant_id"_c == tid) |
+                       order_by("valid_from"_c.desc());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
@@ -165,36 +200,6 @@ std::vector<domain::currency> currency_repository::read_all(context ctx) {
         [](const auto& entities) { return currency_mapper::map(entities); },
         lg(),
         "Reading all currencies.");
-}
-
-std::vector<domain::currency> currency_repository::read_all(context ctx,
-                                                            const std::string& iso_code) {
-    const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("iso_code"_c == iso_code) | order_by("valid_from"_c.desc());
-
-    return execute_read_query<currency_entity, domain::currency>(
-        ctx,
-        query,
-        [](const auto& entities) { return currency_mapper::map(entities); },
-        lg(),
-        "Reading all currencies by ISO code");
-}
-
-void currency_repository::remove(context ctx, const std::string& iso_code) {
-    BOOST_LOG_SEV(lg(), debug) << "Removing currency from database: " << iso_code;
-
-    // Delete only the current record - the database trigger will close the
-    // temporal record instead of actually deleting it (sets valid_to = current_timestamp)
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto query = sqlgen::delete_from<currency_entity> |
-                       where("iso_code"_c == iso_code && "valid_to"_c == max.value());
-
-    execute_delete_query(ctx, query, lg(), "Removing currency from database.");
-}
-
-void currency_repository::remove(context ctx, const std::vector<std::string>& iso_codes) {
-    const auto query = sqlgen::delete_from<currency_entity> | where("iso_code"_c.in(iso_codes));
-    execute_delete_query(ctx, query, lg(), "batch removing currencies");
 }
 
 }

--- a/projects/ores.refdata/core/tests/repository_currency_repository_tests.cpp
+++ b/projects/ores.refdata/core/tests/repository_currency_repository_tests.cpp
@@ -125,7 +125,7 @@ TEST_CASE("read_all_currencies", tags) {
     currency_repository repo;
     repo.write(h.context(), written_currencies);
 
-    auto read_currencies = repo.read_all(h.context());
+    auto read_currencies = repo.read_latest(h.context());
     BOOST_LOG_SEV(lg, debug) << "Read currencies: " << read_currencies;
 
     CHECK(!read_currencies.empty());

--- a/projects/ores.refdata/core/tests/repository_currency_repository_tests.cpp
+++ b/projects/ores.refdata/core/tests/repository_currency_repository_tests.cpp
@@ -125,7 +125,7 @@ TEST_CASE("read_all_currencies", tags) {
     currency_repository repo;
     repo.write(h.context(), written_currencies);
 
-    auto read_currencies = repo.read_latest(h.context());
+    auto read_currencies = repo.read_all(h.context());
     BOOST_LOG_SEV(lg, debug) << "Read currencies: " << read_currencies;
 
     CHECK(!read_currencies.empty());

--- a/projects/ores.refdata/modeling/ores.refdata.currency.org
+++ b/projects/ores.refdata/modeling/ores.refdata.currency.org
@@ -939,51 +939,38 @@ and =helpers.hpp= are already in the standard template output.
 
 *** Repository implementations
 
-#+begin_src cpp :name implementation :implements F2EB1914-5E94-42CA-9C77-46BDB364BF9E
-std::vector<domain::currency>
-currency_repository::read_latest(context ctx, std::uint32_t offset, std::uint32_t limit) {
-    BOOST_LOG_SEV(lg(), debug) << "Reading latest currencies with offset: " << offset
-                               << " and limit: " << limit;
+Note: pagination (=read_latest= with offset/limit), =get_total_currency_count=,
+filtered =read_all=, and batch =remove= are now generated natively by the base
+=repository= template (tenant-aware). =read_at_timepoint=, and the unfiltered
+overloads of =read_all= and =read_at_timepoint= (used by the CLI's
+=export --all-versions= / =export --as-of= without =--key=), have no native
+equivalent and remain custom pastes.
 
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+#+begin_src cpp :name implementation :implements F2EB1914-5E94-42CA-9C77-46BDB364BF9E
+std::vector<domain::currency> currency_repository::read_at_timepoint(context ctx,
+                                                                     const std::string& as_of) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading currencies at timepoint: " << as_of;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto ts = make_timestamp(as_of, lg());
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("valid_to"_c == max.value()) | order_by("valid_from"_c.desc()) |
-                       sqlgen::offset(offset) | sqlgen::limit(limit);
+                       where("tenant_id"_c == tid && "valid_from"_c <= ts.value() &&
+                             "valid_to"_c >= ts.value());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
         query,
         [](const auto& entities) { return currency_mapper::map(entities); },
         lg(),
-        "Reading latest currencies with pagination.");
-}
-
-std::uint32_t currency_repository::get_total_currency_count(context ctx) {
-    BOOST_LOG_SEV(lg(), debug) << "Retrieving total active currency count";
-
-    const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-
-    struct count_result {
-        long long count;
-    };
-
-    const auto query = sqlgen::select_from<currency_entity>(sqlgen::count().as<"count">()) |
-                       where("valid_to"_c == max.value()) | sqlgen::to<count_result>;
-
-    const auto r = sqlgen::session(ctx.connection_pool()).and_then(query);
-    ensure_success(r, lg());
-
-    const auto count = static_cast<std::uint32_t>(r->count);
-    BOOST_LOG_SEV(lg(), debug) << "Total active currency count: " << count;
-    return count;
+        "Reading currencies at timepoint.");
 }
 
 std::vector<domain::currency>
 currency_repository::read_at_timepoint(context ctx, const std::string& as_of,
                                       const std::string& iso_code) {
+    const auto tid = ctx.tenant_id().to_string();
     const auto ts = make_timestamp(as_of, lg());
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("iso_code"_c == iso_code &&
+                       where("tenant_id"_c == tid && "iso_code"_c == iso_code &&
                              "valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
 
     return execute_read_query<currency_entity, domain::currency>(
@@ -994,66 +981,41 @@ currency_repository::read_at_timepoint(context ctx, const std::string& as_of,
         "Reading currencies at timepoint by ISO code.");
 }
 
-std::vector<domain::currency> currency_repository::read_all(context ctx,
-                                                            const std::string& iso_code) {
+std::vector<domain::currency> currency_repository::read_all(context ctx) {
+    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<currency_entity>> |
-                       where("iso_code"_c == iso_code) | order_by("valid_from"_c.desc());
+                       where("tenant_id"_c == tid) | order_by("valid_from"_c.desc());
 
     return execute_read_query<currency_entity, domain::currency>(
         ctx,
         query,
         [](const auto& entities) { return currency_mapper::map(entities); },
         lg(),
-        "Reading all currencies by ISO code");
-}
-
-void currency_repository::remove(context ctx, const std::vector<std::string>& iso_codes) {
-    const auto query = sqlgen::delete_from<currency_entity> | where("iso_code"_c.in(iso_codes));
-    execute_delete_query(ctx, query, lg(), "batch removing currencies");
+        "Reading all currencies.");
 }
 #+end_src
 
-*** read_latest (paginated)
+*** read_at_timepoint (unfiltered and filtered by iso_code)
 
 #+begin_src cpp :name declaration :implements DCA78C69-E508-48D9-9972-A9B8094D91FB
     /**
-     * @brief Reads latest currencies with pagination support.
-     * @param ctx Repository context with database connection
-     * @param offset Number of records to skip
-     * @param limit Maximum number of records to return
-     * @return Vector of currencies within the specified range
+     * @brief Reads currencies at the supplied time point, possibly filtered
+     * by iso_code.
      */
-    std::vector<domain::currency>
-    read_latest(context ctx, std::uint32_t offset, std::uint32_t limit);
-#+end_src
-
-*** get_total_currency_count
-
-#+begin_src cpp :name declaration :implements DCA78C69-E508-48D9-9972-A9B8094D91FB
-    /**
-     * @brief Gets the total count of active currencies.
-     * @param ctx Repository context with database connection
-     * @return Total number of currencies with valid_to == max_timestamp
-     */
-    std::uint32_t get_total_currency_count(context ctx);
-#+end_src
-
-*** read_at_timepoint (filtered by iso_code)
-
-#+begin_src cpp :name declaration :implements DCA78C69-E508-48D9-9972-A9B8094D91FB
+    /**@{*/
+    std::vector<domain::currency> read_at_timepoint(context ctx, const std::string& as_of);
     std::vector<domain::currency>
     read_at_timepoint(context ctx, const std::string& as_of, const std::string& iso_code);
+    /**@}*/
 #+end_src
 
-*** read_all (filtered by iso_code)
+*** read_all (unfiltered)
 
 #+begin_src cpp :name declaration :implements DCA78C69-E508-48D9-9972-A9B8094D91FB
-    std::vector<domain::currency> read_all(context ctx, const std::string& iso_code);
-
     /**
-     * @brief Deletes currencies by closing their temporal validity.
+     * @brief Reads all currencies (all versions), unfiltered.
      */
-    void remove(context ctx, const std::vector<std::string>& iso_codes);
+    std::vector<domain::currency> read_all(context ctx);
 #+end_src
 
 * See also


### PR DESCRIPTION
## Summary

Re-ran the domain, repository, and generator codegen profiles for currency and reconciled drift against the checked-in code.

## Changes

- Repository queries are now tenant-aware; pagination/count/filtered-read/batch-remove now generated natively by the base repository template
- Fixed compass_codegen_entity.py's _diff_entity to seed the tempdir with the repo's .clang-format, so entity diffs reflect real drift instead of clang-format's default-style fallback noise
- Fixed an empty-symbol flake in faker::finance::currencySymbol() usage in the synthetic currency generator
- Fixed a hardcoded version=1 in the synthetic currency generator that broke optimistic-concurrency writes

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: currency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/story.html) | 7F9C0F29-4268-4B62-A1BB-2153ECF0A858 |
| Task | [Sync C++ core codegen for currency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/task_sync_cpp_core_codegen_currency.html) | 8A84D304-431A-45CF-9E3C-6AC649F6A62F |

**Environment:** brave_hopper

🤖 Generated with [Claude Code](https://claude.com/claude-code)