### PR TITLE
[agile] Scaffold hotfix: MacOS CI relevance-guard skips matrix build

### DIFF
--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -73,6 +73,18 @@ jobs:
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Annotate when the build matrix is skipped
+        if: steps.check.outputs.should_build == 'false'
+        run: |
+          {
+            echo "### :warning: macOS build matrix skipped"
+            echo
+            echo "No relevant code changes since the last build — the"
+            echo "\`build\` job did not run. This workflow's overall"
+            echo "**Success** reflects the guard's decision to skip, not"
+            echo "a verified macOS build."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
   build:
     needs: guard
     if: needs.guard.outputs.should_build == 'true'

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/story.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/story.org
@@ -1,0 +1,50 @@
+:PROPERTIES:
+:ID: F3D9E216-DCB2-4621-899D-DF86727FC736
+:END:
+#+title: Story: Hotfix: MacOS CI relevance-guard skips matrix build silently
+#+description: Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:ci:sprint_22:v0:
+#+created: 2026-07-04
+#+updated: 2026-07-04
+#+environment: jolly_knuth
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore real signal from the "Continuous MacOS" scheduled workflow: it
+must not report overall Success when the actual build/test matrix job
+was skipped.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Diagnosed root cause in relevance-guard job. |
+| Waiting on    | Nothing.                               |
+| Next          | Implement and verify the fix.          |
+| Last touched  | 2026-07-04                               |
+
+* Acceptance
+
+- Continuous MacOS run #1781 (and future scheduled runs) either
+  actually run the build matrix, or the workflow's overall status
+  reflects that the matrix was skipped (not a blanket "Success").
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:449DCB86-7319-439F-B24F-6CCD09469AC4][Scaffold story: Hotfix: MacOS CI relevance-guard skips matrix build silently]] | STARTED | 2026-07-04 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:9EA36BBF-28FB-477C-AA24-98AEB7250341][Implement Hotfix: MacOS CI relevance-guard skips matrix build silently]] | BACKLOG | | | Initial task for: Hotfix: MacOS CI relevance-guard skips matrix build silently |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/story.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/story.org
@@ -23,11 +23,11 @@ was skipped.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Diagnosed root cause in relevance-guard job. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Implement and verify the fix.          |
+| Next          | Nothing.                               |
 | Last touched  | 2026-07-04                               |
 
 * Acceptance
@@ -40,10 +40,14 @@ was skipped.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:449DCB86-7319-439F-B24F-6CCD09469AC4][Scaffold story: Hotfix: MacOS CI relevance-guard skips matrix build silently]] | STARTED | 2026-07-04 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:9EA36BBF-28FB-477C-AA24-98AEB7250341][Implement Hotfix: MacOS CI relevance-guard skips matrix build silently]] | BACKLOG | | | Initial task for: Hotfix: MacOS CI relevance-guard skips matrix build silently |
+| [[id:449DCB86-7319-439F-B24F-6CCD09469AC4][Scaffold story: Hotfix: MacOS CI relevance-guard skips matrix build silently]] | DONE | 2026-07-04 | 2026-07-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. |
+| [[id:9EA36BBF-28FB-477C-AA24-98AEB7250341][Implement Hotfix: MacOS CI relevance-guard skips matrix build silently]] | DONE | 2026-07-04 | 2026-07-04 | Annotate the relevance-guard's skip in the job summary so it's not read as a verified build pass. |
 
 * Decisions
+
+- The relevance-guard's skip logic is not a bug and is identical to
+  =continuous-linux.yml=; the fix is to surface the skip clearly rather
+  than to change when it skips.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_implement_macos_ci_relevance_guard_skips_build.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_implement_macos_ci_relevance_guard_skips_build.org
@@ -30,11 +30,11 @@ was actually verified.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] |
-| Now          | Diagnosing.                            |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Decide on fix approach and implement.  |
+| Next         | Nothing.                               |
 | Last touched | 2026-07-04                               |
 
 * Acceptance
