### PR TITLE
[codegen,refdata,sql,qt] Regen country against latest codegen templates

### DIFF
--- a/doc/agile/product_backlog/inbox/gate_unordered_set_include_generator_template.org
+++ b/doc/agile/product_backlog/inbox/gate_unordered_set_include_generator_template.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: 8219B2CA-1C15-4AAF-87FC-DF27220EF462
+:END:
+#+title: Gate unordered_set include in the generator template on actual need
+#+description: cpp_domain_type_generator.cpp.mustache unconditionally includes <unordered_set>, but only entities with a hand-added bulk-unique-generator addendum (e.g. currency's generate_unique_synthetic_currencies) actually use it — every other generated *_generator.cpp carries an unused include (confirmed on country, plus 2 other already-regenerated entities). Compute a needs_unordered_set flag and gate the include.
+#+type: capture
+#+level: cross
+#+filetags: :codegen:templates:cleanup:
+#+created: 2026-07-09
+#+updated: 2026-07-09
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+=projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache=
+(tangled from =ores.cpp.generator.generator_impl.org=) unconditionally
+emits =#include <unordered_set>= for every generated
+=<entity>_generator.cpp=, but the header is only actually used by
+entities that also carry a hand-added bulk-unique-generator addendum
+(e.g. currency's =generate_unique_synthetic_currencies=, which uses a
+=std::unordered_set<std::string> seen= dedup set). Every other
+generated generator file — confirmed on country plus 2 other already-
+regenerated entities — carries the include unused. Compute a
+=needs_unordered_set= flag (true if the entity has the bulk-unique-
+generator addendum) and gate the =#include= on it.
+
+* Why
+
+Flagged as a minor nit during PR #1487's review (country codegen
+regen). Declined fixing by hand-editing the generated file, since the
+include is emitted by the shared template for every entity, not
+something that PR introduced — hand-patching one output file would
+just drift back on the next regen. The real fix belongs in the
+template and affects every already-regenerated entity that doesn't
+have the bulk-unique-generator addendum, so it's a small, independent
+cleanup rather than something to bundle into an unrelated PR.
+
+* References
+
+- PR #1487: https://github.com/OreStudio/OreStudio/pull/1487
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/scenario_verify-country-regen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/scenario_verify-country-regen.org
@@ -1,0 +1,135 @@
+:PROPERTIES:
+:ID: 6E2E18A3-DA33-4BBF-8BAE-E28E3D3668FA
+:END:
+#+title: Test Scenario: Verify country regen against latest codegen templates
+#+description: Manual verification that country's Qt UI, flag rendering, and SQL validation still work correctly after regenerating against the latest codegen templates (needs_item_delegate icon-sizing fix, SQL bootstrap-filter/clock_timestamp fixes).
+#+type: test_scenario
+#+level: s1
+#+filetags: :regen_entities_latest_codegen_templates:sprint_22:v0:
+#+target_dialog: CountryMdiWindow
+#+created: 2026-07-09
+#+updated: 2026-07-09
+#+environment:
+#+todo: PENDING | PASSED FAILED
+
+This page documents a test scenario verifying [[id:82BA40CA-3A4A-47B5-88ED-ADA0178E5695][Regen country against latest codegen templates]] in [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]]. It is filled in with the target dialog and checklist of steps before testing starts; the QA Validation Runner panel rewrites =* Results= in place on save.
+
+* Scenario Info
+
+| Field         | Value                                   |
+|---------------+------------------------------------------|
+| Verifies task | [[id:82BA40CA-3A4A-47B5-88ED-ADA0178E5695][Regen country against latest codegen templates]] |
+| Parent story  | [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]]   |
+| Target dialog | CountryMdiWindow                        |
+| Clients       | (Leave empty for a single client. For a scenario that needs several running clients at once — e.g. checking a NATS notification lands on a second instance — list the instance colours/labels here, e.g. "blue, red".) |
+| State         | PENDING                               |
+
+* Context
+
+Log in as =tenant_admin@barclays_plc= (master password as set up
+locally), select party *BARCLAYS PLC*. If the DB has been recreated
+since, re-run =./compass.sh shell -f
+projects/ores.shell/scripts/library/provisioning/barclays_system_provision.ores=
+first.
+
+* Steps
+
+Each step is its own heading — the title should be short (it's shown
+as a single list entry in the QA Validation Runner); put any longer
+instructions in the body below the title. The panel writes each
+step's PASS/FAIL/PENDING outcome and notes back as a =*** Result=
+child heading directly under it.
+
+** List window loads without crashing
+
+Reference Data > Countries. Confirm the list loads (should show ~249
+countries), is sortable and paginated, and the client does not crash
+while fetching country image IDs (regression check for the crash
+observed during this task's own testing — traced to a stale cached
+object file, not a real bug, but confirm here since it's the exact
+code path this task touched).
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+** Flag icon renders at the correct size
+
+Confirm the flag icon in the =Code= column (Alpha2Code) renders at
+the same 16px height as every other single-flag column in the app
+(e.g. compare against Currency's flag column) — not stretched or
+oversized. This is the =needs_item_delegate= fix: country has no
+badge columns, so previously its flag bypassed the shared sizing
+delegate entirely.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+** Detail dialog: add and save a new country
+
+Open the detail dialog, fill in a new country (unique alpha2/alpha3
+codes), save. Confirm it round-trips (reopen and the data persisted).
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+** Validation rejects an unknown country code elsewhere
+
+Find a field that soft-FKs to country (e.g. a party's country) and
+confirm entering an invalid alpha2 code is rejected with a clear
+error listing valid codes — not a silent pass-through or an opaque
+"Invalid country: (empty list)" error. Regresses the SQL
+active-rows-bootstrap-filter fix landed in this task.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+** Delete and history preserved
+
+Delete a country (use one created in the "add and save" step above).
+Confirm it's removed from the list and its history is preserved
+(open History on it if the UI allows viewing a deleted record's
+history, or verify via the shell/CLI history command).
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+** Synthetic-data generator produces valid data
+
+If the list window's Generate action is enabled (toggle
+=system.synthetic_data_generation= if needed), generate a few
+synthetic countries. Confirm alpha2_code is a real random value, not
+garbage (regression check for the =+"-" + idx= generator bug fixed in
+this task).
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | |
+
+* Results
+
+| Field         | Value |
+|---------------+-------|
+| Status        |       |
+| Completed at  |       |
+| Branch        |       |
+| Commit        |       |
+| Worktree      |       |
+
+* Notes

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/scenario_verify-country-regen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/scenario_verify-country-regen.org
@@ -55,6 +55,12 @@ code path this task touched).
 |--------+-------|
 | Status | |
 
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
 ** Flag icon renders at the correct size
 
 Confirm the flag icon in the =Code= column (Alpha2Code) renders at
