### PR TITLE
[analytics.quant] Add CRM risk recentering, fix pivot as_of staleness bug

### DIFF
--- a/doc/agile/versions/v0/sprint_23/crm_implementation/story.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/story.org
@@ -28,9 +28,9 @@ engine the architecture relies on.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
-| Now           | Implementing the runtime rate_engine (triangulation/derivation). |
+| Now           | Topology, rate engine and risk recentering all done; deciding next task. |
 | Waiting on    | Nothing.                               |
-| Next          | Risk recentering, then wiring into ores.marketdata's ingest path. |
+| Next          | Wire the CRM into ores.marketdata's ingest path, then the management UI. |
 | Last touched  | 2026-07-12                               |
 
 * Acceptance
@@ -46,6 +46,7 @@ engine the architecture relies on.
 |------+-------+-------+-----+-------------|
 | [[id:E7E31384-3616-4DFB-AB20-6CB099114FB3][Model the driver/derived spanning-tree topology]] | DONE | 2026-07-11 | 2026-07-12 | Graph structure over currency pairs for the CRM: driver/derived edges with cycle detection so a pair is never set on both sides simultaneously. |
 | [[id:96522E06-2067-4058-86FC-27B6086DCC26][Implement triangulation/derivation]] | DONE | 2026-07-12 | 2026-07-12 | Runtime rate_engine: consumes a stream of driver_quote ticks (possibly cross-thread) and serves batched derived-rate reads via an atomically-swapped immutable snapshot, computing derived rates by triangulation through the pivot and propagating staleness. |
+| [[id:6EA4B5FC-4581-484C-B5EB-ECF868B3A61D][Implement risk recentering]] | DONE | 2026-07-12 | 2026-07-12 | Re-root the CRM into a star-shaped matrix around a chosen aggregation currency without changing any derived rate's value: rebuild topology as a star, seed it by pulling current derived rates from the source engine for each currency. |
 
 Planned tasks (not yet scaffolded as task docs), following the domain
 model's concept map:
@@ -98,13 +99,28 @@ model's concept map:
 - Rates are represented as cumulative log-rate-from-the-pivot per vertex
   (not per-pair), so any derived rate is one subtraction and one
   =update()= only touches the subtree below the changed edge --
-  =crm_topology= exposes =parent()=/=edge_to_parent()= to support this.
-  Staleness is carried as a per-vertex timestamp alongside the log-rate,
-  recomputed in the same subtree walk rather than as a separate pass.
+  =crm_topology= exposes =parent()= to support this (an =edge_to_parent()=
+  accessor was added alongside it but never used, and was removed in
+  review). Staleness is carried as a per-vertex timestamp alongside the
+  log-rate, recomputed in the same subtree walk rather than as a separate
+  pass. The pivot's own =as_of= is seeded to the maximum time_point (never
+  the limiting factor), not construction time -- an early version wrongly
+  used construction time, which floored every other vertex's freshness at
+  that instant forever; caught by the recentering task's tests.
 - =rate_engine::update()= is single-producer by design (concurrent
   writers are not supported/needed); =rate()=/=rates()= are safe from any
   number of concurrent reader threads. This is documented on the class,
   not enforced at compile time.
