### PR TITLE
[agile] Close per-entity sub-registrars story

### DIFF
--- a/doc/agile/product_backlog/inbox/commit_83292021a_added_party_id_to_ores_marketdata.org
+++ b/doc/agile/product_backlog/inbox/commit_83292021a_added_party_id_to_ores_marketdata.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: F70CF285-C22F-4A09-A36C-5FE7A834F056
+:END:
+#+title: Add RESTRICTIVE party-isolation RLS policies for the four marketdata tables
+#+description: Commit 83292021a added party_id to ores_marketdata_feed_bindings_tbl, _market_fixings_tbl, _market_observations_tbl and _market_series_tbl without the matching AS RESTRICTIVE party-isolation policies, so validate_schemas.sh --strict fails (RLS_002). PR #1397 added a stopgap: the four tables are listed under RLS_002 in projects/ores.sql/utility/validation_ignore.txt. Proper fix: add the RESTRICTIVE policies to marketdata_rls_policies_create.sql and remove the four ignore entries. Until then, party scoping on marketdata is columns-only with no row-level enforcement.
+#+type: capture
+#+level: cross
+#+filetags: :sql:security:rls:marketdata:
+#+created: 2026-07-03
+#+updated: 2026-07-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/story.org
+++ b/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/story.org
@@ -36,12 +36,12 @@ all 20+ entities to be correct simultaneously.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing — all three tasks DONE.        |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-06-27                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-07-04                               |
 
 * Acceptance
 
@@ -63,7 +63,7 @@ all 20+ entities to be correct simultaneously.
 |------+-------+-------+-----+-------------|
 | [[id:B1A68C26-970D-41ED-BCF9-B7187C703218][Introduce nats-sub-registrar codegen templates]] | DONE | 2026-06-27 | 2026-07-02 | nats-sub-registrar facet + archetypes in the physical-space graph. |
 | [[id:818E9AC0-DF64-4480-BB7C-6132D8CA8B0F][Generate sub-registrars for all refdata entities]] | DONE | 2026-06-27 | 2026-07-02 | 26 per-entity registrar pairs regenerated; no_history flags; 2 handler-less entities excluded. |
-| [[id:E704B5A9-9BD4-451F-8DDD-E12A4FA4E9C2][Wire sub-registrars into top-level registrar]] | STARTED | 2026-07-02 |  | Top-level registrar delegates to each register_<entity>_handlers(). |
+| [[id:E704B5A9-9BD4-451F-8DDD-E12A4FA4E9C2][Wire sub-registrars into top-level registrar]] | DONE | 2026-07-02 | 2026-07-03 | Top-level registrar delegates to each register_<entity>_handlers(). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/task_wire-sub-registrars-into-top-level-registrar.org
+++ b/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/task_wire-sub-registrars-into-top-level-registrar.org
@@ -8,7 +8,7 @@
 #+filetags: :introduce-per-entity-sub-registrars:sprint_22:v0:
 #+owner: marco
 #+branch: feature/wire-sub-registrars-into-top-level-registrar
