### PR TITLE
[skill] Reorder PR bookkeeping before review, not after CI green

### DIFF
--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -7,13 +7,20 @@
 #+level: cross
 #+filetags: :llm:runbook:pr:review:github:
 #+created: 2026-05-26
-#+updated: 2026-06-05
+#+updated: 2026-07-11
 
 This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
 
 * Goal
 
-Handle one complete review round: sync with main, read all review comments, decide accept/decline per comment, apply fixes, push, reply to every comment, resolve threads, and record the round in the task.
+Handle one complete review round: sync with main, read all review
+comments, decide accept/decline per comment, apply fixes bundled with
+the round's =* Review= table update, push once, reply to every
+comment, resolve threads, and — if this was the final round — merge
+immediately on green CI. Task/story bookkeeping is not part of this
+runbook: it happens before the PR exists (see [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to
+merged PR]]), so no bookkeeping-only commit should ever follow a
+review round.
 
 * Preconditions
 
@@ -50,9 +57,14 @@ In execution order:
 
 4. /Decide per comment./ For each comment, make an explicit accept/decline decision. Never silently ignore a comment.
 
-5. /Apply fixes./ One commit per logical fix. Never amend commits on a branch under review. Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]].
+5. /Apply fixes./ One commit per logical fix. Never amend commits on a
+   branch under review. Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]]. Build and run tests
+   locally before pushing — the only local verification this round
+   gets. Update the task's =* Review= table for this round (what step
+   10 used to do as a separate step) now, so it lands in the same
+   commit set as the fixes — never as a later, code-free commit.
 
-6. /Push./ =git push=.
+6. /Push./ =git push= — fixes and the =* Review= table update together.
 
 7. /Verify CI is green./ Re-run =compass pr checks <N>= (or =--watch= to poll) and wait until no checks are pending. If any check fails, fix, commit, push, and repeat this step. Do not reply to review comments while CI is red.
 
@@ -60,20 +72,28 @@ In execution order:
 
 9. /Resolve threads./ =compass review resolve <N>= (=--dry-run= to preview).
 
-10. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
+Replying (step 8) and resolving (step 9) are GitHub API calls, not
+commits — they never trigger CI, so they're safe to do after step 7's
+green check without starting a new cycle.
 