+- Risk recentering (=service::recenter=) is a point-in-time snapshot
+  transform, not a live/continuous one: it builds a fresh star-shaped
+  =crm_topology= around the aggregation currency (reusing
+  =topology_builder= unchanged -- a star can never conflict), and seeds
+  the new engine with each currency's *current* rate and *original*
+  =as_of= pulled from the source engine, so recentering never fabricates
+  freshness. =rate_engine= gained an explicit move constructor (loading
+  the moved-from =immer::atom='s value into a fresh one) since
+  =recenter= must return a new engine by value and =immer::atom= itself
+  disallows copy/move.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
@@ -129,7 +129,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =recenter()= called =source.rate()= once per currency (each its own atomic snapshot load), undermining the documented "point-in-time snapshot" guarantee under a concurrently-ticking source | src/service/risk_recentering.cpp | Accepted | Replaced with a single =source.rates(pairs, now)= batch call -- one atomic snapshot load for every currency, matching =rate_engine='s own batch-atomicity contract. |
+| 2 | =recenter()= not marked =[[nodiscard]]=, unlike other factory-style functions in the component (=topology_builder::build=, =rate_engine::rate=/=rates=) | include/.../service/risk_recentering.hpp | Accepted | Added =[[nodiscard]]=. |
+| 3 | =topology_builder::build(..., currency_codes)= passes every currency as =required_majors=, but they're all always reachable by construction (every edge shares =aggregation_code=) -- the =missing_major= diagnostic can never fire, so this is inert/misleading | src/service/risk_recentering.cpp | Accepted | Pass =\{\}= instead, with a comment explaining why; the real "unknown aggregation currency" case is already checked explicitly earlier. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
@@ -1,0 +1,169 @@
+:PROPERTIES:
+:ID: 6EA4B5FC-4581-484C-B5EB-ECF868B3A61D
+:END:
+#+title: Task: Implement risk recentering
+#+description: Re-root the CRM into a star-shaped matrix around a chosen aggregation currency without changing any derived rate's value: rebuild topology as a star, seed it by pulling current derived rates from the source engine for each currency.
+#+type: task
+#+level: s1
+#+filetags: :market_data:crm:fx:sprint_23:v0:crm_implementation:
+#+owner: marco
+#+branch: feature/implement-risk-recentering
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+#+environment: clever_dijkstra
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B38B3869-02FD-4CC7-99BD-9A77904ACA19][Cross-rates matrix (CRM)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a =recenter= operation that re-roots the CRM into a star-shaped
+matrix around a caller-chosen aggregation currency -- every other
+currency directly connected to it -- without changing any derived rate's
+value, per [[id:DC08D216-348D-4511-A42D-4016EBBF38F7][CRM risk: recentering and artefacts]]: bumping one pair in the
+recentred matrix must not disturb any other pair, which the current
+general-tree topology cannot guarantee (a bump ripples to everything
+reachable through it).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:B38B3869-02FD-4CC7-99BD-9A77904ACA19][Cross-rates matrix (CRM)]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-12                               |
+
+* Acceptance
+
+- =service::recenter(source_engine, aggregation_code, policy, now)= builds
+  a *new* star-shaped =crm_topology= (the aggregation currency as pivot,
+  every other known currency directly connected to it, =n-1= edges) via
+  the existing =topology_builder= -- no new topology-construction logic,
+  a star is trivially a valid spanning tree.
+- The new engine is seeded, for every currency, with the *current*
+  derived rate from the source engine (=source.rate(aggregation_code,
+  code, now)=) -- so every rate in the recentred matrix is numerically
+  identical to what the source engine reports right now. A currency whose
+  rate is =unavailable= in the source is left unseeded in the recentred
+  engine, not defaulted to some fabricated value.
+- After recentering, bumping (re-=update()=-ing) any one currency's edge
+  in the new engine leaves every other currency's rate against the
+  aggregation currency unchanged -- verified with a test that recenters,
+  bumps one leg, and asserts every other leg is bit-identical to before.
+- =rate_engine= gains a =topology()= accessor (needed by =recenter= to
+  enumerate the source's known currencies and read =pivot()=/=parent()=
+  where relevant) -- the minimum surface needed, not a general-purpose
+  topology export.
+- Recentering is a point-in-time snapshot operation (matches the
+  knowledge doc: risk runs recenter once per run), not a live/continuous
+  transform -- it produces one new, independent =rate_engine= that the
+  caller owns from then on; it does not keep the source and recentred
+  engines in sync.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+** Design
+
+=service::recenter=, a free function (not a class -- it is a one-shot
+transform, not a stateful object):
+
+#+begin_src c++
+domain::crm_topology build_star_topology(
+    const domain::crm_topology& source, const std::string& aggregation_code);
+
+rate_engine recenter(
+    const rate_engine& source, const std::string& aggregation_code,
+    domain::staleness_policy policy, std::chrono::system_clock::time_point now);
+#+end_src
+
+1. Enumerate every currency code known to =source.topology()= (iterate
+   vertex indices 0..vertex_count-1, =code_of= each -- no new
+   =crm_topology= enumeration API needed, this is the one caller so it
+   stays local to =recenter.cpp=).
+2. Build a =ccy_pair_input= for each non-aggregation currency:
+   ={aggregation_code, code, true}=, and run them through the *existing*
+   =topology_builder::build= with =pivot_code = aggregation_code= and
+   =required_majors= = every currency -- reuses all the existing
+   validation (duplicate/missing-major/etc.) for free; a star can never
+   trigger a cycle_conflict since every edge shares the aggregation
+   currency as one side.
+3. Construct a fresh =rate_engine= over the star topology.
+4. For each non-aggregation currency, query
+   =source.rate(aggregation_code, code, now)=; if =fresh= or =stale=
+   (i.e. seeded at all), =update()= the new engine with that rate and its
+   original =as_of= timestamp (not =now=) -- so the recentred engine's
+   own staleness accounting stays honest about how old the underlying
+   data actually is, it doesn't get artificially refreshed by the act of
+   recentering.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Shipped =service::recenter= (a free function, not a class -- a one-shot
+transform) in =ores.analytics.quant=:
+
+- Builds a fresh star-shaped =crm_topology= around the aggregation
+  currency by feeding =topology_builder::build= one edge per known
+  currency (=aggregation_code=/=code=), reusing all its existing
+  validation for free.
+- Seeds the new =rate_engine= with each currency's *current* derived
+  rate from the source engine, preserving the original =as_of=
+  timestamp (not the recentering time) so the recentred engine's own
+  staleness accounting stays honest. A currency that is =unavailable=
+  in the source is left unseeded.
+- =rate_engine= gained a =topology()= accessor and an explicit move
+  constructor (=immer::atom= disallows copy/move, so returning a new
+  engine by value needed one).
+- 5 new Catch2 test cases (23 total in the component, 44,000+
+  assertions): rate preservation across recentering, =as_of=
+  preservation, bump-one-leg-leaves-others-unchanged, unavailable
+  currencies stay unseeded, and rejection of an unknown aggregation
+  currency.
+
+*Bug found and fixed along the way* (pre-existing, from the previous
+task's PR, not this task's own code): the pivot's =as_of= was seeded to
+construction time instead of the maximum time_point, which wrongly
+floored every other vertex's freshness at that instant forever via the
+=min()= in =update()=. Surfaced by a recentering test where a driver
+ticked well after engine construction; fixed in =make_initial_states=,
+and the constructor's now-vestigial =now= parameter was removed
+end-to-end (header, impl, ~15 call sites across tests) rather than left
+as unused/misleading API surface, per the pattern flagged in PR #1512's
+review.
+
+Acceptance met in full. Story remains STARTED: wiring the CRM into
+=ores.marketdata='s ingest path and the management UI are still open.

