### PR TITLE
[codegen] Land has_version_navigation as a qt-profile capability

### DIFF
--- a/doc/agile/versions/v0/sprint_22/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/story.org
@@ -79,6 +79,14 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
   request/response pair — templating it would redefine the same struct
   names with an incompatible shape.
 
+- Version-navigation UI (first/prev/next/last/revert) generalised as
+  an opt-in =has_version_navigation= =detail_dialog= template
+  capability, currency as first consumer — same minimal-footprint
+  approach as the setting-gated-actions capability: land the
+  mechanism in the template, verify by regenerate+diff against the
+  hand-written file, but leave currency's own file untouched until the
+  final mechanical sync task reconciles all capabilities at once.
+
 * Tasks
 
 | Task | State | Start | End | Description |
@@ -104,6 +112,6 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 | [[id:78BF95FE-1513-4556-BCBC-8A4A1AF48907][Relocate random-pick generator logic out of currency Qt UI]] | DONE | 2026-07-05 | 2026-07-06 | CurrencyDetailDialog::onGenerateClicked() and CurrencyMdiWindow::generateSynthetic() do inline std::uniform_int_distribution random-pick selection over generated currencies; this belongs in the generator/service layer, not the Qt UI. Relocate it before the Qt sync task touches these files, so regeneration wires to the relocated call rather than re-embedding the logic. |
 | [[id:2EAF2F99-B71F-410D-985A-7A616E40CB88][Land CSV/XML import-export as a qt-profile template capability]] | DONE | 2026-07-06 | 2026-07-06 | Currency's CurrencyMdiWindow has hand-rolled CSV export and XML import/export with no template equivalent. Generalise it into an opt-in qt-profile mdi_window template capability, with currency as the first real consumer, so the Qt sync task doesn't silently drop it on regeneration. |
 | [[id:D9CB6853-797A-4144-BED0-AEBDDBBC173C][Land setting-gated action-visibility knob as a qt-profile template capability]] | DONE | 2026-07-06 | 2026-07-06 | Currency's feature-flagged 'generate synthetic test data' button (gated by system.synthetic_data_generation) has no template equivalent. Generalise it as a conditional action-visibility knob in the mdi_window and detail_dialog templates, with currency as the first real consumer. |