@@ -70,6 +76,12 @@ delegate entirely.
 |--------+-------|
 | Status | |
 
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
 ** Detail dialog: add and save a new country
 
 Open the detail dialog, fill in a new country (unique alpha2/alpha3
@@ -80,6 +92,12 @@ codes), save. Confirm it round-trips (reopen and the data persisted).
 | Field  | Value |
 |--------+-------|
 | Status | |
+
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
 
 ** Validation rejects an unknown country code elsewhere
 
@@ -95,6 +113,12 @@ active-rows-bootstrap-filter fix landed in this task.
 |--------+-------|
 | Status | |
 
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
 ** Delete and history preserved
 
 Delete a country (use one created in the "add and save" step above).
@@ -107,6 +131,12 @@ history, or verify via the shell/CLI history command).
 | Field  | Value |
 |--------+-------|
 | Status | |
+
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
 
 ** Synthetic-data generator produces valid data
 
@@ -122,14 +152,20 @@ this task).
 |--------+-------|
 | Status | |
 
+**** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
 * Results
 
 | Field         | Value |
 |---------------+-------|
-| Status        |       |
-| Completed at  |       |
-| Branch        |       |
-| Commit        |       |
-| Worktree      |       |
+| Status        | PASSED |
+| Completed at  | 2026-07-09T19:05:42Z |
+| Branch        | feature/regen-entities-latest-codegen-templates |
+| Commit        | bf76a65c1 |
+| Worktree      | brave_hopper |
 
 * Notes

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/story.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/story.org
@@ -37,9 +37,9 @@ fully-commissioned entity after currency).
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
-| Now           | Country refresh task added.            |
+| Now           | Country regenerated and reconciled — real generator bug, SQL bootstrap-filter/clock_timestamp fixes, and a new needs_item_delegate template generalization (icon-only entities now get the same aspect-correct sizing as badge entities) all landed. |
 | Waiting on    | Nothing.                               |
-| Next          | Work the country refresh task.         |
+| Next          | Pick the next already-commissioned entity to sweep.      |
 | Last touched  | 2026-07-09                               |
 
 * Acceptance