-11. /If this was the final round and the PR delivers the task/, end
-    the bookkeeping now so it rides the PR: =compass task done
-    <slug>=, write the =* Result=, commit, push. Then merge —
-    =compass pr merge= never touches task state.
+10. /If this was the final round and the PR delivers the task, merge
+    immediately./ Task/story bookkeeping should already be in place
+    from *before* the PR was raised (see [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] — it runs
+    ahead of [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][pr-raise]], not after review). Do not push a bookkeeping
+    commit now: that would force a fresh CI cycle for a change with no
+    code content, on a PR that was already green and approved. Go
+    straight to [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
 
 * Postconditions
 
 - All CI checks on the PR are green.
 - All review comments have replies.
 - All threads are resolved.
-- Review round is recorded in the task's =* Review= table.
+- Review round is recorded in the task's =* Review= table, committed
+  together with this round's fixes (not a separate commit).
 - Branch is pushed and PR is updated.
+- If this was the final round: the PR is merged, with no commits
+  pushed after the last green CI run.
 
 * See also
 

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -7,13 +7,21 @@
 #+level: cross
 #+filetags: :llm:agile:task:pr:review:merge:
 #+created: 2026-05-26
-#+updated: 2026-06-03
+#+updated: 2026-07-11
 
 This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
 
 * Goal
 
-Take an existing task from =BACKLOG= through implementation, PR creation, review rounds, and merge — the full development lifecycle.
+Take an existing task from =BACKLOG= through implementation, PR
+creation, review rounds, and merge — the full development lifecycle.
+Task/story bookkeeping happens *before* the PR is raised, not after
+review approves: the work is done as far as the developer is
+concerned by the time review starts, and review is a post-done
+validation activity. This ordering exists specifically so that once
+CI goes green after the final review round, merge is the only
+remaining action — no bookkeeping-only commit forces one more,
+otherwise-avoidable CI cycle.
 
 * Preconditions
 
@@ -55,22 +63,20 @@ In execution order:
 
 4. /Commit./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[component] Imperative summary= with a =Co-Authored-By:= trailer. One logical change per commit. Never amend commits on a branch under review.
 
-5. /Open a PR./ =compass pr create= per [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — it pushes, builds the body with Traceability, records the PR on the task, and stamps the journal.
+5. /Build and test locally./ Same preset the CI would use:
 
-6. /Monitor CI./ Wait for checks to pass. If a check fails, follow [[id:62D39F43-5D91-4A82-B1C3-62C2AF21BEFC][How do I fix a failing CI check?]].
+   #+begin_src sh :results verbatim
+   cmake --build --preset <preset>
+   ctest --preset <preset>
+   #+end_src
 
-7. /Handle review./ When review comments arrive, follow [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]]:
-   - Sync with =main= first (rebase).
-   - Decide accept/decline per comment.
-   - Apply fixes (one commit per logical fix).
-   - Push, reply to every comment, resolve threads.
-   - Record the review round in the task's =* Review= table.
+   Do not proceed until both are clean — this is the only full
+   build/test verification the change gets before review, since CI no
+   longer runs one.
 
-   Repeat step 7 for each review round until the PR is approved.
-
-8. /Close out — before the merge./ When the final review round is
-   done and the PR delivers this task, end the bookkeeping on the PR
-   branch so it rides the PR — never a follow-up PR:
+6. /Close out task/story bookkeeping now — before the PR exists./ The
+   task is done as far as the developer is concerned; review is a
+   post-done validation activity, not something bookkeeping waits on:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh task done <slug>
@@ -78,28 +84,65 @@ In execution order:
 
    Task and story row flip to DONE with end date. Write the task's
    =* Result= by hand, distill any =* Plan= into the parent story's
-   =* Decisions=, commit, and push. A task spanning several PRs stays
-   open — close it on the PR that completes it.
+   =* Decisions=. If this was the final task in the story, update
+   both files in the same commit:
 
-9. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit — still before the merge, so the sync rides the PR too:
+   a. In *story.org* =* Status=: state → =DONE=, =Now= → =Nothing.=, fill =End= date.
+   b. In *sprint.org* =* Stories=: update the story row to =DONE= and fill =End=.
 
-   a. In the *story.org* =* Status= table: state → =DONE=, set =Now= to =Nothing.=, fill =End= date.
-   b. In the *sprint.org* =* Stories= table: update the story row to =DONE= and fill the =End= column.
+   Both files must stay in sync — a story =DONE= in =story.org= but
+   =STARTED=/=BACKLOG= in =sprint.org= is a silent inconsistency the
+   sprint health review will not catch automatically. Commit this
+   bookkeeping now; it will be part of the PR from its very first
+   push, not a follow-up. A task spanning several PRs stays open —
+   close it on the PR that completes it.
 
-   Both files must stay in sync. A story marked =DONE= in =story.org= but =STARTED= or =BACKLOG= in =sprint.org= is a silent inconsistency that the sprint health review will not catch automatically.
+7. /Open a PR./ =compass pr create= per [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — it pushes
+   (bookkeeping commit included), builds the body with Traceability,
+   records the PR on the task, and stamps the journal. Include the
+   step-5 build/test result as an explicit =--change= bullet so it's
+   visible in the PR description.
 
-10. /Merge./ =compass pr merge= — the guards refuse while threads are
-    unresolved or CI is not green; merge never touches task state (a
-    STARTED task only draws a warning), retries GitHub's transient
+8. /Monitor CI./ Wait for checks to pass. If a check fails, follow [[id:62D39F43-5D91-4A82-B1C3-62C2AF21BEFC][How do I fix a failing CI check?]].
+
+9. /Handle review./ When review comments arrive, follow [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]]:
+   - Sync with =main= first (rebase).
+   - Decide accept/decline per comment.
+   - Apply fixes (one commit per logical fix); build and test locally
+     before pushing.
+   - Push once — fixes and this round's =* Review= table update
+     together, never a separate bookkeeping-only commit afterward.
+   - Reply to every comment, resolve threads (API calls, not commits —
+     safe to do after CI is green without starting a new cycle).
+
+   Repeat step 9 for each review round until the PR is approved.
+
+10. /Merge — immediately once CI is green post-approval./ Nothing
+    should be pushed between the last green CI run and the merge:
+    task/story bookkeeping already rode in with step 6, and review-
+    round bookkeeping already rode in with each round's fixes (step
+    9). The only things that legitimately delay a merge after green
+    CI are a real merge conflict with =main= (rebase and let CI run
+    once more) or a genuinely new review round.
+
+    #+begin_src sh :results verbatim
+    ./projects/ores.compass/compass.sh pr merge
+    #+end_src
+
+    The guards refuse while threads are unresolved or CI is not
+    green; merge never touches task state (a STARTED task is a hard
+    stop, not a warning — see [[id:D36BCA19-8926-4E06-8C0B-7F607BD3D4EC][pr-merge]]), retries GitHub's transient
     base-branch-modified race, and deletes the remote branch. See
     [[id:95D560C6-3551-4810-9D11-55F9F82B483C][How do I merge a PR?]].
 
 * Postconditions
 
