### PR TITLE
[analytics.quant] Add CRM runtime rate engine (triangulation/derivation)

### DIFF
--- a/doc/agile/versions/v0/sprint_23/crm_implementation/story.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/story.org
@@ -28,10 +28,10 @@ engine the architecture relies on.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
-| Now           | Modelling the driver/derived spanning-tree topology. |
+| Now           | Implementing the runtime rate_engine (triangulation/derivation). |
 | Waiting on    | Nothing.                               |
-| Next          | Implement triangulation/derivation once the topology is in place. |
-| Last touched  | 2026-07-11                               |
+| Next          | Risk recentering, then wiring into ores.marketdata's ingest path. |
+| Last touched  | 2026-07-12                               |
 
 * Acceptance
 
@@ -45,6 +45,7 @@ engine the architecture relies on.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:E7E31384-3616-4DFB-AB20-6CB099114FB3][Model the driver/derived spanning-tree topology]] | DONE | 2026-07-11 | 2026-07-12 | Graph structure over currency pairs for the CRM: driver/derived edges with cycle detection so a pair is never set on both sides simultaneously. |
+| [[id:96522E06-2067-4058-86FC-27B6086DCC26][Implement triangulation/derivation]] | DONE | 2026-07-12 | 2026-07-12 | Runtime rate_engine: consumes a stream of driver_quote ticks (possibly cross-thread) and serves batched derived-rate reads via an atomically-swapped immutable snapshot, computing derived rates by triangulation through the pivot and propagating staleness. |
 
 Planned tasks (not yet scaffolded as task docs), following the domain
 model's concept map:
@@ -94,6 +95,16 @@ model's concept map:
 - QuantLib is deliberately not introduced as a dependency for this story
   (not currently vendored anywhere in the repo); spot/calendar handling
   stays a caller-supplied parameter.
+- Rates are represented as cumulative log-rate-from-the-pivot per vertex
+  (not per-pair), so any derived rate is one subtraction and one
+  =update()= only touches the subtree below the changed edge --
+  =crm_topology= exposes =parent()=/=edge_to_parent()= to support this.
+  Staleness is carried as a per-vertex timestamp alongside the log-rate,
+  recomputed in the same subtree walk rather than as a separate pass.
+- =rate_engine::update()= is single-producer by design (concurrent
+  writers are not supported/needed); =rate()=/=rates()= are safe from any
+  number of concurrent reader threads. This is documented on the class,
+  not enforced at compile time.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
@@ -118,7 +118,11 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Self-referencing pair on the pivot currency (base==quote==pivot) trivially matched =parent(pivot)==pivot= and silently corrupted every derived rate instead of throwing | src/service/rate_engine.cpp | Accepted | Added an explicit =base_id == quote_id= rejection before the parent-equality branches; new test asserts the throw and that the pivot's own rate stays exactly 1.0 afterwards (state not mutated by a rejected update). |
+| 2 | No validation that =driver_quote::rate= is finite/positive; a bad tick silently propagates NaN/-inf through the whole subtree with =status == fresh= | src/service/rate_engine.cpp | Accepted | Added a =std::isfinite() && > 0.0= check that throws =std::invalid_argument=, consistent with the existing unknown-currency/non-edge checks; new test covers zero, negative, NaN, and infinity. |
+| 3 | Existing "not an edge" test used an unknown currency, so it only exercised the unknown-currency throw, not the known-but-unconnected-currencies branch | tests/rate_engine_tests.cpp | Accepted | Split into two tests: unknown currency, and a genuine known-but-unconnected pair (EUR/JPY, both hang off USD but aren't each other's parent). |
+| 4 | =crm_topology::edge_to_parent()= added but never called anywhere -- speculative API surface | domain/crm_topology.hpp | Accepted | Removed; easy to add back with a real caller. |
+| 5 | =ccy_pair='s doc comment claimed =is_driver= is used by =rate_engine= to pick accumulation direction, but the engine actually derives direction from tree structure, not the flag | domain/ccy_pair.hpp | Accepted | Corrected the doc comment to say direction comes from the tree, not =is_driver=, and that either side of an edge may be ticked. |
 
 * Result
 
@@ -143,18 +147,21 @@ Shipped the runtime rate engine in =ores.analytics.quant=, on top of the
   (=as_of=), recomputed alongside =log_rate= in the same subtree walk --
   so a stale major automatically taints every derived rate depending on
   it, with no separate propagation pass.