@@ -56,7 +56,7 @@ fully-commissioned entity after currency).
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:82BA40CA-3A4A-47B5-88ED-ADA0178E5695][Regen country against latest codegen templates]] | BACKLOG | | | Country was last synced in sprint 21, before currency's commissioning landed substantial new shared-template capability. Re-run every codegen profile country participates in, diff against the repo, and reconcile drift. |
+| [[id:82BA40CA-3A4A-47B5-88ED-ADA0178E5695][Regen country against latest codegen templates]] | DONE | | 2026-07-09 | Country was last synced in sprint 21, before currency's commissioning landed substantial new shared-template capability. Re-run every codegen profile country participates in, diff against the repo, and reconcile drift. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/story.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: AF0EFC5C-899A-4AE9-BD09-7B2D4E304543
+:END:
+#+title: Story: Regen entities with latest codegen templates
+#+description: Substantial shared codegen template capability has landed since several entities were last synced (Qt icon/badge rendering, hidden-column defaults, SQL default-quoting, paste-block extension points, and more). Sweep already-commissioned entities, re-run codegen, diff against the repo, and reconcile drift.
+#+type: story
+#+level: s2
+#+filetags: :codegen:refdata:qt:sql:drift:sprint_22:v0:
+#+created: 2026-07-09
+#+updated: 2026-07-09
+#+environment:
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Currency's commissioning (sprint 22, PR #1470 and the currency_pair
+work it merged with) landed substantial new shared codegen template
+capability that didn't exist when most already-commissioned entities
+were last synced: generic =hidden_by_default= list-column support,
+badge-repaint-on-cache-load fix, aspect-correct icon sizing
+(=icon_text_left= column style), =has_related_entity_shortcuts=,
+=has_generate_action=/=has_toolbar=, version-navigation UI, NATS
+notification-wiring, the paste-block extension-point mechanism, and
+SQL default-value auto-quoting. Sweep entities one at a time, re-run
+their codegen profiles, diff against the repo, and reconcile: adopt
+capability that fits, document any deliberate divergence the way
+currency did for its two permanently-hand-written files.
+
+One task per entity swept, starting with country (the next-oldest
+fully-commissioned entity after currency).
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0924A6E7-FAF0-4A51-8CC1-74B103725E96][Sprint 22]] |
+| Now           | Country refresh task added.            |
+| Waiting on    | Nothing.                               |
+| Next          | Work the country refresh task.         |
+| Last touched  | 2026-07-09                               |
+
+* Acceptance
+
+- For each swept entity: every codegen profile it participates in has
+  been re-run and each output file's diff reviewed.
+- Genuine drift (template capability that should apply but doesn't
+  yet) is adopted; deliberate divergence is documented in the task's
+  =* Result=.
+- Full local build and test suite pass clean per entity.
+- Verified live in the client, not just by diff/compile.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:82BA40CA-3A4A-47B5-88ED-ADA0178E5695][Regen country against latest codegen templates]] | BACKLOG | | | Country was last synced in sprint 21, before currency's commissioning landed substantial new shared-template capability. Re-run every codegen profile country participates in, diff against the repo, and reconcile drift. |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: 82BA40CA-3A4A-47B5-88ED-ADA0178E5695
+:END:
+#+title: Task: Regen country against latest codegen templates
+#+description: Country was last synced in sprint 21, before currency's commissioning landed substantial new shared-template capability. Re-run every codegen profile country participates in, diff against the repo, and reconcile drift.
+#+type: task
+#+level: s1
+#+filetags: :regen_entities_latest_codegen_templates:sprint_22:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-09
+#+updated: 2026-07-09
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Country was last fully synced in sprint 21 (2026-06-29), before
+currency's commissioning (sprint 22, PR #1470 and the currency_pair
+work it merged with) landed substantial new shared codegen template
+capability: generic =hidden_by_default= list-column support,
+badge-repaint-on-cache-load fix, aspect-correct icon sizing
+(=icon_text_left= column style), =has_related_entity_shortcuts=,
+=has_generate_action=/=has_toolbar=, version-navigation UI, NATS
+notification-wiring, the paste-block extension-point mechanism, and
+SQL default-value auto-quoting (=_sql_quote_default=). None of these
+were present when country was synced, so country's generated files
+are increasingly stale relative to what the templates now produce for
+every other entity.
+
+Re-run every codegen profile country participates in (=ores.sql=,
+=ores.cpp.domain=, =ores.cpp.repository=, =ores.cpp.generator=,
+=ores.cpp.qt=, messaging profiles as applicable), diff each output
+file against the repo, and reconcile: adopt template-driven
+capabilities that fit (e.g. hidden-column defaults for any low-signal
+country columns, badge rendering if country has any =is_badge=
+fields), and document any deliberate divergence the same way currency
+did for its two permanently-hand-written files.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-09                               |
+
+* Acceptance
+
+- Every codegen profile country participates in has been re-run and
+  each output file's diff against the repo reviewed.
+- Genuine drift (template capability that should apply to country but
+  doesn't yet) is adopted; deliberate divergence is documented in this
+  task's =* Result= (and the story's =* Decisions= if durable).
+- Full local build and test suite pass clean.
+- Verified live in the client, not just by diff/compile.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -80,7 +80,7 @@ via its "Verifies task" field.
 
 | Scenario | State | Notes |
 |----------+-------+-------|
-|          |       |       |
+| [[id:6E2E18A3-DA33-4BBF-8BAE-E28E3D3668FA][Verify country regen against latest codegen templates]] | PENDING | |
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -8,7 +8,7 @@
 #+filetags: :regen_entities_latest_codegen_templates:sprint_22:v0:
 #+owner: marco
 #+branch: feature/regen-entities-latest-codegen-templates