-- Task is =DONE= with =* Result= filled, and the close-out commit is
-  /inside/ the merged PR.
-- PR is merged into =main=.
-- Review rounds are recorded in the task's =* Review= table.
+- Task is =DONE= with =* Result= filled, and the close-out commit rode
+  in with the *first* push of the PR, not a late one.
+- PR is merged into =main= with no commits after the last green CI
+  run other than genuine review-round fixes or a rebase.
+- Review rounds are recorded in the task's =* Review= table, each
+  entry committed together with that round's fixes.
 - Parent story reflects any decisions from the task's =* Plan=.
 - If the story is complete: =story.org= and =sprint.org= both show =DONE= with matching end dates.
 

--- a/doc/llm/skills/agile-close-task/SKILL.org
+++ b/doc/llm/skills/agile-close-task/SKILL.org
@@ -8,19 +8,31 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
-#+updated: 2026-06-06
+#+updated: 2026-07-11
 
 #+begin_export markdown
 ---
 name: agile-close-task
-description: Close a task's bookkeeping at the end of the review round: DONE, Result, story and sprint sync; cascades to the story when it is the last open task.
+description: Close a task's bookkeeping before raising its PR (not after review): DONE, Result, story and sprint sync; cascades to the story when it is the last open task.
 license: Complete terms in LICENSE.txt
 ---
 #+end_export
 
 * When to use this skill
 
-Ending a task at the end of its review round — /before/ the merge, so the bookkeeping rides the PR. Never close bookkeeping in a follow-up PR.
+As soon as implementation is complete and locally verified (build +
+tests green) — /before/ raising the PR and /before/ requesting
+review. The task is done as far as the developer is concerned; review
+is a post-done validation activity, not a step that bookkeeping waits
+on. Never close bookkeeping after review approves, and never in a
+follow-up PR/commit once CI has already gone green — either wastes a
+full CI cycle for a change with no code content.
+
+If a review round turns up a real functional gap that reopens the
+work, that's an exception to "done" (the implementation genuinely
+wasn't finished) — fix it as part of that round's own commit and
+amend =* Result=/=* Decisions= in the same commit, rather than treating
+routine review feedback as reopening the task by default.
 
 * How to use this skill
 
@@ -37,7 +49,11 @@ Ending a task at the end of its review round — /before/ the merge, so the book
 
 4. /Cascade if last task/: when no open tasks remain, set the story DONE in =story.org= /and/ its row in =sprint.org= — both files in the same commit.
 
-5. /Commit on the PR branch/ per [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]]: =[agile] Close <task>=. Then merge with =pr-merge=.
+5. /Commit/ per [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]]: =[agile] Close <task>=. This commit is
+   part of what =pr-raise= pushes when it opens the PR — not a
+   follow-up. Once the PR is open, CI and review run against a branch
+   that already reflects the task as done; when CI goes green
+   post-approval, merge immediately with =pr-merge=, no further commits.
 
 * Recipes
 

--- a/doc/llm/skills/pr-address-review/SKILL.org
+++ b/doc/llm/skills/pr-address-review/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
-#+updated: 2026-06-06
+#+updated: 2026-07-11
 
 #+begin_export markdown
 ---
@@ -53,7 +53,14 @@ Review comments arrived on a PR: handle one complete round — sync, read, decid
 
 4. /Decide per comment/ — explicit accept or decline; never silently ignore.
 
-5. /Fix/ — one commit per logical fix; never amend on a branch under review. Push.
+5. /Fix/ — one commit per logical fix; never amend on a branch under
+   review. Build and run tests locally before pushing (same preset as
+   =pr-raise=) — this is the only local verification a round gets, so
+   don't skip it. Update the task's =* Review= table (step 7) for this
+   round and include that in the *same* push as the fixes — never push
+   a bookkeeping-only commit after this round's CI has already gone
+   green; that wastes a full CI cycle recording something with no code
+   content. Push.
 
 6. /Reply to every comment/ — accepted: "Fixed in <sha> — ..."; declined: "Not changed. <reason>":
 