-- =crm_topology= gained =parent()=/=edge_to_parent()= accessors (design
-  refinement: needed by the engine to build its children adjacency and to
-  determine, on each tick, which side of the edge is the "child" whose
-  subtree to recompute).
-- 8 new Catch2 test cases (15 total in the component, 43,000+ assertions
+- =crm_topology= gained a =parent()= accessor (design refinement: needed
+  by the engine to build its children adjacency and to determine, on each
+  tick, which side of the edge is the "child" whose subtree to
+  recompute). An =edge_to_parent()= accessor was added alongside it but
+  never used, and was removed in the review round below.
+- 11 new Catch2 test cases (18 total in the component, 45,000+ assertions
   across repeated runs): direct rate passthrough, pivot triangulation,
   unavailable-until-seeded, staleness propagation from the oldest
   contributing driver, subtree-only recompute (an unrelated branch is
   provably unaffected by an update elsewhere), batched =rates()=, reject
-  a non-edge pair, and a concurrent-update-vs-concurrent-read stress test
-  (single writer thread + 4 reader threads, thousands of batched reads)
-  run repeatedly with no crashes/hangs/inconsistent reads.
+  an unknown currency, reject two known-but-unconnected currencies,
+  reject a self-referencing pivot pair, reject a non-finite/non-positive
+  rate, and a concurrent-update-vs-concurrent-read stress test (single
+  writer thread + 4 reader threads, thousands of batched reads) run
+  repeatedly with no crashes/hangs/inconsistent reads.
 - Design docs updated to match: component overview, class diagram
   (=vertex_state= edge fields, =rate_engine= member/signature accuracy),
   no longer describing =rate_engine= as deferred.

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
@@ -1,0 +1,164 @@
+:PROPERTIES:
+:ID: 96522E06-2067-4058-86FC-27B6086DCC26
+:END:
+#+title: Task: Implement triangulation/derivation
+#+description: Runtime rate_engine: consumes a stream of driver_quote ticks (possibly cross-thread) and serves batched derived-rate reads via an atomically-swapped immutable snapshot, computing derived rates by triangulation through the pivot and propagating staleness.
+#+type: task
+#+level: s1
+#+filetags: :market_data:crm:fx:sprint_23:v0:crm_implementation:
+#+owner: marco
+#+branch: feature/implement-triangulation-derivation
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+#+environment: clever_dijkstra
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B38B3869-02FD-4CC7-99BD-9A77904ACA19][Cross-rates matrix (CRM)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Implement the CRM's runtime rate engine on top of the =crm_topology= from
+the previous task: a thread-safe (not multi-threaded), lock-free-on-the-
+hot-path engine that ingests a continuous stream of =driver_quote= ticks
+-- possibly from a different thread than its readers -- and serves
+batched derived-rate reads by triangulation through the pivot, with
+staleness propagated end to end from each contributing driver.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:B38B3869-02FD-4CC7-99BD-9A77904ACA19][Cross-rates matrix (CRM)]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-12                               |
+
+* Acceptance
+
+- =domain::vertex_state=, =domain::rate_snapshot=, =domain::staleness_policy=,
+  =domain::derived_rate=, =domain::rate_status= -- the runtime value types
+  from the agreed design (see the parent task's =design/= diagrams,
+  reused here).
+- =service::rate_engine= holds a fixed =crm_topology= (never mutated) and
+  an =immer::atom<rate_snapshot>= (per-vertex cumulative log-rate from the
+  pivot, so any derived rate is one subtraction of two array entries).
+- =update(driver_quote)=: recomputes only the subtree hanging off the
+  updated edge (not the whole matrix) into a new immutable snapshot via
+  structural sharing, then atomically swaps it in. No internal threads;
+  safe to call from any thread.
+- =rate(pair)= / =rates(pairs)=: exactly one atomic snapshot load per
+  call (one for the whole batch in the plural form), then O(1)/O(N) pure
+  arithmetic -- no locking on the read path, so a batch of hundreds/
+  thousands of pairs is cheap.
+- Staleness: each =vertex_state= carries the timestamp of its oldest
+  contributing input, propagated from its parent plus its own edge's
+  timestamp on every update. =rate()=/=rates()= compare
+  =now - oldest_contributing_timestamp= against a caller-supplied
+  =staleness_policy= and return =rate_status= (fresh/stale/unavailable)
+  alongside the value.
+- A concurrent producer (=update=) and concurrent readers (=rate=/
+  =rates=) never block each other and a reader never observes a torn mix
+  of old/new values within one batch -- verified with a test that
+  interleaves updates and reads across threads.
+- Readable, correct triangulation: for a pair not directly on the tree,
+  the rate is computed via the pivot path (existing =crm_topology::
+  path_to_pivot=), preferring the shorter of the two vertices' own paths
+  (i.e. straightforward log-rate subtraction handles this without special
+  casing, per the design).
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+** Design already agreed (previous task's diagrams apply directly)
+
+See [[file:design/crm_engine_classes.puml][class diagram]] and [[file:design/crm_engine_runtime_sequence.puml][runtime sequence diagram]] from the topology
+task -- the =rate_engine=/=rate_snapshot=/=vertex_state= classes there
+were designed together with =topology_builder= and =crm_topology= in the
+same session; this task implements the parts that were deferred:
+
+- Per-vertex cumulative "log-rate from pivot" representation: derived
+  rate for =(base, quote)= is
+  =exp(log_rate[quote] - log_rate[base])=, O(1) per pair.
+- =update()= walks only the subtree below the changed edge (the tree
+  structure bounds the blast radius of one tick).
+- =immer::atom<rate_snapshot>= for the lock-free publish/read; a reader
+  does one =load()= for an entire =rates(pairs)= batch.
+- Staleness is a per-vertex timestamp, not a separate pass: it is carried
+  and propagated alongside =log_rate= in the same =vertex_state=, updated
+  by the same subtree walk.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Shipped the runtime rate engine in =ores.analytics.quant=, on top of the
+=crm_topology= from the previous task:
+
+- New domain types: =driver_quote=, =rate_status=, =staleness_policy=,
+  =derived_rate=, =vertex_state=, =rate_snapshot= -- matching the design
+  agreed and diagrammed in the topology task, updated where the design
+  needed sharpening (see below).
+- =service::rate_engine=: holds the fixed =crm_topology= plus an
+  =immer::atom<rate_snapshot>=; a per-vertex cumulative "log-rate from the
+  pivot" representation makes any derived rate one subtraction
+  (=exp(log_rate[quote] - log_rate[base])=). =update()= walks only the
+  subtree below the changed edge (via a =children_= adjacency built once
+  at construction from =crm_topology::parent()=) and swaps in a new
+  snapshot via structural sharing (=immer::vector::transient()=/
+  =persistent()=); =rate()=/=rates()= each do exactly one atomic
+  =snapshot_.load()= then pure arithmetic.
+- Staleness: each =vertex_state= carries its own edge's tick timestamp
+  (=edge_observed_at=) plus the cumulative oldest-contributing timestamp
+  (=as_of=), recomputed alongside =log_rate= in the same subtree walk --
+  so a stale major automatically taints every derived rate depending on
+  it, with no separate propagation pass.
+- =crm_topology= gained =parent()=/=edge_to_parent()= accessors (design
+  refinement: needed by the engine to build its children adjacency and to
+  determine, on each tick, which side of the edge is the "child" whose
+  subtree to recompute).
+- 8 new Catch2 test cases (15 total in the component, 43,000+ assertions
+  across repeated runs): direct rate passthrough, pivot triangulation,
+  unavailable-until-seeded, staleness propagation from the oldest
+  contributing driver, subtree-only recompute (an unrelated branch is
+  provably unaffected by an update elsewhere), batched =rates()=, reject
+  a non-edge pair, and a concurrent-update-vs-concurrent-read stress test
+  (single writer thread + 4 reader threads, thousands of batched reads)
+  run repeatedly with no crashes/hangs/inconsistent reads.
+- Design docs updated to match: component overview, class diagram
+  (=vertex_state= edge fields, =rate_engine= member/signature accuracy),
+  no longer describing =rate_engine= as deferred.
+
+Acceptance met in full. Story remains STARTED: risk recentering, wiring
+into =ores.marketdata='s ingest path, and the management UI are still
+open per the story's =* Tasks= plan.

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org
@@ -8,7 +8,7 @@
 #+filetags: :market_data:crm:fx:sprint_23:v0:crm_implementation:
 #+owner: marco
 #+branch: feature/implement-triangulation-derivation
-#+pr:
+#+pr: 1512
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
@@ -112,7 +112,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1512][#1512]] | [analytics.quant] Add CRM runtime rate engine (triangulation/derivation) |
 
 * Review
 

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/ccy_pair.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/ccy_pair.hpp
@@ -27,8 +27,11 @@ namespace ores::analytics::quant::domain {
 /// A quoted currency pair within an already-built topology: base/quote as
 /// resolved @c currency_id handles, not raw ISO codes. @c is_driver carries
 /// forward the driver/derived assignment the edge was built from -- see
-/// @c ccy_pair_input -- so a @c crm_topology consumer (the rate engine) can
-/// tell which direction to accumulate rates without a second lookup.
+/// @c ccy_pair_input. Note @c rate_engine::update does not currently read
+/// this field: it derives accumulation direction purely from which side
+/// of an incoming tick matches the tree's parent/child structure, so
+/// either side of an edge may be ticked regardless of which was marked
+/// the driver at build time.
 struct ccy_pair {
     currency_id base;
     currency_id quote;

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/crm_topology.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/crm_topology.hpp
@@ -71,11 +71,6 @@ public:
         return parent_.at(id.index());
     }
 
-    /// The edge from @p id to its parent, or @c std::nullopt for the pivot.
-    [[nodiscard]] const std::optional<ccy_pair>& edge_to_parent(currency_id id) const {
-        return edge_to_parent_.at(id.index());
-    }
-
     [[nodiscard]] std::optional<currency_id> currency_id_for(const std::string& code) const {
         const auto it = currency_index_.find(code);
         if (it == currency_index_.end())

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/crm_topology.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/crm_topology.hpp
@@ -45,27 +45,41 @@ namespace ores::analytics::quant::domain {
  */
 class crm_topology {
 public:
-    crm_topology(
-        currency_id pivot,
-        std::vector<currency_id> parent,
-        std::vector<std::optional<ccy_pair>> edge_to_parent,
-        std::unordered_map<std::string, currency_id> currency_index,
-        std::vector<std::string> currency_code)
-        : pivot_(pivot), parent_(std::move(parent)),
-          edge_to_parent_(std::move(edge_to_parent)),
-          currency_index_(std::move(currency_index)),
-          currency_code_(std::move(currency_code)) {}
+    crm_topology(currency_id pivot,
+                 std::vector<currency_id> parent,
+                 std::vector<std::optional<ccy_pair>> edge_to_parent,
+                 std::unordered_map<std::string, currency_id> currency_index,
+                 std::vector<std::string> currency_code)
+        : pivot_(pivot)
+        , parent_(std::move(parent))
+        , edge_to_parent_(std::move(edge_to_parent))
+        , currency_index_(std::move(currency_index))
+        , currency_code_(std::move(currency_code)) {}
 
     [[nodiscard]] std::size_t vertex_count() const noexcept {
         return currency_code_.size();
     }
 
-    [[nodiscard]] currency_id pivot() const noexcept { return pivot_; }
+    [[nodiscard]] currency_id pivot() const noexcept {
+        return pivot_;
+    }
 
-    [[nodiscard]] std::optional<currency_id> currency_id_for(
-        const std::string& code) const {
+    /// The parent of @p id in the spanning tree; equals @p id itself iff
+    /// @p id is the pivot. Used by the rate engine to walk the tree without
+    /// re-deriving it.
+    [[nodiscard]] currency_id parent(currency_id id) const {
+        return parent_.at(id.index());
+    }
+
+    /// The edge from @p id to its parent, or @c std::nullopt for the pivot.
+    [[nodiscard]] const std::optional<ccy_pair>& edge_to_parent(currency_id id) const {
+        return edge_to_parent_.at(id.index());
+    }
+
+    [[nodiscard]] std::optional<currency_id> currency_id_for(const std::string& code) const {
         const auto it = currency_index_.find(code);
-        if (it == currency_index_.end()) return std::nullopt;
+        if (it == currency_index_.end())
+            return std::nullopt;
         return it->second;
     }
 

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/currency_id.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/currency_id.hpp
@@ -37,11 +37,17 @@ namespace ores::analytics::quant::domain {
  */
 class currency_id {
 public:
-    constexpr currency_id() noexcept : index_(invalid_index) {}
-    constexpr explicit currency_id(std::uint16_t index) noexcept : index_(index) {}
+    constexpr currency_id() noexcept
+        : index_(invalid_index) {}
+    constexpr explicit currency_id(std::uint16_t index) noexcept
+        : index_(index) {}
 
-    [[nodiscard]] constexpr std::uint16_t index() const noexcept { return index_; }
-    [[nodiscard]] constexpr bool valid() const noexcept { return index_ != invalid_index; }
+    [[nodiscard]] constexpr std::uint16_t index() const noexcept {
+        return index_;
+    }
+    [[nodiscard]] constexpr bool valid() const noexcept {
+        return index_ != invalid_index;
+    }
 
     friend constexpr bool operator==(currency_id lhs, currency_id rhs) noexcept {
         return lhs.index_ == rhs.index_;
@@ -54,8 +60,7 @@ public:
     }
 
 private:
-    static constexpr std::uint16_t invalid_index =
-        std::numeric_limits<std::uint16_t>::max();
+    static constexpr std::uint16_t invalid_index = std::numeric_limits<std::uint16_t>::max();
     std::uint16_t index_;
 };
 
@@ -63,8 +68,7 @@ private:
 
 template <>
 struct std::hash<ores::analytics::quant::domain::currency_id> {
-    std::size_t operator()(
-        ores::analytics::quant::domain::currency_id id) const noexcept {
+    std::size_t operator()(ores::analytics::quant::domain::currency_id id) const noexcept {
         return std::hash<std::uint16_t>{}(id.index());
     }
 };

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/derived_rate.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/derived_rate.hpp
@@ -17,29 +17,28 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_ANALYTICS_QUANT_DOMAIN_CCY_PAIR_HPP
-#define ORES_ANALYTICS_QUANT_DOMAIN_CCY_PAIR_HPP
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_DERIVED_RATE_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_DERIVED_RATE_HPP
 
-#include "ores.analytics.quant/domain/currency_id.hpp"
+#include "ores.analytics.quant/domain/rate_status.hpp"
+#include <chrono>
+#include <string>
 
 namespace ores::analytics::quant::domain {
 
-/// A quoted currency pair within an already-built topology: base/quote as
-/// resolved @c currency_id handles, not raw ISO codes. @c is_driver carries
-/// forward the driver/derived assignment the edge was built from -- see
-/// @c ccy_pair_input -- so a @c crm_topology consumer (the rate engine) can
-/// tell which direction to accumulate rates without a second lookup.
-struct ccy_pair {
-    currency_id base;
-    currency_id quote;
-    bool is_driver;
-
-    friend constexpr bool operator==(const ccy_pair& lhs, const ccy_pair& rhs) noexcept {
-        return lhs.base == rhs.base && lhs.quote == rhs.quote && lhs.is_driver == rhs.is_driver;
-    }
-    friend constexpr bool operator!=(const ccy_pair& lhs, const ccy_pair& rhs) noexcept {
-        return !(lhs == rhs);
-    }
+/// A single rate served by @c rate_engine::rate / @c rate_engine::rates --
+/// direct or triangulated, the caller cannot tell the difference from this
+/// type alone (deliberately: the whole point of the CRM is that callers
+/// don't need to know).
+struct derived_rate {
+    std::string base_code;
+    std::string quote_code;
+    /// Only meaningful when @c status != rate_status::unavailable.
+    double rate;
+    rate_status status;
+    /// The oldest contributing driver tick's timestamp on the path between
+    /// base and quote -- a chain is only as fresh as its stalest link.
+    std::chrono::system_clock::time_point as_of;
 };
 
 } // namespace ores::analytics::quant::domain

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/driver_quote.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/driver_quote.hpp
@@ -17,8 +17,29 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include <catch2/catch_session.hpp>
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_DRIVER_QUOTE_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_DRIVER_QUOTE_HPP
 
-int main(int argc, char* argv[]) {
-    return Catch::Session().run(argc, argv);
-}
+#include <chrono>
+#include <string>
+
+namespace ores::analytics::quant::domain {
+
+/**
+ * @brief One tick on a driver edge already present in a built @c crm_topology.
+ *
+ * Raw currency codes, like @c ccy_pair_input -- the caller adapts its own
+ * quote representation at this boundary. @c rate_engine::update rejects a
+ * pair that is not an edge of its topology.
+ */
+struct driver_quote {
+    std::string base_code;
+    std::string quote_code;
+    /// Spot rate: 1 unit of @c base_code = @c rate units of @c quote_code.
+    double rate;
+    std::chrono::system_clock::time_point observed_at;
+};
+
+} // namespace ores::analytics::quant::domain
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/rate_snapshot.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/rate_snapshot.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_RATE_SNAPSHOT_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_RATE_SNAPSHOT_HPP
+
+#include "ores.analytics.quant/domain/currency_id.hpp"
+#include "ores.analytics.quant/domain/vertex_state.hpp"
+#include <immer/vector.hpp>
+#include <immer/vector_transient.hpp>
+
+namespace ores::analytics::quant::domain {
+
+/**
+ * @brief An immutable, point-in-time view of every currency's cumulative
+ * rate state, indexed by @c currency_id.
+ *
+ * Wraps an @c immer::vector so producing a new snapshot after an update
+ * only copies the touched entries (structural sharing) -- never the whole
+ * vector. Held behind an @c immer::atom by @c rate_engine so readers get a
+ * wait-free, torn-read-free view without any locking.
+ */
+class rate_snapshot {
+public:
+    explicit rate_snapshot(immer::vector<vertex_state> states)
+        : states_(std::move(states)) {}
+
+    [[nodiscard]] const vertex_state& at(currency_id id) const {
+        return states_.at(id.index());
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept {
+        return states_.size();
+    }
+
+    /// A transient copy for a batch of updates; caller persists it back
+    /// into a new @c rate_snapshot once done.
+    [[nodiscard]] immer::vector<vertex_state>::transient_type transient() const {
+        return states_.transient();
+    }
+
+private:
+    immer::vector<vertex_state> states_;
+};
+
+} // namespace ores::analytics::quant::domain
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/rate_status.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/rate_status.hpp
@@ -17,8 +17,20 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include <catch2/catch_session.hpp>
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_RATE_STATUS_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_RATE_STATUS_HPP
 
-int main(int argc, char* argv[]) {
-    return Catch::Session().run(argc, argv);
-}
+namespace ores::analytics::quant::domain {
+
+enum class rate_status {
+    /// Every driver on the path is within the staleness policy's max age.
+    fresh,
+    /// At least one contributing driver is older than the policy allows.
+    stale,
+    /// At least one driver on the path has never received a tick.
+    unavailable,
+};
+
+} // namespace ores::analytics::quant::domain
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/staleness_policy.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/staleness_policy.hpp
@@ -17,8 +17,26 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include <catch2/catch_session.hpp>
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_STALENESS_POLICY_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_STALENESS_POLICY_HPP
 
-int main(int argc, char* argv[]) {
-    return Catch::Session().run(argc, argv);
-}
+#include "ores.analytics.quant/domain/rate_status.hpp"
+#include <chrono>
+
+namespace ores::analytics::quant::domain {
+
+/// Caller-supplied tolerance for how old a contributing driver may be
+/// before a derived rate is considered stale. The engine never fetches
+/// this from anywhere -- it is a plain parameter, per this library's
+/// no-refdata-coupling rule.
+struct staleness_policy {
+    std::chrono::system_clock::duration max_age;
+
+    [[nodiscard]] rate_status evaluate(std::chrono::system_clock::duration age) const {
+        return age <= max_age ? rate_status::fresh : rate_status::stale;
+    }
+};
+
+} // namespace ores::analytics::quant::domain
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/topology_build_error.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/topology_build_error.hpp
@@ -40,7 +40,8 @@ namespace ores::analytics::quant::domain {
 class topology_build_error : public std::runtime_error {
 public:
     explicit topology_build_error(std::vector<topology_error> errors)
-        : std::runtime_error(build_message(errors)), errors_(std::move(errors)) {}
+        : std::runtime_error(build_message(errors))
+        , errors_(std::move(errors)) {}
 
     [[nodiscard]] const std::vector<topology_error>& errors() const noexcept {
         return errors_;
@@ -48,8 +49,8 @@ public:
 
 private:
     static std::string build_message(const std::vector<topology_error>& errors) {
-        std::string message = "CRM topology build failed with " +
-            std::to_string(errors.size()) + " error(s):";
+        std::string message =
+            "CRM topology build failed with " + std::to_string(errors.size()) + " error(s):";
         for (const auto& error : errors) {
             message += "\n  - " + error.describe();
         }

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/topology_error.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/topology_error.hpp
@@ -46,15 +46,15 @@ struct topology_error {
 
     [[nodiscard]] std::string describe() const {
         switch (kind) {
-        case topology_error_kind::missing_major:
-            return base_code + ": required major is unreachable from the pivot";
-        case topology_error_kind::cycle_conflict:
-            return base_code + "/" + quote_code +
-                ": conflicts with an existing path -- would create a cycle";
-        case topology_error_kind::disconnected_currency:
-            return base_code + ": not connected to the pivot";
-        case topology_error_kind::duplicate_edge:
-            return base_code + "/" + quote_code + ": duplicate pair in input";
+            case topology_error_kind::missing_major:
+                return base_code + ": required major is unreachable from the pivot";
+            case topology_error_kind::cycle_conflict:
+                return base_code + "/" + quote_code +
+                       ": conflicts with an existing path -- would create a cycle";
+            case topology_error_kind::disconnected_currency:
+                return base_code + ": not connected to the pivot";
+            case topology_error_kind::duplicate_edge:
+                return base_code + "/" + quote_code + ": duplicate pair in input";
         }
         return base_code + "/" + quote_code + ": unknown topology error";
     }

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/domain/vertex_state.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/domain/vertex_state.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ANALYTICS_QUANT_DOMAIN_VERTEX_STATE_HPP
+#define ORES_ANALYTICS_QUANT_DOMAIN_VERTEX_STATE_HPP
+
+#include <chrono>
+
+namespace ores::analytics::quant::domain {
+
+/**
+ * @brief One currency's state within a @c rate_snapshot: immutable once
+ * constructed, replaced wholesale (not mutated) on every @c rate_engine
+ * update.
+ *
+ * Carries both the vertex's own edge-to-parent (so an unrelated update
+ * elsewhere in the tree can recompute this vertex's cumulative values
+ * without re-reading the original tick) and the cumulative, pivot-relative
+ * values a read actually wants:
+ *
+ * - @c log_rate = sum of every edge's log-rate delta from the pivot down
+ *   to this vertex -- so any derived rate is one subtraction away.
+ * - @c as_of = the oldest contributing tick's timestamp anywhere on that
+ *   path -- a chain is only as fresh as its stalest link.
+ * - @c valid = whether every edge on that path has received at least one
+ *   tick yet.
+ */
+struct vertex_state {
+    /// This vertex's own edge-to-parent, log-space (0 for the pivot).
+    double edge_log_delta = 0.0;
+    std::chrono::system_clock::time_point edge_observed_at{};
+    bool edge_valid = false;
+
+    /// Cumulative from the pivot down to this vertex.
+    double log_rate = 0.0;
+    std::chrono::system_clock::time_point as_of{};
+    bool valid = false;
+};
+
+} // namespace ores::analytics::quant::domain
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/service/rate_engine.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/service/rate_engine.hpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ANALYTICS_QUANT_SERVICE_RATE_ENGINE_HPP
+#define ORES_ANALYTICS_QUANT_SERVICE_RATE_ENGINE_HPP
+
+#include "ores.analytics.quant/domain/crm_topology.hpp"
+#include "ores.analytics.quant/domain/derived_rate.hpp"
+#include "ores.analytics.quant/domain/driver_quote.hpp"
+#include "ores.analytics.quant/domain/rate_snapshot.hpp"
+#include "ores.analytics.quant/domain/staleness_policy.hpp"
+#include "ores.analytics.quant/export.hpp"
+#include <chrono>
+#include <immer/atom.hpp>
+#include <string>
+#include <vector>
+
+namespace ores::analytics::quant::service {
+
+/**
+ * @brief The CRM's runtime rate engine (phase 2): continuously ingests
+ * driver ticks and serves batched derived-rate reads.
+ *
+ * Holds a fixed @c domain::crm_topology (never mutated after construction)
+ * plus an @c immer::atom<domain::rate_snapshot> for the per-vertex
+ * cumulative rate state. Not multi-threaded itself -- it spawns no
+ * threads -- but is thread-safe: @c update() is meant to be called from a
+ * single producer thread; @c rate()/@c rates() may be called concurrently
+ * from any number of reader threads without ever blocking the producer or
+ * each other, and a reader never observes a torn mix of old/new values
+ * within one @c rates() batch because it loads exactly one snapshot for
+ * the whole call.
+ *
+ * Updating one driver edge only recomputes the subtree hanging below it
+ * (the tree structure bounds the blast radius), via structural sharing so
+ * only the touched entries are copied into the new snapshot.
+ */
+class ORES_ANALYTICS_QUANT_EXPORT rate_engine {
+public:
+    rate_engine(domain::crm_topology topology,
+                domain::staleness_policy policy,
+                std::chrono::system_clock::time_point now = std::chrono::system_clock::now());
+
+    /// Applies one tick to a driver edge already present in the topology.
+    /// Throws @c std::invalid_argument if either code is unknown or the
+    /// pair is not an edge of this engine's topology.
+    void update(const domain::driver_quote& quote);
+
+    /// @param now defaults to the wall clock; tests may inject a fixed
+    /// value for deterministic staleness assertions.
+    [[nodiscard]] domain::derived_rate
+    rate(const std::string& base_code,
+         const std::string& quote_code,
+         std::chrono::system_clock::time_point now = std::chrono::system_clock::now()) const;
+
+    /// One atomic snapshot load for the whole batch, then O(N) pure
+    /// arithmetic -- no per-pair locking.
+    [[nodiscard]] std::vector<domain::derived_rate>
+    rates(const std::vector<std::pair<std::string, std::string>>& pairs,
+          std::chrono::system_clock::time_point now = std::chrono::system_clock::now()) const;
+
+private:
+    domain::derived_rate rate_from_snapshot(const domain::rate_snapshot& snapshot,
+                                            const std::string& base_code,
+                                            const std::string& quote_code,
+                                            std::chrono::system_clock::time_point now) const;
+
+    domain::crm_topology topology_;
+    domain::staleness_policy policy_;
+    /// children_[v.index()] lists every vertex whose parent is v; built
+    /// once from the fixed topology so update() can walk a subtree without
+    /// re-deriving tree structure on every tick.
+    std::vector<std::vector<domain::currency_id>> children_;
+    immer::atom<domain::rate_snapshot> snapshot_;
+};
+
+} // namespace ores::analytics::quant::service
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/service/topology_builder.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/service/topology_builder.hpp
@@ -46,10 +46,10 @@ namespace ores::analytics::quant::service {
  */
 class ORES_ANALYTICS_QUANT_EXPORT topology_builder {
 public:
-    [[nodiscard]] static domain::crm_topology build(
-        const std::vector<domain::ccy_pair_input>& pairs,
-        const std::string& pivot_code,
-        const std::vector<std::string>& required_majors);
+    [[nodiscard]] static domain::crm_topology
+    build(const std::vector<domain::ccy_pair_input>& pairs,
+          const std::string& pivot_code,
+          const std::vector<std::string>& required_majors);
 };
 
 } // namespace ores::analytics::quant::service

--- a/projects/ores.analytics.quant/modeling/component_overview.org
+++ b/projects/ores.analytics.quant/modeling/component_overview.org
@@ -35,24 +35,35 @@ library is consumable standalone and fully unit-testable in isolation.
 - =domain::ccy_pair_input= -- raw currency-pair quotes (base/quote codes,
   driver flag) fed to =service::topology_builder::build=.
 - Pivot currency code and the list of required "major" currencies.
+- =domain::driver_quote= -- a single tick on a driver edge, fed to
+  =service::rate_engine::update=.
+- =domain::staleness_policy= -- caller-supplied max age for a derived rate
+  to be considered fresh.
 
 * Outputs
 
 - =domain::crm_topology= -- the immutable, validated spanning tree.
 - =domain::topology_build_error= -- thrown with one =topology_error= per
   offending pair when the input cannot form a valid tree.
+- =domain::derived_rate= -- a rate (direct or triangulated) with its
+  =rate_status= (fresh/stale/unavailable) and the oldest contributing
+  driver's timestamp.
 
 * Entry points
 
 - =service::topology_builder::build(pairs, pivot_code, required_majors)=
+- =service::rate_engine::update(driver_quote)=
+- =service::rate_engine::rate(base_code, quote_code)= /
+  =rates(pairs)=
 
 * Dependencies
 
 - =Boost::graph= / =Boost::boost= -- topology construction
   (=boost::disjoint_sets= for incremental cycle detection, BFS for
   parent/path assignment).
-- =immer= -- lock-free immutable snapshots for the runtime rate engine
-  (a later task in this story).
+- =immer= (=immer::atom<rate_snapshot>=, =immer::vector<vertex_state>=) --
+  lock-free, structural-sharing immutable snapshots for the runtime rate
+  engine.
 - Deliberately *not* linked: =ores.database=, =ores.service=, NATS,
   =ores.refdata=.
 
@@ -60,5 +71,6 @@ library is consumable standalone and fully unit-testable in isolation.
 
 - [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/story.org][Story: Cross-rates matrix (CRM)]]
 - [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/task_model_driver_derived_topology.org][Task: Model the driver/derived spanning-tree topology]]
+- [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org][Task: Implement triangulation/derivation]]
 - [[file:../../../doc/knowledge/domain/crm_graph_topology.org][CRM graph topology and spanning tree]]
 - [[file:../../../doc/knowledge/domain/crm_driver_and_derived_rates.org][Driver and derived rates]]

--- a/projects/ores.analytics.quant/modeling/ores.analytics.quant.puml
+++ b/projects/ores.analytics.quant/modeling/ores.analytics.quant.puml
@@ -82,6 +82,9 @@ namespace ores #F2F2F2 {
                 }
 
                 class vertex_state <<immutable>> {
+                    +edge_log_delta : double
+                    +edge_observed_at : timestamp
+                    +edge_valid : bool
                     +log_rate : double
                     +as_of : timestamp
                     +valid : bool
@@ -105,10 +108,12 @@ namespace ores #F2F2F2 {
                 class rate_engine {
                     -topology_ : crm_topology
                     -policy_ : staleness_policy
+                    -children_ : vector<vector<currency_id>>
                     -snapshot_ : immer::atom<rate_snapshot>
                     +update(driver_quote) : void
-                    +rate(ccy_pair) : derived_rate
-                    +rates(span<ccy_pair>) : vector<derived_rate>
+                    .. throws invalid_argument if the pair is not\nan edge of this topology ..
+                    +rate(base_code, quote_code) : derived_rate
+                    +rates(pairs) : vector<derived_rate>
                 }
 
                 topology_builder ..> crm_topology : builds

--- a/projects/ores.analytics.quant/src/service/rate_engine.cpp
+++ b/projects/ores.analytics.quant/src/service/rate_engine.cpp
@@ -1,0 +1,181 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.analytics.quant/service/rate_engine.hpp"
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace ores::analytics::quant::service {
+
+using domain::ccy_pair;
+using domain::currency_id;
+using domain::derived_rate;
+using domain::driver_quote;
+using domain::rate_snapshot;
+using domain::rate_status;
+using domain::vertex_state;
+
+namespace {
+
+immer::vector<vertex_state> make_initial_states(const domain::crm_topology& topology,
+                                                std::chrono::system_clock::time_point now) {
+    immer::vector<vertex_state> states;
+    auto transient = states.transient();
+    for (std::size_t v = 0; v < topology.vertex_count(); ++v)
+        transient.push_back(vertex_state{});
+
+    vertex_state pivot_state;
+    pivot_state.valid = true;
+    pivot_state.edge_valid = true; // trivially: the pivot needs no edge
+    pivot_state.as_of = now;
+    transient.set(topology.pivot().index(), pivot_state);
+
+    return transient.persistent();
+}
+
+} // namespace
+
+rate_engine::rate_engine(domain::crm_topology topology,
+                         domain::staleness_policy policy,
+                         std::chrono::system_clock::time_point now)
+    : topology_(std::move(topology))
+    , policy_(policy)
+    , children_(topology_.vertex_count())
+    , snapshot_(rate_snapshot(make_initial_states(topology_, now))) {
+    for (std::size_t v = 0; v < topology_.vertex_count(); ++v) {
+        const currency_id id(static_cast<std::uint16_t>(v));
+        if (id == topology_.pivot())
+            continue;
+        children_[topology_.parent(id).index()].push_back(id);
+    }
+}
+
+void rate_engine::update(const driver_quote& quote) {
+    const auto base_id = topology_.currency_id_for(quote.base_code);
+    const auto quote_id = topology_.currency_id_for(quote.quote_code);
+    if (!base_id || !quote_id) {
+        throw std::invalid_argument("rate_engine::update: unknown currency in " + quote.base_code +
+                                    "/" + quote.quote_code);
+    }
+
+    // Determine which side is the child in the tree, and the sign of the
+    // log-rate delta for that direction: quote = base * rate, so
+    // log_rate[quote] = log_rate[base] + log(rate); if base is the child
+    // (parent is quote), the sign inverts.
+    currency_id child;
+    double sign;
+    if (topology_.parent(*base_id) == *quote_id) {
+        child = *base_id;
+        sign = -1.0;
+    } else if (topology_.parent(*quote_id) == *base_id) {
+        child = *quote_id;
+        sign = 1.0;
+    } else {
+        throw std::invalid_argument("rate_engine::update: " + quote.base_code + "/" +
+                                    quote.quote_code + " is not an edge of this topology");
+    }
+
+    const auto current = snapshot_.load().get();
+    auto transient = current.transient();
+
+    const double log_delta = sign * std::log(quote.rate);
+
+    // Depth-first walk of the subtree rooted at `child`: each vertex's
+    // edge_log_delta/edge_observed_at is only touched for `child` itself
+    // (everything below keeps its own edge unchanged), but every
+    // descendant's cumulative log_rate/as_of/valid must be recomputed
+    // because its parent's cumulative values just changed.
+    std::vector<currency_id> stack{child};
+    bool first = true;
+    while (!stack.empty()) {
+        const auto v = stack.back();
+        stack.pop_back();
+
+        vertex_state state = transient[v.index()];
+        if (first) {
+            state.edge_log_delta = log_delta;
+            state.edge_observed_at = quote.observed_at;
+            state.edge_valid = true;
+            first = false;
+        }
+        const auto& parent_state = transient[topology_.parent(v).index()];
+        state.valid = parent_state.valid && state.edge_valid;
+        state.log_rate = parent_state.log_rate + state.edge_log_delta;
+        state.as_of = std::min(parent_state.as_of, state.edge_observed_at);
+        transient.set(v.index(), state);
+
+        for (const auto& descendant : children_[v.index()])
+            stack.push_back(descendant);
+    }
+
+    snapshot_.store(rate_snapshot(transient.persistent()));
+}
+
+derived_rate rate_engine::rate_from_snapshot(const rate_snapshot& snapshot,
+                                             const std::string& base_code,
+                                             const std::string& quote_code,
+                                             std::chrono::system_clock::time_point now) const {
+    const auto base_id = topology_.currency_id_for(base_code);
+    const auto quote_id = topology_.currency_id_for(quote_code);
+    if (!base_id || !quote_id) {
+        return derived_rate{base_code,
+                            quote_code,
+                            0.0,
+                            rate_status::unavailable,
+                            std::chrono::system_clock::time_point{}};
+    }
+
+    const auto& base_state = snapshot.at(*base_id);
+    const auto& quote_state = snapshot.at(*quote_id);
+    if (!base_state.valid || !quote_state.valid) {
+        return derived_rate{base_code,
+                            quote_code,
+                            0.0,
+                            rate_status::unavailable,
+                            std::chrono::system_clock::time_point{}};
+    }
+
+    const double rate = std::exp(quote_state.log_rate - base_state.log_rate);
+    const auto oldest = std::min(base_state.as_of, quote_state.as_of);
+    const auto status = policy_.evaluate(now - oldest);
+    return derived_rate{base_code, quote_code, rate, status, oldest};
+}
+
+derived_rate rate_engine::rate(const std::string& base_code,
+                               const std::string& quote_code,
+                               std::chrono::system_clock::time_point now) const {
+    const auto snapshot = snapshot_.load().get();
+    return rate_from_snapshot(snapshot, base_code, quote_code, now);
+}
+
+std::vector<derived_rate>
+rate_engine::rates(const std::vector<std::pair<std::string, std::string>>& pairs,
+                   std::chrono::system_clock::time_point now) const {
+    // Exactly one atomic snapshot load for the whole batch.
+    const auto snapshot = snapshot_.load().get();
+    std::vector<derived_rate> result;
+    result.reserve(pairs.size());
+    for (const auto& [base_code, quote_code] : pairs) {
+        result.push_back(rate_from_snapshot(snapshot, base_code, quote_code, now));
+    }
+    return result;
+}
+
+} // namespace ores::analytics::quant::service

--- a/projects/ores.analytics.quant/src/service/rate_engine.cpp
+++ b/projects/ores.analytics.quant/src/service/rate_engine.cpp
@@ -74,11 +74,24 @@ void rate_engine::update(const driver_quote& quote) {
         throw std::invalid_argument("rate_engine::update: unknown currency in " + quote.base_code +
                                     "/" + quote.quote_code);
     }
+    if (!std::isfinite(quote.rate) || quote.rate <= 0.0) {
+        throw std::invalid_argument("rate_engine::update: rate must be finite and positive for " +
+                                    quote.base_code + "/" + quote.quote_code);
+    }
 
     // Determine which side is the child in the tree, and the sign of the
     // log-rate delta for that direction: quote = base * rate, so
     // log_rate[quote] = log_rate[base] + log(rate); if base is the child
-    // (parent is quote), the sign inverts.
+    // (parent is quote), the sign inverts. Reject base_id == quote_id up
+    // front: crm_topology::parent(pivot) == pivot by construction, so
+    // without this check a self-referencing pair on the pivot currency
+    // would trivially match the first branch below and corrupt the
+    // pivot's (supposedly invariant) log_rate, silently poisoning every
+    // derived rate in the tree instead of being rejected as a non-edge.
+    if (*base_id == *quote_id) {
+        throw std::invalid_argument("rate_engine::update: " + quote.base_code + "/" +
+                                    quote.quote_code + " is not an edge of this topology");
+    }
     currency_id child;
     double sign;
     if (topology_.parent(*base_id) == *quote_id) {

--- a/projects/ores.analytics.quant/src/service/topology_builder.cpp
+++ b/projects/ores.analytics.quant/src/service/topology_builder.cpp
@@ -19,9 +19,9 @@
  */
 #include "ores.analytics.quant/service/topology_builder.hpp"
 #include "ores.analytics.quant/domain/topology_build_error.hpp"
+#include <queue>
 #include <boost/pending/disjoint_sets.hpp>
 #include <algorithm>
-#include <queue>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -42,17 +42,22 @@ using domain::topology_error_kind;
 class currency_index_builder {
 public:
     currency_id resolve(const std::string& code) {
-        auto [it, inserted] = index_.try_emplace(
-            code, currency_id(static_cast<std::uint16_t>(codes_.size())));
-        if (inserted) codes_.push_back(code);
+        auto [it, inserted] =
+            index_.try_emplace(code, currency_id(static_cast<std::uint16_t>(codes_.size())));
+        if (inserted)
+            codes_.push_back(code);
         return it->second;
     }
 
     [[nodiscard]] std::unordered_map<std::string, currency_id> index() && {
         return std::move(index_);
     }
-    [[nodiscard]] std::vector<std::string> codes() && { return std::move(codes_); }
-    [[nodiscard]] std::size_t size() const noexcept { return codes_.size(); }
+    [[nodiscard]] std::vector<std::string> codes() && {
+        return std::move(codes_);
+    }
+    [[nodiscard]] std::size_t size() const noexcept {
+        return codes_.size();
+    }
 
 private:
     std::unordered_map<std::string, currency_id> index_;
@@ -61,9 +66,9 @@ private:
 
 } // namespace
 
-domain::crm_topology topology_builder::build(
-    const std::vector<ccy_pair_input>& pairs, const std::string& pivot_code,
-    const std::vector<std::string>& required_majors) {
+domain::crm_topology topology_builder::build(const std::vector<ccy_pair_input>& pairs,
+                                             const std::string& pivot_code,
+                                             const std::vector<std::string>& required_majors) {
     currency_index_builder resolver;
     // The pivot itself must be a known vertex even if it never appears as a
     // lone token in a pair, so it is resolved unconditionally alongside
@@ -74,12 +79,13 @@ domain::crm_topology topology_builder::build(
     std::vector<ccy_pair> resolved_pairs;
     resolved_pairs.reserve(pairs.size());
     for (const auto& input : pairs) {
-        resolved_pairs.push_back(ccy_pair{
-            resolver.resolve(input.base_code), resolver.resolve(input.quote_code),
-            input.is_driver});
+        resolved_pairs.push_back(ccy_pair{resolver.resolve(input.base_code),
+                                          resolver.resolve(input.quote_code),
+                                          input.is_driver});
     }
     resolver.resolve(pivot_code);
-    for (const auto& major : required_majors) resolver.resolve(major);
+    for (const auto& major : required_majors)
+        resolver.resolve(major);
 
     const std::size_t vertex_count = resolver.size();
     auto currency_index = std::move(resolver).index();
@@ -95,9 +101,9 @@ domain::crm_topology topology_builder::build(
     // silently.
     std::vector<std::size_t> rank(vertex_count);
     std::vector<std::size_t> parent_rep(vertex_count);
-    boost::disjoint_sets<std::size_t*, std::size_t*> disjoint_set(
-        rank.data(), parent_rep.data());
-    for (std::size_t v = 0; v < vertex_count; ++v) disjoint_set.make_set(v);
+    boost::disjoint_sets<std::size_t*, std::size_t*> disjoint_set(rank.data(), parent_rep.data());
+    for (std::size_t v = 0; v < vertex_count; ++v)
+        disjoint_set.make_set(v);
 
     std::unordered_set<std::uint64_t> seen_edges;
     auto edge_key = [](currency_id a, currency_id b) -> std::uint64_t {
@@ -148,7 +154,8 @@ domain::crm_topology topology_builder::build(
         const auto current = frontier.front();
         frontier.pop();
         for (const auto& [neighbour, edge] : adjacency[current.index()]) {
-            if (visited[neighbour.index()]) continue;
+            if (visited[neighbour.index()])
+                continue;
             visited[neighbour.index()] = true;
             parent[neighbour.index()] = current;
             edge_to_parent[neighbour.index()] = edge;
@@ -164,21 +171,24 @@ domain::crm_topology topology_builder::build(
         const auto id = currency_index.at(major);
         major_ids.insert(id.index());
         if (!visited[id.index()]) {
-            errors.push_back(topology_error{
-                topology_error_kind::missing_major, major, ""});
+            errors.push_back(topology_error{topology_error_kind::missing_major, major, ""});
         }
     }
     for (std::size_t v = 0; v < vertex_count; ++v) {
         if (!visited[v] && !major_ids.contains(static_cast<std::uint16_t>(v))) {
-            errors.push_back(topology_error{
-                topology_error_kind::disconnected_currency, currency_codes[v], ""});
+            errors.push_back(
+                topology_error{topology_error_kind::disconnected_currency, currency_codes[v], ""});
         }
     }
 
-    if (!errors.empty()) throw domain::topology_build_error(std::move(errors));
+    if (!errors.empty())
+        throw domain::topology_build_error(std::move(errors));
 
-    return crm_topology(pivot, std::move(parent), std::move(edge_to_parent),
-        std::move(currency_index), std::move(currency_codes));
+    return crm_topology(pivot,
+                        std::move(parent),
+                        std::move(edge_to_parent),
+                        std::move(currency_index),
+                        std::move(currency_codes));
 }
 
 } // namespace ores::analytics::quant::service

--- a/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
+++ b/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
@@ -1,0 +1,209 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.analytics.quant/domain/driver_quote.hpp"
+#include "ores.analytics.quant/domain/rate_status.hpp"
+#include "ores.analytics.quant/domain/staleness_policy.hpp"
+#include "ores.analytics.quant/service/rate_engine.hpp"
+#include "ores.analytics.quant/service/topology_builder.hpp"
+#include <atomic>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+#include <vector>
+
+using ores::analytics::quant::domain::ccy_pair_input;
+using ores::analytics::quant::domain::driver_quote;
+using ores::analytics::quant::domain::rate_status;
+using ores::analytics::quant::domain::staleness_policy;
+using ores::analytics::quant::service::rate_engine;
+using ores::analytics::quant::service::topology_builder;
+
+namespace {
+
+auto epoch(int seconds) {
+    return std::chrono::system_clock::time_point{} + std::chrono::seconds(seconds);
+}
+
+} // namespace
+
+TEST_CASE("a direct driver rate is served back unchanged", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
+    auto topology = topology_builder::build(pairs, "USD", {"EUR"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(1000)});
+    const auto result = engine.rate("EUR", "USD", epoch(1000));
+
+    CHECK(result.status == rate_status::fresh);
+    CHECK(result.rate == Catch::Approx(1.10));
+}
+
+TEST_CASE("a derived rate triangulates through the pivot", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(1000)});
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(1000)});
+
+    // 1 EUR = 1.10 USD = 1.10 * 150 JPY
+    const auto result = engine.rate("EUR", "JPY", epoch(1000));
+    CHECK(result.status == rate_status::fresh);
+    CHECK(result.rate == Catch::Approx(1.10 * 150.0));
+}
+
+TEST_CASE("an unseeded pair is unavailable until both drivers have ticked", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+
+    CHECK(engine.rate("EUR", "JPY", epoch(1000)).status == rate_status::unavailable);
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(1000)});
+    // JPY leg still unseeded.
+    CHECK(engine.rate("EUR", "JPY", epoch(1000)).status == rate_status::unavailable);
+
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(1000)});
+    CHECK(engine.rate("EUR", "JPY", epoch(1000)).status == rate_status::fresh);
+}
+
+TEST_CASE("staleness propagates from the oldest contributing driver", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    const staleness_policy policy{std::chrono::seconds(60)};
+    rate_engine engine(std::move(topology), policy, epoch(0));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});    // fresh at t=0
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(100)}); // fresh at t=100
+
+    // EUR/JPY depends on the EUR/USD tick from t=0 -- 150s old at t=150,
+    // beyond the 60s policy, so the whole derived rate is stale even
+    // though the USD/JPY leg is fresh on its own.
+    const auto result = engine.rate("EUR", "JPY", epoch(150));
+    CHECK(result.status == rate_status::stale);
+    CHECK(result.as_of == epoch(0));
+}
+
+TEST_CASE("updating one edge only recomputes its own subtree", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+        {"GBP", "USD", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
+    engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)});
+
+    const auto before = engine.rate("GBP", "JPY", epoch(0));
+    REQUIRE(before.status == rate_status::fresh);
+
+    // Re-tick only the EUR leg; GBP/JPY (an unrelated subtree) must be
+    // unaffected.
+    engine.update(driver_quote{"EUR", "USD", 1.12, epoch(1)});
+    const auto after = engine.rate("GBP", "JPY", epoch(0));
+    CHECK(after.rate == Catch::Approx(before.rate));
+
+    const auto eur_after = engine.rate("EUR", "USD", epoch(1));
+    CHECK(eur_after.rate == Catch::Approx(1.12));
+}
+
+TEST_CASE("rates() batches a snapshot load across many pairs", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+        {"GBP", "USD", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
+    engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)});
+
+    const auto results =
+        engine.rates({{"EUR", "USD"}, {"EUR", "JPY"}, {"GBP", "JPY"}, {"USD", "USD"}}, epoch(0));
+
+    REQUIRE(results.size() == 4);
+    for (const auto& r : results)
+        CHECK(r.status == rate_status::fresh);
+    CHECK(results[3].rate == Catch::Approx(1.0)); // USD/USD is always identity via the pivot
+}
+
+TEST_CASE("update rejects a pair that is not an edge of the topology", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
+    auto topology = topology_builder::build(pairs, "USD", {"EUR"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    CHECK_THROWS_AS(engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("concurrent updates and batched reads never crash or hang", "[rate_engine][thread]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+        {"GBP", "USD", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
+    engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)});
+
+    std::atomic<bool> stop{false};
+    std::thread writer([&] {
+        double rate = 1.10;
+        while (!stop.load()) {
+            rate += 0.0001;
+            engine.update(driver_quote{"EUR", "USD", rate, epoch(0)});
+        }
+    });
+
+    std::vector<std::thread> readers;
+    for (int i = 0; i < 4; ++i) {
+        readers.emplace_back([&] {
+            for (int j = 0; j < 2000; ++j) {
+                const auto results =
+                    engine.rates({{"EUR", "USD"}, {"EUR", "JPY"}, {"GBP", "JPY"}}, epoch(0));
+                for (const auto& r : results) {
+                    REQUIRE(r.status == rate_status::fresh);
+                    REQUIRE(r.rate > 0.0);
+                }
+            }
+        });
+    }
+    for (auto& t : readers)
+        t.join();
+    stop.store(true);
+    writer.join();
+}

--- a/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
+++ b/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 #include <thread>
 #include <vector>
 
@@ -158,12 +159,60 @@ TEST_CASE("rates() batches a snapshot load across many pairs", "[rate_engine]") 
     CHECK(results[3].rate == Catch::Approx(1.0)); // USD/USD is always identity via the pivot
 }
 
-TEST_CASE("update rejects a pair that is not an edge of the topology", "[rate_engine]") {
+TEST_CASE("update rejects an unknown currency", "[rate_engine]") {
     const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
     auto topology = topology_builder::build(pairs, "USD", {"EUR"});
     rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
 
     CHECK_THROWS_AS(engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("update rejects two known but unconnected currencies -- not an edge of this topology",
+          "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    // EUR and JPY are both known currencies, but neither is the other's
+    // parent in the tree (both hang off USD) -- not a real edge.
+    CHECK_THROWS_AS(engine.update(driver_quote{"EUR", "JPY", 130.0, epoch(0)}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("update rejects a self-referencing pair on the pivot currency", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
+    auto topology = topology_builder::build(pairs, "USD", {"EUR"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    // Without the base_id == quote_id guard, this would trivially satisfy
+    // parent(pivot) == pivot and corrupt the pivot's log_rate.
+    CHECK_THROWS_AS(engine.update(driver_quote{"USD", "USD", 1.0, epoch(0)}),
+                    std::invalid_argument);
+
+    // The pivot's own rate must still be exactly 1.0 afterwards -- the
+    // rejected update must not have mutated any state.
+    const auto result = engine.rate("USD", "USD", epoch(0));
+    CHECK(result.rate == Catch::Approx(1.0));
+}
+
+TEST_CASE("update rejects a non-finite or non-positive rate", "[rate_engine]") {
+    const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
+    auto topology = topology_builder::build(pairs, "USD", {"EUR"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    CHECK_THROWS_AS(engine.update(driver_quote{"EUR", "USD", 0.0, epoch(0)}),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(engine.update(driver_quote{"EUR", "USD", -1.1, epoch(0)}),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(engine.update(driver_quote{
+                        "EUR", "USD", std::numeric_limits<double>::quiet_NaN(), epoch(0)}),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(engine.update(driver_quote{
+                        "EUR", "USD", std::numeric_limits<double>::infinity(), epoch(0)}),
                     std::invalid_argument);
 }
 

--- a/projects/ores.analytics.quant/tests/topology_builder_tests.cpp
+++ b/projects/ores.analytics.quant/tests/topology_builder_tests.cpp
@@ -86,7 +86,7 @@ TEST_CASE("multi-hop path resolves through the pivot", "[topology_builder]") {
 }
 
 TEST_CASE("a second path between two currencies throws at build time, never resolved silently",
-    "[topology_builder]") {
+          "[topology_builder]") {
     auto pairs = majors_spanning_tree();
     // EUR is already connected to USD via the first edge; this adds a
     // second, independent path EUR -> GBP -> ... -> EUR, i.e. a cycle.
@@ -94,7 +94,8 @@ TEST_CASE("a second path between two currencies throws at build time, never reso
 
     bool threw = false;
     try {
-        [[maybe_unused]] const auto topology = topology_builder::build(pairs, "USD", {"EUR", "GBP"});
+        [[maybe_unused]] const auto topology =
+            topology_builder::build(pairs, "USD", {"EUR", "GBP"});
     } catch (const topology_build_error& error) {
         threw = true;
         REQUIRE(error.errors().size() == 1);
@@ -108,7 +109,8 @@ TEST_CASE("a missing major produces a readable error", "[topology_builder]") {
 
     bool threw = false;
     try {
-        [[maybe_unused]] const auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+        [[maybe_unused]] const auto topology =
+            topology_builder::build(pairs, "USD", {"EUR", "JPY"});
     } catch (const topology_build_error& error) {
         threw = true;
         const auto& errors = error.errors();
@@ -139,7 +141,7 @@ TEST_CASE("a duplicate pair in the input is rejected", "[topology_builder]") {
 }
 
 TEST_CASE("a disconnected currency not on the majors list is still reported",
-    "[topology_builder]") {
+          "[topology_builder]") {
     std::vector<ccy_pair_input> pairs = majors_spanning_tree();
     pairs.push_back({"AUD", "NZD", true}); // an island, disconnected from USD
 


### PR DESCRIPTION
## Summary

Runtime rate_engine on top of the crm_topology from PR #1510: consumes a stream of driver_quote ticks (single producer, possibly cross-thread) and serves batched derived-rate reads via an immer::atom<rate_snapshot> -- no locks on the hot path. Rates are a per-vertex cumulative log-rate from the pivot, so a derived rate is one subtraction and update() only recomputes the subtree below the changed edge. Staleness is a per-vertex timestamp propagated alongside the log-rate, so a stale major automatically taints every derived rate depending on it.

## Changes

- New: driver_quote, rate_status, staleness_policy, derived_rate, vertex_state, rate_snapshot domain types
- New: service::rate_engine (update/rate/rates), crm_topology gained parent()/edge_to_parent() accessors
- 8 new test cases (15 total, 43k+ assertions): triangulation, staleness propagation, subtree-only recompute, batched reads, rejection of non-edge pairs, and a concurrent-update-vs-concurrent-read stress test
- Ran clang-format over the whole component (picked up formatting drift from PR #1510)
- Verification: local build clean (linux-clang-debug-make); ctest ores.analytics.quant.tests 1/1 passed (15 test cases, 43k+ assertions, stable across repeated runs)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Cross-rates matrix (CRM)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/crm_implementation/story.html) | B38B3869-02FD-4CC7-99BD-9A77904ACA19 |
| Task | [Implement triangulation/derivation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.html) | 96522E06-2067-4058-86FC-27B6086DCC26 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)