--- a/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
+++ b/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org
@@ -8,7 +8,7 @@
 #+filetags: :market_data:crm:fx:sprint_23:v0:crm_implementation:
 #+owner: marco
 #+branch: feature/implement-risk-recentering
-#+pr:
+#+pr: 1515
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
@@ -123,7 +123,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1515][#1515]] | [analytics.quant] Add CRM risk recentering, fix pivot as_of staleness bug |
 
 * Review
 

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/service/rate_engine.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/service/rate_engine.hpp
@@ -53,9 +53,24 @@ namespace ores::analytics::quant::service {
  */
 class ORES_ANALYTICS_QUANT_EXPORT rate_engine {
 public:
-    rate_engine(domain::crm_topology topology,
-                domain::staleness_policy policy,
-                std::chrono::system_clock::time_point now = std::chrono::system_clock::now());
+    rate_engine(domain::crm_topology topology, domain::staleness_policy policy);
+
+    /// immer::atom disallows copy/move, so the default special members are
+    /// all implicitly deleted; a move constructor is defined explicitly
+    /// (loading the moved-from atom's current value into a freshly
+    /// constructed one) so an engine can still be returned by value from a
+    /// factory function such as @c recenter. Copy and move-assignment stay
+    /// deleted -- nothing currently needs them.
+    rate_engine(rate_engine&& other);
+    rate_engine(const rate_engine&) = delete;
+    rate_engine& operator=(const rate_engine&) = delete;
+    rate_engine& operator=(rate_engine&&) = delete;
+
+    /// The fixed topology this engine was constructed with -- e.g. so
+    /// @c recenter can enumerate every currency this engine knows about.
+    [[nodiscard]] const domain::crm_topology& topology() const noexcept {
+        return topology_;
+    }
 
     /// Applies one tick to a driver edge already present in the topology.
     /// Throws @c std::invalid_argument if either code is unknown or the

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/service/risk_recentering.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/service/risk_recentering.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ANALYTICS_QUANT_SERVICE_RISK_RECENTERING_HPP
+#define ORES_ANALYTICS_QUANT_SERVICE_RISK_RECENTERING_HPP
+
+#include "ores.analytics.quant/domain/staleness_policy.hpp"
+#include "ores.analytics.quant/export.hpp"
+#include "ores.analytics.quant/service/rate_engine.hpp"
+#include <chrono>
+#include <string>
+
+namespace ores::analytics::quant::service {
+
+/**
+ * @brief Re-roots the CRM into a star-shaped matrix around @p
+ * aggregation_code, for risk: bumping one currency's edge in the returned
+ * engine cannot disturb any other currency's rate, which the general-tree
+ * topology cannot guarantee (see the CRM risk/recentering knowledge doc).
+ *
+ * A one-shot, point-in-time snapshot -- not a live transform. The
+ * returned engine is seeded with @p source's *current* derived rate for
+ * every currency (via @c rate_engine::rate), preserving each rate's
+ * original @c as_of timestamp so the recentred engine's own staleness
+ * accounting stays honest; a currency that is @c unavailable in @p
+ * source is left unseeded, not fabricated. From then on the two engines
+ * are independent -- updating one does not affect the other.
+ *
+ * Reuses @c topology_builder for the new star topology: every edge
+ * shares @p aggregation_code as one side, so it can never trigger a
+ * cycle conflict.
+ */
+ORES_ANALYTICS_QUANT_EXPORT rate_engine
+recenter(const rate_engine& source,
+         const std::string& aggregation_code,
+         domain::staleness_policy policy,
+         std::chrono::system_clock::time_point now = std::chrono::system_clock::now());
+
+} // namespace ores::analytics::quant::service
+
+#endif

--- a/projects/ores.analytics.quant/include/ores.analytics.quant/service/risk_recentering.hpp
+++ b/projects/ores.analytics.quant/include/ores.analytics.quant/service/risk_recentering.hpp
@@ -46,7 +46,7 @@ namespace ores::analytics::quant::service {
  * shares @p aggregation_code as one side, so it can never trigger a
  * cycle conflict.
  */
-ORES_ANALYTICS_QUANT_EXPORT rate_engine
+[[nodiscard]] ORES_ANALYTICS_QUANT_EXPORT rate_engine
 recenter(const rate_engine& source,
          const std::string& aggregation_code,
          domain::staleness_policy policy,

--- a/projects/ores.analytics.quant/modeling/component_overview.org
+++ b/projects/ores.analytics.quant/modeling/component_overview.org
@@ -55,6 +55,9 @@ library is consumable standalone and fully unit-testable in isolation.
 - =service::rate_engine::update(driver_quote)=
 - =service::rate_engine::rate(base_code, quote_code)= /
   =rates(pairs)=
+- =service::recenter(source_engine, aggregation_code, policy, now)= --
+  point-in-time star-shaping around an aggregation currency for risk,
+  preserving every current rate's value.
 
 * Dependencies
 
@@ -72,5 +75,7 @@ library is consumable standalone and fully unit-testable in isolation.
 - [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/story.org][Story: Cross-rates matrix (CRM)]]
 - [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/task_model_driver_derived_topology.org][Task: Model the driver/derived spanning-tree topology]]
 - [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_triangulation_derivation.org][Task: Implement triangulation/derivation]]
+- [[file:../../../doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.org][Task: Implement risk recentering]]
 - [[file:../../../doc/knowledge/domain/crm_graph_topology.org][CRM graph topology and spanning tree]]
 - [[file:../../../doc/knowledge/domain/crm_driver_and_derived_rates.org][Driver and derived rates]]
+- [[file:../../../doc/knowledge/domain/crm_risk_and_recentering.org][CRM risk: recentering and artefacts]]

--- a/projects/ores.analytics.quant/modeling/ores.analytics.quant.puml
+++ b/projects/ores.analytics.quant/modeling/ores.analytics.quant.puml
@@ -125,6 +125,14 @@ namespace ores #F2F2F2 {
                 rate_engine ..> driver_quote : consumes
                 rate_engine ..> derived_rate : produces
                 rate_engine ..> staleness_policy : applies
+
+                class "recenter()" as recenter_fn <<free function>> {
+                    +recenter(source, aggregation_code, policy, now) : rate_engine
+                    .. star-shapes a new engine around\naggregation_code, preserving current values ..
+                }
+                recenter_fn ..> rate_engine : reads (source)
+                recenter_fn ..> topology_builder : builds star topology
+                recenter_fn ..> rate_engine : produces (new)
             }
         }
     }