-#+pr: 1421
+#+pr: 1426
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-27
@@ -70,6 +70,7 @@ wiring. Entities without a valid sub-registrar stay inline.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1426][#1426]] | [agile] Close per-entity sub-registrars story |
 | [[https://github.com/OreStudio/OreStudio/pull/1421][#1421]] | [refdata] Wire per-entity sub-registrars into the top-level registrar |
 
 * Review

--- a/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/task_wire-sub-registrars-into-top-level-registrar.org
+++ b/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/task_wire-sub-registrars-into-top-level-registrar.org
@@ -28,11 +28,11 @@ wiring. Entities without a valid sub-registrar stay inline.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:FA0846D8-5498-4036-8897-812EB053C4B4][Introduce per-entity NATS sub-registrars]] |
-| Now          | Wired and building; subject sets verified identical. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Commit, PR, merge.                     |
+| Next         | Nothing. |
 | Last touched | 2026-07-03                               |
 
 * Acceptance
@@ -76,6 +76,25 @@ wiring. Entities without a valid sub-registrar stay inline.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Include block sorted by filename, call block by function name — couple of entities differ in relative order | registrar.cpp | Declined | Cosmetic; reviewer said not worth a follow-up. Both lists exhaustive, each entity once. |
+| 2 | ctx/verifier copied by value per handler | registrar.cpp | Declined | Pre-existing pattern, unchanged by this refactor. |
 
 * Result
+
+Rewrote =registrar.cpp= (856 -> 283 lines) to delegate to each
+=register_<entity>_handlers()=: 26 entities delegate, 7 stay inline with a
+documented reason (=asset_class=/=business_centre=/=business_unit_type= have no
+codegen model, =purpose_type= is a table, =party_contact=/=counterparty_contact=
+have a handler-vs-protocol name mismatch, =publish_from_dq= is a bespoke
+multi-subject handler).
+
+Extended the =nats-sub-registrar= implementation archetype with two paste
+points so non-codegen wiring lives in the entity model, not hand-edits to
+generated files: =custom_subscriptions= (extra subjects) and =custom_includes=
+(extra headers). Used them to let =party= fully delegate its
+=read_parties_for_cache= subject, and to fix =currency= (dropped an incorrect
+=no_history= flag and pulled in its split =currency_history_protocol.hpp=).
+
+The set of subscribed NATS subjects is unchanged — 144 before and after,
+verified by diff and independently re-confirmed by three PR reviewers.
+=ores.refdata.core= builds. Merged in PR #1421. This closes the story.

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -103,7 +103,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 | [[id:7AA5B5C3-F7DE-4A17-84A0-75FB3761D43E][Codegen unified model — Phase 1: Qt derivation]] | BACKLOG | | | Derive Qt fields from conventions; drop explicit NATS protocol class names from models. |
 | [[id:AE89AD39-05D0-4A45-8BF4-FDC44BBB8A09][Codegen unified model — Phase 3: unify temporal templates]] | BACKLOG | | | Merge temporal and non-temporal C++ template families into single model-controlled templates. |
 | [[id:A083FE26-521D-4046-9E58-AFB901B28809][Codegen developer experience improvements]] | BACKLOG | | | Fix spurious ERRORs in --component mode; add --entity filter; add entity group / tag system for domain-scoped generation. |
-| [[id:FA0846D8-5498-4036-8897-812EB053C4B4][Introduce per-entity NATS sub-registrars]] | BACKLOG | | | Replace monolithic registrar.cpp with generated per-entity sub-registrars; isolate handler compilation; unblock incremental service API migration. |
+| [[id:FA0846D8-5498-4036-8897-812EB053C4B4][Introduce per-entity NATS sub-registrars]] | DONE | | 2026-07-04 | Replace monolithic registrar.cpp with generated per-entity sub-registrars; isolate handler compilation; unblock incremental service API migration. |
 | [[id:FA93094D-718E-42B0-A41A-434051CC6275][Resolve codegen model unification blockers]] | BACKLOG | | | Carried from sprint 21. |
 
 *** Epic: Compass


### PR DESCRIPTION
## Summary

Bookkeeping-only closeout for the now-merged 'Introduce per-entity NATS sub-registrars' story (code landed in #1397 and #1421). Closes the wire task and the story, and files a backlog capture for the outstanding marketdata RLS fix.

## Changes

- Wire-sub-registrars task -> DONE with its Result and declined-review notes
- Story -> DONE (all three tasks complete) and its Sprint 22 row closed
- New backlog capture: add RESTRICTIVE party-isolation RLS policies for the four party-scoped marketdata tables and remove the validation_ignore stopgap

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Introduce per-entity NATS sub-registrars](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/story.html) | FA0846D8-5498-4036-8897-812EB053C4B4 |
| Task | [Wire sub-registrars into the top-level registrar](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/introduce-per-entity-sub-registrars/task_wire-sub-registrars-into-top-level-registrar.html) | E704B5A9-9BD4-451F-8DDD-E12A4FA4E9C2 |

**Environment:** jolly_knuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)