-#+pr:
+#+pr: 1487
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-09
@@ -86,7 +86,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1487][#1487]] | [codegen,refdata,sql,qt] Regen country against latest codegen templates |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-07-09
 #+updated: 2026-07-09
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -46,11 +46,11 @@ did for its two permanently-hand-written files.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-09                               |
 
 * Acceptance
@@ -95,3 +95,41 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Regenerated all applicable profiles for country
+(=./compass.sh codegen entity generate country=, then =--address
+ores.cpp.qt= separately after the template fix below) and reviewed
+every diff before writing:
+
+- Fixed a real bug in the synthetic-data generator
+  (=r.alpha2_code = +"-" + std::to_string(idx)= — unary =+= on a
+  string literal, producing garbage — now generates a real random
+  code via =faker::word::noun()=), and picked up a previously-
+  unreflected =coding_scheme_code= field already declared in the org
+  model.
+- SQL: adopted =clock_timestamp()= (not =current_timestamp=, which is
+  transaction-frozen) in the insert trigger and delete rule; wrapped
+  the delete rule's =do instead= body in parens (multi-statement
+  fix); and the validate function now bootstrap-pass-throughs on
+  *no active rows* rather than *no rows at all* — directly fixing the
+  "Item 2" bug documented in this story's own historical =Commission:
+  country= analysis, which said the fix would "occur naturally
+  through the commissioning pipeline" once propagated. It just did.
+- Picked up =read_at_version()= (temporal composite entity versioning
+  capability, landed generically since country's last sync).
+- Found and fixed one more shared-template gap while at it:
+  =EntityItemDelegate= (the class housing all of currency's icon/badge
+  sizing fixes) was constructed only when =has_badge_columns= was
+  true, so country's own flag column (no badges, just
+  =flag_icon_column=) rendered via Qt's default item-view path
+  instead — the exact "bypasses the aspect-correct sizing" bug fixed
+  for currency_pair, just not yet visibly wrong since country only
+  has one icon column competing for one iconSize. Widened the gate to
+  a new =needs_item_delegate= flag (=has_badge_columns OR
+  has_any_flag_icon=); =badgeCache_= itself stays gated on
+  =has_badge_columns= only, since =EntityItemDelegate='s constructor
+  never required it. Zero diff on regenerating currency/currency_pair
+  confirms no regression for badge-bearing entities.
+
+Full local build (0 errors) and ctest suite (69/69, 100%) verified
+clean.

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :regen_entities_latest_codegen_templates:sprint_22:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/regen-entities-latest-codegen-templates
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -92,7 +92,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Two independent Claude review passes: both verified every claim in the PR description against the diff, no blocking issues | (whole PR) | Accepted (no change needed) | Both passes confirmed the needs_item_delegate gate, SQL fixes, and generator fix are correct and match sibling entities' already-shipped patterns. |
+| 2 | Unused =#include <unordered_set>= in country_generator.cpp | country_generator.cpp | Declined | Emitted unconditionally by the shared generator template for every entity, not introduced by this PR — 2 other already-regenerated entities have the same unused include. Hand-patching the generated file would drift back on next regen; filed as a follow-up capture (gate_unordered_set_include_generator_template) instead. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
+++ b/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.org
@@ -80,7 +80,7 @@ via its "Verifies task" field.
 
 | Scenario | State | Notes |
 |----------+-------+-------|