-| [[id:DBDECEFC-7154-4A40-A554-C897AA51BEEE][Land version-navigation UI as a qt-profile detail_dialog template capability]] | BACKLOG | | | Currency's CurrencyDetailDialog has a full version-navigation UI (first/prev/next/last/revert) 100% absent from the template and the synced peer. Generalise it as a detail_dialog template capability, with currency as the first real consumer. |
+| [[id:DBDECEFC-7154-4A40-A554-C897AA51BEEE][Land version-navigation UI as a qt-profile detail_dialog template capability]] | DONE | 2026-07-06 | 2026-07-07 | Currency's CurrencyDetailDialog has a full version-navigation UI (first/prev/next/last/revert) 100% absent from the template and the synced peer. Generalise it as a detail_dialog template capability, with currency as the first real consumer. |
 | [[id:D613BDFD-FE12-4945-8878-5C92FA109E40][Land NATS notification-wiring capability in the qt-profile controller template]] | BACKLOG | | | Currency's CurrencyController has hand-added onNotificationReceived staleness-propagation logic; the template's changed_event_class flag wires the subscription but generates no handler. Land the handler-generation half of this capability, with currency as the first real consumer (no peer currently configures changed_event_class). |
 | [[id:318EE3EB-E15E-4F10-BCF7-154658A4AFE8][Reconcile currency's flag image handling and wire the piloted combo-field mechanism]] | BACKLOG | | | Migrate currency's hand-rolled flag image handling onto the template's existing has_flag_icon mechanism (no new template work, just a call-site migration). Wire currency's 3 soft-FK combo fields (rounding_type, monetary_nature, market_tier) to the already-piloted populateDynamicCombo<Entity> helper via the small per-field codegen emit. Decide and land the fetch-failure-signalling gap flagged during the combo-field pilot before finalizing the emit. |

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_land-version-nav-ui-qt-template.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_land-version-nav-ui-qt-template.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
 #+branch: feature/land-version-nav-ui-qt-template
-#+pr:
+#+pr: 1458
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-04
@@ -93,7 +93,7 @@ confirming the divergence this capability was meant to close.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1458][#1458]] | [codegen] Land has_version_navigation as a qt-profile capability |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_land-version-nav-ui-qt-template.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_land-version-nav-ui-qt-template.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/land-version-nav-ui-qt-template
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-04
 #+updated: 2026-07-04
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -30,12 +30,12 @@ regenerate plan (task 6E0CD16E).
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-04                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-07                               |
 
 * Acceptance
 
@@ -47,11 +47,47 @@ regenerate plan (task 6E0CD16E).
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Followed the same minimal-footprint pattern as the setting-gated-actions
+capability (task D9CB6853): add an opt-in =has_version_navigation=
+mustache section to the =detail_dialog= hpp/cpp templates (and their
+=ores.cpp.qt.detail_dialog_{header,impl}.org= literate sources), flip
+it on for currency's model, regenerate, diff against the hand-written
+file to verify equivalence, then discard the regenerated currency
+files — currency itself stays hand-written until the final mechanical
+sync task (EA647CBC, step 9).
+
+Landed capability, gated by =domain_entity.qt.has_version_navigation=
+(plus =version_history_include= / =version_history_type= properties):
+
+- Header: =setReadOnly(bool, int = 0)= overload (replaces the 1-arg
+  form), =setHistory=, revert signal, 5 nav/revert slots, 3 private
+  helpers (=displayCurrentVersion=, =updateVersionNavButtonStates=,
+  =showVersionNavActions=), and the toolbar/action/history members.
+- Impl: toolbar + 5 QActions built in =setupUi()= (mirrors currency's
+  hand-rolled toolbar construction verbatim, entity-name substituted),
+  =setReadOnly= extended to toggle =revertAction_= visibility,
+  =setHistory=/=displayCurrentVersion=/nav slots/=onRevertClicked=
+  implemented generically off =history_.versions[i].{data,version_number}=
+  (the shape currency's hand-written =currency_version= struct already
+  uses).
+
+Verified via =./codegen.sh generate --model .../currency.org --address
+ores.cpp.qt= then diffing the regenerated =CurrencyDetailDialog.{hpp,cpp}=
+against the repo: the generated version-nav/revert methods reproduce
+the hand-written behaviour exactly (same toolbar order, same
+enable/disable logic, same slot bodies) modulo formatting; the rest of
+the diff is pre-existing unrelated Qt-layer drift tracked by the sync
+task. Also regenerated a peer without the flag (party_status) and
+confirmed zero version-nav leakage. Discarded both regenerated trees
+after verification (=git checkout=/=git clean=) — no C++ source
+changed by this task, only templates/org-model/org-docs.
 
 * Notes
+
+Currency's actual =setReadOnly(bool, int)= signature was already
+2-argument (matching what this capability now generates); the
+template's prior 1-argument =setReadOnly(bool)= was the outlier,
+confirming the divergence this capability was meant to close.
 
 * PRs
 
@@ -66,3 +102,11 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+Version-navigation UI (first/prev/next/last/revert) landed as an
+opt-in =has_version_navigation= capability in the =detail_dialog=
+qt-profile template, currency flipped on as first consumer. Verified
+by regenerating and diffing against the hand-written file — behaviour
+matches exactly. Currency's own file is untouched (mechanical
+reconciliation is the sync task's job); 4 of 6 prerequisites for
+"Sync Qt codegen for currency" (EA647CBC) are now DONE.

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -90,6 +90,63 @@ void {{domain_entity.entity_pascal}}DetailDialog::setupUi() {
     // Flag editor hosted in the .ui flagGroup; base class owns the button.
     initFlagButton(ui_->flagGroup->layout());
 {{/domain_entity.qt.has_flag_icon}}
+{{#domain_entity.qt.has_version_navigation}}
+
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    revertAction_ = new QAction(tr("Revert"), this);
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+    revertAction_->setToolTip(
+        tr("Revert {{domain_entity.entity_singular_words}} to this historical version"));
+    connect(revertAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onRevertClicked);
+    toolBar_->addAction(revertAction_);
+    revertAction_->setVisible(false);
+
+    toolBar_->addSeparator();
+
+    firstVersionAction_ = new QAction(tr("First"), this);
+    firstVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowPrevious, IconUtils::DefaultIconColor));
+    firstVersionAction_->setToolTip(tr("First version"));
+    connect(firstVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onFirstVersionClicked);
+    toolBar_->addAction(firstVersionAction_);
+    firstVersionAction_->setVisible(false);
+
+    prevVersionAction_ = new QAction(tr("Previous"), this);
+    prevVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowLeft, IconUtils::DefaultIconColor));
+    prevVersionAction_->setToolTip(tr("Previous version"));
+    connect(prevVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onPrevVersionClicked);
+    toolBar_->addAction(prevVersionAction_);
+    prevVersionAction_->setVisible(false);
+
+    nextVersionAction_ = new QAction(tr("Next"), this);
+    nextVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowRight, IconUtils::DefaultIconColor));
+    nextVersionAction_->setToolTip(tr("Next version"));
+    connect(nextVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onNextVersionClicked);
+    toolBar_->addAction(nextVersionAction_);
+    nextVersionAction_->setVisible(false);
+
+    lastVersionAction_ = new QAction(tr("Last"), this);
+    lastVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowNext, IconUtils::DefaultIconColor));
+    lastVersionAction_->setToolTip(tr("Last version"));
+    connect(lastVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onLastVersionClicked);
+    toolBar_->addAction(lastVersionAction_);
+    lastVersionAction_->setVisible(false);
+
+    if (auto* mainLayout = qobject_cast<QVBoxLayout*>(layout()))
+        mainLayout->insertWidget(0, toolBar_);
+{{/domain_entity.qt.has_version_navigation}}
 }
 {{#domain_entity.qt.has_flag_icon}}
 
@@ -269,7 +326,13 @@ void {{domain_entity.entity_pascal}}DetailDialog::markDirty() {
     updateSaveButtonState();
 }
 
+{{^domain_entity.qt.has_version_navigation}}
 void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly) {
+{{/domain_entity.qt.has_version_navigation}}
+{{#domain_entity.qt.has_version_navigation}}
+void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly, int versionNumber) {
+    historicalVersion_ = versionNumber;
+{{/domain_entity.qt.has_version_navigation}}
     readOnly_ = readOnly;
 {{#domain_entity.qt.detail_fields}}
 {{#is_key}}
@@ -309,7 +372,120 @@ void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly) {
 {{/domain_entity.qt.detail_fields}}
     ui_->saveButton->setVisible(!readOnly);
     ui_->deleteButton->setVisible(!readOnly);
+{{#domain_entity.qt.has_version_navigation}}
+    if (revertAction_)
+        revertAction_->setVisible(readOnly);
+{{/domain_entity.qt.has_version_navigation}}
 }
+{{#domain_entity.qt.has_version_navigation}}
+
+void {{domain_entity.entity_pascal}}DetailDialog::setHistory(
+    const {{domain_entity.qt.version_history_type}}& history, int versionNumber) {
+    history_ = history;
+
+    // Find index of the requested version (history is newest-first)
+    currentHistoryIndex_ = 0;
+    for (size_t i = 0; i < history_.versions.size(); ++i) {
+        if (history_.versions[i].version_number == versionNumber) {
+            currentHistoryIndex_ = static_cast<int>(i);
+            break;
+        }
+    }
+
+    displayCurrentVersion();
+    showVersionNavActions(true);
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::displayCurrentVersion() {
+    if (history_.versions.empty() || currentHistoryIndex_ < 0 ||
+        currentHistoryIndex_ >= static_cast<int>(history_.versions.size())) {
+        return;
+    }
+
+    const auto& version = history_.versions[currentHistoryIndex_];
+    set{{domain_entity.entity_pascal_short}}(version.data);
+    setReadOnly(true, version.version_number);
+    updateVersionNavButtonStates();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::updateVersionNavButtonStates() {
+    if (history_.versions.empty()) {
+        showVersionNavActions(false);
+        return;
+    }
+
+    bool atOldest = (currentHistoryIndex_ == static_cast<int>(history_.versions.size()) - 1);
+    bool atNewest = (currentHistoryIndex_ == 0);
+
+    if (firstVersionAction_)
+        firstVersionAction_->setEnabled(!atOldest); // Go to oldest
+    if (prevVersionAction_)
+        prevVersionAction_->setEnabled(!atOldest); // Go to older
+    if (nextVersionAction_)
+        nextVersionAction_->setEnabled(!atNewest); // Go to newer
+    if (lastVersionAction_)
+        lastVersionAction_->setEnabled(!atNewest); // Go to latest
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::showVersionNavActions(bool visible) {
+    if (firstVersionAction_)
+        firstVersionAction_->setVisible(visible);
+    if (prevVersionAction_)
+        prevVersionAction_->setVisible(visible);
+    if (nextVersionAction_)
+        nextVersionAction_->setVisible(visible);
+    if (lastVersionAction_)
+        lastVersionAction_->setVisible(visible);
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onFirstVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    currentHistoryIndex_ = static_cast<int>(history_.versions.size()) - 1;
+    displayCurrentVersion();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onPrevVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    if (currentHistoryIndex_ < static_cast<int>(history_.versions.size()) - 1) {
+        ++currentHistoryIndex_;
+        displayCurrentVersion();
+    }
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onNextVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    if (currentHistoryIndex_ > 0) {
+        --currentHistoryIndex_;
+        displayCurrentVersion();
+    }
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onLastVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    currentHistoryIndex_ = 0;
+    displayCurrentVersion();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
+    auto reply = MessageBoxHelper::question(
+        this,
+        tr("Revert {{domain_entity.entity_title}}"),
+        tr("Are you sure you want to revert '%1' to version %2?\n\n"
+           "This will create a new version with the data from version %2.")
+            .arg(QString::fromStdString({{domain_entity.qt.item_var}}_.{{domain_entity.key_field}}))
+            .arg(historicalVersion_),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes)
+        return;
+
+    emit revertRequested({{domain_entity.qt.item_var}}_);
+}
+{{/domain_entity.qt.has_version_navigation}}
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.hpp.mustache
@@ -13,6 +13,12 @@
 #include "ores.qt/SettingGatedActionController.hpp"
 #include <QAction>
 {{/domain_entity.qt.has_setting_gated_actions}}
+{{#domain_entity.qt.has_version_navigation}}
+#include "ores.qt/IconUtils.hpp"
+#include "{{domain_entity.qt.version_history_include}}"
+#include <QAction>
+#include <QToolBar>
+{{/domain_entity.qt.has_version_navigation}}
 {{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
 #include "{{combo_include}}"
 {{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
@@ -55,7 +61,24 @@ public:
     void setUsername(const std::string& username);
     void set{{domain_entity.entity_pascal_short}}(const {{domain_entity.qt.domain_class}}& {{domain_entity.qt.item_var}});
     void setCreateMode(bool createMode);
+{{^domain_entity.qt.has_version_navigation}}
     void setReadOnly(bool readOnly);
+{{/domain_entity.qt.has_version_navigation}}
+{{#domain_entity.qt.has_version_navigation}}
+    void setReadOnly(bool readOnly, int versionNumber = 0);
+
+    /**
+     * @brief Sets the history for version navigation.
+     *
+     * Shows a navigation toolbar allowing the user to navigate between
+     * versions (first/prev/next/last); the flag is grayed out for
+     * non-latest versions.
+     *
+     * @param history All versions ordered newest-first (index 0 is latest)
+     * @param versionNumber The version number to initially display
+     */
+    void setHistory(const {{domain_entity.qt.version_history_type}}& history, int versionNumber);
+{{/domain_entity.qt.has_version_navigation}}
 
     /**
      * @brief Force the dialog into the unsaved-changes state.
@@ -72,12 +95,27 @@ public:
 signals:
     void {{domain_entity.qt.item_var}}Saved(const QString& code);
     void {{domain_entity.qt.item_var}}Deleted(const QString& code);
+{{#domain_entity.qt.has_version_navigation}}
+
+    /**
+     * @brief Emitted when user requests to revert to the displayed historical version.
+     * @param {{domain_entity.qt.item_var}} The {{domain_entity.entity_singular_words}} data to revert to.
+     */
+    void revertRequested(const {{domain_entity.qt.domain_class}}& {{domain_entity.qt.item_var}});
+{{/domain_entity.qt.has_version_navigation}}
 
 private slots:
     void onSaveClicked();
     void onDeleteClicked();
     void onCodeChanged(const QString& text);
     void onFieldChanged();
+{{#domain_entity.qt.has_version_navigation}}
+    void onRevertClicked();
+    void onFirstVersionClicked();
+    void onPrevVersionClicked();
+    void onNextVersionClicked();
+    void onLastVersionClicked();
+{{/domain_entity.qt.has_version_navigation}}
 
 protected:
     QTabWidget* tabWidget() const override;
@@ -106,6 +144,11 @@ private:
 {{#domain_entity.qt.detail_fields}}{{#is_flagged_combo}}
     void populate{{field_pascal}}Combo();
 {{/is_flagged_combo}}{{/domain_entity.qt.detail_fields}}
+{{#domain_entity.qt.has_version_navigation}}
+    void displayCurrentVersion();
+    void updateVersionNavButtonStates();
+    void showVersionNavActions(bool visible);
+{{/domain_entity.qt.has_version_navigation}}
 
     Ui::{{domain_entity.entity_pascal}}DetailDialog* ui_;
     ClientManager* clientManager_;
@@ -123,6 +166,17 @@ private:
 {{/domain_entity.qt.setting_gated_actions}}
     SettingGatedActionController* settingGatedActions_{nullptr};
 {{/domain_entity.qt.has_setting_gated_actions}}
+{{#domain_entity.qt.has_version_navigation}}
+    QToolBar* toolBar_{nullptr};
+    QAction* revertAction_{nullptr};
+    QAction* firstVersionAction_{nullptr};
+    QAction* prevVersionAction_{nullptr};
+    QAction* nextVersionAction_{nullptr};
+    QAction* lastVersionAction_{nullptr};
+    {{domain_entity.qt.version_history_type}} history_;
+    int currentHistoryIndex_{0};
+    int historicalVersion_{0};
+{{/domain_entity.qt.has_version_navigation}}
 };
 
 }

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_header.org
@@ -38,6 +38,12 @@ The full template source. Edit here and re-tangle with
 #include "ores.qt/SettingGatedActionController.hpp"
 #include <QAction>
 {{/domain_entity.qt.has_setting_gated_actions}}
+{{#domain_entity.qt.has_version_navigation}}
+#include "ores.qt/IconUtils.hpp"
+#include "{{domain_entity.qt.version_history_include}}"
+#include <QAction>
+#include <QToolBar>
+{{/domain_entity.qt.has_version_navigation}}
 {{#domain_entity.qt.detail_fields}}{{#is_dynamic_combo}}
 #include "{{combo_include}}"
 {{/is_dynamic_combo}}{{/domain_entity.qt.detail_fields}}
@@ -80,7 +86,24 @@ public:
     void setUsername(const std::string& username);
     void set{{domain_entity.entity_pascal_short}}(const {{domain_entity.qt.domain_class}}& {{domain_entity.qt.item_var}});
     void setCreateMode(bool createMode);
+{{^domain_entity.qt.has_version_navigation}}
     void setReadOnly(bool readOnly);
+{{/domain_entity.qt.has_version_navigation}}
+{{#domain_entity.qt.has_version_navigation}}
+    void setReadOnly(bool readOnly, int versionNumber = 0);
+
+    /**
+     * @brief Sets the history for version navigation.
+     *
+     * Shows a navigation toolbar allowing the user to navigate between
+     * versions (first/prev/next/last); the flag is grayed out for
+     * non-latest versions.
+     *
+     * @param history All versions ordered newest-first (index 0 is latest)
+     * @param versionNumber The version number to initially display
+     */
+    void setHistory(const {{domain_entity.qt.version_history_type}}& history, int versionNumber);
+{{/domain_entity.qt.has_version_navigation}}
 
     /**
      * @brief Force the dialog into the unsaved-changes state.
@@ -97,12 +120,27 @@ public:
 signals:
     void {{domain_entity.qt.item_var}}Saved(const QString& code);
     void {{domain_entity.qt.item_var}}Deleted(const QString& code);
+{{#domain_entity.qt.has_version_navigation}}
+
+    /**
+     * @brief Emitted when user requests to revert to the displayed historical version.
+     * @param {{domain_entity.qt.item_var}} The {{domain_entity.entity_singular_words}} data to revert to.
+     */
+    void revertRequested(const {{domain_entity.qt.domain_class}}& {{domain_entity.qt.item_var}});
+{{/domain_entity.qt.has_version_navigation}}
 
 private slots:
     void onSaveClicked();
     void onDeleteClicked();
     void onCodeChanged(const QString& text);
     void onFieldChanged();
+{{#domain_entity.qt.has_version_navigation}}
+    void onRevertClicked();
+    void onFirstVersionClicked();
+    void onPrevVersionClicked();
+    void onNextVersionClicked();
+    void onLastVersionClicked();
+{{/domain_entity.qt.has_version_navigation}}
 
 protected:
     QTabWidget* tabWidget() const override;
@@ -131,6 +169,11 @@ private:
 {{#domain_entity.qt.detail_fields}}{{#is_flagged_combo}}
     void populate{{field_pascal}}Combo();
 {{/is_flagged_combo}}{{/domain_entity.qt.detail_fields}}
+{{#domain_entity.qt.has_version_navigation}}
+    void displayCurrentVersion();
+    void updateVersionNavButtonStates();
+    void showVersionNavActions(bool visible);
+{{/domain_entity.qt.has_version_navigation}}
 
     Ui::{{domain_entity.entity_pascal}}DetailDialog* ui_;
     ClientManager* clientManager_;
@@ -148,6 +191,17 @@ private:
 {{/domain_entity.qt.setting_gated_actions}}
     SettingGatedActionController* settingGatedActions_{nullptr};
 {{/domain_entity.qt.has_setting_gated_actions}}
+{{#domain_entity.qt.has_version_navigation}}
+    QToolBar* toolBar_{nullptr};
+    QAction* revertAction_{nullptr};
+    QAction* firstVersionAction_{nullptr};
+    QAction* prevVersionAction_{nullptr};
+    QAction* nextVersionAction_{nullptr};
+    QAction* lastVersionAction_{nullptr};
+    {{domain_entity.qt.version_history_type}} history_;
+    int currentHistoryIndex_{0};
+    int historicalVersion_{0};
+{{/domain_entity.qt.has_version_navigation}}
 };
 
 }

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
@@ -115,6 +115,63 @@ void {{domain_entity.entity_pascal}}DetailDialog::setupUi() {
     // Flag editor hosted in the .ui flagGroup; base class owns the button.
     initFlagButton(ui_->flagGroup->layout());
 {{/domain_entity.qt.has_flag_icon}}
+{{#domain_entity.qt.has_version_navigation}}
+
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    revertAction_ = new QAction(tr("Revert"), this);
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+    revertAction_->setToolTip(
+        tr("Revert {{domain_entity.entity_singular_words}} to this historical version"));
+    connect(revertAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onRevertClicked);
+    toolBar_->addAction(revertAction_);
+    revertAction_->setVisible(false);
+
+    toolBar_->addSeparator();
+
+    firstVersionAction_ = new QAction(tr("First"), this);
+    firstVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowPrevious, IconUtils::DefaultIconColor));
+    firstVersionAction_->setToolTip(tr("First version"));
+    connect(firstVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onFirstVersionClicked);
+    toolBar_->addAction(firstVersionAction_);
+    firstVersionAction_->setVisible(false);
+
+    prevVersionAction_ = new QAction(tr("Previous"), this);
+    prevVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowLeft, IconUtils::DefaultIconColor));
+    prevVersionAction_->setToolTip(tr("Previous version"));
+    connect(prevVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onPrevVersionClicked);
+    toolBar_->addAction(prevVersionAction_);
+    prevVersionAction_->setVisible(false);
+
+    nextVersionAction_ = new QAction(tr("Next"), this);
+    nextVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowRight, IconUtils::DefaultIconColor));
+    nextVersionAction_->setToolTip(tr("Next version"));
+    connect(nextVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onNextVersionClicked);
+    toolBar_->addAction(nextVersionAction_);
+    nextVersionAction_->setVisible(false);
+
+    lastVersionAction_ = new QAction(tr("Last"), this);
+    lastVersionAction_->setIcon(
+        IconUtils::createRecoloredIcon(Icon::ArrowNext, IconUtils::DefaultIconColor));
+    lastVersionAction_->setToolTip(tr("Last version"));
+    connect(lastVersionAction_, &QAction::triggered, this,
+            &{{domain_entity.entity_pascal}}DetailDialog::onLastVersionClicked);
+    toolBar_->addAction(lastVersionAction_);
+    lastVersionAction_->setVisible(false);
+
+    if (auto* mainLayout = qobject_cast<QVBoxLayout*>(layout()))
+        mainLayout->insertWidget(0, toolBar_);
+{{/domain_entity.qt.has_version_navigation}}
 }
 {{#domain_entity.qt.has_flag_icon}}
 
@@ -294,7 +351,13 @@ void {{domain_entity.entity_pascal}}DetailDialog::markDirty() {
     updateSaveButtonState();
 }
 
+{{^domain_entity.qt.has_version_navigation}}
 void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly) {
+{{/domain_entity.qt.has_version_navigation}}
+{{#domain_entity.qt.has_version_navigation}}
+void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly, int versionNumber) {
+    historicalVersion_ = versionNumber;
+{{/domain_entity.qt.has_version_navigation}}
     readOnly_ = readOnly;
 {{#domain_entity.qt.detail_fields}}
 {{#is_key}}
@@ -334,7 +397,120 @@ void {{domain_entity.entity_pascal}}DetailDialog::setReadOnly(bool readOnly) {
 {{/domain_entity.qt.detail_fields}}
     ui_->saveButton->setVisible(!readOnly);
     ui_->deleteButton->setVisible(!readOnly);
+{{#domain_entity.qt.has_version_navigation}}
+    if (revertAction_)
+        revertAction_->setVisible(readOnly);
+{{/domain_entity.qt.has_version_navigation}}
 }
+{{#domain_entity.qt.has_version_navigation}}
+
+void {{domain_entity.entity_pascal}}DetailDialog::setHistory(
+    const {{domain_entity.qt.version_history_type}}& history, int versionNumber) {
+    history_ = history;
+
+    // Find index of the requested version (history is newest-first)
+    currentHistoryIndex_ = 0;
+    for (size_t i = 0; i < history_.versions.size(); ++i) {
+        if (history_.versions[i].version_number == versionNumber) {
+            currentHistoryIndex_ = static_cast<int>(i);
+            break;
+        }
+    }
+
+    displayCurrentVersion();
+    showVersionNavActions(true);
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::displayCurrentVersion() {
+    if (history_.versions.empty() || currentHistoryIndex_ < 0 ||
+        currentHistoryIndex_ >= static_cast<int>(history_.versions.size())) {
+        return;
+    }
+
+    const auto& version = history_.versions[currentHistoryIndex_];
+    set{{domain_entity.entity_pascal_short}}(version.data);
+    setReadOnly(true, version.version_number);
+    updateVersionNavButtonStates();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::updateVersionNavButtonStates() {
+    if (history_.versions.empty()) {
+        showVersionNavActions(false);
+        return;
+    }
+
+    bool atOldest = (currentHistoryIndex_ == static_cast<int>(history_.versions.size()) - 1);
+    bool atNewest = (currentHistoryIndex_ == 0);
+
+    if (firstVersionAction_)
+        firstVersionAction_->setEnabled(!atOldest); // Go to oldest
+    if (prevVersionAction_)
+        prevVersionAction_->setEnabled(!atOldest); // Go to older
+    if (nextVersionAction_)
+        nextVersionAction_->setEnabled(!atNewest); // Go to newer
+    if (lastVersionAction_)
+        lastVersionAction_->setEnabled(!atNewest); // Go to latest
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::showVersionNavActions(bool visible) {
+    if (firstVersionAction_)
+        firstVersionAction_->setVisible(visible);
+    if (prevVersionAction_)
+        prevVersionAction_->setVisible(visible);
+    if (nextVersionAction_)
+        nextVersionAction_->setVisible(visible);
+    if (lastVersionAction_)
+        lastVersionAction_->setVisible(visible);
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onFirstVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    currentHistoryIndex_ = static_cast<int>(history_.versions.size()) - 1;
+    displayCurrentVersion();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onPrevVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    if (currentHistoryIndex_ < static_cast<int>(history_.versions.size()) - 1) {
+        ++currentHistoryIndex_;
+        displayCurrentVersion();
+    }
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onNextVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    if (currentHistoryIndex_ > 0) {
+        --currentHistoryIndex_;
+        displayCurrentVersion();
+    }
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onLastVersionClicked() {
+    if (history_.versions.empty())
+        return;
+    currentHistoryIndex_ = 0;
+    displayCurrentVersion();
+}
+
+void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
+    auto reply = MessageBoxHelper::question(
+        this,
+        tr("Revert {{domain_entity.entity_title}}"),
+        tr("Are you sure you want to revert '%1' to version %2?\n\n"
+           "This will create a new version with the data from version %2.")
+            .arg(QString::fromStdString({{domain_entity.qt.item_var}}_.{{domain_entity.key_field}}))
+            .arg(historicalVersion_),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes)
+        return;
+
+    emit revertRequested({{domain_entity.qt.item_var}}_);
+}
+{{/domain_entity.qt.has_version_navigation}}
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}

--- a/projects/ores.refdata/modeling/ores.refdata.currency.org
+++ b/projects/ores.refdata/modeling/ores.refdata.currency.org
@@ -435,6 +435,9 @@ version-navigation UI that consumes this richer shape.
 :xml_import_class:            ore::xml::importer
 :xml_import_method:           import_currency_config
 :xml_validate_method:         validate_currency
+:has_version_navigation:      true
+:version_history_include:     ores.refdata.api/messaging/currency_history_protocol.hpp
+:version_history_type:        refdata::messaging::currency_version_history
 :END:
 
 *** Columns (Qt model)


### PR DESCRIPTION
## Summary

Generalise currency's hand-written version-navigation UI (first/prev/next/last/revert) into an opt-in detail_dialog qt-profile template capability, verified by regenerate+diff against the hand-written file.

## Changes

- Add has_version_navigation-gated toolbar/actions/slots to cpp_qt_detail_dialog.hpp/.cpp.mustache and their literate .org sources
- Flip has_version_navigation on for currency's model with version_history_include/version_history_type
- Verify by regenerating currency's qt profile and diffing the version-nav sections against the hand-written CurrencyDetailDialog; confirm zero leakage into a peer without the flag (party_status)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: currency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/story.html) | 7F9C0F29-4268-4B62-A1BB-2153ECF0A858 |
| Task | [Land version-navigation UI as a qt-profile detail_dialog template capability](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/task_land-version-nav-ui-qt-template.html) | DBDECEFC-7154-4A40-A554-C897AA51BEEE |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)