### PR TITLE
[ores.qt,ores.codegen] Book detail-dialog combo/badge/flag codegen; abandon shell/CLI tasks

### DIFF
--- a/doc/agile/product_backlog/inbox/evaluate_screamer_for_analytics.org
+++ b/doc/agile/product_backlog/inbox/evaluate_screamer_for_analytics.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: B5A279DE-316F-49F1-B0D7-26167388BE19
+:END:
+#+title: Evaluate adding screamer to ores.analytics
+#+description: screamer is a C++/Python library of causal, streaming-safe rolling indicators (moving stats, polynomial fits, signal filters) that could back real-time analytics without look-ahead bias.
+#+type: capture
+#+level: cross
+#+filetags: :ores.analytics:third-party:streaming:quant:
+#+created: 2026-07-07
+#+updated: 2026-07-07
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+[[https://github.com/quantfinlib/screamer][screamer]] is a Python library, engineered in C++ (~63% C++, ~34%
+Python), for quantitative-finance time series analysis — "screamingly
+fast streaming indicators with C++ performance and Python simplicity."
+Its defining architectural property, per the
+[[https://screamer.readthedocs.io/en/latest/][docs]], is that the
+*same function runs unchanged on a static NumPy array or on a live
+stream*: every function is strictly causal (output depends only on
+current and past inputs, never future ones), which rules out
+look-ahead bias by construction rather than by convention. Documented
+building blocks include rolling statistics, polynomial curve fits over
+sliding windows (e.g. =RollingPoly2=, fitting a line per window and
+returning its slope), directional/sign transforms, and general
+"technical indicators and signal filters." Benchmarks claim it beats
+NumPy/pandas equivalents "often by factors of two or more." Installs
+via =pip install screamer=; actively maintained (332 commits, 46
+releases) but small (5 stars, 1 fork) — worth weighing project
+maturity/bus-factor against the technical fit before committing to it.
+
+Investigate whether =ores.analytics= (pricing engines, model
+configuration/products/parameters — see
+=projects/ores.analytics/modeling/component_overview.org=) has a
+concrete need for streaming rolling-window indicators (e.g. for live
+risk metrics, real-time exposure/PnL rolling stats, or feeding model
+calibration with online moving-window statistics) where screamer's
+causal-by-construction streaming/batch duality would be a genuine fit,
+versus building bespoke rolling-window code or using an existing
+C++ dependency already in the stack.
+
+* Why
+
+ORE Studio's analytics layer computes model outputs (pricing, risk)
+that could benefit from correct, fast rolling-window statistics if any
+future feature needs live/streaming recalculation (e.g. real-time
+market data feeding continuously-updated exposure or volatility
+estimates) rather than batch-only computation. screamer's core
+guarantee — identical code path for batch and streaming, with no
+look-ahead risk — directly targets the class of bugs that plague
+hand-rolled rolling-window code (accidentally peeking at future data
+in a window, or diverging behavior between backtest and live code
+paths). Worth a spike to confirm whether ORE Studio has (or will soon
+have) a concrete streaming-analytics use case before adopting a new
+third-party C++/Python dependency.
+
+* References
+
+- [[https://github.com/quantfinlib/screamer][screamer GitHub repository]]
+- [[https://screamer.readthedocs.io/en/latest/][screamer documentation]]
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_22/commission_book/story.org
+++ b/doc/agile/versions/v0/sprint_22/commission_book/story.org
@@ -26,7 +26,7 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | C++ core/SQL and Qt UI sync done (PR #1449). Shell and CLI tasks broken out (BACKLOG); manual chapter and remaining Qt verification not started. |
+| Now           | C++ core/SQL and Qt UI sync done (PR #1449). Shell and CLI tasks abandoned — superseded by the top-level shell/CLI codegen commissioning stories (product backlog inbox). Manual chapter and remaining Qt verification not started. |
 | Waiting on    | Nothing.                               |
 | Next          | Break out remaining tasks: manual chapter, Qt eventing/delete verification, Wt/HTTP backlog captures. |
 | Last touched  | 2026-07-07                               |
@@ -54,5 +54,5 @@ the entity chapter to the user manual. File backlog captures for Wt and HTTP sup
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:9AB461BD-AD46-4980-A801-BE6104270C52][Sync C++ core codegen output for book]] | DONE | 2026-07-03 | 2026-07-06 | Regenerate book's api/core/sql from the new graph-based codegen and land a build-consistent core sync. |
-| [[id:EA1377BB-EDC7-4A7A-97ED-25C0316735D9][Implement shell list/add/remove commands for book]] | BACKLOG | | | Add book CRUD scripts to the ores.shell library following the same pattern as countries and currencies. |
-| [[id:2F991961-F55B-4403-B4D4-278DA91E4107][Implement CLI list/add/remove commands for book]] | BACKLOG | | | Add book support to ores.cli following the same pattern as countries and currencies: options struct, entity parser, and list/add/remove subcommands. |
+| [[id:EA1377BB-EDC7-4A7A-97ED-25C0316735D9][Implement shell list/add/remove commands for book]] | ABANDONED | 2026-07-07 | 2026-07-07 | Superseded by the shell entity commands top-level commissioning story (product backlog inbox). |
+| [[id:2F991961-F55B-4403-B4D4-278DA91E4107][Implement CLI list/add/remove commands for book]] | ABANDONED | | 2026-07-07 | Superseded by the CLI commands top-level commissioning story (product backlog inbox). |

--- a/doc/agile/versions/v0/sprint_22/commission_book/task_implement_cli_book.org
+++ b/doc/agile/versions/v0/sprint_22/commission_book/task_implement_cli_book.org
@@ -26,11 +26,11 @@ Create the CLI support for book in projects/ores.cli — options header and sour
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:04BE9B6F-B43C-426B-96D1-AED89F88FA93][Commission: book]] |
-| Now          | Not yet started.                       |
+| Now          | Superseded.                             |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing — covered by the CLI top-level commissioning story. |
 | Last touched | 2026-07-07                               |
 
 * Acceptance
@@ -49,6 +49,14 @@ are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
 
 * Notes
+
+Abandoned in favour of the "CLI commands — top-level commissioning
+story" capture (=doc/agile/product_backlog/inbox/cli_commands_codegen_top_level_story.org=,
+id 469958E3-B249-4D4C-95A9-E7CDB703F0C0), which explicitly supersedes
+per-commission CLI tasks: =ores.cli= has no codegen profile, and CLI
+commands should be established/templatized once as a horizontal layer
+rather than hand-written per entity as this task would have done. No
+CLI code was written for book.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_22/commission_book/task_implement_shell_book.org
+++ b/doc/agile/versions/v0/sprint_22/commission_book/task_implement_shell_book.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :commission_book:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-shell-book
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-07
 #+updated: 2026-07-07
-#+environment:
+#+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:04BE9B6F-B43C-426B-96D1-AED89F88FA93][Commission: book]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,11 +26,11 @@ Create the book shell script set (list/get, add, remove, history, help) in proje
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:04BE9B6F-B43C-426B-96D1-AED89F88FA93][Commission: book]] |
-| Now          | Not yet started.                       |
+| Now          | Superseded.                             |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing — covered by the shell top-level commissioning story. |
 | Last touched | 2026-07-07                               |
 
 * Acceptance
@@ -50,6 +50,15 @@ are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
 
 * Notes
+
+Abandoned in favour of the "Shell entity commands — top-level
+commissioning story" capture (=doc/agile/product_backlog/inbox/shell_commands_codegen_top_level_story.org=,
+id 8BCD0D1C-AAFB-4FAA-A0E3-022FC6EF93C2), which explicitly supersedes
+per-commission shell tasks: =ores.shell= has no codegen profile, and
+shell commands should be established/templatized once as a horizontal
+layer (reference entity, generated aggregator, codegen facet) rather
+than hand-written per entity as this task would have done. No shell
+code was written for book.
 
 * PRs
 

--- a/doc/knowledge/architecture/badge_system_wiring.org
+++ b/doc/knowledge/architecture/badge_system_wiring.org
@@ -118,6 +118,35 @@ returns a display name (=tr("Online")=), the badge mapping key must
 use that display name. If the model returns the raw DB code (="user"=),
 the mapping key must use the raw code.
 
+** Available badge collections (code domains)
+
+Every =code_domain= currently seeded by
+=dq_badge_system_populate.sql=, in =display_order=. Check here before
+adding a new domain — an existing one (or its =badge_definition=
+colours) may already fit.
+
+| Domain                      | Order | Purpose                                                                   |
+|------------------------------+-------+----------------------------------------------------------------------------|
+| =party_status=              |     1 | Lifecycle status codes for party and counterparty records.               |
+| =book_status=               |     2 | Lifecycle status codes for book records.                                 |
+| =portfolio_status=          |     3 | Lifecycle status codes for portfolio records.                            |
+| =portfolio_type=            |     4 | Type codes for portfolio records (Virtual, Physical).                    |
+| =book_type=                 |     5 | Type codes for book records (Trading, Banking).                          |
+| =login_status=              |     6 | Login activity status for user accounts (Never, Old, Recent, Online).    |
+| =account_locked=            |     7 | Account lock status (Locked, Unlocked).                                  |
+| =compute_task_state=        |     8 | State codes for compute task records.                                    |
+| =compute_task_outcome=      |     9 | Outcome codes for completed compute tasks.                               |
+| =report_concurrency_policy= |    10 | Concurrency policy codes for report definitions (Skip, Queue, Fail).     |
+| =report_fsm_state=          |    11 | FSM lifecycle state codes for report definitions.                        |
+| =dq_origin=                 |    12 | Data quality origin dimension codes.                                     |
+| =dq_nature=                 |    13 | Data quality nature dimension codes.                                     |
+| =dq_treatment=              |    14 | Data quality treatment dimension codes.                                  |
+| =tenant_status=             |    15 | Lifecycle status codes for tenant records.                              |
+| =workspace_status=          |    16 | Lifecycle status codes for workspace records.                            |
+| =account_type=              |    17 | Classification of account types (user, service, algorithm, llm).         |
+| =account_online=            |    18 | Boolean online indicator for accounts (Yes, No).                        |
+| =book_is_trading=           |    19 | Whether a book is a trading book (Yes/No), reuses =account_online='s colours. |
+
 ** Worked example — account_type
 
 =account_type= badge (added in sprint 19):

--- a/projects/ores.codegen/library/templates/cpp_qt_controller.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_controller.cpp.mustache
@@ -206,6 +206,9 @@ void {{domain_entity.entity_pascal}}Controller::showAddWindow() {
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
 {{#domain_entity.qt.has_parent_relationship}}
@@ -262,6 +265,9 @@ void {{domain_entity.entity_pascal}}Controller::showDetailWindow(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setCreateMode(false);
@@ -415,6 +421,9 @@ void {{domain_entity.entity_pascal}}Controller::onOpenVersion(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->set{{domain_entity.entity_pascal_short}}({{domain_entity.qt.item_var}});
@@ -468,6 +477,9 @@ void {{domain_entity.entity_pascal}}Controller::onRevertVersion(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     auto reverted_{{domain_entity.qt.item_var}} = {{domain_entity.qt.item_var}};

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -266,6 +266,21 @@ void {{domain_entity.entity_pascal}}DetailDialog::setClientManager(ClientManager
 }
 {{#domain_entity.qt.detail_fields}}
 {{#is_flagged_combo}}
+{{#combo_helper}}
+
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo() {
+    {{combo_helper}}(ui_->{{widget}}, this, clientManager_, imageCache(), [this]() {
+{{#is_optional_string}}
+        const auto& v = {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}};
+        return v ? QString::fromStdString(*v) : QString();
+{{/is_optional_string}}
+{{^is_optional_string}}
+        return QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+{{/is_optional_string}}
+    });
+}
+{{/combo_helper}}
+{{^combo_helper}}
 
 void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo() {
     if (!clientManager_ || !clientManager_->isConnected())
@@ -315,6 +330,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo(
     auto* cm = clientManager_;
     watcher->setFuture(QtConcurrent::run([cm]() { return {{combo_fetch}}(cm); }));
 }
+{{/combo_helper}}
 {{/is_flagged_combo}}
 {{/domain_entity.qt.detail_fields}}
 

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -10,6 +10,7 @@
 #include <QPlainTextEdit>
 {{/domain_entity.qt.has_text_edit_fields}}
 {{#domain_entity.qt.has_combo_fields}}
+#include "ores.qt/WidgetUtils.hpp"
 #include <QComboBox>
 {{/domain_entity.qt.has_combo_fields}}
 {{#domain_entity.qt.has_uuid_primary_key}}
@@ -28,6 +29,13 @@
 #include <QIcon>
 #include <QLineEdit>
 {{/domain_entity.qt.has_flag_icon}}
+{{#domain_entity.qt.has_combo_flag_source}}
+#include "ores.qt/FlagIconHelper.hpp"
+#include <algorithm>
+{{/domain_entity.qt.has_combo_flag_source}}
+{{#domain_entity.qt.has_combo_badge_source}}
+#include "ores.qt/BadgeComboHelper.hpp"
+{{/domain_entity.qt.has_combo_badge_source}}
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "{{domain_entity.qt.protocol_include}}"
@@ -46,6 +54,9 @@ using namespace ores::logging;
       settingGatedActions_(nullptr){{/domain_entity.qt.has_setting_gated_actions}} {
 
     ui_->setupUi(this);
+{{#domain_entity.qt.has_combo_fields}}
+    WidgetUtils::setupComboBoxes(this);
+{{/domain_entity.qt.has_combo_fields}}
     setupUi();
 {{#domain_entity.qt.has_combo_fields}}
     setupCombos();
@@ -223,6 +234,18 @@ void {{domain_entity.entity_pascal}}DetailDialog::setupConnections() {
 
 void {{domain_entity.entity_pascal}}DetailDialog::setClientManager(ClientManager* clientManager) {
     clientManager_ = clientManager;
+{{#domain_entity.qt.detail_fields}}
+{{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    populate{{combo_setter_pascal}}();
+{{/combo_fetch_fn}}
+{{/is_dynamic_combo}}
+{{#is_static_combo}}
+{{#badge_key}}
+    setup_badge_combo(this, ui_->{{widget}}, badgeCache(), "{{badge_key}}");
+{{/badge_key}}
+{{/is_static_combo}}
+{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_setting_gated_actions}}
 
     if (clientManager_) {
@@ -489,6 +512,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}
+{{^combo_fetch_fn}}
 void {{domain_entity.entity_pascal}}DetailDialog::{{combo_setter}}(
     const std::vector<{{combo_type}}>& items) {
     {{combo_items_member}}_ = items;
@@ -511,7 +535,52 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}
         if (idx >= 0) ui_->{{widget}}->setCurrentIndex(idx);
     }
 }
+{{/combo_fetch_fn}}
+{{#combo_fetch_fn}}
+{{#combo_helper}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    {{combo_helper}}(ui_->{{widget}}, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+    });
+}
+{{/combo_helper}}
+{{^combo_helper}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    if (!clientManager_ || !clientManager_->isConnected())
+        return;
+    if (findChild<QFutureWatcherBase*>("{{combo_items_member}}FetchWatcher"))
+        return;
 
+    QPointer<{{domain_entity.entity_pascal}}DetailDialog> self = this;
+    auto* cm = clientManager_;
+    QFuture<std::vector<{{combo_type}}>> future =
+        QtConcurrent::run([cm]() { return {{combo_fetch_fn}}(cm); });
+
+    auto* watcher = new QFutureWatcher<std::vector<{{combo_type}}>>(this);
+    watcher->setObjectName("{{combo_items_member}}FetchWatcher");
+    connect(watcher, &QFutureWatcher<std::vector<{{combo_type}}>>::finished, this, [self, watcher]() {
+        auto items = watcher->result();
+        watcher->deleteLater();
+        if (!self)
+            return;
+
+        std::sort(items.begin(), items.end());
+        const auto current = self->ui_->{{widget}}->currentText();
+        self->ui_->{{widget}}->clear();
+        for (const auto& v : items)
+            self->ui_->{{widget}}->addItem(QString::fromStdString(v));
+        const auto to_select = !current.isEmpty() ? current :
+            QString::fromStdString(self->{{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+        if (!to_select.isEmpty())
+            self->ui_->{{widget}}->setCurrentText(to_select);
+{{#flag_source}}
+        apply_flag_icons(self->ui_->{{widget}}, self->imageCache(), FlagSource::{{flag_source}});
+{{/flag_source}}
+    });
+    watcher->setFuture(future);
+}
+{{/combo_helper}}
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{/domain_entity.qt.detail_fields}}
 void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.entity_pascal_short}}() {
@@ -584,11 +653,17 @@ void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.en
     }
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    ui_->{{widget}}->setCurrentText(QString::fromStdString(
+        {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}}));
+{{/combo_fetch_fn}}
+{{^combo_fetch_fn}}
     {
         const auto val = QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
         const int idx = ui_->{{widget}}->findData(val);
         if (idx >= 0) ui_->{{widget}}->setCurrentIndex(idx);
     }
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
     {
@@ -702,8 +777,14 @@ void {{domain_entity.entity_pascal}}DetailDialog::update{{domain_entity.entity_p
         ui_->{{widget}}->currentData().toString().toStdString();
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}} =
+        ui_->{{widget}}->currentText().toStdString();
+{{/combo_fetch_fn}}
+{{^combo_fetch_fn}}
     {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}} =
         ui_->{{widget}}->currentData().toString().toStdString();
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
 {{#is_optional_string}}

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.hpp.mustache
@@ -20,7 +20,12 @@
 #include <QToolBar>
 {{/domain_entity.qt.has_version_navigation}}
 {{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{^combo_fetch_fn}}
 #include "{{combo_include}}"
+{{/combo_fetch_fn}}
+{{#combo_fetch_fn}}
+#include "{{combo_fetch_include}}"
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_flagged_combo_fields}}
 #include "ores.qt/FlagIconHelper.hpp"
@@ -88,9 +93,9 @@ public:
      * the act of loading a past version's values is itself the change.
      */
     void markDirty();
-{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}{{^combo_fetch_fn}}
     void {{combo_setter}}(const std::vector<{{combo_type}}>& items);
-{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
+{{/combo_fetch_fn}}{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 
 signals:
     void {{domain_entity.qt.item_var}}Saved(const QString& code);
@@ -157,9 +162,9 @@ private:
     bool createMode_{true};
     bool readOnly_{false};
     bool hasChanges_{false};
-{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}{{^combo_fetch_fn}}
     std::vector<{{combo_type}}> {{combo_items_member}}_;
-{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
+{{/combo_fetch_fn}}{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_setting_gated_actions}}
 {{#domain_entity.qt.setting_gated_actions}}
     QAction* {{action}}_;

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.controller_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.controller_impl.org
@@ -231,6 +231,9 @@ void {{domain_entity.entity_pascal}}Controller::showAddWindow() {
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
 {{#domain_entity.qt.has_parent_relationship}}
@@ -287,6 +290,9 @@ void {{domain_entity.entity_pascal}}Controller::showDetailWindow(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setCreateMode(false);
@@ -440,6 +446,9 @@ void {{domain_entity.entity_pascal}}Controller::onOpenVersion(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->set{{domain_entity.entity_pascal_short}}({{domain_entity.qt.item_var}});
@@ -533,6 +542,9 @@ void {{domain_entity.entity_pascal}}Controller::onRevertVersion(
 {{#domain_entity.qt.needs_image_cache}}
     detailDialog->setImageCache(imageCache_);
 {{/domain_entity.qt.needs_image_cache}}
+{{#domain_entity.qt.has_combo_badge_source}}
+    detailDialog->setBadgeCache(badgeCache_);
+{{/domain_entity.qt.has_combo_badge_source}}
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     auto reverted_{{domain_entity.qt.item_var}} = {{domain_entity.qt.item_var}};

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_header.org
@@ -45,7 +45,12 @@ The full template source. Edit here and re-tangle with
 #include <QToolBar>
 {{/domain_entity.qt.has_version_navigation}}
 {{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{^combo_fetch_fn}}
 #include "{{combo_include}}"
+{{/combo_fetch_fn}}
+{{#combo_fetch_fn}}
+#include "{{combo_fetch_include}}"
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_flagged_combo_fields}}
 #include "ores.qt/FlagIconHelper.hpp"
@@ -113,9 +118,9 @@ public:
      * the act of loading a past version's values is itself the change.
      */
     void markDirty();
-{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}{{^combo_fetch_fn}}
     void {{combo_setter}}(const std::vector<{{combo_type}}>& items);
-{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
+{{/combo_fetch_fn}}{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 
 signals:
     void {{domain_entity.qt.item_var}}Saved(const QString& code);
@@ -182,9 +187,9 @@ private:
     bool createMode_{true};
     bool readOnly_{false};
     bool hasChanges_{false};
-{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
+{{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}{{^combo_fetch_fn}}
     std::vector<{{combo_type}}> {{combo_items_member}}_;
-{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
+{{/combo_fetch_fn}}{{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_setting_gated_actions}}
 {{#domain_entity.qt.setting_gated_actions}}
     QAction* {{action}}_;

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
@@ -35,6 +35,7 @@ The full template source. Edit here and re-tangle with
 #include <QPlainTextEdit>
 {{/domain_entity.qt.has_text_edit_fields}}
 {{#domain_entity.qt.has_combo_fields}}
+#include "ores.qt/WidgetUtils.hpp"
 #include <QComboBox>
 {{/domain_entity.qt.has_combo_fields}}
 {{#domain_entity.qt.has_uuid_primary_key}}
@@ -53,6 +54,13 @@ The full template source. Edit here and re-tangle with
 #include <QIcon>
 #include <QLineEdit>
 {{/domain_entity.qt.has_flag_icon}}
+{{#domain_entity.qt.has_combo_flag_source}}
+#include "ores.qt/FlagIconHelper.hpp"
+#include <algorithm>
+{{/domain_entity.qt.has_combo_flag_source}}
+{{#domain_entity.qt.has_combo_badge_source}}
+#include "ores.qt/BadgeComboHelper.hpp"
+{{/domain_entity.qt.has_combo_badge_source}}
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "{{domain_entity.qt.protocol_include}}"
@@ -71,6 +79,9 @@ using namespace ores::logging;
       settingGatedActions_(nullptr){{/domain_entity.qt.has_setting_gated_actions}} {
 
     ui_->setupUi(this);
+{{#domain_entity.qt.has_combo_fields}}
+    WidgetUtils::setupComboBoxes(this);
+{{/domain_entity.qt.has_combo_fields}}
     setupUi();
 {{#domain_entity.qt.has_combo_fields}}
     setupCombos();
@@ -248,6 +259,18 @@ void {{domain_entity.entity_pascal}}DetailDialog::setupConnections() {
 
 void {{domain_entity.entity_pascal}}DetailDialog::setClientManager(ClientManager* clientManager) {
     clientManager_ = clientManager;
+{{#domain_entity.qt.detail_fields}}
+{{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    populate{{combo_setter_pascal}}();
+{{/combo_fetch_fn}}
+{{/is_dynamic_combo}}
+{{#is_static_combo}}
+{{#badge_key}}
+    setup_badge_combo(this, ui_->{{widget}}, badgeCache(), "{{badge_key}}");
+{{/badge_key}}
+{{/is_static_combo}}
+{{/domain_entity.qt.detail_fields}}
 {{#domain_entity.qt.has_setting_gated_actions}}
 
     if (clientManager_) {
@@ -514,6 +537,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}
+{{^combo_fetch_fn}}
 void {{domain_entity.entity_pascal}}DetailDialog::{{combo_setter}}(
     const std::vector<{{combo_type}}>& items) {
     {{combo_items_member}}_ = items;
@@ -536,7 +560,52 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}
         if (idx >= 0) ui_->{{widget}}->setCurrentIndex(idx);
     }
 }
+{{/combo_fetch_fn}}
+{{#combo_fetch_fn}}
+{{#combo_helper}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    {{combo_helper}}(ui_->{{widget}}, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+    });
+}
+{{/combo_helper}}
+{{^combo_helper}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    if (!clientManager_ || !clientManager_->isConnected())
+        return;
+    if (findChild<QFutureWatcherBase*>("{{combo_items_member}}FetchWatcher"))
+        return;
 
+    QPointer<{{domain_entity.entity_pascal}}DetailDialog> self = this;
+    auto* cm = clientManager_;
+    QFuture<std::vector<{{combo_type}}>> future =
+        QtConcurrent::run([cm]() { return {{combo_fetch_fn}}(cm); });
+
+    auto* watcher = new QFutureWatcher<std::vector<{{combo_type}}>>(this);
+    watcher->setObjectName("{{combo_items_member}}FetchWatcher");
+    connect(watcher, &QFutureWatcher<std::vector<{{combo_type}}>>::finished, this, [self, watcher]() {
+        auto items = watcher->result();
+        watcher->deleteLater();
+        if (!self)
+            return;
+
+        std::sort(items.begin(), items.end());
+        const auto current = self->ui_->{{widget}}->currentText();
+        self->ui_->{{widget}}->clear();
+        for (const auto& v : items)
+            self->ui_->{{widget}}->addItem(QString::fromStdString(v));
+        const auto to_select = !current.isEmpty() ? current :
+            QString::fromStdString(self->{{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+        if (!to_select.isEmpty())
+            self->ui_->{{widget}}->setCurrentText(to_select);
+{{#flag_source}}
+        apply_flag_icons(self->ui_->{{widget}}, self->imageCache(), FlagSource::{{flag_source}});
+{{/flag_source}}
+    });
+    watcher->setFuture(future);
+}
+{{/combo_helper}}
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{/domain_entity.qt.detail_fields}}
 void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.entity_pascal_short}}() {
@@ -609,11 +678,17 @@ void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.en
     }
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    ui_->{{widget}}->setCurrentText(QString::fromStdString(
+        {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}}));
+{{/combo_fetch_fn}}
+{{^combo_fetch_fn}}
     {
         const auto val = QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
         const int idx = ui_->{{widget}}->findData(val);
         if (idx >= 0) ui_->{{widget}}->setCurrentIndex(idx);
     }
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
     {
@@ -727,8 +802,14 @@ void {{domain_entity.entity_pascal}}DetailDialog::update{{domain_entity.entity_p
         ui_->{{widget}}->currentData().toString().toStdString();
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
+{{#combo_fetch_fn}}
+    {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}} =
+        ui_->{{widget}}->currentText().toStdString();
+{{/combo_fetch_fn}}
+{{^combo_fetch_fn}}
     {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}} =
         ui_->{{widget}}->currentData().toString().toStdString();
+{{/combo_fetch_fn}}
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
 {{#is_optional_string}}

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
@@ -291,6 +291,21 @@ void {{domain_entity.entity_pascal}}DetailDialog::setClientManager(ClientManager
 }
 {{#domain_entity.qt.detail_fields}}
 {{#is_flagged_combo}}
+{{#combo_helper}}
+
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo() {
+    {{combo_helper}}(ui_->{{widget}}, this, clientManager_, imageCache(), [this]() {
+{{#is_optional_string}}
+        const auto& v = {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}};
+        return v ? QString::fromStdString(*v) : QString();
+{{/is_optional_string}}
+{{^is_optional_string}}
+        return QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}});
+{{/is_optional_string}}
+    });
+}
+{{/combo_helper}}
+{{^combo_helper}}
 
 void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo() {
     if (!clientManager_ || !clientManager_->isConnected())
@@ -340,6 +355,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{field_pascal}}Combo(
     auto* cm = clientManager_;
     watcher->setFuture(QtConcurrent::run([cm]() { return {{combo_fetch}}(cm); }));
 }
+{{/combo_helper}}
 {{/is_flagged_combo}}
 {{/domain_entity.qt.detail_fields}}
 

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_ui.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_ui.org
@@ -112,7 +112,7 @@ The full template source. Edit here and re-tangle with
            </widget>
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
-           <widget class="QComboBox" name="{{widget}}">
+           <widget class="{{#combo_widget_class}}{{combo_widget_class}}{{/combo_widget_class}}{{^combo_widget_class}}QComboBox{{/combo_widget_class}}" name="{{widget}}">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>
@@ -241,6 +241,13 @@ The full template source. Edit here and re-tangle with
    <extends>QWidget</extends>
    <header>ores.qt/ProvenanceWidget.hpp</header>
   </customwidget>
+{{#domain_entity.qt.combo_widget_customs}}
+  <customwidget>
+   <class>{{class}}</class>
+   <extends>{{extends}}</extends>
+   <header>{{header}}</header>
+  </customwidget>
+{{/domain_entity.qt.combo_widget_customs}}
  </customwidgets>
  <resources/>
  <connections/>

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_ui.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_ui.org
@@ -119,7 +119,7 @@ The full template source. Edit here and re-tangle with
            </widget>
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
-           <widget class="QComboBox" name="{{widget}}">
+           <widget class="{{#combo_widget_class}}{{combo_widget_class}}{{/combo_widget_class}}{{^combo_widget_class}}QComboBox{{/combo_widget_class}}" name="{{widget}}">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>

--- a/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
+++ b/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
@@ -87,7 +87,7 @@
            </widget>
 {{/is_static_combo}}
 {{#is_dynamic_combo}}
-           <widget class="QComboBox" name="{{widget}}">
+           <widget class="{{#combo_widget_class}}{{combo_widget_class}}{{/combo_widget_class}}{{^combo_widget_class}}QComboBox{{/combo_widget_class}}" name="{{widget}}">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>
@@ -216,6 +216,13 @@
    <extends>QWidget</extends>
    <header>ores.qt/ProvenanceWidget.hpp</header>
   </customwidget>
+{{#domain_entity.qt.combo_widget_customs}}
+  <customwidget>
+   <class>{{class}}</class>
+   <extends>{{extends}}</extends>
+   <header>{{header}}</header>
+  </customwidget>
+{{/domain_entity.qt.combo_widget_customs}}
  </customwidgets>
  <resources/>
  <connections/>

--- a/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
+++ b/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
@@ -94,7 +94,7 @@
            </widget>
 {{/is_dynamic_combo}}
 {{#is_flagged_combo}}
-           <widget class="QComboBox" name="{{widget}}">
+           <widget class="{{#combo_widget_class}}{{combo_widget_class}}{{/combo_widget_class}}{{^combo_widget_class}}QComboBox{{/combo_widget_class}}" name="{{widget}}">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>

--- a/projects/ores.codegen/src/codegen/core.py
+++ b/projects/ores.codegen/src/codegen/core.py
@@ -2245,6 +2245,34 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             qt['has_static_combo_fields'] = any(
                 f.get('type') == 'static_combo' for f in detail_fields
             )
+            # Deduplicated <customwidgets> entries for any promoted combo
+            # widget class a detail field resolved to above (e.g. every
+            # currency-flag combo needs the same OreCurrencyComboBox
+            # registration once, however many currency fields the entity
+            # has). Computed here, not in org_loader.py: it depends on
+            # combo_widget_class values that is_flagged_combo/is_dynamic_combo
+            # handling above defaults in, which runs after org_loader.py.
+            seen_widget_classes = set()
+            combo_customs = []
+            for f in detail_fields:
+                cls = f.get('combo_widget_class')
+                if not cls or cls in seen_widget_classes:
+                    continue
+                seen_widget_classes.add(cls)
+                combo_customs.append({
+                    'class': cls,
+                    'extends': f.get('combo_widget_extends', 'QComboBox'),
+                    'header': f.get('combo_widget_header', ''),
+                })
+            if combo_customs:
+                qt['combo_widget_customs'] = combo_customs
+            # Whether any static_combo detail field renders its items as
+            # badges (via the badge system) — gates BadgeCache wiring into
+            # the detail dialog itself (has_badge_columns only wires it
+            # into the list/MDI window).
+            qt['has_combo_badge_source'] = any(
+                f.get('badge_key') for f in detail_fields if f.get('type') == 'static_combo'
+            )
             qt['has_uuid_detail_fields'] = any(
                 f.get('is_uuid') or f.get('is_optional_uuid') for f in detail_fields
             )

--- a/projects/ores.codegen/src/codegen/core.py
+++ b/projects/ores.codegen/src/codegen/core.py
@@ -2072,9 +2072,13 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                             qt_col['column_style'] = 'cs::mono_center'
                         else:
                             qt_col['column_style'] = 'cs::text_left'
-                # Compute has_badge_columns flag
-                qt['has_badge_columns'] = any(
-                    c.get('is_badge') for c in qt['columns']
+                # Compute has_badge_columns flag — also true when a detail
+                # field's static_combo uses the badge system (needs the same
+                # BadgeCache threaded to the controller even with no badge
+                # list columns), not just list-view is_badge columns.
+                qt['has_badge_columns'] = (
+                    any(c.get('is_badge') for c in qt['columns'])
+                    or qt.get('has_combo_badge_source', False)
                 )
             # has_explorer_api opts a controller into the public
             # openAdd()/openEdit()/openHistory() surface a sibling explorer
@@ -2129,6 +2133,10 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                 f['is_text_edit'] = f.get('type') in ('text_edit', 'plain_text_edit')
                 f['is_static_combo'] = f.get('type') == 'static_combo'
                 f['is_dynamic_combo'] = f.get('type') == 'dynamic_combo'
+                if f['is_dynamic_combo'] and f.get('combo_fetch_fn'):
+                    field_pascal = snake_to_pascal(f.get('field', ''))
+                    f.setdefault('combo_setter_pascal', field_pascal)
+                    f.setdefault('combo_items_member', field_pascal[0].lower() + field_pascal[1:])
                 # A flagged_combo is a single-select combo asynchronously
                 # populated from a plain code list (e.g. fetch_currency_codes),
                 # with an optional per-item flag icon. Generalises the
@@ -2142,6 +2150,19 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                     f.setdefault('combo_allow_blank', False)
                     flag_source = f.get('flag_source', 'currency')
                     f['flag_source_pascal'] = snake_to_pascal(flag_source)
+                    # A currency flagged_combo has a ready-made shared
+                    # implementation (setup_currency_combo) and promoted
+                    # widget class (OreCurrencyComboBox, for uic's standard
+                    # combo-popup sizing/positioning) -- reuse both instead
+                    # of falling back to the generic per-entity inlined
+                    # fetch and a plain QComboBox. Other flag sources
+                    # (country, business_centre) have no such helper yet
+                    # and keep the generic inline path.
+                    if flag_source == 'currency':
+                        f.setdefault('combo_helper', 'setup_currency_combo')
+                        f.setdefault('combo_widget_class', 'ores::qt::OreCurrencyComboBox')
+                        f.setdefault('combo_widget_extends', 'QComboBox')
+                        f.setdefault('combo_widget_header', 'ores.qt/OreCurrencyComboBox.hpp')
                 f['is_check_box'] = f.get('type') == 'check_box'
                 f['is_spin_box'] = f.get('type') == 'spin_box'
                 field_cpp = domain_col_types.get(f.get('field'), '')

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -31,29 +31,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Known soft-FK "reference entity" lookups a dynamic_combo detail field
-# can point at via :references_entity:, instead of spelling out
-# combo_type/combo_fetch_fn/combo_fetch_include/flag_source by hand. Add
-# an entry here (and, if it needs flags, a matching setup_<entity>_combo
-# helper alongside FlagIconHelper::setup_currency_combo) to support a new
-# reference entity — no template changes required.
-REFERENCE_ENTITY_LOOKUPS = {
-    'currency': {
-        'combo_type': 'std::string',
-        'combo_fetch_fn': 'fetch_currency_codes',
-        'combo_fetch_include': 'ores.qt/LookupFetcher.hpp',
-        'flag_source': 'Currency',
-        'combo_helper': 'setup_currency_combo',
-        # Promoted widget class: uic needs this in the .ui's <customwidgets>
-        # to generate the right member type instead of falling back to a
-        # plain QComboBox that setup_currency_combo() still populates but
-        # that lacks whatever styling/behaviour the marker class carries.
-        'combo_widget_class': 'ores::qt::OreCurrencyComboBox',
-        'combo_widget_extends': 'QComboBox',
-        'combo_widget_header': 'ores.qt/OreCurrencyComboBox.hpp',
-    },
-}
-
 
 # --------------------------------------------------------------------------
 # Low-level parsing: org file -> tree of nodes
@@ -778,21 +755,6 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
             df = _section(qt, "Detail fields")
             if df:
                 qt_out["detail_fields"] = _detail_fields(df)
-                for f in qt_out["detail_fields"]:
-                    ref_entity = f.get('references_entity')
-                    if not ref_entity:
-                        continue
-                    lookup = REFERENCE_ENTITY_LOOKUPS.get(ref_entity)
-                    if not lookup:
-                        raise ValueError(
-                            f"detail field '{f.get('field')}' sets "
-                            f"references_entity: {ref_entity}, but no such "
-                            f"entry exists in REFERENCE_ENTITY_LOOKUPS "
-                            f"(org_loader.py). Known entities: "
-                            f"{sorted(REFERENCE_ENTITY_LOOKUPS)}"
-                        )
-                    for k, v in lookup.items():
-                        f.setdefault(k, v)
                 # static_combo fields declare their fixed option set as a
                 # comma-separated :combo_values: string (e.g. "Active,
                 # Inactive,Closed") — parsed here into the {label, value}
@@ -806,33 +768,11 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
                             {'label': v.strip(), 'value': v.strip()}
                             for v in raw.split(',') if v.strip()
                         ]
-                # Deduplicated <customwidgets> entries for any promoted combo
-                # widget class a detail field resolved to above (e.g. every
-                # currency-flag combo needs the same OreCurrencyComboBox
-                # registration once, however many currency fields the
-                # entity has).
-                seen_widget_classes: set[str] = set()
-                combo_customs = []
-                for f in qt_out["detail_fields"]:
-                    cls = f.get('combo_widget_class')
-                    if not cls or cls in seen_widget_classes:
-                        continue
-                    seen_widget_classes.add(cls)
-                    combo_customs.append({
-                        'class': cls,
-                        'extends': f.get('combo_widget_extends', 'QComboBox'),
-                        'header': f.get('combo_widget_header', ''),
-                    })
-                if combo_customs:
-                    qt_out["combo_widget_customs"] = combo_customs
-                # Whether any static_combo detail field renders its items as
-                # badges (via the badge system) — gates BadgeCache wiring
-                # into the detail dialog itself (has_badge_columns only
-                # wires it into the list/MDI window).
-                qt_out["has_combo_badge_source"] = any(
-                    f.get('badge_key') for f in qt_out["detail_fields"]
-                    if f.get('type') == 'static_combo'
-                )
+                # combo_widget_customs/has_combo_badge_source are computed in
+                # core.py, not here: they depend on combo_widget_class /
+                # badge_key values that core.py's is_flagged_combo /
+                # is_static_combo handling defaults in, which runs after
+                # this module.
             qc = _section(qt, "Columns (Qt model)")
             if qc:
                 qt_out["columns"] = _qt_columns(qc)

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -31,6 +31,29 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+# Known soft-FK "reference entity" lookups a dynamic_combo detail field
+# can point at via :references_entity:, instead of spelling out
+# combo_type/combo_fetch_fn/combo_fetch_include/flag_source by hand. Add
+# an entry here (and, if it needs flags, a matching setup_<entity>_combo
+# helper alongside FlagIconHelper::setup_currency_combo) to support a new
+# reference entity — no template changes required.
+REFERENCE_ENTITY_LOOKUPS = {
+    'currency': {
+        'combo_type': 'std::string',
+        'combo_fetch_fn': 'fetch_currency_codes',
+        'combo_fetch_include': 'ores.qt/LookupFetcher.hpp',
+        'flag_source': 'Currency',
+        'combo_helper': 'setup_currency_combo',
+        # Promoted widget class: uic needs this in the .ui's <customwidgets>
+        # to generate the right member type instead of falling back to a
+        # plain QComboBox that setup_currency_combo() still populates but
+        # that lacks whatever styling/behaviour the marker class carries.
+        'combo_widget_class': 'ores::qt::OreCurrencyComboBox',
+        'combo_widget_extends': 'QComboBox',
+        'combo_widget_header': 'ores.qt/OreCurrencyComboBox.hpp',
+    },
+}
+
 
 # --------------------------------------------------------------------------
 # Low-level parsing: org file -> tree of nodes
@@ -755,6 +778,61 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
             df = _section(qt, "Detail fields")
             if df:
                 qt_out["detail_fields"] = _detail_fields(df)
+                for f in qt_out["detail_fields"]:
+                    ref_entity = f.get('references_entity')
+                    if not ref_entity:
+                        continue
+                    lookup = REFERENCE_ENTITY_LOOKUPS.get(ref_entity)
+                    if not lookup:
+                        raise ValueError(
+                            f"detail field '{f.get('field')}' sets "
+                            f"references_entity: {ref_entity}, but no such "
+                            f"entry exists in REFERENCE_ENTITY_LOOKUPS "
+                            f"(org_loader.py). Known entities: "
+                            f"{sorted(REFERENCE_ENTITY_LOOKUPS)}"
+                        )
+                    for k, v in lookup.items():
+                        f.setdefault(k, v)
+                # static_combo fields declare their fixed option set as a
+                # comma-separated :combo_values: string (e.g. "Active,
+                # Inactive,Closed") — parsed here into the {label, value}
+                # dicts the template iterates. label == value; if a field
+                # ever needs them to differ, extend this to accept
+                # "label:value" pairs.
+                for f in qt_out["detail_fields"]:
+                    raw = f.get('combo_values')
+                    if f.get('type') == 'static_combo' and isinstance(raw, str) and raw:
+                        f['combo_values'] = [
+                            {'label': v.strip(), 'value': v.strip()}
+                            for v in raw.split(',') if v.strip()
+                        ]
+                # Deduplicated <customwidgets> entries for any promoted combo
+                # widget class a detail field resolved to above (e.g. every
+                # currency-flag combo needs the same OreCurrencyComboBox
+                # registration once, however many currency fields the
+                # entity has).
+                seen_widget_classes: set[str] = set()
+                combo_customs = []
+                for f in qt_out["detail_fields"]:
+                    cls = f.get('combo_widget_class')
+                    if not cls or cls in seen_widget_classes:
+                        continue
+                    seen_widget_classes.add(cls)
+                    combo_customs.append({
+                        'class': cls,
+                        'extends': f.get('combo_widget_extends', 'QComboBox'),
+                        'header': f.get('combo_widget_header', ''),
+                    })
+                if combo_customs:
+                    qt_out["combo_widget_customs"] = combo_customs
+                # Whether any static_combo detail field renders its items as
+                # badges (via the badge system) — gates BadgeCache wiring
+                # into the detail dialog itself (has_badge_columns only
+                # wires it into the list/MDI window).
+                qt_out["has_combo_badge_source"] = any(
+                    f.get('badge_key') for f in qt_out["detail_fields"]
+                    if f.get('type') == 'static_combo'
+                )
             qc = _section(qt, "Columns (Qt model)")
             if qc:
                 qt_out["columns"] = _qt_columns(qc)
@@ -795,8 +873,16 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
             # code in the client model itself) so that a model using only
             # the newer multi-column mechanism still gets ImageCache wired
             # through everywhere it's needed.
-            qt_out["needs_image_cache"] = qt_out["has_flag_icon"] or qt_out.get(
-                "has_icon_columns", False
+            # Whether any dynamic-combo detail field decorates its items with
+            # flag icons (e.g. a currency combo) via FlagIconHelper —
+            # gates the include and the ImageCache wiring below.
+            qt_out["has_combo_flag_source"] = any(
+                f.get("flag_source") for f in qt_out.get("detail_fields", [])
+            )
+            qt_out["needs_image_cache"] = (
+                qt_out["has_flag_icon"]
+                or qt_out.get("has_icon_columns", False)
+                or qt_out["has_combo_flag_source"]
             )
             de["qt"] = qt_out
 

--- a/projects/ores.qt/api/include/ores.qt/BadgeComboHelper.hpp
+++ b/projects/ores.qt/api/include/ores.qt/BadgeComboHelper.hpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_BADGE_COMBO_HELPER_HPP
+#define ORES_QT_BADGE_COMBO_HELPER_HPP
+
+#include "ores.qt/export.hpp"
+#include <QComboBox>
+#include <QObject>
+#include <string>
+
+namespace ores::qt {
+
+class BadgeCache;
+
+/**
+ * @brief Render every item in a combo box as a badge, using the
+ * database-driven badge system — counterpart to
+ * FlagIconHelper::apply_flag_icons for badges instead of flags.
+ *
+ * Installs an item delegate that paints each row (popup and the current
+ * selection alike) as a left-aligned badge pill via
+ * DelegatePaintUtils::draw_inline_badge() — the same badge rendering
+ * EntityItemDelegate uses for grid columns, just left- rather than
+ * centre-anchored to suit a combo row — resolving each badge from
+ * (@p badge_key, item text) at paint time so the combo always reflects
+ * the live cache.
+ *
+ * @param combo     The combo box to decorate (no-op if null).
+ * @param cache     The badge cache (no-op if null); painting falls back
+ * to the same neutral badge EntityItemDelegate uses when a value has no
+ * resolvable definition.
+ * @param badge_key The code_domain to resolve items against.
+ */
+ORES_QT_API void apply_combo_badges(QComboBox* combo, BadgeCache* cache, const std::string& badge_key);
+
+/**
+ * @brief Wire up a combo box to render its items as badges — currently
+ * just apply_combo_badges(), kept as a distinct entry point (mirroring
+ * setup_flag_combo()'s shape) in case a future live-refresh signal needs
+ * reconnecting here, the way flags reconnect on ImageCache::allLoaded.
+ *
+ * @param context   The QObject whose lifetime governs the delegate.
+ * @param combo     The combo box to decorate (no-op if null).
+ * @param cache     The badge cache (no-op if null).
+ * @param badge_key The code_domain to resolve items against.
+ */
+ORES_QT_API void
+setup_badge_combo(QObject* context, QComboBox* combo, BadgeCache* cache, const std::string& badge_key);
+
+}
+
+#endif

--- a/projects/ores.qt/api/include/ores.qt/BoolYesNoLabel.hpp
+++ b/projects/ores.qt/api/include/ores.qt/BoolYesNoLabel.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_BOOL_YES_NO_LABEL_HPP
+#define ORES_QT_BOOL_YES_NO_LABEL_HPP
+
+#include <QCoreApplication>
+#include <QString>
+
+namespace ores::qt {
+
+/**
+ * @brief "Yes"/"No" label for an integer-backed boolean flag column.
+ *
+ * Domain models often store boolean flags as int (e.g. 0/1) rather than
+ * a native bool column type. Pair with an is_badge column whose
+ * badge_key maps "Yes"/"No" to colours via the database-driven badge
+ * system (BadgeCache) — this formatter only produces the display text
+ * the badge resolver keys off.
+ */
+inline QString boolYesNoLabel(int value) {
+    return value != 0 ? QCoreApplication::translate("BoolYesNoLabel", "Yes") :
+                        QCoreApplication::translate("BoolYesNoLabel", "No");
+}
+
+}
+
+#endif

--- a/projects/ores.qt/api/include/ores.qt/FlagIconHelper.hpp
+++ b/projects/ores.qt/api/include/ores.qt/FlagIconHelper.hpp
@@ -26,12 +26,17 @@
 #include <QIcon>
 #include <QLineEdit>
 #include <QObject>
+#include <QPointer>
 #include <QSignalBlocker>
 #include <QSize>
+#include <QString>
+#include <functional>
 #include <string>
+#include <vector>
 
 namespace ores::qt {
 
+class ClientManager;
 class ImageCache;
 
 /**
@@ -164,6 +169,38 @@ inline void set_line_edit_flag_icon(QLineEdit* edit, const QIcon& icon, QAction*
         action_ptr = edit->addAction(icon, QLineEdit::LeadingPosition);
     }
 }
+
+/**
+ * @brief Populate a combo box with ISO currency codes and flag icons.
+ *
+ * The one function every currency-picker combo in the app should go
+ * through — fetches the current code list asynchronously, repopulates
+ * the combo (preserving the current selection if still present), then
+ * applies flag icons via apply_flag_icons(). Re-entrant: a fetch already
+ * in flight for @p combo is not duplicated.
+ *
+ * @param combo             The combo box to populate (no-op if null).
+ * @param owner             Object outliving the async operation; also
+ * used as the re-entrancy guard (a child QFutureWatcher named after
+ * @p combo already existing on it means a fetch is already in flight).
+ * @param client_manager    Used to run the fetch; no-op if null or
+ * disconnected.
+ * @param image_cache       Passed to apply_flag_icons() once populated.
+ * @param fallback_selection Evaluated at fetch-completion time (not at
+ * call time) to get the selection to restore if the combo had none —
+ * e.g. the entity's currently-stored value for this field, which may
+ * not be set on the widget yet when setup_currency_combo is called
+ * (a controller's setClientManager() call, which triggers this fetch,
+ * always runs before its set<Entity>() call, which is what actually
+ * populates the widget from the loaded record). Optional; omit for a
+ * combo with no entity value to restore (e.g. a filter/picker).
+ */
+ORES_QT_API void setup_currency_combo(
+    QComboBox* combo,
+    QObject* owner,
+    ClientManager* client_manager,
+    ImageCache* image_cache,
+    std::function<QString()> fallback_selection = {});
 
 }
 

--- a/projects/ores.qt/api/include/ores.qt/OreCurrencyComboBox.hpp
+++ b/projects/ores.qt/api/include/ores.qt/OreCurrencyComboBox.hpp
@@ -19,19 +19,24 @@
 #ifndef ORES_QT_ORE_CURRENCY_COMBO_BOX_HPP
 #define ORES_QT_ORE_CURRENCY_COMBO_BOX_HPP
 
+#include "ores.qt/export.hpp"
 #include <QComboBox>
+
+namespace ores::qt {
 
 /**
  * @brief QComboBox subclass for ISO currency selection with flag icons.
  *
  * Acts as a typed marker so uic generates the right widget class and
- * includes the correct header. Currency codes are populated asynchronously
- * by the owning form via LookupFetcher::fetch_currency_codes(); flag icons
- * are applied via FlagIconHelper::setup_flag_combo().
+ * includes the correct header. Populate with setup_currency_combo()
+ * (FlagIconHelper.hpp), which fetches currency codes asynchronously and
+ * applies flag icons.
  */
-class OreCurrencyComboBox : public QComboBox {
+class ORES_QT_API OreCurrencyComboBox : public QComboBox {
 public:
     explicit OreCurrencyComboBox(QWidget* parent = nullptr);
 };
+
+}
 
 #endif

--- a/projects/ores.qt/api/src/BadgeComboHelper.cpp
+++ b/projects/ores.qt/api/src/BadgeComboHelper.cpp
@@ -1,0 +1,87 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/BadgeComboHelper.hpp"
+#include "ores.qt/BadgeCache.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/DelegatePaintUtils.hpp"
+#include "ores.dq.api/domain/badge_definition.hpp"
+#include <QApplication>
+#include <QPainter>
+#include <QPointer>
+#include <QStyledItemDelegate>
+
+namespace ores::qt {
+
+namespace {
+
+class BadgeItemDelegate final : public QStyledItemDelegate {
+public:
+    BadgeItemDelegate(QObject* parent, QPointer<BadgeCache> cache, std::string badge_key)
+        : QStyledItemDelegate(parent)
+        , cache_(std::move(cache))
+        , badge_key_(std::move(badge_key)) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+              const QModelIndex& index) const override {
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+        opt.text.clear();
+        QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &opt, painter);
+
+        const QString text = index.data(Qt::DisplayRole).toString();
+        if (text.isEmpty())
+            return;
+
+        QColor bg = color_constants::badge_fallback;
+        QColor fg = color_constants::badge_fallback_text;
+        if (const auto* def = cache_ ? cache_->resolve(badge_key_, text.toStdString()) : nullptr) {
+            bg = QColor(QString::fromStdString(def->background_colour));
+            fg = QColor(QString::fromStdString(def->text_colour));
+        }
+
+        QFont badgeFont = opt.font;
+        badgeFont.setPointSize(qRound(badgeFont.pointSize() * 0.8));
+        badgeFont.setBold(true);
+
+        QRect rect = opt.rect;
+        DelegatePaintUtils::draw_inline_badge(painter, rect, text, bg, fg, badgeFont);
+    }
+
+private:
+    QPointer<BadgeCache> cache_;
+    std::string badge_key_;
+};
+
+}
+
+void apply_combo_badges(QComboBox* combo, BadgeCache* cache, const std::string& badge_key) {
+    if (!combo || !cache)
+        return;
+
+    combo->setItemDelegate(new BadgeItemDelegate(combo, cache, badge_key));
+}
+
+void setup_badge_combo(QObject* context, QComboBox* combo, BadgeCache* cache,
+                       const std::string& badge_key) {
+    (void)context;
+    apply_combo_badges(combo, cache, badge_key);
+}
+
+}

--- a/projects/ores.qt/api/src/FlagIconHelper.cpp
+++ b/projects/ores.qt/api/src/FlagIconHelper.cpp
@@ -18,9 +18,14 @@
  *
  */
 #include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ImageCache.hpp"
+#include "ores.qt/LookupFetcher.hpp"
+#include <QFutureWatcher>
 #include <QPainter>
 #include <QPixmap>
+#include <QtConcurrent>
+#include <algorithm>
 
 namespace ores::qt {
 
@@ -94,6 +99,44 @@ void setup_flag_combo(QObject* context, QComboBox* combo, ImageCache* cache, Fla
     QObject::connect(cache, &ImageCache::allLoaded, context, [combo, cache, source]() {
         apply_flag_icons(combo, cache, source);
     });
+}
+
+void setup_currency_combo(QComboBox* combo, QObject* owner, ClientManager* client_manager,
+                          ImageCache* image_cache, std::function<QString()> fallback_selection) {
+    if (!combo || !owner || !client_manager || !client_manager->isConnected())
+        return;
+
+    const QString watcher_name = combo->objectName() + "CurrencyFetchWatcher";
+    if (owner->findChild<QFutureWatcherBase*>(watcher_name))
+        return;
+
+    QPointer<QComboBox> comboPtr = combo;
+    QPointer<QObject> ownerPtr = owner;
+    auto future = QtConcurrent::run([client_manager]() { return fetch_currency_codes(client_manager); });
+
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(owner);
+    watcher->setObjectName(watcher_name);
+    QObject::connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, owner,
+        [comboPtr, ownerPtr, watcher, image_cache, fallback_selection]() {
+            auto codes = watcher->result();
+            watcher->deleteLater();
+            if (!comboPtr || !ownerPtr)
+                return;
+
+            std::sort(codes.begin(), codes.end());
+            const auto current = comboPtr->currentText();
+            comboPtr->clear();
+            for (const auto& code : codes)
+                comboPtr->addItem(QString::fromStdString(code));
+
+            const QString to_select =
+                !current.isEmpty() ? current : (fallback_selection ? fallback_selection() : QString());
+            if (!to_select.isEmpty())
+                comboPtr->setCurrentText(to_select);
+
+            apply_flag_icons(comboPtr, image_cache, FlagSource::Currency);
+        });
+    watcher->setFuture(future);
 }
 
 }

--- a/projects/ores.qt/api/src/FlagIconHelper.cpp
+++ b/projects/ores.qt/api/src/FlagIconHelper.cpp
@@ -134,7 +134,12 @@ void setup_currency_combo(QComboBox* combo, QObject* owner, ClientManager* clien
             if (!to_select.isEmpty())
                 comboPtr->setCurrentText(to_select);
 
-            apply_flag_icons(comboPtr, image_cache, FlagSource::Currency);
+            // setup_flag_combo, not apply_flag_icons: the image cache may
+            // still be loading when the combo first populates (icons would
+            // resolve empty and never be revisited), so this also
+            // reconnects on ImageCache::allLoaded to re-apply once the
+            // full set has downloaded.
+            setup_flag_combo(ownerPtr, comboPtr, image_cache, FlagSource::Currency);
         });
     watcher->setFuture(future);
 }

--- a/projects/ores.qt/api/src/OreCurrencyComboBox.cpp
+++ b/projects/ores.qt/api/src/OreCurrencyComboBox.cpp
@@ -18,5 +18,9 @@
  */
 #include "ores.qt/OreCurrencyComboBox.hpp"
 
+namespace ores::qt {
+
 OreCurrencyComboBox::OreCurrencyComboBox(QWidget* parent)
     : QComboBox(parent) {}
+
+}

--- a/projects/ores.qt/refdata/include/ores.qt/BookController.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookController.hpp
@@ -33,7 +33,9 @@ namespace ores::qt {
 
 class BookMdiWindow;
 class DetachableMdiSubWindow;
+class BadgeCache;
 class ChangeReasonCache;
+class ImageCache;
 
 /**
  * @brief Controller for managing book windows and operations.
@@ -57,8 +59,10 @@ public:
     BookController(QMainWindow* mainWindow,
                    QMdiArea* mdiArea,
                    ClientManager* clientManager,
+                   ImageCache* imageCache,
                    ChangeReasonCache* changeReasonCache,
                    const QString& username,
+                   BadgeCache* badgeCache,
                    QObject* parent = nullptr);
 
     void showListWindow() override;
@@ -90,6 +94,7 @@ private:
     void showHistoryWindow(const refdata::domain::book& book);
 
     ChangeReasonCache* changeReasonCache_;
+    BadgeCache* badgeCache_;
     BookMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt/refdata/include/ores.qt/BookDetailDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookDetailDialog.hpp
@@ -23,10 +23,10 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/DetailDialogBase.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/LookupFetcher.hpp"
 #include "ores.refdata.api/domain/book.hpp"
 #include <vector>
-
 
 namespace Ui {
 class BookDetailDialog;
@@ -100,7 +100,8 @@ private:
     void updateSaveButtonState();
     bool validateInput();
 
-    void populateLedgerCcy();
+
+    void populateLedgerCcyCombo();
 
 
     Ui::BookDetailDialog* ui_;

--- a/projects/ores.qt/refdata/include/ores.qt/BookDetailDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookDetailDialog.hpp
@@ -23,6 +23,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/DetailDialogBase.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.refdata.api/domain/book.hpp"
 #include <vector>
 
@@ -93,10 +94,13 @@ protected:
 private:
     void setupUi();
     void setupConnections();
+    void setupCombos();
     void updateUiFromBook();
     void updateBookFromUi();
     void updateSaveButtonState();
     bool validateInput();
+
+    void populateLedgerCcy();
 
 
     Ui::BookDetailDialog* ui_;

--- a/projects/ores.qt/refdata/include/ores.qt/BookMdiWindow.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookMdiWindow.hpp
@@ -32,6 +32,8 @@
 
 namespace ores::qt {
 
+class BadgeCache;
+class ImageCache;
 
 /**
  * @brief MDI window for displaying and managing books.
@@ -54,6 +56,8 @@ private:
 public:
     explicit BookMdiWindow(ClientManager* clientManager,
                            const QString& username,
+                           BadgeCache* badgeCache,
+                           ImageCache* imageCache,
                            QWidget* parent = nullptr);
     ~BookMdiWindow() override = default;
 
@@ -94,6 +98,8 @@ private:
 
     ClientManager* clientManager_;
     QString username_;
+    BadgeCache* badgeCache_;
+    ImageCache* imageCache_;
 
     QToolBar* toolbar_;
     QTableView* tableView_;

--- a/projects/ores.qt/refdata/include/ores.qt/ClientBookModel.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ClientBookModel.hpp
@@ -75,6 +75,15 @@ public:
     QVariant
     headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
+protected:
+    /** @brief Columns whose Qt::DecorationRole shows an icon (flag, etc.). */
+    std::vector<int> iconColumns() const override {
+        return {
+            Column::LedgerCcy,
+        };
+    }
+
+public:
     /**
      * @brief Refresh book data from server asynchronously.
      */
@@ -87,6 +96,7 @@ public:
      * @return The book, or nullptr if row is invalid.
      */
     const refdata::domain::book* getBook(int row) const;
+
 
     /**
      * @brief Load a specific page of data.

--- a/projects/ores.qt/refdata/include/ores.qt/ClientCurrencyPairModel.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/ClientCurrencyPairModel.hpp
@@ -99,6 +99,7 @@ public:
      */
     const refdata::domain::currency_pair* getPair(int row) const;
 
+
     /**
      * @brief Load a specific page of data.
      */

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyPairController.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyPairController.hpp
@@ -66,6 +66,7 @@ public:
     void closeAllWindows() override;
     void reloadListWindow() override;
 
+
 signals:
     void statusMessage(const QString& message);
     void errorMessage(const QString& error);

--- a/projects/ores.qt/refdata/src/BookController.cpp
+++ b/projects/ores.qt/refdata/src/BookController.cpp
@@ -43,13 +43,17 @@ constexpr std::string_view book_event_name =
 BookController::BookController(QMainWindow* mainWindow,
                                QMdiArea* mdiArea,
                                ClientManager* clientManager,
+                               ImageCache* imageCache,
                                ChangeReasonCache* changeReasonCache,
                                const QString& username,
+                               BadgeCache* badgeCache,
                                QObject* parent)
     : EntityController(mainWindow, mdiArea, clientManager, username, book_event_name, parent)
     , changeReasonCache_(changeReasonCache)
+    , badgeCache_(badgeCache)
     , listWindow_(nullptr)
     , listMdiSubWindow_(nullptr) {
+    setImageCache(imageCache);
 
     BOOST_LOG_SEV(lg(), debug) << "BookController created";
 }
@@ -64,7 +68,7 @@ void BookController::showListWindow() {
     }
 
     // Create new window
-    listWindow_ = new BookMdiWindow(clientManager_, username_);
+    listWindow_ = new BookMdiWindow(clientManager_, username_, badgeCache_, imageCache_);
 
     // Connect signals
     connect(listWindow_, &BookMdiWindow::statusChanged, this, &BookController::statusMessage);
@@ -162,6 +166,7 @@ void BookController::showAddWindow(boost::uuids::uuid parentPortfolioId) {
     auto* detailDialog = new BookDetailDialog(mainWindow_);
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
+    detailDialog->setImageCache(imageCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     if (!parentPortfolioId.is_nil()) {
@@ -211,6 +216,7 @@ void BookController::showDetailWindow(const refdata::domain::book& book) {
     auto* detailDialog = new BookDetailDialog(mainWindow_);
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
+    detailDialog->setImageCache(imageCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setCreateMode(false);
@@ -344,6 +350,7 @@ void BookController::onOpenVersion(const refdata::domain::book& book, int versio
     auto* detailDialog = new BookDetailDialog(mainWindow_);
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
+    detailDialog->setImageCache(imageCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setBook(book);
@@ -394,6 +401,7 @@ void BookController::onRevertVersion(const refdata::domain::book& book) {
     auto* detailDialog = new BookDetailDialog(mainWindow_);
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
+    detailDialog->setImageCache(imageCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     auto reverted_book = book;

--- a/projects/ores.qt/refdata/src/BookController.cpp
+++ b/projects/ores.qt/refdata/src/BookController.cpp
@@ -167,6 +167,7 @@ void BookController::showAddWindow(boost::uuids::uuid parentPortfolioId) {
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setImageCache(imageCache_);
+    detailDialog->setBadgeCache(badgeCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     if (!parentPortfolioId.is_nil()) {
@@ -217,6 +218,7 @@ void BookController::showDetailWindow(const refdata::domain::book& book) {
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setImageCache(imageCache_);
+    detailDialog->setBadgeCache(badgeCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setCreateMode(false);
@@ -351,6 +353,7 @@ void BookController::onOpenVersion(const refdata::domain::book& book, int versio
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setImageCache(imageCache_);
+    detailDialog->setBadgeCache(badgeCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     detailDialog->setBook(book);
@@ -402,6 +405,7 @@ void BookController::onRevertVersion(const refdata::domain::book& book) {
     if (changeReasonCache_)
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setImageCache(imageCache_);
+    detailDialog->setBadgeCache(badgeCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
     auto reverted_book = book;

--- a/projects/ores.qt/refdata/src/BookDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/BookDetailDialog.cpp
@@ -41,6 +41,11 @@ BookDetailDialog::BookDetailDialog(QWidget* parent)
     ui_->setupUi(this);
     setupUi();
     setupConnections();
+    // Hierarchy tree seam: a future :implements 9B165431-2921-4CAC-A2E8-2C186741E523
+    // block is expected to construct a HierarchyModelBuilder-derived model
+    // for this entity, wrap it in a HierarchyTreeWidget, and insert that
+    // widget into this dialog's layout (e.g. a dedicated tab). Left empty
+    // when no entity implements this kind.
 }
 
 BookDetailDialog::~BookDetailDialog() {
@@ -266,7 +271,8 @@ void BookDetailDialog::onDeleteClicked() {
         return;
     }
 
-    const auto crSel = promptChangeReason(ChangeReasonDialog::OperationType::Delete, false);
+    const auto crSel =
+        promptChangeReason(ChangeReasonDialog::OperationType::Delete, false, "common");
     if (!crSel)
         return;
 

--- a/projects/ores.qt/refdata/src/BookDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/BookDetailDialog.cpp
@@ -114,8 +114,14 @@ void BookDetailDialog::setupConnections() {
 
 void BookDetailDialog::setClientManager(ClientManager* clientManager) {
     clientManager_ = clientManager;
-    populateLedgerCcy();
     setup_badge_combo(this, ui_->bookStatusCombo, badgeCache(), "book_status");
+    populateLedgerCcyCombo();
+}
+
+void BookDetailDialog::populateLedgerCcyCombo() {
+    setup_currency_combo(ui_->ledgerCcyEdit, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString(book_.ledger_ccy);
+    });
 }
 
 void BookDetailDialog::setUsername(const std::string& username) {
@@ -155,15 +161,14 @@ void BookDetailDialog::setReadOnly(bool readOnly) {
     ui_->deleteButton->setVisible(!readOnly);
 }
 
-void BookDetailDialog::populateLedgerCcy() {
-    setup_currency_combo(ui_->ledgerCcyEdit, this, clientManager_, imageCache(), [this]() {
-        return QString::fromStdString(book_.ledger_ccy);
-    });
-}
 void BookDetailDialog::updateUiFromBook() {
     ui_->idEdit->setText(QString::fromStdString(boost::uuids::to_string(book_.id)));
     ui_->nameEdit->setText(QString::fromStdString(book_.name));
-    ui_->ledgerCcyEdit->setCurrentText(QString::fromStdString(book_.ledger_ccy));
+    {
+        const auto val = QString::fromStdString(book_.ledger_ccy);
+        const int idx = ui_->ledgerCcyEdit->findText(val);
+        ui_->ledgerCcyEdit->setCurrentIndex(idx);
+    }
     ui_->glAccountRefEdit->setText(QString::fromStdString(book_.gl_account_ref));
     ui_->costCenterEdit->setText(QString::fromStdString(book_.cost_center));
     {

--- a/projects/ores.qt/refdata/src/BookDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/BookDetailDialog.cpp
@@ -18,16 +18,21 @@
  *
  */
 #include "ores.qt/BookDetailDialog.hpp"
+#include "ores.qt/BadgeComboHelper.hpp"
 #include "ores.qt/ChangeReasonDialog.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/book_protocol.hpp"
 #include "ui_BookDetailDialog.h"
+#include <QComboBox>
 #include <QFutureWatcher>
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <algorithm>
 
 namespace ores::qt {
 
@@ -39,7 +44,9 @@ BookDetailDialog::BookDetailDialog(QWidget* parent)
     , clientManager_(nullptr) {
 
     ui_->setupUi(this);
+    WidgetUtils::setupComboBoxes(this);
     setupUi();
+    setupCombos();
     setupConnections();
     // Hierarchy tree seam: a future :implements 9B165431-2921-4CAC-A2E8-2C186741E523
     // block is expected to construct a HierarchyModelBuilder-derived model
@@ -76,6 +83,15 @@ void BookDetailDialog::setupUi() {
         IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
 }
 
+void BookDetailDialog::setupCombos() {
+    ui_->bookStatusCombo->clear();
+    ui_->bookStatusCombo->addItem(tr("Active"), QString("Active"));
+    ui_->bookStatusCombo->addItem(tr("Inactive"), QString("Inactive"));
+    ui_->bookStatusCombo->addItem(tr("Closed"), QString("Closed"));
+    ui_->bookStatusCombo->addItem(tr("Frozen"), QString("Frozen"));
+    ui_->bookStatusCombo->addItem(tr("Pending"), QString("Pending"));
+}
+
 void BookDetailDialog::setupConnections() {
     connect(ui_->saveButton, &QPushButton::clicked, this, &BookDetailDialog::onSaveClicked);
     connect(ui_->deleteButton, &QPushButton::clicked, this, &BookDetailDialog::onDeleteClicked);
@@ -83,15 +99,23 @@ void BookDetailDialog::setupConnections() {
 
     connect(ui_->idEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onCodeChanged);
     connect(ui_->nameEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onFieldChanged);
-    connect(ui_->ledgerCcyEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onFieldChanged);
+    connect(ui_->ledgerCcyEdit,
+            &QComboBox::currentIndexChanged,
+            this,
+            &BookDetailDialog::onFieldChanged);
     connect(
         ui_->glAccountRefEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onFieldChanged);
     connect(ui_->costCenterEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onFieldChanged);
-    connect(ui_->bookStatusEdit, &QLineEdit::textChanged, this, &BookDetailDialog::onFieldChanged);
+    connect(ui_->bookStatusCombo,
+            &QComboBox::currentIndexChanged,
+            this,
+            &BookDetailDialog::onFieldChanged);
 }
 
 void BookDetailDialog::setClientManager(ClientManager* clientManager) {
     clientManager_ = clientManager;
+    populateLedgerCcy();
+    setup_badge_combo(this, ui_->bookStatusCombo, badgeCache(), "book_status");
 }
 
 void BookDetailDialog::setUsername(const std::string& username) {
@@ -123,21 +147,31 @@ void BookDetailDialog::setReadOnly(bool readOnly) {
     readOnly_ = readOnly;
     ui_->idEdit->setReadOnly(true);
     ui_->nameEdit->setReadOnly(readOnly);
-    ui_->ledgerCcyEdit->setReadOnly(readOnly);
+    ui_->ledgerCcyEdit->setEnabled(!readOnly);
     ui_->glAccountRefEdit->setReadOnly(readOnly);
     ui_->costCenterEdit->setReadOnly(readOnly);
-    ui_->bookStatusEdit->setReadOnly(readOnly);
+    ui_->bookStatusCombo->setEnabled(!readOnly);
     ui_->saveButton->setVisible(!readOnly);
     ui_->deleteButton->setVisible(!readOnly);
 }
 
+void BookDetailDialog::populateLedgerCcy() {
+    setup_currency_combo(ui_->ledgerCcyEdit, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString(book_.ledger_ccy);
+    });
+}
 void BookDetailDialog::updateUiFromBook() {
     ui_->idEdit->setText(QString::fromStdString(boost::uuids::to_string(book_.id)));
     ui_->nameEdit->setText(QString::fromStdString(book_.name));
-    ui_->ledgerCcyEdit->setText(QString::fromStdString(book_.ledger_ccy));
+    ui_->ledgerCcyEdit->setCurrentText(QString::fromStdString(book_.ledger_ccy));
     ui_->glAccountRefEdit->setText(QString::fromStdString(book_.gl_account_ref));
     ui_->costCenterEdit->setText(QString::fromStdString(book_.cost_center));
-    ui_->bookStatusEdit->setText(QString::fromStdString(book_.book_status));
+    {
+        const int idx = ui_->bookStatusCombo->findData(QString::fromStdString(book_.book_status));
+        if (idx >= 0)
+            ui_->bookStatusCombo->setCurrentIndex(idx);
+    }
+    ui_->isTradingBookCheck->setChecked(book_.is_trading_book);
 
     populateProvenance(book_.version,
                        book_.modified_by,
@@ -152,10 +186,11 @@ void BookDetailDialog::updateUiFromBook() {
 
 void BookDetailDialog::updateBookFromUi() {
     book_.name = ui_->nameEdit->text().trimmed().toStdString();
-    book_.ledger_ccy = ui_->ledgerCcyEdit->text().trimmed().toStdString();
+    book_.ledger_ccy = ui_->ledgerCcyEdit->currentText().toStdString();
     book_.gl_account_ref = ui_->glAccountRefEdit->text().trimmed().toStdString();
     book_.cost_center = ui_->costCenterEdit->text().trimmed().toStdString();
-    book_.book_status = ui_->bookStatusEdit->text().trimmed().toStdString();
+    book_.book_status = ui_->bookStatusCombo->currentData().toString().toStdString();
+    book_.is_trading_book = ui_->isTradingBookCheck->isChecked();
     book_.modified_by = username_;
 }
 

--- a/projects/ores.qt/refdata/src/BookHistoryDialog.cpp
+++ b/projects/ores.qt/refdata/src/BookHistoryDialog.cpp
@@ -112,6 +112,7 @@ HistoryDialogBase::DiffResult BookHistoryDialog::calculateDiffAt(int ci, int pi)
     checkString(diffs, tr("GL Account Ref"), curr.gl_account_ref, prev.gl_account_ref);
     checkString(diffs, tr("Cost Center"), curr.cost_center, prev.cost_center);
     checkString(diffs, tr("Status"), curr.book_status, prev.book_status);
+    checkBool(diffs, tr("Trading Book"), curr.is_trading_book, prev.is_trading_book);
     return diffs;
 }
 
@@ -127,6 +128,7 @@ void BookHistoryDialog::displayFullDetails(int index) {
     ui_->glAccountRefValue->setText(QString::fromStdString(version.gl_account_ref));
     ui_->costCenterValue->setText(QString::fromStdString(version.cost_center));
     ui_->bookStatusValue->setText(QString::fromStdString(version.book_status));
+    ui_->isTradingBookCheck->setText(version.is_trading_book ? tr("true") : tr("false"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
     ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));

--- a/projects/ores.qt/refdata/src/BookMdiWindow.cpp
+++ b/projects/ores.qt/refdata/src/BookMdiWindow.cpp
@@ -18,8 +18,11 @@
  *
  */
 #include "ores.qt/BookMdiWindow.hpp"
+#include "ores.qt/BadgeCache.hpp"
 #include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/EntityItemDelegate.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ImageCache.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.refdata.api/messaging/book_protocol.hpp"
 #include <QFutureWatcher>
@@ -33,10 +36,16 @@ namespace ores::qt {
 
 using namespace ores::logging;
 
-BookMdiWindow::BookMdiWindow(ClientManager* clientManager, const QString& username, QWidget* parent)
+BookMdiWindow::BookMdiWindow(ClientManager* clientManager,
+                             const QString& username,
+                             BadgeCache* badgeCache,
+                             ImageCache* imageCache,
+                             QWidget* parent)
     : EntityListMdiWindow(parent)
     , clientManager_(clientManager)
     , username_(username)
+    , badgeCache_(badgeCache)
+    , imageCache_(imageCache)
     , toolbar_(nullptr)
     , tableView_(nullptr)
     , model_(nullptr)
@@ -108,6 +117,7 @@ void BookMdiWindow::setupToolbar() {
 
 void BookMdiWindow::setupTable() {
     model_ = new ClientBookModel(clientManager_, this);
+    model_->setImageCache(imageCache_);
     proxyModel_ = new QSortFilterProxyModel(this);
     proxyModel_->setSourceModel(model_);
     proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
@@ -120,6 +130,42 @@ void BookMdiWindow::setupTable() {
     tableView_->setAlternatingRowColors(true);
     tableView_->verticalHeader()->setVisible(false);
 
+    using cs = column_style;
+    auto* delegate = new EntityItemDelegate(
+        {
+            cs::text_left,
+            cs::text_left,
+            cs::badge_centered,
+            cs::text_left,
+            cs::badge_centered,
+            cs::mono_center,
+            cs::text_left,
+            cs::text_left,
+        },
+        tableView_);
+    delegate->set_badge_color_resolver(
+        2, [cache = badgeCache_](const QString& value) -> badge_color_pair {
+            static const badge_color_pair default_gray{QColor(0x6B, 0x72, 0x80), Qt::white};
+            if (!cache)
+                return default_gray;
+            auto* def = cache->resolve("book_status", value.toStdString());
+            if (!def)
+                return default_gray;
+            return {QColor(QString::fromStdString(def->background_colour)),
+                    QColor(QString::fromStdString(def->text_colour))};
+        });
+    delegate->set_badge_color_resolver(
+        4, [cache = badgeCache_](const QString& value) -> badge_color_pair {
+            static const badge_color_pair default_gray{QColor(0x6B, 0x72, 0x80), Qt::white};
+            if (!cache)
+                return default_gray;
+            auto* def = cache->resolve("book_is_trading", value.toStdString());
+            if (!def)
+                return default_gray;
+            return {QColor(QString::fromStdString(def->background_colour)),
+                    QColor(QString::fromStdString(def->text_colour))};
+        });
+    tableView_->setItemDelegate(delegate);
 
     initializeTableSettings(tableView_, model_, "BookListWindow", {}, {900, 400}, 1);
 }
@@ -357,5 +403,6 @@ void BookMdiWindow::deleteSelected() {
     QFuture<DeleteResult> future = QtConcurrent::run(task);
     watcher->setFuture(future);
 }
+
 
 }

--- a/projects/ores.qt/refdata/src/ClientBookModel.cpp
+++ b/projects/ores.qt/refdata/src/ClientBookModel.cpp
@@ -18,8 +18,10 @@
  *
  */
 #include "ores.qt/ClientBookModel.hpp"
+#include "ores.qt/BoolYesNoLabel.hpp"
 #include "ores.qt/ColorConstants.hpp"
 #include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.refdata.api/messaging/book_protocol.hpp"
 #include <QtConcurrent>
@@ -88,7 +90,7 @@ QVariant ClientBookModel::data(const QModelIndex& index, int role) const {
             case CostCenter:
                 return QString::fromStdString(book.cost_center);
             case IsTradingBook:
-                return static_cast<qlonglong>(book.is_trading_book);
+                return boolYesNoLabel(book.is_trading_book);
             case Version:
                 return static_cast<qlonglong>(book.version);
             case ModifiedBy:
@@ -98,6 +100,11 @@ QVariant ClientBookModel::data(const QModelIndex& index, int role) const {
             default:
                 return {};
         }
+    }
+
+    if (role == Qt::DecorationRole && imageCache_) {
+        if (index.column() == Column::LedgerCcy)
+            return currency_flag_icon(*imageCache_, book.ledger_ccy);
     }
 
     if (role == Qt::ForegroundRole) {
@@ -280,6 +287,7 @@ const refdata::domain::book* ClientBookModel::getBook(int row) const {
         return nullptr;
     return &books_[idx];
 }
+
 
 QVariant ClientBookModel::recency_foreground_color(const std::string& code) const {
     if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {

--- a/projects/ores.qt/refdata/src/ClientCurrencyPairModel.cpp
+++ b/projects/ores.qt/refdata/src/ClientCurrencyPairModel.cpp
@@ -300,6 +300,7 @@ const refdata::domain::currency_pair* ClientCurrencyPairModel::getPair(int row) 
     return &pairs_[idx];
 }
 
+
 QVariant ClientCurrencyPairModel::recency_foreground_color(const std::string& code) const {
     if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
         return color_constants::stale_indicator;

--- a/projects/ores.qt/refdata/src/CurrencyPairController.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyPairController.cpp
@@ -155,6 +155,7 @@ void CurrencyPairController::onAddNewRequested() {
     showAddWindow();
 }
 
+
 void CurrencyPairController::onShowHistory(const refdata::domain::currency_pair& pair) {
     BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << pair.pair_code;
     showHistoryWindow(QString::fromStdString(pair.pair_code));
@@ -322,6 +323,7 @@ void CurrencyPairController::showHistoryWindow(const QString& code) {
     historyWindow->setWindowTitle(QString("Currency Pair History: %1").arg(code));
     historyWindow->setWindowIcon(
         IconUtils::createRecoloredIcon(Icon::History, IconUtils::DefaultIconColor));
+    connect_dialog_close(historyDialog, historyWindow);
 
     // Track this history window
     track_window(windowKey, historyWindow);

--- a/projects/ores.qt/refdata/src/CurrencyPairDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyPairDetailDialog.cpp
@@ -19,14 +19,17 @@
  */
 #include "ores.qt/CurrencyPairDetailDialog.hpp"
 #include "ores.qt/ChangeReasonDialog.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/WidgetUtils.hpp"
 #include "ores.refdata.api/messaging/protocol.hpp"
 #include "ui_CurrencyPairDetailDialog.h"
 #include <QComboBox>
 #include <QFutureWatcher>
 #include <QMessageBox>
 #include <QtConcurrent>
+#include <algorithm>
 
 namespace ores::qt {
 
@@ -38,9 +41,15 @@ CurrencyPairDetailDialog::CurrencyPairDetailDialog(QWidget* parent)
     , clientManager_(nullptr) {
 
     ui_->setupUi(this);
+    WidgetUtils::setupComboBoxes(this);
     setupUi();
     setupCombos();
     setupConnections();
+    // Hierarchy tree seam: a future :implements 9B165431-2921-4CAC-A2E8-2C186741E523
+    // block is expected to construct a HierarchyModelBuilder-derived model
+    // for this entity, wrap it in a HierarchyTreeWidget, and insert that
+    // widget into this dialog's layout (e.g. a dedicated tab). Left empty
+    // when no entity implements this kind.
 }
 
 CurrencyPairDetailDialog::~CurrencyPairDetailDialog() {
@@ -112,123 +121,23 @@ void CurrencyPairDetailDialog::setClientManager(ClientManager* clientManager) {
 }
 
 void CurrencyPairDetailDialog::populateBaseCurrencyCombo() {
-    if (!clientManager_ || !clientManager_->isConnected())
-        return;
-
-    QPointer<CurrencyPairDetailDialog> self = this;
-    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
-    QObject::connect(
-        watcher, &QFutureWatcher<std::vector<std::string>>::finished, self, [self, watcher]() {
-            auto codes = watcher->result();
-            watcher->deleteLater();
-            if (!self)
-                return;
-
-            auto* combo = self->ui_->baseCurrencyCombo;
-            const QString previous = combo->currentText();
-            combo->blockSignals(true);
-            combo->clear();
-            for (const auto& c : codes)
-                combo->addItem(QString::fromStdString(c));
-            // fallback_selection is evaluated here (fetch-completion time), not
-            // at populate-call time, since setPair() may run before or
-            // after setClientManager() triggers this fetch.
-            const QString fallback = QString::fromStdString(self->pair_.base_currency);
-            const QString to_select = !previous.isEmpty() ? previous : fallback;
-            if (!to_select.isEmpty()) {
-                const int idx = combo->findText(to_select);
-                if (idx >= 0)
-                    combo->setCurrentIndex(idx);
-            }
-            combo->blockSignals(false);
-
-            if (self->imageCache())
-                apply_flag_icons(combo, self->imageCache(), FlagSource::Currency);
-        });
-
-    auto* cm = clientManager_;
-    watcher->setFuture(QtConcurrent::run([cm]() { return fetch_currency_codes(cm); }));
+    setup_currency_combo(ui_->baseCurrencyCombo, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString(pair_.base_currency);
+    });
 }
 
 void CurrencyPairDetailDialog::populateQuoteCurrencyCombo() {
-    if (!clientManager_ || !clientManager_->isConnected())
-        return;
-
-    QPointer<CurrencyPairDetailDialog> self = this;
-    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
-    QObject::connect(
-        watcher, &QFutureWatcher<std::vector<std::string>>::finished, self, [self, watcher]() {
-            auto codes = watcher->result();
-            watcher->deleteLater();
-            if (!self)
-                return;
-
-            auto* combo = self->ui_->quoteCurrencyCombo;
-            const QString previous = combo->currentText();
-            combo->blockSignals(true);
-            combo->clear();
-            for (const auto& c : codes)
-                combo->addItem(QString::fromStdString(c));
-            // fallback_selection is evaluated here (fetch-completion time), not
-            // at populate-call time, since setPair() may run before or
-            // after setClientManager() triggers this fetch.
-            const QString fallback = QString::fromStdString(self->pair_.quote_currency);
-            const QString to_select = !previous.isEmpty() ? previous : fallback;
-            if (!to_select.isEmpty()) {
-                const int idx = combo->findText(to_select);
-                if (idx >= 0)
-                    combo->setCurrentIndex(idx);
-            }
-            combo->blockSignals(false);
-
-            if (self->imageCache())
-                apply_flag_icons(combo, self->imageCache(), FlagSource::Currency);
-        });
-
-    auto* cm = clientManager_;
-    watcher->setFuture(QtConcurrent::run([cm]() { return fetch_currency_codes(cm); }));
+    setup_currency_combo(ui_->quoteCurrencyCombo, this, clientManager_, imageCache(), [this]() {
+        return QString::fromStdString(pair_.quote_currency);
+    });
 }
 
 void CurrencyPairDetailDialog::populateSettlementCurrencyCombo() {
-    if (!clientManager_ || !clientManager_->isConnected())
-        return;
-
-    QPointer<CurrencyPairDetailDialog> self = this;
-    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
-    QObject::connect(
-        watcher, &QFutureWatcher<std::vector<std::string>>::finished, self, [self, watcher]() {
-            auto codes = watcher->result();
-            watcher->deleteLater();
-            if (!self)
-                return;
-
-            auto* combo = self->ui_->settlementCurrencyCombo;
-            const QString previous = combo->currentText();
-            combo->blockSignals(true);
-            combo->clear();
-            combo->addItem(QString());
-            for (const auto& c : codes)
-                combo->addItem(QString::fromStdString(c));
-            // fallback_selection is evaluated here (fetch-completion time), not
-            // at populate-call time, since setPair() may run before or
-            // after setClientManager() triggers this fetch.
-            const QString fallback = self->pair_.settlement_currency ?
-                                         QString::fromStdString(*self->pair_.settlement_currency) :
-                                         QString{};
-            const QString to_select = !previous.isEmpty() ? previous : fallback;
-            if (!to_select.isEmpty()) {
-                const int idx = combo->findText(to_select);
-                if (idx >= 0)
-                    combo->setCurrentIndex(idx);
-            }
-            combo->blockSignals(false);
-
-            if (self->imageCache())
-                apply_flag_icons(combo, self->imageCache(), FlagSource::Currency);
+    setup_currency_combo(
+        ui_->settlementCurrencyCombo, this, clientManager_, imageCache(), [this]() {
+            const auto& v = pair_.settlement_currency;
+            return v ? QString::fromStdString(*v) : QString();
         });
-
-    auto* cm = clientManager_;
-    watcher->setFuture(QtConcurrent::run([cm]() { return fetch_currency_codes(cm); }));
 }
 
 void CurrencyPairDetailDialog::setUsername(const std::string& username) {
@@ -437,7 +346,8 @@ void CurrencyPairDetailDialog::onDeleteClicked() {
         return;
     }
 
-    const auto crSel = promptChangeReason(ChangeReasonDialog::OperationType::Delete, false);
+    const auto crSel =
+        promptChangeReason(ChangeReasonDialog::OperationType::Delete, false, "common");
     if (!crSel)
         return;
 

--- a/projects/ores.qt/refdata/src/CurrencyPairMdiWindow.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyPairMdiWindow.cpp
@@ -364,4 +364,5 @@ void CurrencyPairMdiWindow::deleteSelected() {
     watcher->setFuture(future);
 }
 
+
 }

--- a/projects/ores.qt/refdata/ui/BookDetailDialog.ui
+++ b/projects/ores.qt/refdata/ui/BookDetailDialog.ui
@@ -77,9 +77,9 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="ledgerCcyEdit">
-            <property name="placeholderText">
-             <string>Enter ledger currency</string>
+           <widget class="ores::qt::OreCurrencyComboBox" name="ledgerCcyEdit">
+            <property name="insertPolicy">
+             <enum>QComboBox::NoInsert</enum>
             </property>
            </widget>
           </item>
@@ -119,9 +119,23 @@
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="bookStatusEdit">
-            <property name="placeholderText">
-             <string>Enter status</string>
+           <widget class="QComboBox" name="bookStatusCombo">
+            <property name="insertPolicy">
+             <enum>QComboBox::NoInsert</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelIsTradingBook">
+            <property name="text">
+             <string>Trading Book:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="isTradingBookCheck">
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
@@ -201,6 +215,11 @@
    <class>ores::qt::ProvenanceWidget</class>
    <extends>QWidget</extends>
    <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ores::qt::OreCurrencyComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ores.qt/OreCurrencyComboBox.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/projects/ores.qt/refdata/ui/BookHistoryDialog.ui
+++ b/projects/ores.qt/refdata/ui/BookHistoryDialog.ui
@@ -234,55 +234,69 @@
                 </widget>
                </item>
                <item row="6" column="0">
-                <widget class="QLabel" name="versionNumberLabel">
+                <widget class="QLabel" name="is_trading_bookLabel">
                  <property name="text">
-                  <string>Version:</string>
+                  <string>Trading Book:</string>
                  </property>
                 </widget>
                </item>
                <item row="6" column="1">
-                <widget class="QLabel" name="versionNumberValue">
+                <widget class="QLabel" name="isTradingBookCheck">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="7" column="0">
-                <widget class="QLabel" name="modifiedByLabel">
+                <widget class="QLabel" name="versionNumberLabel">
                  <property name="text">
-                  <string>Modified By:</string>
+                  <string>Version:</string>
                  </property>
                 </widget>
                </item>
                <item row="7" column="1">
-                <widget class="QLabel" name="modifiedByValue">
+                <widget class="QLabel" name="versionNumberValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="8" column="0">
-                <widget class="QLabel" name="recordedAtLabel">
+                <widget class="QLabel" name="modifiedByLabel">
                  <property name="text">
-                  <string>Recorded At:</string>
+                  <string>Modified By:</string>
                  </property>
                 </widget>
                </item>
                <item row="8" column="1">
-                <widget class="QLabel" name="recordedAtValue">
+                <widget class="QLabel" name="modifiedByValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="9" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
                 <widget class="QLabel" name="changeCommentaryLabel">
                  <property name="text">
                   <string>Change Commentary:</string>
                  </property>
                 </widget>
                </item>
-               <item row="9" column="1">
+               <item row="10" column="1">
                 <widget class="QLabel" name="changeCommentaryValue">
                  <property name="text">
                   <string/>

--- a/projects/ores.qt/refdata/ui/CurrencyPairDetailDialog.ui
+++ b/projects/ores.qt/refdata/ui/CurrencyPairDetailDialog.ui
@@ -50,6 +50,9 @@
             <property name="placeholderText">
              <string>e.g. EUR/USD</string>
             </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -60,7 +63,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="baseCurrencyCombo">
+           <widget class="ores::qt::OreCurrencyComboBox" name="baseCurrencyCombo">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>
@@ -74,7 +77,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QComboBox" name="quoteCurrencyCombo">
+           <widget class="ores::qt::OreCurrencyComboBox" name="quoteCurrencyCombo">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>
@@ -102,7 +105,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QComboBox" name="settlementCurrencyCombo">
+           <widget class="ores::qt::OreCurrencyComboBox" name="settlementCurrencyCombo">
             <property name="insertPolicy">
              <enum>QComboBox::NoInsert</enum>
             </property>
@@ -212,6 +215,11 @@
    <class>ores::qt::ProvenanceWidget</class>
    <extends>QWidget</extends>
    <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ores::qt::OreCurrencyComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ores.qt/OreCurrencyComboBox.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/projects/ores.qt/trading/src/TradingPlugin.cpp
+++ b/projects/ores.qt/trading/src/TradingPlugin.cpp
@@ -81,8 +81,10 @@ void TradingPlugin::on_login(const plugin_context& ctx) {
     bookController_ = std::make_unique<BookController>(ctx_.main_window,
                                                        ctx_.mdi_area,
                                                        ctx_.client_manager,
+                                                       ctx_.image_cache,
                                                        ctx_.change_reason_cache,
                                                        ctx_.username,
+                                                       ctx_.badge_cache,
                                                        this);
     connectControllerSignals(bookController_.get());
 

--- a/projects/ores.qt/trading/ui/BondInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/BondInstrumentForm.ui
@@ -47,7 +47,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Face Value:</string></property></widget>
@@ -264,7 +264,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/CommodityInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/CommodityInstrumentForm.ui
@@ -49,7 +49,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Quantity:</string></property></widget>
@@ -315,7 +315,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/CreditInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/CreditInstrumentForm.ui
@@ -47,7 +47,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
@@ -266,7 +266,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/EquityInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/EquityInstrumentForm.ui
@@ -49,7 +49,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
@@ -311,7 +311,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxAccumulatorInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxAccumulatorInstrumentForm.ui
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelFixingAmount">
@@ -157,7 +157,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxAsianForwardInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxAsianForwardInstrumentForm.ui
@@ -53,7 +53,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="referenceCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="referenceCurrencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="labelReferenceNotional">
@@ -74,7 +74,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="OreCurrencyComboBox" name="settlementCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="settlementCurrencyCombo"/>
           </item>
           <item row="5" column="0">
            <widget class="QLabel" name="labelSettlementNotional">
@@ -111,7 +111,7 @@
            </widget>
           </item>
           <item row="8" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel" name="labelFixingAmount">
@@ -199,7 +199,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxBarrierOptionInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxBarrierOptionInstrumentForm.ui
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="OreCurrencyComboBox" name="boughtCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="boughtCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelBoughtAmount">
@@ -66,7 +66,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="OreCurrencyComboBox" name="soldCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="soldCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelSoldAmount">
@@ -194,7 +194,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxDigitalOptionInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxDigitalOptionInstrumentForm.ui
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="OreCurrencyComboBox" name="foreignCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="foreignCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelDomesticCurrency">
@@ -53,7 +53,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="domesticCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="domesticCurrencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="labelPayoffCurrency">
@@ -61,7 +61,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="OreCurrencyComboBox" name="payoffCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="payoffCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelPayoffAmount">
@@ -194,7 +194,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxInstrumentForm.ui
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="OreCurrencyComboBox" name="boughtCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="boughtCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelBoughtAmount">
@@ -66,7 +66,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="OreCurrencyComboBox" name="soldCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="soldCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelSoldAmount">
@@ -197,7 +197,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxVanillaOptionInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxVanillaOptionInstrumentForm.ui
@@ -45,7 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="OreCurrencyComboBox" name="boughtCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="boughtCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelBoughtAmount">
@@ -66,7 +66,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="OreCurrencyComboBox" name="soldCurrencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="soldCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelSoldAmount">
@@ -160,7 +160,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/FxVarianceSwapInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/FxVarianceSwapInstrumentForm.ui
@@ -61,7 +61,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelUnderlyingCode">
@@ -160,7 +160,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.qt/trading/ui/SwapInstrumentForm.ui
+++ b/projects/ores.qt/trading/ui/SwapInstrumentForm.ui
@@ -42,7 +42,7 @@
           </item>
           <item row="2" column="0"><widget class="QLabel" name="labelCurrency"><property name="text"><string>Currency:</string></property></widget></item>
           <item row="2" column="1">
-           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
+           <widget class="ores::qt::OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0"><widget class="QLabel" name="labelStartDate"><property name="text"><string>Start Date:</string></property></widget></item>
           <item row="3" column="1">
@@ -141,7 +141,7 @@
   <header>ores.qt/OreDateEdit.hpp</header>
  </customwidget>
  <customwidget>
-  <class>OreCurrencyComboBox</class>
+  <class>ores::qt::OreCurrencyComboBox</class>
   <extends>QComboBox</extends>
   <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>

--- a/projects/ores.refdata/modeling/ores.refdata.book.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book.org
@@ -319,16 +319,26 @@ Basel III/IV classification.
 
 *** Columns (Qt model)
 
-| enum_name     | field           | header      | type      | width |
-|---------------+-----------------+-------------+-----------+-------|
-| Name          | name            | Name        | string    | 200   |
-| LedgerCcy     | ledger_ccy      | Ledger Ccy  | string    | 100   |
-| BookStatus    | book_status     | Status      | string    | 100   |
-| CostCenter    | cost_center     | Cost Center | string    | 120   |
-| IsTradingBook | is_trading_book | Trading     | int       | 70    |
-| Version       | version         | Version     | int       | 80    |
-| ModifiedBy    | modified_by     | Modified By | string    | 120   |
-| RecordedAt    | recorded_at     | Recorded At | timestamp | 150   |
+| enum_name     | field           | header      | type      | width | is_badge | badge_key       | formatter      | formatter_include            |
+|---------------+-----------------+-------------+-----------+-------+----------+-----------------+----------------+-------------------------------|
+| Name          | name            | Name        | string    | 200   |          |                 |                |                               |
+| LedgerCcy     | ledger_ccy      | Ledger Ccy  | string    | 100   |          |                 |                |                               |
+| BookStatus    | book_status     | Status      | string    | 100   | true     | book_status     |                |                               |
+| CostCenter    | cost_center     | Cost Center | string    | 120   |          |                 |                |                               |
+| IsTradingBook | is_trading_book | Trading     | int       | 70    | true     | book_is_trading | boolYesNoLabel | ores.qt/BoolYesNoLabel.hpp    |
+| Version       | version         | Version     | int       | 80    |          |                 |                |                               |
+| ModifiedBy    | modified_by     | Modified By | string    | 120   |          |                 |                |                               |
+| RecordedAt    | recorded_at     | Recorded At | timestamp | 150   |          |                 |                |                               |
+
+*** Icon columns (Qt model)
+
+Ledger currency gets its own flag icon, same as any other
+single-currency cell (e.g. Currency's own code column) — no
+compositing needed since it's a single column.
+
+| column    | accessor           | field1     | field2 |
+|-----------+--------------------+------------+--------|
+| LedgerCcy | currency_flag_icon | ledger_ccy |        |
 
 ** Custom repository methods
 

--- a/projects/ores.refdata/modeling/ores.refdata.book.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book.org
@@ -308,14 +308,14 @@ Basel III/IV classification.
 
 *** Detail fields
 
-| field           | label           | widget            | type          | is_key | is_required | placeholder                 | references_entity | combo_values                              | badge_key   |
-|-----------------+-----------------+-------------------+---------------+--------+-------------+------------------------------+--------------------+--------------------------------------------+-------------|
-| id              | Id              | idEdit            | line_edit     | true   | true        | Book id                     |                    |                                            |             |
-| name            | Name            | nameEdit          | line_edit     |        | true        | Enter book name              |                    |                                            |             |
-| ledger_ccy      | Ledger Currency | ledgerCcyEdit     | dynamic_combo |        |             |                              | currency           |                                            |             |
-| gl_account_ref  | GL Account Ref  | glAccountRefEdit  | line_edit     |        |             | Enter GL account reference   |                    |                                            |             |
-| cost_center     | Cost Center     | costCenterEdit    | line_edit     |        |             | Enter cost center            |                    |                                            |             |
-| book_status     | Status          | bookStatusCombo   | static_combo  |        |             |                              |                    | Active,Inactive,Closed,Frozen,Pending      | book_status |
+| field           | label           | widget            | type          | is_key | is_required | placeholder                 | flag_source | combo_values                              | badge_key   |
+|-----------------+-----------------+-------------------+---------------+--------+-------------+------------------------------+--------------+--------------------------------------------+-------------|
+| id              | Id              | idEdit            | line_edit     | true   | true        | Book id                     |              |                                            |             |
+| name            | Name            | nameEdit          | line_edit     |        | true        | Enter book name              |              |                                            |             |
+| ledger_ccy      | Ledger Currency | ledgerCcyEdit     | flagged_combo |        |             |                              | currency     |                                            |             |
+| gl_account_ref  | GL Account Ref  | glAccountRefEdit  | line_edit     |        |             | Enter GL account reference   |              |                                            |             |
+| cost_center     | Cost Center     | costCenterEdit    | line_edit     |        |             | Enter cost center            |              |                                            |             |
+| book_status     | Status          | bookStatusCombo   | static_combo  |        |             |                              |              | Active,Inactive,Closed,Frozen,Pending      | book_status |
 | is_trading_book | Trading Book    | isTradingBookCheck | check_box     |        |             |                              |                    |                                            |             |
 
 *** Columns (Qt model)

--- a/projects/ores.refdata/modeling/ores.refdata.book.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book.org
@@ -308,14 +308,15 @@ Basel III/IV classification.
 
 *** Detail fields
 
-| field          | label           | widget           | type      | is_key | is_required | placeholder                |
-|----------------+-----------------+------------------+-----------+--------+-------------+----------------------------|
-| id             | Id              | idEdit           | line_edit | true   | true        | Book id                    |
-| name           | Name            | nameEdit         | line_edit |        | true        | Enter book name            |
-| ledger_ccy     | Ledger Currency | ledgerCcyEdit    | line_edit |        |             | Enter ledger currency      |
-| gl_account_ref | GL Account Ref  | glAccountRefEdit | line_edit |        |             | Enter GL account reference |
-| cost_center    | Cost Center     | costCenterEdit   | line_edit |        |             | Enter cost center          |
-| book_status    | Status          | bookStatusEdit   | line_edit |        |             | Enter status               |
+| field           | label           | widget            | type          | is_key | is_required | placeholder                 | references_entity | combo_values                              | badge_key   |
+|-----------------+-----------------+-------------------+---------------+--------+-------------+------------------------------+--------------------+--------------------------------------------+-------------|
+| id              | Id              | idEdit            | line_edit     | true   | true        | Book id                     |                    |                                            |             |
+| name            | Name            | nameEdit          | line_edit     |        | true        | Enter book name              |                    |                                            |             |
+| ledger_ccy      | Ledger Currency | ledgerCcyEdit     | dynamic_combo |        |             |                              | currency           |                                            |             |
+| gl_account_ref  | GL Account Ref  | glAccountRefEdit  | line_edit     |        |             | Enter GL account reference   |                    |                                            |             |
+| cost_center     | Cost Center     | costCenterEdit    | line_edit     |        |             | Enter cost center            |                    |                                            |             |
+| book_status     | Status          | bookStatusCombo   | static_combo  |        |             |                              |                    | Active,Inactive,Closed,Frozen,Pending      | book_status |
+| is_trading_book | Trading Book    | isTradingBookCheck | check_box     |        |             |                              |                    |                                            |             |
 
 *** Columns (Qt model)
 

--- a/projects/ores.sql/populate/dq/dq_badge_system_populate.sql
+++ b/projects/ores.sql/populate/dq/dq_badge_system_populate.sql
@@ -72,6 +72,10 @@ BEGIN
         'Lifecycle status codes for book records.', 2);
 
     PERFORM ores_dq_code_domains_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'book_is_trading', 'Book Is Trading',
+        'Whether a book is a trading book (Yes/No badge).', 19);
+
+    PERFORM ores_dq_code_domains_upsert_fn(ores_utility_system_tenant_id_fn(),
         'portfolio_status', 'Portfolio Status',
         'Lifecycle status codes for portfolio records.', 3);
 
@@ -359,6 +363,13 @@ BEGIN
         'book_status', 'Frozen', 'frozen');
     PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
         'book_status', 'Pending', 'pending');
+
+    -- book_is_trading (reuses login_online/inactive colours — same
+    -- generic positive/negative palette as account_online)
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'book_is_trading', 'Yes', 'login_online');
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'book_is_trading', 'No', 'inactive');
 
     -- portfolio_status
     PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),


### PR DESCRIPTION
## Summary

Two unrelated pieces of work landed on this branch:

1. **Agile bookkeeping**: abandons Book's shell/CLI tasks in favour of the top-level shell/CLI codegen commissioning stories (product backlog inbox), and captures an idea to evaluate the `screamer` C++/Python streaming-indicators library for `ores.analytics`.
2. **Codegen**: two new, fully generic detail-dialog field capabilities (a soft-FK reference combo with flag icons, and a badge-rendered static combo), built out while giving Book's detail dialog a proper Ledger Currency / Status / Trading Book editing experience, plus several real bugs fixed along the way (some pre-existing, found while building this).

## Changes

### Agile
- Mark "Implement shell/CLI list/add/remove commands for book" ABANDONED, pointing at the superseding top-level commissioning captures
- Capture: evaluate adding `screamer` to `ores.analytics`

### Codegen: `flagged_combo` improvements (reconciled with main)
- `main` landed `flagged_combo` independently (`6dec81357`, currency_pair work) solving the same "flag-icon combo" problem this branch's `references_entity`/`dynamic_combo` mechanism did. Reconciled onto the single already-shipped mechanism rather than carrying two overlapping ways to author the same field — dropped `references_entity`/`REFERENCE_ENTITY_LOOKUPS` entirely; Book's `ledger_ccy` now uses `flagged_combo` like `currency_pair`'s fields do
- Ported this branch's fixes onto `flagged_combo` instead: a `flag_source: currency` field now defaults `combo_helper: setup_currency_combo`, so its populate function calls the shared helper instead of inlining a near-duplicate fetch/populate body per entity — this also retroactively simplifies `currency_pair`'s 3 existing currency fields, regenerated as part of this work
- Fixed `is_dynamic_combo`'s external setter path being dead code (generated but never called by any entity, including the one pre-existing user, `pricing_model_product`) — the self-populating `combo_fetch_fn` path now covers it

### Codegen: static-combo badges (new capability, didn't exist before)
- New `BadgeComboHelper` (`apply_combo_badges`/`setup_badge_combo`): badge-system counterpart to `FlagIconHelper`. Installs an item delegate that paints each combo row as a left-aligned badge pill via `DelegatePaintUtils::draw_inline_badge()` — the same call `EntityItemDelegate` uses for grid badge columns
- `combo_values` (comma-separated string) + `badge_key`: `static_combo` authoring support that never existed — `is_static_combo` was previously dead code too (its one user had no value source, so its combo was always empty)
- `has_combo_badge_source` threads `BadgeCache` into the detail dialog itself (`has_badge_columns` only wired it into the list/MDI window)

### Shared `ores.qt/api` fixes
- `FlagIconHelper::setup_currency_combo()`: extracted from logic duplicated by hand across every `*InstrumentForm.cpp` in `ores.qt/trading`. Fixed a real race — a controller's `setClientManager()` (which triggers the async fetch) always runs before its `set<Entity>()` (which holds the entity's stored value), so the initial selection was silently lost; added a lazy `fallback_selection` callback evaluated at fetch-completion time
- Moved `OreCurrencyComboBox` from `ores.qt/trading` to `ores.qt/api` (generic Designer marker widget, not trading-specific) and namespaced it into `ores::qt`; updated all 12 trading `.ui` files' `<customwidgets>` entries
- `combo_widget_class`/`combo_widget_customs`: `flagged_combo`/`is_dynamic_combo` fields can now promote to a custom widget class (uic `<customwidgets>` entry emitted once per unique class) instead of always falling back to plain `QComboBox` — this is what was silently dropping `OreCurrencyComboBox`'s standard popup behaviour for Book's (and `currency_pair`'s) combos; a `flag_source: currency` field now defaults to it
- `combo_widget_customs`/`has_combo_badge_source` computation moved from `org_loader.py` to `core.py`: both depend on `combo_widget_class`/`badge_key` values that `is_flagged_combo`/`is_static_combo` handling defaults in, which runs after `org_loader.py` — computing them in `org_loader.py` was an ordering bug (same class fixed earlier for `has_combo_flag_source`)
- `WidgetUtils::setupComboBoxes(this)` wired into the generated constructor (gated on `has_combo_fields`): every hand-written detail dialog already called this for standard combo popup sizing/positioning; codegen never had it
- `setup_currency_combo()` now calls `setup_flag_combo()` instead of one-shot `apply_flag_icons()`: if the image cache hadn't finished loading yet when a combo first populated, its flags silently never appeared — `setup_flag_combo()` also reconnects on `ImageCache::allLoaded` to re-apply once the full set has downloaded, matching every other flag-combo call site in the app

### Book
- `ledger_ccy`: `line_edit` → `flagged_combo` with `flag_source: currency` (flagged currency picker)
- `book_status`: `line_edit` → `static_combo` with `badge_key: book_status` (badge-rendered status picker)
- `is_trading_book`: added as a checkbox field — was missing from the add/edit dialog entirely

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: book](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_book/story.html) | 04BE9B6F-B43C-426B-96D1-AED89F88FA93 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