-| [[id:6E2E18A3-DA33-4BBF-8BAE-E28E3D3668FA][Verify country regen against latest codegen templates]] | PENDING | |
+| [[id:6E2E18A3-DA33-4BBF-8BAE-E28E3D3668FA][Verify country regen against latest codegen templates]] | PASSED | All 6 steps passed live in the client (2026-07-09T19:05:42Z). |
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_22/sprint.org
+++ b/doc/agile/versions/v0/sprint_22/sprint.org
@@ -79,6 +79,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity. Carried fr
 | [[id:CF179370-5F28-49DC-9277-E5BB28654E23][Commission: day_count_fraction_type]] | BACKLOG | | | Move from ores.trading to ores.refdata (update trading_swap_legs' one reference), then commission fully to Qt; spun off from the currency pair story. |
 | [[id:D83F5588-5F05-4AF6-9CCF-98489309DE4A][Move book, book_status, and portfolio to ores.trading]] | BACKLOG | | | These are trading/booking structures, not static reference data; relocate full stack out of ores.refdata. |
 | [[id:9763FBBF-7912-4EA2-A544-67E90EA27882][Codegen: generate per-entity NATS event-mapping registrar]] | DONE | | 2026-07-08 | Hand-wired application.cpp eventing registration caused a missed-wiring regression (purpose_type); generate it per-entity instead. |
+| [[id:AF0EFC5C-899A-4AE9-BD09-7B2D4E304543][Regen entities with latest codegen templates]] | STARTED | 2026-07-09 | | Sweep already-commissioned entities (starting with country) against the shared codegen templates' substantial new capability landed via currency's commissioning. |
 | [[id:EA22E78F-E4CB-4E76-B854-F85EB4E6AF48][Book data model cleanup]] | STARTED | 2026-07-08 | | 2/9 tasks done (the 2 live bugs); add classification flags, rename ledger_ccy, investigate legal-entity/branch fields, add rates centre, analyse allowed lists, enrich manual with domain concepts remain. |
 
 *** Epic: Market data generation

--- a/projects/ores.codegen/library/templates/cpp_qt_mdi_window.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_mdi_window.cpp.mustache
@@ -29,13 +29,15 @@
 #include <QFileDialog>
 #include <QUrl>
 {{/domain_entity.qt.has_csv_xml_io}}
-{{#domain_entity.qt.has_badge_columns}}
+{{#domain_entity.qt.needs_item_delegate}}
 #include "ores.qt/EntityItemDelegate.hpp"
+{{/domain_entity.qt.needs_item_delegate}}
+{{#domain_entity.qt.has_badge_columns}}
 #include "ores.qt/BadgeCache.hpp"
+{{/domain_entity.qt.has_badge_columns}}
 {{#domain_entity.qt.needs_image_cache}}
 #include "ores.qt/ImageCache.hpp"
 {{/domain_entity.qt.needs_image_cache}}
-{{/domain_entity.qt.has_badge_columns}}
 #include "{{domain_entity.qt.protocol_include}}"
 
 namespace ores::qt {
@@ -231,7 +233,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
 {{/domain_entity.qt.has_any_flag_icon}}
 {{/domain_entity.qt.has_pair_icon_column}}
 
-{{#domain_entity.qt.has_badge_columns}}
+{{#domain_entity.qt.needs_item_delegate}}
     using cs = column_style;
     auto* delegate = new EntityItemDelegate({
 {{#domain_entity.qt.columns}}
@@ -252,6 +254,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
 {{/is_badge}}
 {{/domain_entity.qt.columns}}
     tableView_->setItemDelegate(delegate);
+{{#domain_entity.qt.has_badge_columns}}
     if (badgeCache_) {
         if (badgeCache_->isLoaded())
             tableView_->viewport()->update();
@@ -260,6 +263,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
         });
     }
 {{/domain_entity.qt.has_badge_columns}}
+{{/domain_entity.qt.needs_item_delegate}}
 
     initializeTableSettings(tableView_, model_,
         "{{domain_entity.qt.settings_group}}",

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.mdi_window_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.mdi_window_impl.org
@@ -64,13 +64,15 @@ The full template source. Edit here and re-tangle with
 #include <QFileDialog>
 #include <QUrl>
 {{/domain_entity.qt.has_csv_xml_io}}
-{{#domain_entity.qt.has_badge_columns}}
+{{#domain_entity.qt.needs_item_delegate}}
 #include "ores.qt/EntityItemDelegate.hpp"
+{{/domain_entity.qt.needs_item_delegate}}
+{{#domain_entity.qt.has_badge_columns}}
 #include "ores.qt/BadgeCache.hpp"
+{{/domain_entity.qt.has_badge_columns}}
 {{#domain_entity.qt.needs_image_cache}}
 #include "ores.qt/ImageCache.hpp"
 {{/domain_entity.qt.needs_image_cache}}
-{{/domain_entity.qt.has_badge_columns}}
 #include "{{domain_entity.qt.protocol_include}}"
 
 namespace ores::qt {
@@ -266,7 +268,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
 {{/domain_entity.qt.has_any_flag_icon}}
 {{/domain_entity.qt.has_pair_icon_column}}
 
-{{#domain_entity.qt.has_badge_columns}}
+{{#domain_entity.qt.needs_item_delegate}}
     using cs = column_style;
     auto* delegate = new EntityItemDelegate({
 {{#domain_entity.qt.columns}}
@@ -287,6 +289,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
 {{/is_badge}}
 {{/domain_entity.qt.columns}}
     tableView_->setItemDelegate(delegate);
+{{#domain_entity.qt.has_badge_columns}}
     if (badgeCache_) {
         if (badgeCache_->isLoaded())
             tableView_->viewport()->update();
@@ -295,6 +298,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupTable() {
         });
     }
 {{/domain_entity.qt.has_badge_columns}}
+{{/domain_entity.qt.needs_item_delegate}}
 
     initializeTableSettings(tableView_, model_,
         "{{domain_entity.qt.settings_group}}",

--- a/projects/ores.codegen/src/codegen/core.py
+++ b/projects/ores.codegen/src/codegen/core.py
@@ -2129,6 +2129,23 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                     any(c.get('is_badge') for c in qt['columns'])
                     or qt.get('has_combo_badge_source', False)
                 )
+                # EntityItemDelegate (icon_centered/icon_text_left sizing,
+                # badge_centered rendering) is needed whenever the list view
+                # has ANY icon or badge column — not just badge columns.
+                # Gating it on has_badge_columns alone left icon-only
+                # entities (e.g. country, with just its own flag column)
+                # rendering that icon through Qt's default item-view path,
+                # which uses decorationSize directly instead of the
+                # aspect-correct, height-constrained sizing the delegate
+                # provides — the same class of bug fixed for currency_pair's
+                # mixed icon/text columns, just not yet visibly wrong for a
+                # single-icon-column view. EntityItemDelegate's constructor
+                # doesn't require a BadgeCache, so this is safe to widen
+                # independently of badgeCache_ (which stays gated on
+                # has_badge_columns, since only badge columns need it).
+                qt['needs_item_delegate'] = (
+                    qt['has_badge_columns'] or qt.get('has_any_flag_icon', False)
+                )
             # has_explorer_api opts a controller into the public
             # openAdd()/openEdit()/openHistory() surface a sibling explorer
             # window (e.g. PortfolioExplorer, OrgExplorer) needs to drive it

--- a/projects/ores.qt/refdata/src/CountryDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CountryDetailDialog.cpp
@@ -352,10 +352,5 @@ void CountryDetailDialog::onDeleteClicked() {
     watcher->setFuture(future);
 }
 
-// Extra method implementations seam: a future
-// :implements EC97923E-BC8D-4A50-9970-CBC5CBD4B732 block is expected to
-// define the bodies of any methods declared via the header seam at
-// F55CB64E-165A-4E15-A50A-5723C0320E97 — see paste_blocks_in_codegen.org.
-// Left empty when no entity implements this kind.
 
 }

--- a/projects/ores.qt/refdata/src/CountryMdiWindow.cpp
+++ b/projects/ores.qt/refdata/src/CountryMdiWindow.cpp
@@ -19,8 +19,10 @@
  */
 #include "ores.qt/CountryMdiWindow.hpp"
 #include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/EntityItemDelegate.hpp"
 #include "ores.qt/FlagIconHelper.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ImageCache.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.refdata.api/messaging/country_protocol.hpp"
 #include <QFutureWatcher>
@@ -126,6 +128,20 @@ void CountryMdiWindow::setupTable() {
     tableView_->verticalHeader()->setVisible(false);
     tableView_->setIconSize(single_flag_icon_size());
 
+    using cs = column_style;
+    auto* delegate = new EntityItemDelegate(
+        {
+            cs::icon_text_left,
+            cs::text_left,
+            cs::text_left,
+            cs::text_left,
+            cs::text_left,
+            cs::mono_center,
+            cs::text_left,
+            cs::text_left,
+        },
+        tableView_);
+    tableView_->setItemDelegate(delegate);
 
     initializeTableSettings(tableView_, model_, "CountryListWindow", {}, {900, 400}, 1);
 }

--- a/projects/ores.refdata/api/include/ores.refdata.api/domain/country.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/domain/country.hpp
@@ -81,6 +81,11 @@ struct country final {
     std::optional<boost::uuids::uuid> image_id;
 
     /**
+     * @brief Optional coding scheme code for the country.
+     */
+    std::optional<std::string> coding_scheme_code;
+
+    /**
      * @brief Username of the person who last modified this country.
      */
     std::string modified_by;

--- a/projects/ores.refdata/api/src/generators/country_generator.cpp
+++ b/projects/ores.refdata/api/src/generators/country_generator.cpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include <string>
+#include <unordered_set>
 
 namespace ores::refdata::generators {
 
@@ -35,17 +36,18 @@ domain::country generate_synthetic_country(utility::generation::generation_conte
         ctx.env().get_or(std::string(generation_keys::tenant_id), std::string("system"));
 
     domain::country r;
-    r.version = 1;
+    r.version = 0;
     r.tenant_id =
         utility::uuid::tenant_id::from_string(tid_str).value_or(utility::uuid::tenant_id::system());
     const auto idx = counter.fetch_add(1, std::memory_order_relaxed);
-    r.alpha2_code = +"-" + std::to_string(idx);
+    r.alpha2_code = std::string(faker::word::noun()) + "-" + std::to_string(idx);
     r.alpha3_code = std::string(faker::location::countryCode()) + "X" + "-" + std::to_string(idx);
     r.numeric_code =
         std::to_string(faker::number::integer(10001, 99999)) + "-" + std::to_string(idx);
     r.name = std::string(faker::location::country());
     r.official_name = "Republic of " + std::string(faker::location::country());
     r.image_id = std::nullopt;
+    r.coding_scheme_code = std::nullopt;
     r.modified_by = modified_by;
     r.performed_by = modified_by;
     r.change_reason_code = "system.test";

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/country_entity.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/country_entity.hpp
@@ -40,11 +40,16 @@ struct country_entity {
     sqlgen::PrimaryKey<std::string> alpha2_code;
     std::string tenant_id;
     int version = 0;
+
     std::string alpha3_code;
+
+
     std::string numeric_code;
+
     std::string name;
     std::string official_name;
     std::optional<std::string> image_id;
+    std::optional<std::string> coding_scheme_code;
     std::string modified_by;
     std::string performed_by;
     std::string change_reason_code;

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/country_repository.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/country_repository.hpp
@@ -24,7 +24,9 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.refdata.api/domain/country.hpp"
 #include "ores.refdata.core/export.hpp"
+#include <chrono>
 #include <cstdint>
+#include <optional>
 #include <sqlgen/postgres.hpp>
 #include <string>
 #include <vector>
@@ -72,6 +74,20 @@ public:
      * @brief Reads all countries, possibly filtered by alpha2_code.
      */
     std::vector<domain::country> read_all(context ctx, const std::string& alpha2_code);
+
+    /**
+     * @brief Reads a single country as it stood at a specific
+     * version — the version's own [valid_from, valid_to) window is returned
+     * verbatim, so the caller can compose child entities "as of" the same
+     * window. See the "Temporal composite entity versioning" architecture
+     * doc.
+     * @param ctx Repository context with database connection
+     * @param alpha2_code The alpha2_code to look up
+     * @param version The version to fetch
+     */
+    std::optional<domain::country>
+    read_at_version(context ctx, const std::string& alpha2_code, std::uint32_t version);
+
 
     /**
      * @brief Reads latest countries with pagination support.

--- a/projects/ores.refdata/core/include/ores.refdata.core/service/country_service.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/service/country_service.hpp
@@ -27,6 +27,7 @@
 #include "ores.refdata.core/repository/country_repository.hpp"
 #include "ores.refdata.core/repository/party_country_repository.hpp"
 #include <boost/uuid/uuid.hpp>
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -75,6 +76,17 @@ public:
      * @return Total number of active countries.
      */
     std::uint32_t count_countries();
+
+    /**
+     * @brief Retrieves a single country as it stood at a specific
+     * version. See the "Temporal composite entity versioning" architecture doc.
+     *
+     * @param alpha2_code The alpha2_code of the country.
+     * @param version The version to fetch.
+     * @return The country at that version if found, std::nullopt otherwise.
+     */
+    std::optional<domain::country> get_country_at_version(const std::string& alpha2_code,
+                                                          std::uint32_t version);
 
     /**
      * @brief Retrieves a single country by its alpha2_code.

--- a/projects/ores.refdata/core/src/repository/country_entity.cpp
+++ b/projects/ores.refdata/core/src/repository/country_entity.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.refdata.core/repository/country_entity.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <ostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>

--- a/projects/ores.refdata/core/src/repository/country_mapper.cpp
+++ b/projects/ores.refdata/core/src/repository/country_mapper.cpp
@@ -35,13 +35,18 @@ domain::country country_mapper::map(const country_entity& v) {
     r.version = v.version;
     r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.alpha2_code = v.alpha2_code.value();
+
     r.alpha3_code = v.alpha3_code;
+
+
     r.numeric_code = v.numeric_code;
+
     r.name = v.name;
     r.official_name = v.official_name;
     r.image_id = v.image_id.has_value() ?
                      std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.image_id)) :
                      std::nullopt;
+    r.coding_scheme_code = v.coding_scheme_code;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;
     r.change_reason_code = v.change_reason_code;
@@ -59,12 +64,17 @@ country_entity country_mapper::map(const domain::country& v) {
     r.alpha2_code = v.alpha2_code;
     r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
+
     r.alpha3_code = v.alpha3_code;
+
+
     r.numeric_code = v.numeric_code;
+
     r.name = v.name;
     r.official_name = v.official_name;
     r.image_id =
         v.image_id.has_value() ? std::optional(boost::uuids::to_string(*v.image_id)) : std::nullopt;
+    r.coding_scheme_code = v.coding_scheme_code;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;
     r.change_reason_code = v.change_reason_code;

--- a/projects/ores.refdata/core/src/repository/country_repository.cpp
+++ b/projects/ores.refdata/core/src/repository/country_repository.cpp
@@ -95,6 +95,30 @@ std::vector<domain::country> country_repository::read_all(context ctx,
         "Reading all country versions by alpha2_code.");
 }
 
+std::optional<domain::country> country_repository::read_at_version(context ctx,
+                                                                   const std::string& alpha2_code,
+                                                                   std::uint32_t version) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading country at version. alpha2_code: " << alpha2_code
+                               << " version: " << version;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query =
+        sqlgen::read<std::vector<country_entity>> |
+        where("tenant_id"_c == tid && "alpha2_code"_c == alpha2_code && "version"_c == version) |
+        sqlgen::limit(1);
+
+    const auto entities = execute_read_query<country_entity, domain::country>(
+        ctx,
+        query,
+        [](const auto& entities) { return country_mapper::map(entities); },
+        lg(),
+        "Reading country at version.");
+
+    if (entities.empty())
+        return std::nullopt;
+    return entities.front();
+}
+
+
 void country_repository::remove(context ctx, const std::string& alpha2_code) {
     BOOST_LOG_SEV(lg(), debug) << "Removing country: " << alpha2_code;
     static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));

--- a/projects/ores.refdata/core/src/service/country_service.cpp
+++ b/projects/ores.refdata/core/src/service/country_service.cpp
@@ -46,6 +46,13 @@ std::uint32_t country_service::count_countries() {
     return repo_.get_total_country_count(ctx_);
 }
 
+std::optional<domain::country>
+country_service::get_country_at_version(const std::string& alpha2_code, std::uint32_t version) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting country at version: " << alpha2_code
+                               << " version: " << version;
+    return repo_.read_at_version(ctx_, alpha2_code, version);
+}
+
 std::optional<domain::country> country_service::get_country(const std::string& alpha2_code) {
     BOOST_LOG_SEV(lg(), debug) << "Getting country: " << alpha2_code;
     auto results = repo_.read_latest(ctx_, alpha2_code);

--- a/projects/ores.sql/create/refdata/refdata_countries_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_create.sql
@@ -107,17 +107,22 @@ begin
         end if;
         NEW.version = current_version + 1;
 
+        -- clock_timestamp(), not current_timestamp: current_timestamp is
+        -- frozen for the whole transaction, so a same-transaction
+        -- multi-write to this row (e.g. a composite entity's parent
+        -- touched twice by two different children in one transaction)
+        -- would collide with itself. clock_timestamp() always advances.
         update "ores_refdata_countries_tbl"
-        set valid_to = current_timestamp
+        set valid_to = clock_timestamp()
         where tenant_id = NEW.tenant_id
           and alpha2_code = NEW.alpha2_code
           and valid_to = ores_utility_infinity_timestamp_fn()
-          and valid_from < current_timestamp;
+          and valid_from < clock_timestamp();
     else
         NEW.version = 1;
     end if;
 
-    NEW.valid_from = current_timestamp;
+    NEW.valid_from = clock_timestamp();
     NEW.valid_to = ores_utility_infinity_timestamp_fn();
     NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
     NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
@@ -131,17 +136,19 @@ before insert on "ores_refdata_countries_tbl"
 for each row execute function ores_refdata_countries_insert_fn();
 
 create or replace rule ores_refdata_countries_delete_rule as
-on delete to "ores_refdata_countries_tbl" do instead
+on delete to "ores_refdata_countries_tbl" do instead (
     update "ores_refdata_countries_tbl"
-    set valid_to = current_timestamp
+    set valid_to = clock_timestamp()
     where tenant_id = OLD.tenant_id
       and alpha2_code = OLD.alpha2_code
       and valid_to = ores_utility_infinity_timestamp_fn();
+);
 
 -- =============================================================================
 -- Validation function for country
 -- Validates that a alpha2_code exists in the countries table.
 -- Returns the validated value, or default if null/empty.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
 -- =============================================================================
 create or replace function ores_refdata_validate_country_fn(
     p_tenant_id uuid,
@@ -154,6 +161,30 @@ begin
             using errcode = '23502';
     end if;
 
+    -- Allow pass-through if neither this tenant nor the system tenant has
+    -- seeded active countries yet (freshly provisioned tenant).
+    if not exists (
+        select 1 from ores_refdata_countries_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        return p_value;
+    end if;
+
+    -- Validate against this tenant's values and the system tenant's canonical set.
+    if not exists (
+        select 1 from ores_refdata_countries_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+          and alpha2_code = p_value
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid country: %. Must be one of: %', p_value, (
+            select string_agg(alpha2_code::text, ', ' order by alpha2_code)
+            from ores_refdata_countries_tbl
+            where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) using errcode = '23503';
+    end if;
 
     return p_value;
 end;


### PR DESCRIPTION
## Summary

Country's generated files were stale relative to shared codegen template capability landed via currency's commissioning (sprint 22). Regenerates country, reconciles all drift, and generalizes one more shared-template gap found along the way.

## Changes

- Regenerated country via compass codegen entity generate; fixed a real synthetic-data-generator bug (garbage alpha2_code), picked up a previously-unreflected coding_scheme_code field
- SQL: clock_timestamp() instead of transaction-frozen current_timestamp; delete rule DO INSTEAD wrapped in parens; validate function's bootstrap pass-through now checks active rows only (fixes country's own historically-documented Item 2 bug)
- Picked up read_at_version() (temporal composite entity versioning, landed generically since country's last sync)
- Found and fixed a shared-template gap: EntityItemDelegate (icon/badge sizing) was only constructed when has_badge_columns was true, so country's own flag column bypassed the aspect-correct sizing fix landed for currency_pair. Widened the gate to a new needs_item_delegate flag; zero regen diff for currency/currency_pair confirms no regression
- Added and ran a live test scenario (6/6 steps PASSED) covering the flag-sizing fix, SQL validation fix, and generator fix

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Regen entities with latest codegen templates](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/story.html) | AF0EFC5C-899A-4AE9-BD09-7B2D4E304543 |
| Task | [Regen country against latest codegen templates](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_22/regen_entities_latest_codegen_templates/task_refresh_country_codegen.html) | 82BA40CA-3A4A-47B5-88ED-ADA0178E5695 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)