### PR TITLE
[codegen,qt] Reconcile currency flag/combo handling

### DIFF
--- a/doc/agile/versions/v0/sprint_22/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/story.org
@@ -99,6 +99,17 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
   bug in the previous version-nav PR (wrong mustache path, silently
   empty, broke compilation).
 
+- Flag/combo reconciliation: unlike the 5 prior capability tasks,
+  this one really did migrate currency's checked-in files (not just
+  land-template-then-discard) — flag handling now calls
+  =DetailDialogBase='s existing generic mechanism, dropping ~180
+  lines of duplicated hand-rolled code. The combo-field codegen emit
+  (=combo_domain_type=, calling =populateDynamicCombo<Entity>=) is
+  new; only currency's 3 combo fields are modelled in its "Detail
+  fields" org table, the other 11 stay unmodelled until the final
+  sync task. The pilot's flagged fetch-failure gap was fixed for
+  real (=std::expected= + =on_error= callback), not deferred.
+
 * Tasks
 
 | Task | State | Start | End | Description |
@@ -126,4 +137,5 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 | [[id:D9CB6853-797A-4144-BED0-AEBDDBBC173C][Land setting-gated action-visibility knob as a qt-profile template capability]] | DONE | 2026-07-06 | 2026-07-06 | Currency's feature-flagged 'generate synthetic test data' button (gated by system.synthetic_data_generation) has no template equivalent. Generalise it as a conditional action-visibility knob in the mdi_window and detail_dialog templates, with currency as the first real consumer. |
 | [[id:DBDECEFC-7154-4A40-A554-C897AA51BEEE][Land version-navigation UI as a qt-profile detail_dialog template capability]] | DONE | 2026-07-06 | 2026-07-07 | Currency's CurrencyDetailDialog has a full version-navigation UI (first/prev/next/last/revert) 100% absent from the template and the synced peer. Generalise it as a detail_dialog template capability, with currency as the first real consumer. |
 | [[id:D613BDFD-FE12-4945-8878-5C92FA109E40][Land NATS notification-wiring capability in the qt-profile controller template]] | DONE | 2026-07-08 | 2026-07-08 | Currency's CurrencyController has hand-added onNotificationReceived staleness-propagation logic; the template's changed_event_class flag wires the subscription but generates no handler. Land the handler-generation half of this capability, with currency as the first real consumer (no peer currently configures changed_event_class). |
