### PR TITLE
[agile] Capture: Explore diffusion models for synthetic trade generation

### DIFF
--- a/doc/agile/product_backlog/inbox/diffusion_model_synthetic_trade_generation.org
+++ b/doc/agile/product_backlog/inbox/diffusion_model_synthetic_trade_generation.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 72C1BFB2-BCBD-4DFB-A8CB-C90A6112F411
+:END:
+#+title: Explore diffusion models for synthetic trade generation
+#+description: TRADES (Berti, Prenkaj, Velardi, arXiv:2502.07071) trains a diffusion model on historical order-book/transaction data to generate realistic synthetic market transaction sequences.
+#+type: capture
+#+level: cross
+#+filetags: :marketdata:synthetic:ml:research:
+#+created: 2026-07-09
+#+updated: 2026-07-09
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+TRADES (Berti, Prenkaj, Velardi — [[https://arxiv.org/pdf/2502.07071][arXiv:2502.07071]]) trains a diffusion
+model directly on historical order-book/transaction sequences, then
+generates new synthetic transaction sequences by iteratively denoising
+a random sequence toward the learned distribution — no hand-written
+market-mechanics rules, no explicit stochastic-process specification
+(unlike ORE Studio's current =ores.synthetic= approach, which
+generates market data from configured stochastic-process parameters
+per instrument type, e.g. curve templates, FX spot config). Explore
+whether a diffusion-based approach could complement or eventually
+replace parts of =ores.synthetic='s config-driven generation — likely
+starting with a single asset class (FX or rates, where
+=ores.synthetic= already has generation configs to train against) as
+a proof of concept, not a wholesale replacement.
+
+* Why
+
+=ores.synthetic= currently generates market data and trades from
+explicit, hand-configured stochastic-process parameters (per-entity
+generation configs — see =ores.synthetic.fx_spot_generation_config.org=,
+=ores.synthetic.market_data_generation_config.org=). This requires
+someone to specify realistic parameters up front and doesn't
+automatically capture the finer statistical structure (clustering,
+autocorrelation, microstructure effects) that real historical data
+has. A diffusion model trained on real (or realistically-shaped)
+historical sequences could, in principle, produce more realistic
+synthetic trade/tick sequences with less manual parameter tuning —
+worth a scoped investigation before committing to it, given it would
+introduce an ML training/inference dependency this codebase doesn't
+currently have.
+
+* References
+
+- [[https://arxiv.org/pdf/2502.07071][TRADES: Generating Realistic Market Simulations with Diffusion Models]] (arXiv:2502.07071)
+
+* See also
+
+- [[id:44039E5B-3435-4BCB-824F-3990AF341FBE][ores.synthetic.api]] — current config-driven synthetic market data/trade
+  generation this would complement or inform.
+- [[id:3247E7A0-73CD-459D-B2C5-119FC0D7DA33][Story: Rethink synthetic reference-data generation across entities]]
+- [[id:C75D1DCC-ED4A-48D0-9035-0B9E4D9C2593][Capture: stochastic tick arrival times]] — related idea on the
+  statistical realism of generated market data.


### PR DESCRIPTION
## Summary
Docs-only capture. TRADES (arXiv:2502.07071) trains a diffusion model on historical order-book/transaction sequences to generate realistic synthetic trades — worth exploring as a complement to ores.synthetic's current config-driven generation.

## Changes
- New inbox capture doc, linked to ores.synthetic.api and the related rethink-synthetic-entity-generation story and stochastic-tick-arrival-times capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)