### PR TITLE
[build] Make ores.qt.exe depend on every Qt plugin lib

### DIFF
--- a/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/story.org
+++ b/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/story.org
@@ -15,28 +15,38 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+An ordinary =cmake --build --target ores.qt.exe= must never leave a
+QPluginLoader-loaded plugin .so stale against a freshly-linked exe's ABI —
+CMake needs a real build-order dependency from the exe to every plugin lib,
+even though none of them are link-time dependencies of it.
 
 * Status
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing.                       |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing.            |
 | Last touched  | 2026-07-08                               |
 
 * Acceptance
 
--
+- [X] =ores.qt.exe= has an =add_dependencies()= edge to every
+  QPluginLoader-loaded Qt plugin lib (admin, analytics, compute,
+  data_transfer, marketdata, mktdata, party, refdata, scheduler, synthetic,
+  trading, workspace), forcing build order without adding a compile-time
+  link dependency.
+- [X] A plain =cmake --build --target ores.qt.exe= now rebuilds every
+  plugin alongside the exe, so this specific stale-plugin-ABI crash can no
+  longer happen from that command.
 
 * Tasks
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:7D3E64E2-B54E-46FD-A325-C1F654776E36][Make ores.qt.exe depend on every Qt plugin lib]] | BACKLOG | | | Add CMake add_dependencies() edges from ores.qt.exe to every QPluginLoader-loaded plugin lib, so an ordinary cmake --build --target ores.qt.exe can no longer leave a stale plugin .so sitting next to a freshly-linked exe. |
+| [[id:7D3E64E2-B54E-46FD-A325-C1F654776E36][Make ores.qt.exe depend on every Qt plugin lib]] | DONE | 2026-07-08 | 2026-07-08 | Add CMake add_dependencies() edges from ores.qt.exe to every QPluginLoader-loaded plugin lib, so an ordinary cmake --build --target ores.qt.exe can no longer leave a stale plugin .so sitting next to a freshly-linked exe. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/story.org
+++ b/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/story.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: 7E3D15A2-7B55-4703-8495-AFB7ED3C9456
+:END:
+#+title: Story: Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change
+#+description: Domain plugins are QPluginLoader-loaded at runtime, not linked, so CMake never rebuilt them when ores.qt.api's ABI changed -- a stale plugin .so then segfaults on first virtual call into the mismatched vtable. Land the add_dependencies() fix (already written on feature/vintage-guard) on its own, ahead of that unrelated/unfinished PR.
+#+type: story
+#+level: s2
+#+filetags: :sprint_22:v0:
+#+created: 2026-07-08
+#+updated: 2026-07-08
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-07-08                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:7D3E64E2-B54E-46FD-A325-C1F654776E36][Make ores.qt.exe depend on every Qt plugin lib]] | BACKLOG | | | Add CMake add_dependencies() edges from ores.qt.exe to every QPluginLoader-loaded plugin lib, so an ordinary cmake --build --target ores.qt.exe can no longer leave a stale plugin .so sitting next to a freshly-linked exe. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
+++ b/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
@@ -68,7 +68,8 @@ plan itself stays — it is the historical record of what we did.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | CMake list is correct; plugin-list drift risk flagged as a non-blocking follow-up | CMakeLists.txt | Declined (as-is) | Pre-existing risk in the cherry-picked commit, not introduced by this PR; could file a capture if wanted |
+| 2 | story.org left as unfilled scaffold, disagreed with task/sprint state | story.org, sprint.org | Fixed | 7f58b3385 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
+++ b/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
@@ -8,7 +8,7 @@
 #+filetags: :qt_plugin_stale_abi_crash_hotfix:sprint_22:v0:
 #+owner: marco
 #+branch: feature/qt-plugin-rebuild-dependency
-#+pr:
+#+pr: 1474
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-08
@@ -62,7 +62,7 @@ plan itself stays — it is the historical record of what we did.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1474][#1474]] | [build] Make ores.qt.exe depend on every Qt plugin lib |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
+++ b/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.org
@@ -1,0 +1,78 @@
+:PROPERTIES:
+:ID: 7D3E64E2-B54E-46FD-A325-C1F654776E36
+:END:
+#+title: Task: Make ores.qt.exe depend on every Qt plugin lib
+#+description: Add CMake add_dependencies() edges from ores.qt.exe to every QPluginLoader-loaded plugin lib, so an ordinary cmake --build --target ores.qt.exe can no longer leave a stale plugin .so sitting next to a freshly-linked exe.
+#+type: task
+#+level: s1
+#+filetags: :qt_plugin_stale_abi_crash_hotfix:sprint_22:v0:
+#+owner: marco
+#+branch: feature/qt-plugin-rebuild-dependency
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-08
+#+updated: 2026-07-08
+#+environment: clever_dijkstra
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7E3D15A2-7B55-4703-8495-AFB7ED3C9456][Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Domain plugins are QPluginLoader-loaded at runtime, not linked, so CMake's
+dependency graph had no reason to rebuild them when ores.qt.api.lib's ABI
+changed. A plugin .so compiled against the old layout then sits next to a
+freshly-linked exe — QPluginLoader loads it anyway (same .so name, no
+version check) and it segfaults on the first virtual call into the
+mismatched vtable. Hit this while testing Book's regulatory_book_type
+combo work on feature/fix-book-status-and-trading-flag; the fix already
+existed on feature/vintage-guard (unrelated, still-open PR #1467) —
+cherry-pick it onto its own branch so it can land independently.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:7E3D15A2-7B55-4703-8495-AFB7ED3C9456][Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change]] |
+| Now          | Nothing.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing.                  |
+| Last touched | 2026-07-08                               |
+
+* Acceptance
+
+- [X] =ores.qt.exe= has an =add_dependencies()= edge (not
+  =target_link_libraries=) to every Qt plugin lib, so it stays
+  compile-time decoupled from plugin internals but forces build order.
+- [X] An ordinary =cmake --build --target ores.qt.exe= now also rebuilds
+  every plugin, so a stale plugin .so next to a freshly-linked exe can no
+  longer happen from that command.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Cherry-picked commit 3c187cc74 (originally authored on feature/vintage-guard)
+onto a fresh branch off main, feature/qt-plugin-rebuild-dependency, so this
+build-system fix lands independently of that unrelated, still-open PR.
+Applied cleanly, no conflicts.

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -173,6 +173,7 @@ More stories expected here over time as other consumers emerge.
 |-------+-------+-------+-----+-------------|
 | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] | DONE | 2026-07-04 | 2026-07-04 | Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified. |
 | [[id:2B91141E-1785-4090-892C-52B8438DAD86][Hotfix: refdata generator/repository test fixtures out of sync with DB constraints]] | DONE | 2026-07-04 | 2026-07-05 | Root cause: 2 counterparty codegen-facet commits introduced generator values violating DB constraints and test expectations; fixed and migrated touched literals to shared change-reason constants. |