-| [[id:318EE3EB-E15E-4F10-BCF7-154658A4AFE8][Reconcile currency's flag image handling and wire the piloted combo-field mechanism]] | BACKLOG | | | Migrate currency's hand-rolled flag image handling onto the template's existing has_flag_icon mechanism (no new template work, just a call-site migration). Wire currency's 3 soft-FK combo fields (rounding_type, monetary_nature, market_tier) to the already-piloted populateDynamicCombo<Entity> helper via the small per-field codegen emit. Decide and land the fetch-failure-signalling gap flagged during the combo-field pilot before finalizing the emit. |
+| [[id:318EE3EB-E15E-4F10-BCF7-154658A4AFE8][Reconcile currency's flag image handling and wire the piloted combo-field mechanism]] | DONE | 2026-07-08 | 2026-07-08 | Migrate currency's hand-rolled flag image handling onto the template's existing has_flag_icon mechanism (no new template work, just a call-site migration). Wire currency's 3 soft-FK combo fields (rounding_type, monetary_nature, market_tier) to the already-piloted populateDynamicCombo<Entity> helper via the small per-field codegen emit. Decide and land the fetch-failure-signalling gap flagged during the combo-field pilot before finalizing the emit. |
+| [[id:AEEDE877-C48C-4CE1-A5FA-9CB6D023CC28][Render currency's monetary_nature and market_tier combos as badges]] | BACKLOG | | | Currency's monetary_nature and market_tier detail-dialog fields are soft-FK dynamic combos populated via populateDynamicCombo<Entity>; render them as colored badges like Book's book_status field does (setup_badge_combo/BadgeCache), instead of plain text combo items. |

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
@@ -151,7 +151,7 @@ template, and the =DynamicComboSetup=/=LookupFetcher= API changes).
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Debug log lines use human-readable field names ("rounding type") but the codegen template emits snake_case ("rounding_type") — checked-in code doesn't byte-match what regeneration produces | =CurrencyDetailDialog.cpp= | Fixed | Fixed in 48b1b0b0f. Three independent review passes found no other issues. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/reconcile-currency-qt-flag-image-and-combos
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-04
 #+updated: 2026-07-04
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -34,12 +34,12 @@ emit.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-04                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-08                               |
 
 * Acceptance
 
@@ -53,11 +53,93 @@ emit.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Unlike the 5 prior capability-landing tasks in this story, this one
+was scoped as a genuine call-site migration of currency's real files
+— not a land-template-then-verify-by-diff-then-discard pass. Two
+independent pieces of work:
+
+** 1. Flag image handling migration
+
+=DetailDialogBase= already has a complete, mature flag mechanism
+(=initFlagButton=, =entityImageId()=/=keyFlagField()=/=keyFlagIcon()=
+virtual accessors, =onSelectFlagClicked=, =updateFlagDisplay=,
+=flagChanged()=/=selectedImageId()=/=resetFlagChanged()=) — confirmed
+by =CountryDetailDialog= already using it end to end. Currency's
+~180 lines of hand-rolled equivalent (=flagButton_=,
+=pendingImageId_=, =flagChanged_=, =onCurrencyImageSet=, manual
+=updateFlagDisplay=) were 100% redundant duplication, migrated to
+match Country's pattern exactly:
+- =initFlagButton(ui_->iconGroup->layout())= replaces the hand-built
+  flag button/container.
+- =entityImageId()=/=keyFlagField()=/=keyFlagIcon()= overrides added
+  (matching Country's).
+- =getCurrency()= now uses =flagChanged()=/=selectedImageId()=
+  instead of the local =pendingImageId_= staging.
+- Dropped currency's extra =onCurrencyImageSet= NATS-confirmation
+  toast handling — Country doesn't have this either; the generic
+  =imagesLoaded=/=allLoaded= → =updateFlagDisplay= wiring (already in
+  base's =setImageCache=) covers the refresh.
+- Also dropped the "no-flag placeholder ID" auto-seeding quirk in the
+  old =setCurrency= — unique to currency, inconsistent with how
+  every other flag-icon entity handles a null =image_id=.
+
+** 2. Combo-field codegen wiring
+
+Landed a new =combo_domain_type=-gated branch in the
+=detail_dialog= template (=cpp_qt_detail_dialog.cpp.mustache=)
+generating a =populateDynamicCombo<Entity>= call from per-field org
+properties (=combo_domain_type=, =combo_fetch_fn=,
+=combo_watcher_name=, =combo_code_field=, =combo_tooltip_field=,
+=combo_sort_field=, =combo_label=, =combo_setter_pascal=) — distinct
+from the pre-existing (unused) =combo_helper=/=combo_fetch_fn=
+branches, which don't match the piloted helper's real 9-argument
+signature. Added currency's 3 combo fields (=rounding_type=,
+=monetary_nature=, =market_tier=) to a new "Detail fields" org table
+section (only these 3 — the other 11 currency fields stay unmodelled
+until the final sync task populates the full table).
+
+*Process note*: initially hand-typed the =on_error= callback
+addition directly into =CurrencyDetailDialog.cpp= before adding the
+template capability — caught mid-edit (thanks to a review prompt)
+and reverted. Correct order followed after: land the template
+capability first, regenerate + diff to verify the generated
+=populate*Combo()= bodies match currency's real code, *then* copy
+the verified generated snippet in (adjusting only the real file's
+=currentCurrency_= member name vs. the model's generic =item_var=
+naming — a pre-existing, unrelated drift).
+
+** 3. Fetch-failure-signalling decision
+
+The pilot (task 8AA363F8) flagged that =populateDynamicCombo='s bare
+=std::vector<Entity>= fetch signature can't distinguish "fetch
+failed" from "legitimately empty" — both render a silently-empty
+combo. *Decision*: land the fix, not just document a deferral.
+Changed =populateDynamicCombo='s =fetch= parameter to
+=std::function<std::expected<std::vector<Entity>, QString>(ClientManager*)>=
+and added an =on_error= callback (default no-op) plus a distinct
+"Failed to load" combo placeholder. Updated the 3
+=LookupFetcher= functions currency uses (confirmed sole callers) to
+return =std::expected=, propagating
+=process_authenticated_request='s existing error channel instead of
+silently swallowing it. Currency's 3 combo call sites (both hand and
+generated) now pass an =on_error= callback that emits
+=errorMessage()=.
+
+Scoped to just the 3 functions currency uses — did not touch the
+rest of =LookupFetcher='s many other bare-vector fetchers (out of
+scope, no other entity affected).
 
 * Notes
+
+Verified with a real regenerate + rebuild of =ores.qt.refdata.lib=
+(not a diff-only check): =CurrencyDetailDialog.cpp= compiles clean
+with the migrated flag handling and the generated combo methods.
+Also regenerated Country (no dynamic-combo fields) to confirm the
+new =code()= accessor generalises cleanly with zero
+=combo_domain_type= leakage into peers without it. All regenerated
+trees discarded after verification per this branch's actual
+deliverable (the hand-migrated =CurrencyDetailDialog.{hpp,cpp}=, the
+template, and the =DynamicComboSetup=/=LookupFetcher= API changes).
 
 * PRs
 
@@ -72,3 +154,15 @@ plan itself stays — it is the historical record of what we did.)
 |   |                 |      |          |       |
 
 * Result
+
+All three items landed. Currency's flag handling now calls
+=DetailDialogBase='s generic mechanism (real code change, ~180 lines
+of duplication removed). The 3 soft-FK combo fields are wired through
+a new =combo_domain_type= codegen emit calling
+=populateDynamicCombo<Entity>=, verified equivalent to currency's
+hand-migrated code via regenerate+diff, then applied for real. The
+fetch-failure-signalling gap is closed with a real =std::expected=
+propagation + =on_error= callback, not just documented. Full
+whole-app build (=cmake --build --preset linux-clang-debug-make=)
+passes clean. This closes the last of the 6 prerequisites for "Sync
+Qt codegen for currency" (EA647CBC) — that task is now unblocked.

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.org
@@ -8,7 +8,7 @@
 #+filetags: :commission_currency:sprint_22:v0:
 #+owner: marco
 #+branch: feature/reconcile-currency-qt-flag-image-and-combos
-#+pr:
+#+pr: 1468
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-04
@@ -145,7 +145,7 @@ template, and the =DynamicComboSetup=/=LookupFetcher= API changes).
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1468][#1468]] | [codegen,qt] Reconcile currency flag/combo handling |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/commission_currency/task_render-currency-combos-as-badges.org
+++ b/doc/agile/versions/v0/sprint_22/commission_currency/task_render-currency-combos-as-badges.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: AEEDE877-C48C-4CE1-A5FA-9CB6D023CC28
+:END:
+#+title: Task: Render currency's monetary_nature and market_tier combos as badges
+#+description: Currency's monetary_nature and market_tier detail-dialog fields are soft-FK dynamic combos populated via populateDynamicCombo<Entity>; render them as colored badges like Book's book_status field does (setup_badge_combo/BadgeCache), instead of plain text combo items.
+#+type: task
+#+level: s1
+#+filetags: :commission_currency:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-08
+#+updated: 2026-07-08
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Currency's =monetary_nature= and =market_tier= combos currently show
+plain text (via the =populateDynamicCombo<Entity>= mechanism landed
+in task 318EE3EB). Render them as colored badges instead, matching
+=Book='s =book_status= field (=setup_badge_combo=/=BadgeCache=, see
+=clever_dijkstra= worktree's book-status work if not yet merged into
+main).
+
+=book_status= is a =static_combo= field with a fixed value set and a
+=badge_key= property — =BadgeCache= presumably keys off a small, known
+enum. =monetary_nature=/=market_tier= are *dynamic*, server-fetched
+reference-table combos (=populateDynamicCombo<Entity>=, not
+=static_combo=), so the existing badge mechanism doesn't apply
+as-is. This task needs to either:
+- extend the badge mechanism to work with dynamically-fetched combo
+  items (badge color keyed off each item's =code=, not a static enum), or
+- find that the fetched reference-table rows already carry a badge
+  color mapping the server can express, or
+- conclude it's not a good fit and document why.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-08                               |
+
+* Acceptance
+
+- =monetary_nature= and =market_tier= combos render colored badges
+  matching =book_status='s visual pattern, OR a documented reason
+  they can't/shouldn't (e.g. mechanism mismatch, no natural badge
+  color source) with the decision recorded here.
+- Build passes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -13,6 +13,10 @@
 #include "ores.qt/WidgetUtils.hpp"
 #include <QComboBox>
 {{/domain_entity.qt.has_combo_fields}}
+{{#domain_entity.qt.has_dynamic_combo_helper_fields}}
+#include "ores.qt/DynamicComboSetup.hpp"
+#include "ores.qt/LookupFetcher.hpp"
+{{/domain_entity.qt.has_dynamic_combo_helper_fields}}
 {{#domain_entity.qt.has_uuid_primary_key}}
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -532,6 +536,25 @@ void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}
+{{#combo_domain_type}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    BOOST_LOG_SEV(lg(), debug) << "Populating {{field}} combo";
+    populateDynamicCombo<{{combo_domain_type}}>(
+        ui_->{{widget}},
+        this,
+        clientManager_,
+        &{{combo_fetch_fn}},
+        "{{combo_watcher_name}}",
+        [](const auto& t) { return QString::fromStdString(t.{{combo_code_field}}); },
+        [](const auto& t) { return QString::fromStdString(t.{{combo_tooltip_field}}); },
+        [](const auto& t) { return t.{{combo_sort_field}}; },
+        [this]() { return QString::fromStdString({{domain_entity.qt.item_var}}_.{{field}}); },
+        [this](const QString& error) {
+            emit errorMessage(tr("Failed to load {{combo_label}}: %1").arg(error));
+        });
+}
+{{/combo_domain_type}}
+{{^combo_domain_type}}
 {{^combo_fetch_fn}}
 void {{domain_entity.entity_pascal}}DetailDialog::{{combo_setter}}(
     const std::vector<{{combo_type}}>& items) {
@@ -601,6 +624,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}
 }
 {{/combo_helper}}
 {{/combo_fetch_fn}}
+{{/combo_domain_type}}
 {{/is_dynamic_combo}}
 {{/domain_entity.qt.detail_fields}}
 void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.entity_pascal_short}}() {

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.detail_dialog_impl.org
@@ -38,6 +38,10 @@ The full template source. Edit here and re-tangle with
 #include "ores.qt/WidgetUtils.hpp"
 #include <QComboBox>
 {{/domain_entity.qt.has_combo_fields}}
+{{#domain_entity.qt.has_dynamic_combo_helper_fields}}
+#include "ores.qt/DynamicComboSetup.hpp"
+#include "ores.qt/LookupFetcher.hpp"
+{{/domain_entity.qt.has_dynamic_combo_helper_fields}}
 {{#domain_entity.qt.has_uuid_primary_key}}
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -557,6 +561,25 @@ void {{domain_entity.entity_pascal}}DetailDialog::onRevertClicked() {
 
 {{#domain_entity.qt.detail_fields}}
 {{#is_dynamic_combo}}
+{{#combo_domain_type}}
+void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}}() {
+    BOOST_LOG_SEV(lg(), debug) << "Populating {{field}} combo";
+    populateDynamicCombo<{{combo_domain_type}}>(
+        ui_->{{widget}},
+        this,
+        clientManager_,
+        &{{combo_fetch_fn}},
+        "{{combo_watcher_name}}",
+        [](const auto& t) { return QString::fromStdString(t.{{combo_code_field}}); },
+        [](const auto& t) { return QString::fromStdString(t.{{combo_tooltip_field}}); },
+        [](const auto& t) { return t.{{combo_sort_field}}; },
+        [this]() { return QString::fromStdString({{domain_entity.qt.item_var}}_.{{field}}); },
+        [this](const QString& error) {
+            emit errorMessage(tr("Failed to load {{combo_label}}: %1").arg(error));
+        });
+}
+{{/combo_domain_type}}
+{{^combo_domain_type}}
 {{^combo_fetch_fn}}
 void {{domain_entity.entity_pascal}}DetailDialog::{{combo_setter}}(
     const std::vector<{{combo_type}}>& items) {
@@ -626,6 +649,7 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}
 }
 {{/combo_helper}}
 {{/combo_fetch_fn}}
+{{/combo_domain_type}}
 {{/is_dynamic_combo}}
 {{/domain_entity.qt.detail_fields}}
 void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.entity_pascal_short}}() {

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -819,6 +819,14 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
             qt_out["has_combo_flag_source"] = any(
                 f.get("flag_source") for f in qt_out.get("detail_fields", [])
             )
+            # Whether any dynamic-combo detail field uses the
+            # populateDynamicCombo<Entity> helper (fetch/sort/tooltip/
+            # placeholder/restore-selection, piloted on currency's
+            # rounding_type/monetary_nature/market_tier combos) — gates
+            # the DynamicComboSetup.hpp/LookupFetcher.hpp includes.
+            qt_out["has_dynamic_combo_helper_fields"] = any(
+                f.get("combo_domain_type") for f in qt_out.get("detail_fields", [])
+            )
             qt_out["needs_image_cache"] = (
                 qt_out["has_flag_icon"]
                 or qt_out.get("has_icon_columns", False)

--- a/projects/ores.qt/api/include/ores.qt/DynamicComboSetup.hpp
+++ b/projects/ores.qt/api/include/ores.qt/DynamicComboSetup.hpp
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QtConcurrent>
 #include <algorithm>
+#include <expected>
 #include <functional>
 #include <vector>
 
@@ -50,9 +51,11 @@ namespace ores::qt {
  * QFutureWatcherBase child named watcher_name already existing on it
  * means a fetch is already in flight).
  * @param client_manager Client manager used to run the fetch.
- * @param fetch Synchronous call fetching the full entity vector;
- * intended to be one of the LookupFetcher functions, run off the UI
- * thread by this helper.
+ * @param fetch Synchronous call fetching the full entity vector, or an
+ * error message on failure; intended to be one of the LookupFetcher
+ * functions, run off the UI thread by this helper. Distinguishing
+ * failure from a legitimately-empty result lets the caller surface a
+ * fetch error instead of silently rendering an empty combo.
  * @param watcher_name Unique object name for the QFutureWatcher,
  * used both for re-entrancy guarding and lookup.
  * @param code_of Extracts the value stored as combo item data and
@@ -65,19 +68,27 @@ namespace ores::qt {
  * selection on the combo — e.g. the current entity's stored value for
  * this field, which may not be set yet when populateDynamicCombo is
  * called (setClientManager runs before setCurrency).
+ * @param on_error Called with the error message when the fetch fails;
+ * the combo shows a distinct "Failed to load" placeholder in that
+ * case. Defaults to a no-op for callers that don't need to surface it
+ * beyond the placeholder.
  * @param loading_placeholder Text shown while the fetch is in flight.
+ * @param error_placeholder Text shown in the combo when the fetch fails.
  */
 template <typename Entity>
-void populateDynamicCombo(QComboBox* combo,
-                          QObject* owner,
-                          ClientManager* client_manager,
-                          std::function<std::vector<Entity>(ClientManager*)> fetch,
-                          const QString& watcher_name,
-                          std::function<QString(const Entity&)> code_of,
-                          std::function<QString(const Entity&)> tooltip_of,
-                          std::function<int(const Entity&)> sort_key_of,
-                          std::function<QString()> fallback_selection,
-                          const QString& loading_placeholder = QObject::tr("Loading…")) {
+void populateDynamicCombo(
+    QComboBox* combo,
+    QObject* owner,
+    ClientManager* client_manager,
+    std::function<std::expected<std::vector<Entity>, QString>(ClientManager*)> fetch,
+    const QString& watcher_name,
+    std::function<QString(const Entity&)> code_of,
+    std::function<QString(const Entity&)> tooltip_of,
+    std::function<int(const Entity&)> sort_key_of,
+    std::function<QString()> fallback_selection,
+    std::function<void(const QString&)> on_error = [](const QString&) {},
+    const QString& loading_placeholder = QObject::tr("Loading…"),
+    const QString& error_placeholder = QObject::tr("Failed to load")) {
     if (!combo || !owner || !client_manager || !client_manager->isConnected())
         return;
 
@@ -92,18 +103,18 @@ void populateDynamicCombo(QComboBox* combo,
     combo->blockSignals(false);
 
     QPointer<QObject> self = owner;
-    QFuture<std::vector<Entity>> future =
-        QtConcurrent::run([self, client_manager, fetch]() -> std::vector<Entity> {
-            if (!self)
-                return {};
-            return fetch(client_manager);
-        });
+    using Result = std::expected<std::vector<Entity>, QString>;
+    QFuture<Result> future = QtConcurrent::run([self, client_manager, fetch]() -> Result {
+        if (!self)
+            return std::vector<Entity>{};
+        return fetch(client_manager);
+    });
 
-    auto* watcher = new QFutureWatcher<std::vector<Entity>>(owner);
+    auto* watcher = new QFutureWatcher<Result>(owner);
     watcher->setObjectName(watcher_name);
     QObject::connect(
         watcher,
-        &QFutureWatcher<std::vector<Entity>>::finished,
+        &QFutureWatcher<Result>::finished,
         owner,
         [self,
          watcher,
@@ -112,13 +123,25 @@ void populateDynamicCombo(QComboBox* combo,
          fallback_selection,
          code_of,
          tooltip_of,
-         sort_key_of]() {
-            auto items = watcher->result();
+         sort_key_of,
+         on_error,
+         error_placeholder]() {
+            auto result = watcher->result();
             watcher->deleteLater();
 
             if (!self)
                 return;
 
+            if (!result) {
+                combo->blockSignals(true);
+                combo->clear();
+                combo->addItem(error_placeholder);
+                combo->blockSignals(false);
+                on_error(result.error());
+                return;
+            }
+
+            auto items = std::move(*result);
             std::sort(items.begin(), items.end(), [&sort_key_of](const auto& a, const auto& b) {
                 return sort_key_of(a) < sort_key_of(b);
             });

--- a/projects/ores.qt/api/include/ores.qt/LookupFetcher.hpp
+++ b/projects/ores.qt/api/include/ores.qt/LookupFetcher.hpp
@@ -24,6 +24,8 @@
 #include "ores.refdata.api/domain/currency_market_tier.hpp"
 #include "ores.refdata.api/domain/monetary_nature.hpp"
 #include "ores.refdata.api/domain/rounding_type.hpp"
+#include <QString>
+#include <expected>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -145,27 +147,32 @@ ORES_QT_API std::vector<business_unit_entry> fetch_business_unit_entries(ClientM
  *
  * Synchronous call intended to be run from within QtConcurrent::run.
  * Used by DynamicComboSetup to populate currency's rounding_type combo.
- * Returns empty vector on failure.
+ * Returns an error message on failure, distinguishing it from a
+ * legitimately-empty result.
  */
-ORES_QT_API std::vector<refdata::domain::rounding_type> fetch_rounding_types(ClientManager* cm);
+ORES_QT_API std::expected<std::vector<refdata::domain::rounding_type>, QString>
+fetch_rounding_types(ClientManager* cm);
 
 /**
  * @brief Fetches all monetary natures from the server.
  *
  * Synchronous call intended to be run from within QtConcurrent::run.
  * Used by DynamicComboSetup to populate currency's monetary_nature combo.
- * Returns empty vector on failure.
+ * Returns an error message on failure, distinguishing it from a
+ * legitimately-empty result.
  */
-ORES_QT_API std::vector<refdata::domain::monetary_nature> fetch_monetary_natures(ClientManager* cm);
+ORES_QT_API std::expected<std::vector<refdata::domain::monetary_nature>, QString>
+fetch_monetary_natures(ClientManager* cm);
 
 /**
  * @brief Fetches all currency market tiers from the server.
  *
  * Synchronous call intended to be run from within QtConcurrent::run.
  * Used by DynamicComboSetup to populate currency's market_tier combo.
- * Returns empty vector on failure.
+ * Returns an error message on failure, distinguishing it from a
+ * legitimately-empty result.
  */
-ORES_QT_API std::vector<refdata::domain::currency_market_tier>
+ORES_QT_API std::expected<std::vector<refdata::domain::currency_market_tier>, QString>
 fetch_currency_market_tiers(ClientManager* cm);
 
 }

--- a/projects/ores.qt/api/src/LookupFetcher.cpp
+++ b/projects/ores.qt/api/src/LookupFetcher.cpp
@@ -184,40 +184,40 @@ std::vector<business_unit_entry> fetch_business_unit_entries(ClientManager* cm) 
     return entries;
 }
 
-std::vector<refdata::domain::rounding_type> fetch_rounding_types(ClientManager* cm) {
-    std::vector<refdata::domain::rounding_type> types;
+std::expected<std::vector<refdata::domain::rounding_type>, QString>
+fetch_rounding_types(ClientManager* cm) {
     if (!cm)
-        return types;
+        return std::unexpected(QStringLiteral("Not connected to server."));
 
     refdata::messaging::get_rounding_types_request request;
     auto response = cm->process_authenticated_request(std::move(request));
-    if (response)
-        types = std::move(response->rounding_types);
-    return types;
+    if (!response)
+        return std::unexpected(QString::fromStdString(response.error()));
+    return std::move(response->rounding_types);
 }
 
-std::vector<refdata::domain::monetary_nature> fetch_monetary_natures(ClientManager* cm) {
-    std::vector<refdata::domain::monetary_nature> natures;
+std::expected<std::vector<refdata::domain::monetary_nature>, QString>
+fetch_monetary_natures(ClientManager* cm) {
     if (!cm)
-        return natures;
+        return std::unexpected(QStringLiteral("Not connected to server."));
 
     refdata::messaging::get_monetary_natures_request request;
     auto response = cm->process_authenticated_request(std::move(request));
-    if (response)
-        natures = std::move(response->monetary_natures);
-    return natures;
+    if (!response)
+        return std::unexpected(QString::fromStdString(response.error()));
+    return std::move(response->monetary_natures);
 }
 
-std::vector<refdata::domain::currency_market_tier> fetch_currency_market_tiers(ClientManager* cm) {
-    std::vector<refdata::domain::currency_market_tier> tiers;
+std::expected<std::vector<refdata::domain::currency_market_tier>, QString>
+fetch_currency_market_tiers(ClientManager* cm) {
     if (!cm)
-        return tiers;
+        return std::unexpected(QStringLiteral("Not connected to server."));
 
     refdata::messaging::get_currency_market_tiers_request request;
     auto response = cm->process_authenticated_request(std::move(request));
-    if (response)
-        tiers = std::move(response->currency_market_tiers);
-    return tiers;
+    if (!response)
+        return std::unexpected(QString::fromStdString(response.error()));
+    return std::move(response->currency_market_tiers);
 }
 
 }

--- a/projects/ores.qt/refdata/include/ores.qt/CurrencyDetailDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CurrencyDetailDialog.hpp
@@ -23,14 +23,17 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/DetailDialogBase.hpp"
-#include "ores.qt/ImageCache.hpp"
 #include "ores.qt/SettingGatedActionController.hpp"
 #include "ores.refdata.api/domain/currency.hpp"
 #include "ores.refdata.api/messaging/currency_history_protocol.hpp"
 #include <QAction>
+#include <QIcon>
+#include <QLineEdit>
 #include <QPushButton>
 #include <QToolBar>
+#include <boost/uuid/uuid.hpp>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Ui {
@@ -59,7 +62,6 @@ public:
 
     void setClientManager(ClientManager* clientManager);
     void setUsername(const std::string& username);
-    void setImageCache(ImageCache* imageCache);
 
     void setCurrency(const refdata::domain::currency& currency);
     [[nodiscard]] refdata::domain::currency getCurrency() const;
@@ -114,6 +116,9 @@ protected:
     bool hasUnsavedChanges() const override {
         return isDirty_;
     }
+    std::optional<boost::uuids::uuid> entityImageId() const override;
+    QLineEdit* keyFlagField() const override;
+    QIcon keyFlagIcon(const std::string& key) const override;
 
 signals:
     void currencyUpdated(const QString& iso_code);
@@ -133,8 +138,6 @@ private slots:
     void onDeleteClicked();
     void onRevertClicked();
     void onFieldChanged();
-    void onSelectFlagClicked();
-    void onCurrencyImageSet(const QString& iso_code, bool success, const QString& message);
     void onGenerateClicked();
 
     // Version navigation slots
@@ -146,7 +149,6 @@ private slots:
 private:
     void updateSaveResetButtonState();
     void setFieldsReadOnly(bool readOnly);
-    void updateFlagDisplay();
     void displayCurrentVersion();
     void updateVersionNavButtonStates();
     void showVersionNavActions(bool visible);
@@ -161,20 +163,15 @@ private:
     bool isAddMode_;
     bool isReadOnly_;
     bool isStale_;
-    bool flagChanged_;
     int historicalVersion_;
     std::string username_;
     QToolBar* toolBar_;
     QAction* revertAction_;
     QAction* generateAction_;
-    QPushButton* flagButton_;
 
     ClientManager* clientManager_;
-    ImageCache* imageCache_;
     SettingGatedActionController* settingGatedActions_{nullptr};
-    QAction* isoCodeFlagAction_{nullptr};
     refdata::domain::currency currentCurrency_;
-    QString pendingImageId_;
     static constexpr const char* max_timestamp = "9999-12-31 23:59:59";
 
     // Version navigation members

--- a/projects/ores.qt/refdata/src/CurrencyDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyDetailDialog.cpp
@@ -20,9 +20,8 @@
 #include "ores.qt/CurrencyDetailDialog.hpp"
 #include "ores.qt/ChangeReasonDialog.hpp"
 #include "ores.qt/DynamicComboSetup.hpp"
-#include "ores.qt/FlagIconHelper.hpp"
-#include "ores.qt/FlagSelectorDialog.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ImageCache.hpp"
 #include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/MdiUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
@@ -64,9 +63,7 @@ CurrencyDetailDialog::CurrencyDetailDialog(QWidget* parent)
     , isReadOnly_(false)
     , isStale_(false)
     , historicalVersion_(0)
-    , flagButton_(nullptr)
     , clientManager_(nullptr)
-    , imageCache_(nullptr)
     , currentHistoryIndex_(0)
     , firstVersionAction_(nullptr)
     , prevVersionAction_(nullptr)
@@ -140,29 +137,8 @@ CurrencyDetailDialog::CurrencyDetailDialog(QWidget* parent)
     if (mainLayout)
         mainLayout->insertWidget(0, toolBar_);
 
-    // Add clickable flag button into the iconGroup in the General tab
-    {
-        auto* flagContainer = new QWidget(this);
-        auto* flagLayout = new QHBoxLayout(flagContainer);
-        flagLayout->setContentsMargins(0, 4, 0, 4);
-
-        flagButton_ = new QPushButton(this);
-        flagButton_->setFixedSize(52, 52);
-        flagButton_->setIconSize(QSize(48, 48));
-        flagButton_->setFlat(true);
-        flagButton_->setStyleSheet(
-            "QPushButton { border: none; background: transparent; padding: 0px; } "
-            "QPushButton:hover { background: rgba(255, 255, 255, 15); }");
-        flagButton_->setCursor(Qt::PointingHandCursor);
-        flagButton_->setToolTip(tr("Click to select flag"));
-        connect(
-            flagButton_, &QPushButton::clicked, this, &CurrencyDetailDialog::onSelectFlagClicked);
-        flagLayout->addStretch();
-        flagLayout->addWidget(flagButton_);
-        flagLayout->addStretch();
-
-        ui_->iconGroup->layout()->addWidget(flagContainer);
-    }
+    // Flag editor hosted in the .ui iconGroup; base class owns the button.
+    initFlagButton(ui_->iconGroup->layout());
 
     // Setup bottom buttons
     ui_->saveButton->setIcon(
@@ -229,6 +205,7 @@ CurrencyDetailDialog::CurrencyDetailDialog(QWidget* parent)
                 const auto tip = ui_->marketTierCombo->itemData(idx, Qt::ToolTipRole).toString();
                 ui_->marketTierCombo->setToolTip(tip);
             });
+    connect(this, &DetailDialogBase::flagEdited, this, &CurrencyDetailDialog::onFieldChanged);
 
     // Initially disable save/reset buttons
     updateSaveResetButtonState();
@@ -273,23 +250,6 @@ void CurrencyDetailDialog::setUsername(const std::string& username) {
     username_ = username;
 }
 
-void CurrencyDetailDialog::setImageCache(ImageCache* imageCache) {
-    imageCache_ = imageCache;
-    if (imageCache_) {
-        connect(imageCache_,
-                &ImageCache::currencyImageSet,
-                this,
-                &CurrencyDetailDialog::onCurrencyImageSet);
-        // Connect to imagesLoaded (not currencyMappingsLoaded) because:
-        // - currencyMappingsLoaded fires before icons are re-rendered
-        // - imagesLoaded fires after icons are ready in currency_icons_
-        connect(
-            imageCache_, &ImageCache::imagesLoaded, this, &CurrencyDetailDialog::updateFlagDisplay);
-        connect(
-            imageCache_, &ImageCache::allLoaded, this, &CurrencyDetailDialog::updateFlagDisplay);
-    }
-}
-
 CurrencyDetailDialog::~CurrencyDetailDialog() {
     const auto watchers = findChildren<QFutureWatcherBase*>();
     for (auto* watcher : watchers) {
@@ -308,22 +268,21 @@ ProvenanceWidget* CurrencyDetailDialog::provenanceWidget() const {
     return ui_->provenanceWidget;
 }
 
+std::optional<boost::uuids::uuid> CurrencyDetailDialog::entityImageId() const {
+    return currentCurrency_.image_id;
+}
+
+QLineEdit* CurrencyDetailDialog::keyFlagField() const {
+    return ui_->isoCodeEdit;
+}
+
+QIcon CurrencyDetailDialog::keyFlagIcon(const std::string& key) const {
+    return imageCache() ? imageCache()->getCurrencyFlagIcon(key) : QIcon();
+}
+
 void CurrencyDetailDialog::setCurrency(const refdata::domain::currency& currency) {
     currentCurrency_ = currency;
     isAddMode_ = currency.iso_code.empty();
-
-    if (currency.image_id) {
-        pendingImageId_ = QString::fromStdString(boost::uuids::to_string(*currency.image_id));
-    } else if (imageCache_) {
-        std::string noFlagId = imageCache_->getNoFlagImageId();
-        if (!noFlagId.empty()) {
-            pendingImageId_ = QString::fromStdString(noFlagId);
-        } else {
-            pendingImageId_.clear();
-        }
-    } else {
-        pendingImageId_.clear();
-    }
 
     ui_->isoCodeEdit->setReadOnly(!isAddMode_);
     ui_->isoCodeEdit->setText(QString::fromStdString(currency.iso_code));
@@ -345,7 +304,6 @@ void CurrencyDetailDialog::setCurrency(const refdata::domain::currency& currency
                        currency.change_commentary);
 
     isDirty_ = false;
-    flagChanged_ = false;
     emit isDirtyChanged(false);
     updateSaveResetButtonState();
     updateFlagDisplay();
@@ -366,10 +324,8 @@ refdata::domain::currency CurrencyDetailDialog::getCurrency() const {
     currency.market_tier = ui_->marketTierCombo->currentText().toStdString();
     currency.modified_by = username_.empty() ? "qt_user" : username_;
 
-    if (!pendingImageId_.isEmpty()) {
-        boost::uuids::string_generator gen;
-        currency.image_id = gen(pendingImageId_.toStdString());
-    }
+    if (flagChanged())
+        currency.image_id = selectedImageId();
 
     return currency;
 }
@@ -387,10 +343,8 @@ void CurrencyDetailDialog::clearDialog() {
     ui_->monetaryNatureCombo->setCurrentIndex(-1);
     ui_->marketTierCombo->setCurrentIndex(-1);
     clearProvenance();
-    pendingImageId_.clear();
 
     isDirty_ = false;
-    flagChanged_ = false;
     emit isDirtyChanged(false);
     updateSaveResetButtonState();
 }
@@ -448,10 +402,9 @@ void CurrencyDetailDialog::onSaveClicked() {
         if (success) {
             BOOST_LOG_SEV(lg(), debug) << "Currency saved successfully.";
 
-            self->pendingImageId_.clear();
+            self->resetFlagChanged();
 
             self->isDirty_ = false;
-            self->flagChanged_ = false;
             emit self->isDirtyChanged(false);
             self->updateSaveResetButtonState();
 
@@ -591,9 +544,6 @@ void CurrencyDetailDialog::setReadOnly(bool readOnly, int versionNumber) {
     ui_->saveButton->setVisible(!readOnly);
     ui_->deleteButton->setVisible(!readOnly);
 
-    if (flagButton_)
-        flagButton_->setEnabled(!readOnly);
-
     if (revertAction_)
         revertAction_->setVisible(readOnly);
 
@@ -651,125 +601,6 @@ QString CurrencyDetailDialog::isoCode() const {
     return QString::fromStdString(currentCurrency_.iso_code);
 }
 
-void CurrencyDetailDialog::onSelectFlagClicked() {
-    if (!imageCache_) {
-        BOOST_LOG_SEV(lg(), warn) << "Flag clicked but no image cache available.";
-        emit errorMessage("Image cache not available");
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Opening flag selector for: " << currentCurrency_.iso_code;
-
-    // Get current image ID - use pending if set, otherwise from the currency
-    QString currentImageId =
-        pendingImageId_.isEmpty() ?
-            (currentCurrency_.image_id ?
-                 QString::fromStdString(boost::uuids::to_string(*currentCurrency_.image_id)) :
-                 QString()) :
-            pendingImageId_;
-
-    FlagSelectorDialog dialog(imageCache_, currentImageId, this);
-    if (dialog.exec() == QDialog::Accepted) {
-        QString selectedImageId = dialog.selectedImageId();
-        BOOST_LOG_SEV(lg(), debug) << "Selected flag image: " << selectedImageId.toStdString();
-
-        // Store the selection locally - will be persisted on Save
-        pendingImageId_ = selectedImageId;
-        flagChanged_ = true;
-
-        // Update display to show the new selection
-        updateFlagDisplay();
-
-        // Mark as dirty so Save button is enabled
-        if (!isDirty_) {
-            isDirty_ = true;
-            emit isDirtyChanged(true);
-            updateSaveResetButtonState();
-        }
-
-        emit statusMessage(tr("Flag changed. Click Save to apply."));
-    }
-}
-
-void CurrencyDetailDialog::onCurrencyImageSet(const QString& iso_code,
-                                              bool success,
-                                              const QString& message) {
-
-    if (iso_code.toStdString() != currentCurrency_.iso_code) {
-        return; // Not our currency
-    }
-
-    if (success) {
-        BOOST_LOG_SEV(lg(), info) << "Flag updated successfully for: " << currentCurrency_.iso_code;
-        emit statusMessage(
-            tr("Flag updated for %1").arg(QString::fromStdString(currentCurrency_.iso_code)));
-        updateFlagDisplay();
-    } else {
-        BOOST_LOG_SEV(lg(), error) << "Failed to update flag for " << currentCurrency_.iso_code
-                                   << ": " << message.toStdString();
-        emit errorMessage(tr("Failed to update flag: %1").arg(message));
-        MessageBoxHelper::critical(this, "Flag Update Failed", message);
-    }
-    pendingImageId_.clear();
-}
-
-void CurrencyDetailDialog::updateFlagDisplay() {
-    if (!flagButton_)
-        return;
-
-    // Update styling based on changed state
-    if (flagChanged_) {
-        // Show orange border to indicate unsaved change
-        flagButton_->setStyleSheet("QPushButton { border: 2px solid orange; background: "
-                                   "transparent; padding: 0px; border-radius: 4px; } "
-                                   "QPushButton:hover { background: rgba(255, 255, 255, 15); }");
-        flagButton_->setToolTip(tr("Flag changed (unsaved)"));
-    } else {
-        // Normal transparent style
-        flagButton_->setStyleSheet(
-            "QPushButton { border: none; background: transparent; padding: 0px; } "
-            "QPushButton:hover { background: rgba(255, 255, 255, 15); }");
-        flagButton_->setToolTip(tr("Click to select flag"));
-    }
-
-    if (!imageCache_) {
-        // No image cache available - use the no-flag placeholder from cache
-        // when it becomes available
-        return;
-    }
-
-    // Determine which image ID to show
-    QString imageIdToShow;
-
-    if (flagChanged_) {
-        // If changed, show pending ID (even if empty - meaning cleared)
-        imageIdToShow = pendingImageId_;
-    } else if (currentCurrency_.image_id) {
-        // Get image_id from the currency domain object
-        imageIdToShow = QString::fromStdString(boost::uuids::to_string(*currentCurrency_.image_id));
-    }
-
-    // If we have an ID, try to get the icon
-    if (!imageIdToShow.isEmpty()) {
-        QIcon icon = imageCache_->getIcon(imageIdToShow.toStdString());
-        if (!icon.isNull()) {
-            flagButton_->setIcon(icon);
-            return;
-        }
-    }
-
-    // Default to "no-flag" placeholder icon
-    QIcon noFlagIcon = imageCache_->getNoFlagIcon();
-    if (!noFlagIcon.isNull()) {
-        flagButton_->setIcon(noFlagIcon);
-    }
-
-    // Inline flag icon on ISO code field
-    const auto iso = ui_->isoCodeEdit->text().trimmed().toStdString();
-    QIcon inlineIcon = imageCache_->getCurrencyFlagIcon(iso);
-    set_line_edit_flag_icon(ui_->isoCodeEdit, inlineIcon, isoCodeFlagAction_);
-}
-
 void CurrencyDetailDialog::showVersionNavActions(bool visible) {
     if (firstVersionAction_)
         firstVersionAction_->setVisible(visible);
@@ -815,12 +646,6 @@ void CurrencyDetailDialog::displayCurrentVersion() {
 
     // Update button states
     updateVersionNavButtonStates();
-
-    // Gray out flag in history view - all versions are read-only
-    if (flagButton_) {
-        flagButton_->setEnabled(false);
-        flagButton_->setToolTip(tr("Historical version - flag display only"));
-    }
 
     // Update window title with short version format
     QWidget* parent = parentWidget();
@@ -965,7 +790,10 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
         [](const auto& t) { return QString::fromStdString(t.code); },
         [](const auto& t) { return QString::fromStdString(t.description); },
         [](const auto& t) { return t.display_order; },
-        [this]() { return QString::fromStdString(currentCurrency_.rounding_type); });
+        [this]() { return QString::fromStdString(currentCurrency_.rounding_type); },
+        [this](const QString& error) {
+            emit errorMessage(tr("Failed to load rounding types: %1").arg(error));
+        });
 }
 
 void CurrencyDetailDialog::populateMonetaryNatureCombo() {
@@ -979,7 +807,10 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
         [](const auto& t) { return QString::fromStdString(t.code); },
         [](const auto& t) { return QString::fromStdString(t.description); },
         [](const auto& t) { return t.display_order; },
-        [this]() { return QString::fromStdString(currentCurrency_.monetary_nature); });
+        [this]() { return QString::fromStdString(currentCurrency_.monetary_nature); },
+        [this](const QString& error) {
+            emit errorMessage(tr("Failed to load monetary natures: %1").arg(error));
+        });
 }
 
 void CurrencyDetailDialog::populateMarketTierCombo() {
@@ -993,7 +824,10 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
         [](const auto& t) { return QString::fromStdString(t.code); },
         [](const auto& t) { return QString::fromStdString(t.description); },
         [](const auto& t) { return t.display_order; },
-        [this]() { return QString::fromStdString(currentCurrency_.market_tier); });
+        [this]() { return QString::fromStdString(currentCurrency_.market_tier); },
+        [this](const QString& error) {
+            emit errorMessage(tr("Failed to load currency market tiers: %1").arg(error));
+        });
 }
 
 }

--- a/projects/ores.qt/refdata/src/CurrencyDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CurrencyDetailDialog.cpp
@@ -780,7 +780,7 @@ void CurrencyDetailDialog::onGenerateClicked() {
 }
 
 void CurrencyDetailDialog::populateRoundingTypeCombo() {
-    BOOST_LOG_SEV(lg(), debug) << "Populating rounding type combo";
+    BOOST_LOG_SEV(lg(), debug) << "Populating rounding_type combo";
     populateDynamicCombo<refdata::domain::rounding_type>(
         ui_->roundingTypeCombo,
         this,
@@ -797,7 +797,7 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
 }
 
 void CurrencyDetailDialog::populateMonetaryNatureCombo() {
-    BOOST_LOG_SEV(lg(), debug) << "Populating monetary nature combo";
+    BOOST_LOG_SEV(lg(), debug) << "Populating monetary_nature combo";
     populateDynamicCombo<refdata::domain::monetary_nature>(
         ui_->monetaryNatureCombo,
         this,
@@ -814,7 +814,7 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
 }
 
 void CurrencyDetailDialog::populateMarketTierCombo() {
-    BOOST_LOG_SEV(lg(), debug) << "Populating market tier combo";
+    BOOST_LOG_SEV(lg(), debug) << "Populating market_tier combo";
     populateDynamicCombo<refdata::domain::currency_market_tier>(
         ui_->marketTierCombo,
         this,

--- a/projects/ores.refdata/modeling/ores.refdata.currency.org
+++ b/projects/ores.refdata/modeling/ores.refdata.currency.org
@@ -442,6 +442,20 @@ version-navigation UI that consumes this richer shape.
 :changed_event_include:       ores.refdata.api/eventing/currency_changed_event.hpp
 :END:
 
+*** Detail fields
+
+Only currency's 3 soft-FK dynamic-combo fields are modelled here — the
+=populateDynamicCombo<Entity>= mechanism (task 318EE3EB), verified by
+regenerate+diff against the hand-migrated =CurrencyDetailDialog.cpp=.
+The remaining 11 fields stay unmodelled until the final "Sync Qt
+codegen for currency" task populates the full table.
+
+| field           | widget               | type          | combo_domain_type                     | combo_fetch_include                                    | combo_fetch_fn              | combo_watcher_name    | combo_code_field | combo_tooltip_field | combo_sort_field | combo_label          | combo_setter_pascal |
+|-----------------+----------------------+---------------+----------------------------------------+-------------------------------------------------------+------------------------------+-----------------------+------------------+----------------------+------------------+----------------------+----------------------|
+| rounding_type   | roundingTypeCombo    | dynamic_combo | refdata::domain::rounding_type         | ores.qt/LookupFetcher.hpp                              | fetch_rounding_types         | roundingTypeWatcher   | code             | description          | display_order    | rounding types        | RoundingTypeCombo    |
+| monetary_nature | monetaryNatureCombo  | dynamic_combo | refdata::domain::monetary_nature       | ores.qt/LookupFetcher.hpp                              | fetch_monetary_natures       | monetaryNatureWatcher | code             | description          | display_order    | monetary natures      | MonetaryNatureCombo  |
+| market_tier     | marketTierCombo      | dynamic_combo | refdata::domain::currency_market_tier  | ores.qt/LookupFetcher.hpp                              | fetch_currency_market_tiers  | marketTierWatcher     | code             | description          | display_order    | currency market tiers | MarketTierCombo      |
+
 *** Columns (Qt model)
 
 | enum_name          | field              | header          | type      | width | import_preview |


### PR DESCRIPTION
## Summary

Migrate currency's real flag-handling and combo-field code onto existing/new codegen mechanisms, closing the last prerequisite for the final Qt codegen sync.

## Changes

- Migrate CurrencyDetailDialog's flag image handling onto DetailDialogBase's generic mechanism, removing ~180 lines of duplicated hand-rolled code
- Add combo_domain_type-gated detail_dialog codegen emit generating populateDynamicCombo<Entity> calls; wire currency's 3 soft-FK combo fields via a new Detail fields org table
- Fix the pilot's flagged fetch-failure-signalling gap for real: populateDynamicCombo now takes std::expected-returning fetchers plus an on_error callback
- Verify via real regenerate+rebuild (not diff-only) and a full whole-app build

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: currency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/story.html) | 7F9C0F29-4268-4B62-A1BB-2153ECF0A858 |
| Task | [Reconcile currency's flag image handling and wire the piloted combo-field mechanism](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/commission_currency/task_reconcile-currency-qt-flag-image-and-combos.html) | 318EE3EB-E15E-4F10-BCF7-154658A4AFE8 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)