@@ -72,11 +72,26 @@ Diagnosis (from screenshot of run #1781 and reading
 
 * Notes
 
+Compared against =continuous-linux.yml=: the =relevance-guard= job and the
+=if: needs.guard.outputs.should_build == 'true'= gate are byte-for-byte
+identical between the two workflows, so this is not a macOS-specific
+scripting bug. Run #1781 skipped legitimately — its head SHA matched the
+prior run's, i.e. no new commits landed on =main= in that 3-hour window —
+the guard did exactly what it was designed to do.
+
+The actual problem is presentation, not logic: a skipped build matrix
+still yields an overall workflow **Success**, and the skipped matrix job
+renders with its unexpanded =${{ matrix.family }}-...= name in the GitHub
+UI, which reads as broken/confusing at a glance. Fixed by adding a guard
+step that writes a clear warning to the job summary whenever
+=should_build=false=, so a quiet-period skip is visually distinguishable
+from a verified build pass.
+
 * PRs
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1431][#1431]] | [agile] Scaffold hotfix: MacOS CI relevance-guard skips matrix build |
 
 * Review
 
@@ -85,3 +100,9 @@ Diagnosis (from screenshot of run #1781 and reading
 |   |                 |      |          |       |
 
 * Result
+
+Added a step to =continuous-macos.yml='s =relevance-guard= job that writes
+a warning to =$GITHUB_STEP_SUMMARY= whenever =should_build=false=, making a
+guard-skip visually distinct from a genuine build pass in the GitHub
+Actions UI. No change to the skip logic itself — it was already correct
+and matches =continuous-linux.yml=.

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_implement_macos_ci_relevance_guard_skips_build.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_implement_macos_ci_relevance_guard_skips_build.org
@@ -1,0 +1,87 @@
+:PROPERTIES:
+:ID: 9EA36BBF-28FB-477C-AA24-98AEB7250341
+:END:
+#+title: Task: Implement Hotfix: MacOS CI relevance-guard skips matrix build silently
+#+description: Initial task for: Hotfix: MacOS CI relevance-guard skips matrix build silently
+#+type: task
+#+level: s1
+#+filetags: :macos_ci_relevance_guard_skips_build:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-04
+#+updated: 2026-07-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix `.github/workflows/continuous-macos.yml` so a scheduled run that
+skips the build matrix (via `relevance-guard`) cannot be reported as
+an overall "Success" — either the guard's skip should be surfaced
+distinctly, or the workflow conclusion should reflect that no build
+was actually verified.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] |
+| Now          | Diagnosing.                            |
+| Waiting on   | Nothing.                               |
+| Next         | Decide on fix approach and implement.  |
+| Last touched | 2026-07-04                               |
+
+* Acceptance
+
+- A scheduled run where `relevance-guard` sets `should_build=false`
+  no longer reads as an unqualified green "Success" masking an
+  unverified macOS build.
+
+* Plan
+
+Diagnosis (from screenshot of run #1781 and reading
+`.github/workflows/continuous-macos.yml`):
+
+- The `guard` job (`relevance-guard`) computes `should_build` by
+  diffing against the last successful scheduled run's SHA, skipping
+  the build when only doc/codegen-model changes are detected since
+  then.
+- The `build` job has `if: needs.guard.outputs.should_build == 'true'`.
+  When the condition is false, GitHub Actions marks the `build` job
+  (and its whole matrix) as *skipped*, not failed — and a workflow
+  with only skipped/successful jobs is reported as overall
+  **Success**.
+- This is a legitimate "no code changed" optimization for normal
+  scheduled ticks, but it silently hides two real failure modes:
+  (1) the relevance-guard logic itself has a bug and is skipping runs
+  that should build, or (2) stakeholders reading the green check
+  assume macOS was actually built/tested when it wasn't.
+- Options to consider: emit a distinct workflow summary/annotation
+  when skipped so it's visually distinguishable from an actual build
+  pass; and/or verify the guard's diff logic against last-known-good
+  SHA is correctly finding recent code changes (needs checking why it
+  decided to skip on this particular run — confirm whether there
+  actually were no relevant commits since the last successful run, or
+  whether the guard misfired).
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
@@ -8,7 +8,7 @@
 #+filetags: :macos_ci_relevance_guard_skips_build:sprint_22:v0:
 #+owner: marco
 #+branch: hotfix/macos-ci-relevance-guard-skips-build
-#+pr:
+#+pr: 1431
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-04
@@ -49,7 +49,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1431][#1431]] | [agile] Scaffold hotfix: MacOS CI relevance-guard skips matrix build |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 449DCB86-7319-439F-B24F-6CCD09469AC4
+:END:
+#+title: Task: Scaffold story: Hotfix: MacOS CI relevance-guard skips matrix build silently
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :macos_ci_relevance_guard_skips_build:sprint_22:v0:
+#+owner: marco
+#+branch: hotfix/macos-ci-relevance-guard-skips-build
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-04
+#+updated: 2026-07-04
+#+environment: jolly_knuth
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
+++ b/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.org
@@ -26,11 +26,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                                |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-07-04                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -141,7 +141,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-|       |       |       |     |             |
+| [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] | BACKLOG | | | Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -141,7 +141,7 @@ and CI checks so generated code stays trustworthy. Carried from sprint 21.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] | BACKLOG | | | Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified. |
+| [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] | DONE | 2026-07-04 | 2026-07-04 | Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified. |
 
 * Achievements
 


### PR DESCRIPTION
## Summary

Scaffold the hotfix story/task for investigating why the Continuous MacOS scheduled workflow reports Success while the build matrix is sometimes skipped.

## Changes

- Add hotfix story and task docs under sprint_22/macos_ci_relevance_guard_skips_build
- Wire the hotfix into sprint_22's Hotfixes section

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: MacOS CI relevance-guard skips matrix build silently](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/story.html) | F3D9E216-DCB2-4621-899D-DF86727FC736 |
| Task | [Scaffold story: Hotfix: MacOS CI relevance-guard skips matrix build silently](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/macos_ci_relevance_guard_skips_build/task_scaffold_macos_ci_relevance_guard_skips_build.html) | 449DCB86-7319-439F-B24F-6CCD09469AC4 |

**Environment:** jolly_knuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)