+| [[id:7E3D15A2-7B55-4703-8495-AFB7ED3C9456][Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change]] | STARTED | 2026-07-08 | | CMake had no dependency edge from ores.qt.exe to the QPluginLoader-loaded plugin libs, so an ABI change could leave a stale plugin .so segfaulting on load. Cherry-picked the fix off feature/vintage-guard onto its own branch. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -173,7 +173,7 @@ More stories expected here over time as other consumers emerge.
 |-------+-------+-------+-----+-------------|
 | [[id:F3D9E216-DCB2-4621-899D-DF86727FC736][Hotfix: MacOS CI relevance-guard skips matrix build silently]] | DONE | 2026-07-04 | 2026-07-04 | Continuous MacOS workflow reports overall Success while the scheduled relevance-guard skips the build matrix, so macOS builds are not actually being verified. |
 | [[id:2B91141E-1785-4090-892C-52B8438DAD86][Hotfix: refdata generator/repository test fixtures out of sync with DB constraints]] | DONE | 2026-07-04 | 2026-07-05 | Root cause: 2 counterparty codegen-facet commits introduced generator values violating DB constraints and test expectations; fixed and migrated touched literals to shared change-reason constants. |
-| [[id:7E3D15A2-7B55-4703-8495-AFB7ED3C9456][Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change]] | STARTED | 2026-07-08 | | CMake had no dependency edge from ores.qt.exe to the QPluginLoader-loaded plugin libs, so an ABI change could leave a stale plugin .so segfaulting on load. Cherry-picked the fix off feature/vintage-guard onto its own branch. |
+| [[id:7E3D15A2-7B55-4703-8495-AFB7ED3C9456][Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change]] | DONE | 2026-07-08 | 2026-07-08 | CMake had no dependency edge from ores.qt.exe to the QPluginLoader-loaded plugin libs, so an ABI change could leave a stale plugin .so segfaulting on load. Cherry-picked the fix off feature/vintage-guard onto its own branch. |
 
 * Achievements
 

--- a/projects/ores.qt/application/src/CMakeLists.txt
+++ b/projects/ores.qt/application/src/CMakeLists.txt
@@ -119,6 +119,29 @@ if(NOT WIN32)
     target_link_options(${exe_target_name} PRIVATE -rdynamic)
 endif()
 
+# Domain plugins are loaded at runtime via QPluginLoader, not linked — so
+# CMake's own dependency graph has no reason to know ores.qt.exe needs them
+# rebuilt. Without this, a change to ores.qt.api.lib's ABI can leave a plugin
+# .so compiled against the old layout sitting next to a freshly-linked exe:
+# QPluginLoader loads it anyway (same .so name, no version check), and it
+# segfaults on first virtual call into the mismatched vtable — reproduced
+# twice while touching ores.qt.api during vintage-guard/price_source work.
+# Force every plugin to always be rebuilt alongside the exe so this can't
+# happen from an ordinary `cmake --build --target ores.qt.exe`.
+add_dependencies(${exe_target_name}
+    ores.qt.admin.lib
+    ores.qt.analytics.lib
+    ores.qt.compute.lib
+    ores.qt.data_transfer.lib
+    ores.qt.marketdata.lib
+    ores.qt.mktdata.lib
+    ores.qt.party.lib
+    ores.qt.refdata.lib
+    ores.qt.scheduler.lib
+    ores.qt.synthetic.lib
+    ores.qt.trading.lib
+    ores.qt.workspace.lib)
+
 # Copy main assets from assets/images directory
 file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 file(GLOB ORES_MAIN_ASSETS "${CMAKE_SOURCE_DIR}/assets/images/*.png")


### PR DESCRIPTION
## Summary

Cherry-picks a build-system fix off the unrelated, still-open feature/vintage-guard branch so it can land on its own: CMake had no dependency edge forcing plugin libs to rebuild when ores.qt.api's ABI changes, so a stale plugin .so can segfault on load.

## Changes

- add_dependencies() from ores.qt.exe to every QPluginLoader-loaded plugin lib (not target_link_libraries, so no compile-time coupling to plugin internals)
- Files a Hotfix story/task documenting the crash and the fix

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: stale Qt plugin causes crash after ores.qt.api ABI change](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/story.html) | 7E3D15A2-7B55-4703-8495-AFB7ED3C9456 |
| Task | [Make ores.qt.exe depend on every Qt plugin lib](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/qt_plugin_stale_abi_crash_hotfix/task_make_qt_exe_depend_on_plugins.html) | 7D3E64E2-B54E-46FD-A325-C1F654776E36 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)