@@ -62,11 +69,19 @@ Review comments arrived on a PR: handle one complete round — sync, read, decid
    #+end_src
 
 
-7. /Resolve threads and record the round/ in the task's =* Review= table:
+7. /Resolve threads/ — already recorded in the =* Review= table and
+   pushed together with step 5's fixes, not as a separate follow-up
+   commit:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh review resolve <N>
    #+end_src
+
+   Replying and resolving are GitHub API calls, not commits — they
+   don't trigger CI. Once this round's CI is green and the reviewer
+   approves, task/story bookkeeping should already be in place from
+   before the PR was raised (see [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]]) — merge immediately
+   with [[id:D36BCA19-8926-4E06-8C0B-7F607BD3D4EC][pr-merge]], no additional commits.
 
 
 * Recipes

--- a/doc/llm/skills/pr-merge/SKILL.org
+++ b/doc/llm/skills/pr-merge/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
-#+updated: 2026-06-06
+#+updated: 2026-07-11
 
 #+begin_export markdown
 ---
@@ -20,29 +20,26 @@ license: Complete terms in LICENSE.txt
 
 * When to use this skill
 
-Merging an approved PR. Guard rails refuse while review threads are unresolved or CI is red.
+Merging an approved PR, the moment CI goes green. Guard rails refuse
+while review threads are unresolved or CI is red. This should be the
+*only* action taken once CI is green post-review — no bookkeeping
+commit, no rebuild, nothing that would push a new commit and force
+another CI cycle. If the task isn't closed and the story/sprint
+aren't synced by this point, that's a process gap (see
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] — it should have happened before =pr-raise=), not a
+step to perform now.
 
 * How to use this skill
 
-1. /Build and run tests locally first/, on the latest commit about to
-   be merged. CI does not run a full C++ build/test job on PRs (the
-   old "canary" job was removed — it took too long and slowed down
-   development), so this is the only build/test verification a merge
-   gets:
+1. /Verify the task is already closed/ — =DONE=, =* Result= written,
+   story/sprint rows synced. This should already be true (closed
+   before the PR was even raised, per [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]]'s ordering). A
+   STARTED task is a hard stop: if it's not closed, close it now —
+   but treat that as recovering from a skipped step, not the normal
+   path, and know that the resulting commit will trigger one more CI
+   cycle before you can merge.
 
-   #+begin_src sh :results verbatim
-   cmake --build --preset <preset>
-   ctest --preset <preset>
-   #+end_src
-
-   Do not merge until both are clean.
-
-2. /Close the task first/ — run =agile-close-task= on the feature branch
-   *before* merging. Bookkeeping must ride the PR, not follow it. A
-   STARTED task is a hard stop: do not proceed to merge until the task
-   is closed.
-
-3. /Merge/ (merge commit, never squash):
+2. /Merge/ (merge commit, never squash), as soon as CI is green:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh pr merge
@@ -50,7 +47,12 @@ Merging an approved PR. Guard rails refuse while review threads are unresolved o
 
    =--force= overrides the guards — only on explicit user instruction.
 
-4. /Verify/ the remote branch was deleted and the journal stamped.
+3. /Verify/ the remote branch was deleted and the journal stamped.
+
+Local build/test verification already happened before the PR was
+raised (per [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][pr-raise]], recorded in the PR description) and again after
+each review-round fix (per [[id:38ACE767-95D6-4A6E-88A8-EC93BB350292][pr-address-review]]) — there is nothing left
+to (re)verify locally at merge time beyond CI being green.
 
 * Recipes
 

--- a/doc/llm/skills/pr-raise/SKILL.org
+++ b/doc/llm/skills/pr-raise/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:pr:github:claude:review:
 #+created: 2026-06-07
-#+updated: 2026-06-07
+#+updated: 2026-07-11
 
 #+begin_export markdown
 ---
@@ -24,33 +24,55 @@ When the user is ready to open a pull request from a feature branch.
 Raises the PR with =compass pr create= and immediately posts an
 =@claude= comment to trigger an interactive code review.
 
+By the time this skill runs, the work is *done* from the developer's
+side — review is a post-done validation activity, not a continuation
+of implementation. That means task/story bookkeeping (see
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]]) happens *before* this skill, not after review
+approves. A PR should never need a bookkeeping-only commit once CI
+has gone green post-review — that wastes a full CI cycle for a change
+with no code content. See [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]] for why the
+lifecycle is ordered this way.
+
 * How to use this skill
 