--- a/projects/ores.analytics.quant/src/service/rate_engine.cpp
+++ b/projects/ores.analytics.quant/src/service/rate_engine.cpp
@@ -34,8 +34,7 @@ using domain::vertex_state;
 
 namespace {
 
-immer::vector<vertex_state> make_initial_states(const domain::crm_topology& topology,
-                                                std::chrono::system_clock::time_point now) {
+immer::vector<vertex_state> make_initial_states(const domain::crm_topology& topology) {
     immer::vector<vertex_state> states;
     auto transient = states.transient();
     for (std::size_t v = 0; v < topology.vertex_count(); ++v)
@@ -44,7 +43,10 @@ immer::vector<vertex_state> make_initial_states(const domain::crm_topology& topo
     vertex_state pivot_state;
     pivot_state.valid = true;
     pivot_state.edge_valid = true; // trivially: the pivot needs no edge
-    pivot_state.as_of = now;
+    // The pivot itself is never stale -- it must never be the vertex that
+    // caps a descendant's as_of via the min() in update(), so it is seeded
+    // to the latest possible time_point rather than construction time.
+    pivot_state.as_of = std::chrono::system_clock::time_point::max();
     transient.set(topology.pivot().index(), pivot_state);
 
     return transient.persistent();
@@ -52,13 +54,11 @@ immer::vector<vertex_state> make_initial_states(const domain::crm_topology& topo
 
 } // namespace
 
-rate_engine::rate_engine(domain::crm_topology topology,
-                         domain::staleness_policy policy,
-                         std::chrono::system_clock::time_point now)
+rate_engine::rate_engine(domain::crm_topology topology, domain::staleness_policy policy)
     : topology_(std::move(topology))
     , policy_(policy)
     , children_(topology_.vertex_count())
-    , snapshot_(rate_snapshot(make_initial_states(topology_, now))) {
+    , snapshot_(rate_snapshot(make_initial_states(topology_))) {
     for (std::size_t v = 0; v < topology_.vertex_count(); ++v) {
         const currency_id id(static_cast<std::uint16_t>(v));
         if (id == topology_.pivot())
@@ -66,6 +66,12 @@ rate_engine::rate_engine(domain::crm_topology topology,
         children_[topology_.parent(id).index()].push_back(id);
     }
 }
+
+rate_engine::rate_engine(rate_engine&& other)
+    : topology_(std::move(other.topology_))
+    , policy_(other.policy_)
+    , children_(std::move(other.children_))
+    , snapshot_(other.snapshot_.load()) {}
 
 void rate_engine::update(const driver_quote& quote) {
     const auto base_id = topology_.currency_id_for(quote.base_code);

--- a/projects/ores.analytics.quant/src/service/risk_recentering.cpp
+++ b/projects/ores.analytics.quant/src/service/risk_recentering.cpp
@@ -1,0 +1,70 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.analytics.quant/service/risk_recentering.hpp"
+#include "ores.analytics.quant/domain/ccy_pair_input.hpp"
+#include "ores.analytics.quant/domain/currency_id.hpp"
+#include "ores.analytics.quant/domain/driver_quote.hpp"
+#include "ores.analytics.quant/domain/rate_status.hpp"
+#include "ores.analytics.quant/service/topology_builder.hpp"
+#include <stdexcept>
+
+namespace ores::analytics::quant::service {
+
+using domain::ccy_pair_input;
+using domain::currency_id;
+using domain::driver_quote;
+using domain::rate_status;
+
+rate_engine recenter(const rate_engine& source,
+                     const std::string& aggregation_code,
+                     domain::staleness_policy policy,
+                     std::chrono::system_clock::time_point now) {
+    const auto& source_topology = source.topology();
+    if (!source_topology.currency_id_for(aggregation_code)) {
+        throw std::invalid_argument("recenter: unknown aggregation currency " + aggregation_code);
+    }
+
+    std::vector<std::string> currency_codes;
+    for (std::size_t v = 0; v < source_topology.vertex_count(); ++v) {
+        const currency_id id(static_cast<std::uint16_t>(v));
+        auto code = source_topology.code_of(id);
+        if (code != aggregation_code)
+            currency_codes.push_back(std::move(code));
+    }
+
+    std::vector<ccy_pair_input> star_edges;
+    star_edges.reserve(currency_codes.size());
+    for (const auto& code : currency_codes)
+        star_edges.push_back({aggregation_code, code, true});
+
+    auto star_topology = topology_builder::build(star_edges, aggregation_code, currency_codes);
+    rate_engine recentred(std::move(star_topology), policy);
+
+    for (const auto& code : currency_codes) {
+        const auto current = source.rate(aggregation_code, code, now);
+        if (current.status == rate_status::unavailable)
+            continue;
+        recentred.update(driver_quote{aggregation_code, code, current.rate, current.as_of});
+    }
+
+    return recentred;
+}
+
+} // namespace ores::analytics::quant::service

--- a/projects/ores.analytics.quant/src/service/risk_recentering.cpp
+++ b/projects/ores.analytics.quant/src/service/risk_recentering.cpp
@@ -54,14 +54,30 @@ rate_engine recenter(const rate_engine& source,
     for (const auto& code : currency_codes)
         star_edges.push_back({aggregation_code, code, true});
 
-    auto star_topology = topology_builder::build(star_edges, aggregation_code, currency_codes);
+    // Every currency in `currency_codes` is directly wired to
+    // aggregation_code by star_edges above, so all are always reachable;
+    // required_majors is intentionally left empty rather than passing
+    // currency_codes again -- the missing_major diagnostic could never
+    // fire here.
+    auto star_topology = topology_builder::build(star_edges, aggregation_code, {});
     rate_engine recentred(std::move(star_topology), policy);
 
-    for (const auto& code : currency_codes) {
-        const auto current = source.rate(aggregation_code, code, now);
+    // One atomic snapshot load of `source` for every currency, not one
+    // load per currency -- otherwise a concurrent update() on `source`
+    // could seed different legs of the recentred star from different
+    // instants of `source`'s history, breaking the point-in-time
+    // guarantee this function documents.
+    std::vector<std::pair<std::string, std::string>> pairs;
+    pairs.reserve(currency_codes.size());
+    for (const auto& code : currency_codes)
+        pairs.emplace_back(aggregation_code, code);
+
+    const auto current_rates = source.rates(pairs, now);
+    for (const auto& current : current_rates) {
         if (current.status == rate_status::unavailable)
             continue;
-        recentred.update(driver_quote{aggregation_code, code, current.rate, current.as_of});
+        recentred.update(
+            driver_quote{current.base_code, current.quote_code, current.rate, current.as_of});
     }
 
     return recentred;

--- a/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
+++ b/projects/ores.analytics.quant/tests/rate_engine_tests.cpp
@@ -47,7 +47,7 @@ auto epoch(int seconds) {
 TEST_CASE("a direct driver rate is served back unchanged", "[rate_engine]") {
     const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
     auto topology = topology_builder::build(pairs, "USD", {"EUR"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(1000)});
     const auto result = engine.rate("EUR", "USD", epoch(1000));
@@ -62,7 +62,7 @@ TEST_CASE("a derived rate triangulates through the pivot", "[rate_engine]") {
         {"USD", "JPY", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(1000)});
     engine.update(driver_quote{"USD", "JPY", 150.0, epoch(1000)});
@@ -79,7 +79,7 @@ TEST_CASE("an unseeded pair is unavailable until both drivers have ticked", "[ra
         {"USD", "JPY", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     CHECK(engine.rate("EUR", "JPY", epoch(1000)).status == rate_status::unavailable);
 
@@ -98,7 +98,7 @@ TEST_CASE("staleness propagates from the oldest contributing driver", "[rate_eng
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
     const staleness_policy policy{std::chrono::seconds(60)};
-    rate_engine engine(std::move(topology), policy, epoch(0));
+    rate_engine engine(std::move(topology), policy);
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});    // fresh at t=0
     engine.update(driver_quote{"USD", "JPY", 150.0, epoch(100)}); // fresh at t=100
@@ -118,7 +118,7 @@ TEST_CASE("updating one edge only recomputes its own subtree", "[rate_engine]") 
         {"GBP", "USD", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
     engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
@@ -144,7 +144,7 @@ TEST_CASE("rates() batches a snapshot load across many pairs", "[rate_engine]") 
         {"GBP", "USD", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
     engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
@@ -162,7 +162,7 @@ TEST_CASE("rates() batches a snapshot load across many pairs", "[rate_engine]") 
 TEST_CASE("update rejects an unknown currency", "[rate_engine]") {
     const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
     auto topology = topology_builder::build(pairs, "USD", {"EUR"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     CHECK_THROWS_AS(engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)}),
                     std::invalid_argument);
@@ -175,7 +175,7 @@ TEST_CASE("update rejects two known but unconnected currencies -- not an edge of
         {"USD", "JPY", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     // EUR and JPY are both known currencies, but neither is the other's
     // parent in the tree (both hang off USD) -- not a real edge.
@@ -186,7 +186,7 @@ TEST_CASE("update rejects two known but unconnected currencies -- not an edge of
 TEST_CASE("update rejects a self-referencing pair on the pivot currency", "[rate_engine]") {
     const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
     auto topology = topology_builder::build(pairs, "USD", {"EUR"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     // Without the base_id == quote_id guard, this would trivially satisfy
     // parent(pivot) == pivot and corrupt the pivot's log_rate.
@@ -202,7 +202,7 @@ TEST_CASE("update rejects a self-referencing pair on the pivot currency", "[rate
 TEST_CASE("update rejects a non-finite or non-positive rate", "[rate_engine]") {
     const std::vector<ccy_pair_input> pairs = {{"EUR", "USD", true}};
     auto topology = topology_builder::build(pairs, "USD", {"EUR"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     CHECK_THROWS_AS(engine.update(driver_quote{"EUR", "USD", 0.0, epoch(0)}),
                     std::invalid_argument);
@@ -223,7 +223,7 @@ TEST_CASE("concurrent updates and batched reads never crash or hang", "[rate_eng
         {"GBP", "USD", true},
     };
     auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
-    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)}, epoch(0));
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
 
     engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
     engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});

--- a/projects/ores.analytics.quant/tests/risk_recentering_tests.cpp
+++ b/projects/ores.analytics.quant/tests/risk_recentering_tests.cpp
@@ -1,0 +1,140 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.analytics.quant/domain/driver_quote.hpp"
+#include "ores.analytics.quant/domain/rate_status.hpp"
+#include "ores.analytics.quant/domain/staleness_policy.hpp"
+#include "ores.analytics.quant/service/rate_engine.hpp"
+#include "ores.analytics.quant/service/risk_recentering.hpp"
+#include "ores.analytics.quant/service/topology_builder.hpp"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using ores::analytics::quant::domain::ccy_pair_input;
+using ores::analytics::quant::domain::driver_quote;
+using ores::analytics::quant::domain::rate_status;
+using ores::analytics::quant::domain::staleness_policy;
+using ores::analytics::quant::service::rate_engine;
+using ores::analytics::quant::service::recenter;
+using ores::analytics::quant::service::topology_builder;
+
+namespace {
+
+auto epoch(int seconds) {
+    return std::chrono::system_clock::time_point{} + std::chrono::seconds(seconds);
+}
+
+rate_engine build_usd_pivot_engine() {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+        {"GBP", "USD", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY", "GBP"});
+    rate_engine engine(std::move(topology), staleness_policy{std::chrono::minutes(5)});
+    engine.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    engine.update(driver_quote{"USD", "JPY", 150.0, epoch(0)});
+    engine.update(driver_quote{"GBP", "USD", 1.25, epoch(0)});
+    return engine;
+}
+
+} // namespace
+
+TEST_CASE("recentering preserves every rate's current value", "[risk_recentering]") {
+    const auto source = build_usd_pivot_engine();
+
+    // Recenter on GBP: everything must now route directly through GBP,
+    // but the numeric rates against GBP must match the source engine's
+    // triangulated values exactly.
+    const auto expected_eur_gbp = source.rate("EUR", "GBP", epoch(0));
+    const auto expected_jpy_gbp = source.rate("JPY", "GBP", epoch(0));
+    const auto expected_usd_gbp = source.rate("USD", "GBP", epoch(0));
+    REQUIRE(expected_eur_gbp.status == rate_status::fresh);
+    REQUIRE(expected_jpy_gbp.status == rate_status::fresh);
+    REQUIRE(expected_usd_gbp.status == rate_status::fresh);
+
+    const auto recentred =
+        recenter(source, "GBP", staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    CHECK(recentred.rate("EUR", "GBP", epoch(0)).rate == Catch::Approx(expected_eur_gbp.rate));
+    CHECK(recentred.rate("JPY", "GBP", epoch(0)).rate == Catch::Approx(expected_jpy_gbp.rate));
+    CHECK(recentred.rate("USD", "GBP", epoch(0)).rate == Catch::Approx(expected_usd_gbp.rate));
+}
+
+TEST_CASE("recentering keeps the original as_of, not the recentering time", "[risk_recentering]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    rate_engine source(std::move(topology), staleness_policy{std::chrono::minutes(5)});
+    source.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    source.update(driver_quote{"USD", "JPY", 150.0, epoch(50)});
+
+    const auto recentred =
+        recenter(source, "USD", staleness_policy{std::chrono::minutes(5)}, epoch(1000));
+
+    // Recentering happens at t=1000, long after the underlying ticks --
+    // the recentred engine must report the *original* as_of, not t=1000,
+    // so its own staleness accounting stays honest.
+    CHECK(recentred.rate("EUR", "USD", epoch(1000)).as_of == epoch(0));
+    CHECK(recentred.rate("USD", "JPY", epoch(1000)).as_of == epoch(50));
+}
+
+TEST_CASE("bumping one leg of a recentred matrix leaves every other leg unchanged",
+          "[risk_recentering]") {
+    const auto source = build_usd_pivot_engine();
+    auto recentred = recenter(source, "USD", staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    const auto jpy_before = recentred.rate("USD", "JPY", epoch(0));
+    const auto gbp_before = recentred.rate("USD", "GBP", epoch(0));
+
+    // In the un-recentred source, USD is already the pivot, so this test
+    // is only meaningful once recentred is genuinely star-shaped -- bump
+    // the EUR leg and confirm JPY/GBP (unrelated legs off the same star
+    // centre) are bit-for-bit unaffected.
+    recentred.update(driver_quote{"USD", "EUR", 1.0 / 1.12, epoch(1)});
+
+    CHECK(recentred.rate("USD", "JPY", epoch(0)).rate == Catch::Approx(jpy_before.rate));
+    CHECK(recentred.rate("USD", "GBP", epoch(0)).rate == Catch::Approx(gbp_before.rate));
+}
+
+TEST_CASE("an unavailable rate in the source is left unseeded after recentering",
+          "[risk_recentering]") {
+    const std::vector<ccy_pair_input> pairs = {
+        {"EUR", "USD", true},
+        {"USD", "JPY", true},
+    };
+    auto topology = topology_builder::build(pairs, "USD", {"EUR", "JPY"});
+    rate_engine source(std::move(topology), staleness_policy{std::chrono::minutes(5)});
+    source.update(driver_quote{"EUR", "USD", 1.10, epoch(0)});
+    // JPY never ticked -- unavailable in the source.
+
+    const auto recentred =
+        recenter(source, "USD", staleness_policy{std::chrono::minutes(5)}, epoch(0));
+
+    CHECK(recentred.rate("USD", "EUR", epoch(0)).status == rate_status::fresh);
+    CHECK(recentred.rate("USD", "JPY", epoch(0)).status == rate_status::unavailable);
+}
+
+TEST_CASE("recentering on an unknown currency throws", "[risk_recentering]") {
+    const auto source = build_usd_pivot_engine();
+    CHECK_THROWS_AS(recenter(source, "XXX", staleness_policy{std::chrono::minutes(5)}, epoch(0)),
+                    std::invalid_argument);
+}


### PR DESCRIPTION
## Summary

service::recenter re-roots the CRM into a star-shaped matrix around a chosen aggregation currency (every other currency directly connected to it, so bumping one leg cannot ripple to others) without changing any derived rate's value: reuses topology_builder to build the star, seeds the new engine with each currency's current rate + original as_of pulled from the source engine. Also fixes a pre-existing bug (from PR #1512): the pivot's as_of was seeded to construction time instead of the maximum time_point, wrongly flooring every other vertex's freshness at that instant forever.

## Changes

- New: service::recenter free function, star-topology rebuild + rate-preserving seed
- rate_engine gained topology() accessor and an explicit move constructor (immer::atom disallows copy/move)
- Fixed pivot as_of bug: seeded to time_point::max() instead of construction time; removed the now-vestigial constructor now parameter end-to-end rather than leave it unused
- 5 new test cases (23 total, 44k+ assertions): rate preservation, as_of preservation, bump-one-leg isolation, unavailable-stays-unseeded, unknown-aggregation-currency rejection
- Verification: local build clean (linux-clang-debug-make); ctest ores.analytics.quant.tests 1/1 passed (23 test cases, stable across repeated runs)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Cross-rates matrix (CRM)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/crm_implementation/story.html) | B38B3869-02FD-4CC7-99BD-9A77904ACA19 |
| Task | [Implement risk recentering](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/crm_implementation/task_implement_risk_recentering.html) | 6EA4B5FC-4581-484C-B5EB-ECF868B3A61D |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)