-1. *Build and run tests locally first*. CI no longer runs a full
-   C++ build/test job on PRs (the old "canary" job was removed — it
-   took too long and slowed down development), so this step is the
-   only thing that catches a broken build before review:
+1. *MANDATORY — build and run tests locally first, and do not skip
+   this even under time pressure*. CI no longer runs a full C++
+   build/test job on PRs (the old "canary" job was removed — it took
+   too long and slowed down development), so this step is the *only*
+   thing that catches a broken build before review, and the PR
+   description is the only record that it happened:
 
    #+begin_src sh :results verbatim
    cmake --build --preset <preset>
    ctest --preset <preset>
    #+end_src
 
-   Do not raise the PR until both are clean.
+   Do not raise the PR until both are clean. Note the preset, the
+   build result, and the test tally (e.g. "142/142 passed") — they go
+   into the PR description in step 2.
 
-2. *Raise the PR*:
+2. *Close task/story bookkeeping now, if not already done*. The task
+   should already be =DONE= with its =* Result= written and the parent
+   story/sprint rows synced (per [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]]) — do this *before*
+   raising the PR, not after review. If it's not done yet, do it now,
+   as part of the same commit set the PR will contain from the start.
+
+3. *Raise the PR*, including the local verification from step 1 as an
+   explicit =--change= bullet so it's visible in the PR description
+   (reviewers and future readers can see it happened without asking):
 
    #+begin_src sh :results verbatim
    ./compass.sh pr create --title "[component] Description" \
      --summary "What changes, why." \
-     --change "First change" --change "Second change"
+     --change "First change" --change "Second change" \
+     --change "Verification: local build clean (<preset>); ctest <N>/<N> passed"
    #+end_src
 
    Compass validates the title, builds the body, pushes the branch,
    opens the PR, records it on the task, and stamps the journal. Note
    the PR number it prints.
 
-3. *Trigger Claude review* by posting a PR comment:
+4. *Trigger Claude review* by posting a PR comment:
 
    #+begin_src sh :results verbatim
    gh pr comment <N> --body "@claude please review this pull request"
@@ -66,6 +88,8 @@ Raises the PR with =compass pr create= and immediately posts an
 * Reference
 
 - [[id:FCF81F0B-AFBF-4169-BD24-04DBD08180A9][GitHub recipes]] — full GitHub recipe index.
+- [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][Agile close task]] — close bookkeeping before raising the PR, not after review.
+- [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]] — the full lifecycle this fits into.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :github:pr:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-06-08
+#+updated: 2026-07-11
 
 The body content should be assembled via [[id:1882D6DF-4012-4C6E-BF62-0D943EF805B0][How do I generate a PR
 summary?]] before running the =gh= command here.
@@ -19,14 +19,23 @@ correctly-formatted title and a structured body?
 
 * Answer
 
-1. /Build and run tests locally first/. CI does not run a full C++
-   build/test job on PRs (the old "canary" job was removed — it took
-   too long and slowed down development), so this local step is the
-   only thing that catches a broken build before review: =cmake
-   --build --preset <preset>= then =ctest --preset <preset>=, both
-   clean, before proceeding.
+1. /Build and run tests locally first — mandatory, never skip/. CI
+   does not run a full C++ build/test job on PRs (the old "canary" job
+   was removed — it took too long and slowed down development), so
+   this local step is the only thing that catches a broken build
+   before review, and the PR description (step 2) is the only record
+   that it happened: =cmake --build --preset <preset>= then =ctest
+   --preset <preset>=, both clean, before proceeding.
 
-2. /Create the PR/ with =compass pr create=. It validates the title
+2. /Close task/story bookkeeping now, if not already done/ — task
+   =DONE=, =* Result= written, story/sprint rows synced (see
+   [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]]). This happens *before* raising the PR, so the
+   bookkeeping commit is part of the very first push, not a follow-up
+   after review.
+
+3. /Create the PR/ with =compass pr create=, including the step-1
+   verification result as a =--change= bullet so it's visible in the
+   description without asking. It validates the title
    convention, assembles the body (Summary, Changes, and the
    =## Traceability= table derived from the branch's task and story
    docs, with an =Environment= row alongside Story and Task), pushes
@@ -37,7 +46,8 @@ correctly-formatted title and a structured body?
    #+begin_src sh :results verbatim
    ./compass.sh pr create --title "[component] One-line description" \
      --summary "What changes, why." \
-     --change "First change" --change "Second change"
+     --change "First change" --change "Second change" \
+     --change "Verification: local build clean (<preset>); ctest <N>/<N> passed"
    #+end_src
 
    Use =--draft= for a draft PR, =--task <uuid-or-slug>= when the
@@ -46,7 +56,7 @@ correctly-formatted title and a structured body?
    =#+environment:= frontmatter field, e.g. =prime_origin=; falls
    back to =(none)= if the task doesn't record one).
 
-3. /Confirm the PR URL/ it prints. There is nothing else to do — the
+4. /Confirm the PR URL/ it prints. There is nothing else to do — the
    task-doc record is already committed and pushed.
 
 * Conventions

--- a/doc/recipes/github/how_do_i_merge_a_pr.org
+++ b/doc/recipes/github/how_do_i_merge_a_pr.org
@@ -7,11 +7,15 @@
 #+level: cross
 #+filetags: :github:pr:merge:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-06-07
+#+updated: 2026-07-11
 
 This is the last step in the =PR Manager= lifecycle. Only run it
 after the user has explicitly confirmed CI is green and all review
-threads are resolved.
+threads are resolved. Merge should be the *only* action taken at this
+point — nothing gets built, tested, or committed here that could push
+a new commit and force another CI cycle. That verification already
+happened before the PR was raised (see [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]]) and
+again after each review-round fix.
 
 * Question
 
@@ -19,20 +23,16 @@ How do I merge a green, approved PR and delete its feature branch?
 
 * Answer
 
-1. /Build and run tests locally first/, on the latest commit about to
-   be merged. CI does not run a full C++ build/test job on PRs (the
-   old "canary" job was removed — it took too long and slowed down
-   development), so this is the only build/test verification a merge
-   gets: =cmake --build --preset <preset>= then =ctest --preset
-   <preset>=, both clean, before merging.
+1. /Verify the task is already closed/ — =DONE=, =* Result= written,
+   story/sprint synced. It should already be, since bookkeeping runs
+   *before* the PR is raised (see [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]]), not at merge
+   time. A task that is still STARTED is a hard stop — go close it
+   (tasks may legitimately span several PRs and stay open on purpose,
+   but that's a deliberate choice, not the default). Note that closing
+   it now means one more commit and one more CI cycle before merging —
+   this is recovering from a skipped step, not the normal path.
 
-2. /Close the bookkeeping first/ if this PR delivers its task: run
-   =compass task done <slug>=, write the =* Result=, and commit on
-   the PR branch — the close-out rides the PR. Merge never touches
-   task state; a task that is still STARTED only draws a warning
-   (tasks may legitimately span several PRs).
-
-3. /Merge/ — the guard rails are built in: the command refuses while
+2. /Merge/ — the guard rails are built in: the command refuses while
    review threads are unresolved or CI is not green, merges (always
    a merge commit — never squash/rebase), retries GitHub's transient
    base-branch-modified race, and deletes the remote branch
@@ -44,10 +44,7 @@ How do I merge a green, approved PR and delete its feature branch?
    ./compass.sh pr merge --force       # override the guards, stating what was bypassed
    #+end_src
 
-4. If the task was left open on purpose, close it on the PR that
-   really finishes it — never with a bookkeeping-only PR.
-
-5. /Sync local main/:
+3. /Sync local main/:
 
    #+begin_src sh :results verbatim
    git checkout main


### PR DESCRIPTION
## Summary

Task/story close-out bookkeeping was happening after the final review round approved — pushing a bookkeeping-only commit right when CI had just gone green, forcing a wasted extra CI cycle before merge was possible. Reorder the lifecycle so bookkeeping happens before the PR is even raised: the task is done as far as the developer is concerned, and review is a post-done validation activity, not something bookkeeping waits on.

## Changes

- Move task/story close-out (`agile-close-task`) to run before `pr-raise`, not after the final review round
- Fold each review round's `* Review` table update into that round's own fix commit/push, never a separate follow-up
- Once CI is green post-review, the only things that legitimately delay a merge are a real merge conflict or a genuine new review round — never bookkeeping
- Make local build+test mandatory and explicit before raising a PR and after every review-round fix
- Record that verification as a visible `--change` bullet in the PR description itself, not tribal knowledge

## Verification

Docs-only change (skills, runbooks, recipes) — no C++ source touched, no build/test applicable.