### PR TITLE
[compass] Add vcpkg drift check to bearings; add devops-update-environment skill

### DIFF
--- a/doc/agile/versions/v0/sprint_23/compass_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/story.org
@@ -1,0 +1,51 @@
+:PROPERTIES:
+:ID: C816DF00-1E36-4ED7-99E0-854589EF4EF3
+:END:
+#+title: Story: Compass improvements
+#+description: Catch-all story for small compass enhancements: bearings/vcpkg drift check, environment-update tooling, and similar cross-cutting improvements that don't warrant their own dedicated story.
+#+type: story
+#+level: s2
+#+filetags: :compass:sprint_23:v0:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+#+environment: merry_newton
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+A home for small, cross-cutting compass enhancements that don't
+warrant their own dedicated story — surfaced drift warnings,
+convenience tooling — so this kind of work stays tracked without
+inflating the backlog with one-off stories.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
+| Now           | First task (vcpkg drift check + devops-update-environment skill) is DONE. |
+| Waiting on    | Nothing.                               |
+| Next          | Left open as the ongoing catch-all for further small compass enhancements this sprint; add tasks as they come up. |
+| Last touched  | 2026-07-12                               |
+
+* Acceptance
+
+- =compass bearings= warns when the vcpkg submodule checked out
+  locally doesn't match what =origin/main= expects.
+- A new skill exists to bring a worktree fully up to date with main
+  (fetch, checkout latest, submodules, settings, skills).
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:745B765F-BEB2-4CBA-8BA8-852FBDDBA399][Add vcpkg drift check to bearings and a devops-update-environment skill]] | DONE | 2026-07-12 | 2026-07-12 | Add a vcpkg-vs-main drift warning to compass bearings, and create a new devops-update-environment skill that brings a worktree fully up to date with main (fetch, detached checkout, submodules, settings, skills). |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
@@ -81,7 +81,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | vcpkg_drift() misclassifies an uninitialized/deinitialized submodule as initialized (empty dir passes is_dir(), rev-parse HEAD walks up to superproject) | compass.py | Accepted | Detect via (vcpkg_dir / ".git").exists() instead; also guard current is None |
+| 2 | Skill #+title uses kebab-case name instead of readable Title Case | devops-update-environment/SKILL.org | Accepted | Retitled to "Update a worktree to latest main" |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_improvements:sprint_23:v0:
 #+owner: marco
 #+branch: feature/vcpkg-drift-and-update-environment
-#+pr:
+#+pr: 1520
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
@@ -75,7 +75,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1520][#1520]] | [compass] Add vcpkg drift check to bearings; add devops-update-environment skill |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.org
@@ -1,0 +1,103 @@
+:PROPERTIES:
+:ID: 745B765F-BEB2-4CBA-8BA8-852FBDDBA399
+:END:
+#+title: Task: Add vcpkg drift check to bearings and a devops-update-environment skill
+#+description: Add a vcpkg-vs-main drift warning to compass bearings, and create a new devops-update-environment skill that brings a worktree fully up to date with main (fetch, detached checkout, submodules, settings, skills).
+#+type: task
+#+level: s1
+#+filetags: :compass_improvements:sprint_23:v0:
+#+owner: marco
+#+branch: feature/vcpkg-drift-and-update-environment
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+#+environment: merry_newton
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C816DF00-1E36-4ED7-99E0-854589EF4EF3][Compass improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=compass bearings= should flag when a worktree's checked-out vcpkg
+submodule commit drifts from what =origin/main= expects, the way it
+already flags stale =.env= versions. And there should be a single
+skill a developer reaches for to bring a worktree fully up to date
+with main: fetch, detached checkout of the latest commit, sync
+submodules (vcpkg), and rebuild settings/skills.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:C816DF00-1E36-4ED7-99E0-854589EF4EF3][Compass improvements]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-12                               |
+
+* Acceptance
+
+- =compass bearings= prints a warning line when the vcpkg submodule
+  commit differs from =origin/main:vcpkg=, with the fix-it command.
+- No warning when vcpkg is in sync (verified against the fleet).
+- New skill =devops-update-environment= exists, scaffolded via the
+  standard skill machinery, indexing a new recipe for the fetch →
+  detached-checkout → submodules → settings → skills sequence.
+
+* Plan
+
+Add a =vcpkg_drift()= helper alongside the existing
+=branch_staleness()= git-log-only pattern in compass.py (no network
+call: reads cached =origin/main:vcpkg= and the submodule's checked-out
+HEAD), wire it into the bearings "Is the environment up?" section next
+to the =.env= version check. Scaffold the =devops-update-environment=
+skill and its recipe via the standard =compass add skill=/=add
+recipe= machinery, cross-reference from the s1_agent function doc and
+regenerate the skills catalogue.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Added =vcpkg_drift()= to compass.py and wired a warning into
+=compass bearings= "Is the environment up?" section, triggering when
+the local vcpkg submodule commit differs from what =origin/main:vcpkg=
+records. Verified silent when in sync (confirmed against the fleet's
+vcpkg commits via =git submodule status=) and confirmed the underlying
+drift this task started from (this worktree was on an older vcpkg
+commit than main) was real and is now fixed by =git submodule update
+--init vcpkg=.
+
+Scaffolded the =devops-update-environment= skill
+([[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][SKILL.org]]) and its recipe
+([[id:B223B31B-5789-439D-BBA2-5959D82F3D65][How do I update a worktree
+to latest main?]]), documenting: fetch + detached checkout of
+=origin/main=, =git submodule update --init vcpkg=, then rebuild
+settings and skills. Cross-referenced from =s1_agent.org= and
+regenerated the skills catalogue.

--- a/doc/agile/versions/v0/sprint_23/sprint.org
+++ b/doc/agile/versions/v0/sprint_23/sprint.org
@@ -63,6 +63,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:B38B3869-02FD-4CC7-99BD-9A77904ACA19][Cross-rates matrix (CRM)]] | BACKLOG | 2026-07-11 | | Pulled in from product backlog next: driver/derived spanning-tree topology, no-arbitrage triangulation, risk recentering, management UI in ores.marketdata. |
 | [[id:1014DD4F-B011-4102-8C60-983364E9BFBE][Sprint 23 planning session]] | DONE | 2026-07-11 | 2026-07-11 | 16 stories seeded into sprint 23; deep backlog refinement audited all 559 items (71 discarded/relocated, 1 merged); bucket rescoring moved 310 items and emptied inbox. |
 | [[id:CEB88862-4602-4D02-871F-EB8099DCE1B3][Extract stochastic process math from ores.synthetic into ores.analytics.quant]] | DONE | 2026-07-12 | 2026-07-12 | Moved GMM/OU stochastic processes, process factory, and parameter validation out of ores.synthetic into ores.analytics.quant, with 54 new Catch2 tests and updated component documentation. |
+| [[id:C816DF00-1E36-4ED7-99E0-854589EF4EF3][Compass improvements]] | STARTED | 2026-07-12 | | Catch-all for small compass enhancements: bearings/vcpkg drift check, environment-update tooling. |
 
 ** Hotfixes
 

--- a/doc/functions/s1_agent.org
+++ b/doc/functions/s1_agent.org
@@ -77,6 +77,9 @@ The Claude Code [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skills]] you invoke p
   environment (Qt UI verification, manual testing): stop services,
   recreate the database, start services, provision the tenant, start
   the client.
+- [[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][devops-update-environment]] — when a worktree has drifted from main
+  (stale vcpkg submodule, settings, or skills bundle): fetch, detached
+  checkout of latest main, sync submodules, rebuild settings/skills.
 - Entity / component / type creators ([[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][codegen-add-cli-entity]],
   [[id:59D662B0-D4E4-6A34-9EAB-EAC6E98F6BC9][codegen-add-component]], [[id:B1450696-8C51-4CC5-8910-84912A411AB6][code-add-domain-type]], [[id:BDCC47D4-B050-409E-8C50-3D179843A274][codegen-add-http-entity]],
   [[id:C6ADAC80-F4E6-44E8-9525-3760CB98C41D][codegen-add-qt-entity]], [[id:6A76FDFE-9AA7-4F73-8570-87A458C24553][codegen-add-shell-entity]]) — when the task is

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -42,14 +42,14 @@ Stories, tasks, sprints, backlog, journal, orientation.
 | [[id:DD7857D9-068E-D724-5C63-A67BD5F1C009][agile-add-release-notes]] | Agile Add Release Notes | Generate ORE Studio release notes from merged PRs and the closing sprint backlog, then tag main and open a... |
 | [[id:A11D7893-53FB-40BF-B1F1-A760D24D86BC][agile-add-story]] | Agile Add Story | Create a story with docs only — no branch, no journal; backlog refinement and sprint planning use this. |
 | [[id:DBBBE507-E750-40DF-B9EF-06E829836087][agile-add-task]] | Agile Add Task | Add a task to an existing story, docs only — no branch side effects. |
-| [[id:1B837DB5-B27A-451B-A0D0-DD17142476E4][agile-add-timeline-snapshot]] | Agile Add Timeline Snapshot | Create a 20-minute timeline snapshot of recent agile activity; write it to the current sprint's timeline/ folder. |
+| [[id:1B837DB5-B27A-451B-A0D0-DD17142476E4][agile-add-timeline-snapshot]] | Agile Add Timeline Snapshot | Create a 20-minute timeline snapshot of recent agile activity; write it to the current sprint's timeline/ f... |
 | [[id:460C89DA-50D2-40C3-88B2-BE52E430D170][agile-brainstorm-idea]] | Agile Brainstorm Idea | Explore user intent and design through collaborative dialogue — one question at a time, alternatives with t... |
-| [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] | Agile Close Task | Close a task's bookkeeping at the end of the review round: DONE, Result, story and sprint sync; cascades to... |
+| [[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][agile-close-task]] | Agile Close Task | Close a task's bookkeeping before raising its PR (not after review): DONE, Result, story and sprint sync; c... |
 | [[id:936389EC-7E0A-4925-9023-D4FA33C0FBF4][agile-find-bearings]] | Agile Find Bearings | Initialise a session — compass-first operation, recipe search for command info, bearings, then a summary an... |
 | [[id:117A7CC5-67B7-4B51-BD6D-41E0A00B5A3D][agile-find-heading]] | Agile Find Heading | Find the next work item — run compass heading, surface the ranked suggestions, and recommend the top action. |
 | [[id:C5EEF144-BB9D-2F44-453B-4B7338D8A457][agile-open-sprint]] | Agile Open Sprint | Open a new ORE Studio sprint. Scaffold the sprint folder via codegen, set its mission, link it from the ver... |
 | [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][agile-plan-sprint]] | Agile Plan Sprint | Run a sprint planning session: read the sprint mission, score next-backlog captures against sprint goals, p... |
-| [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][agile-refine-backlog]] | Agile Refine Backlog | Run a backlog housekeeping session: scan the next/deferred captures, clarify descriptions, cull stale items... |
+| [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][agile-refine-backlog]] | Agile Refine Backlog | / |
 | [[id:A7B3C241-D8E9-4F0A-B1C2-D3E4F5061728][agile-review-sprint]] | Agile Review Sprint | / |
 | [[id:3D5955A1-008F-4108-AB81-4AE996D96257][agile-show-backlog]] | Agile Show Backlog | Show the product backlog buckets: inbox, next, deferred, discarded. |
 | [[id:618B9D09-7DF7-4928-97DF-2A17F8F50871][agile-show-fleet]] | Agile Show Fleet | Show what every git worktree is doing: branch, story, task, open PR. |
@@ -68,6 +68,7 @@ PR lifecycle.
 |------+-------+-------------|
 | [[id:38ACE767-95D6-4A6E-88A8-EC93BB350292][pr-address-review]] | PR Address Review | Handle one complete PR review round: sync, read comments, decide, fix, push, reply, resolve, record. |
 | [[id:D36BCA19-8926-4E06-8C0B-7F607BD3D4EC][pr-merge]] | PR Merge | Merge a PR with guard rails: threads resolved, CI green, task bookkeeping already closed. |
+| [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][pr-raise]] | PR Raise | Open a pull request with compass pr create, then post an @claude comment to trigger the interactive code re... |
 | [[id:25EDDA60-36D2-4F7C-9D99-D75B43705D08][pr-show-checks]] | PR Show Checks | Show CI check status for a PR, optionally watching until completion. |
 | [[id:D3CF614D-4889-409F-B938-22C877189B07][pr-sync-branch]] | PR Sync Branch | Rebase the current feature branch on origin/main and report divergence; never work on a stale branch. |
 
@@ -80,7 +81,7 @@ Recipes, knowledge, manual, memory, diagrams, search.
 | [[id:E8629813-4F4A-4165-85AA-27BE7F38E32C][doc-add-chart]] | Doc Add Chart | / |
 | [[id:D6D86317-4961-6754-A6DB-9C12B5FAC997][doc-add-class-diagram]] | Doc Add Class Diagram | Author or update a PlantUML class diagram for an ORE Studio component, or the system-level architecture dia... |
 | [[id:B0B99088-D88E-4980-A4EE-7D6A9A8E96A5][doc-add-component-model]] | Doc Add Component Model | Create or update component_overview.org and the PlantUML class diagram for an ORE Studio component. |
-| [[id:E8E892B8-184D-474A-839F-FFCA1A5148EF][doc-add-entity-chapter]] | Doc Add Entity Chapter | Author a complete user-manual chapter for a reference-data entity, from domain grounding through screenshot capture, ready for human review. |
+| [[id:E8E892B8-184D-474A-839F-FFCA1A5148EF][doc-add-entity-chapter]] | Doc Add Entity Chapter | Author a complete user-manual chapter for a reference-data entity, from domain grounding through screenshot... |
 | [[id:8777ABEB-35B6-4216-B2BA-7E3E575A2986][doc-add-er-diagram]] | Doc Add ER Diagram | Author or update the PlantUML ER diagram for the ORE Studio SQL schema — tables, relationships, temporal pa... |
 | [[id:D3767A34-DC32-4366-ADAB-534D6FC4C607][doc-add-knowledge]] | Doc Add Knowledge | Create a knowledge document: scaffold, fill Summary and Detail, tag, and wire the knowledge index. |
 | [[id:7357C672-A49F-4974-9399-A166F761D222][doc-add-memory]] | Doc Add Memory | When the user gives feedback worth remembering, or asks "remember this", write or update a memory under doc... |
@@ -130,15 +131,18 @@ Environment, database, services, shell, client, site.
 | [[id:7BB0B6CC-A88D-4EA1-900C-7AC01B5B432F][devops-deploy-settings]] | Devops Deploy Settings | Tangle Claude Code settings.json from its org source. |
 | [[id:C6E41D12-6D7A-4C5E-BD89-C399A4ECA021][devops-deploy-site]] | Devops Deploy Site | Build and publish the documentation website from the org-roam graph. |
 | [[id:1226649E-49D5-4C80-878D-6A17D3F20A62][devops-deploy-skills]] | Devops Deploy Skills | Build the Claude Code skills bundle from doc/llm/skills and purge stale deployed directories. |
+| [[id:3A869409-B8E7-420B-9BFA-0BAC9E9F804F][devops-deprovision-environment]] | Deprovision a named environment | Use compass env deprovision to remove a named worktree and its directory. |
+| [[id:AA14F8A0-F037-4303-88D9-059771BD764D][devops-provision-environment]] | Provision a new named environment | Use compass env provision to create a named worktree, assign isolated ports, and write a skeleton .env. |
 | [[id:435BD960-CA83-4B1A-829D-F345181206B2][devops-recreate-db]] | Devops Recreate DB | Rebuild the database from scratch: drop, recreate, restore schema and seed data. |
 | [[id:A8102388-6D8B-40D8-B6B1-1DB29E9DD6D2][devops-run-client]] | Devops Run Client | Launch the Qt client detached, with optional colour and instance name for parallel runs. |
-| [[id:7562DD4F-8F75-408B-BAE2-BB943839969D][devops-run-environment]] | Devops Run Environment | Run the full environment-readying sequence: stop services, recreate the database, start services, provision the Barclays Plc tenant, and start the Qt client. |
+| [[id:7562DD4F-8F75-408B-BAE2-BB943839969D][devops-run-environment]] | Devops Run Environment | Run the full environment-readying sequence: stop services, recreate the database, start services, provision... |
 | [[id:40DE3AD0-7A32-45FF-9DFA-5F9492187F2A][devops-run-shell]] | Devops Run Shell | Launch ores.shell with NATS and login defaults from .env, interactively or scripted with -f. |
 | [[id:29075D79-6152-4C3A-B9E0-4E97010D8E0B][devops-run-sql]] | Devops Run SQL | Run SQL in the environment via compass with credentials and connection from .env. |
 | [[id:C35F1575-4894-46B9-9356-E68F275CFD3B][devops-setup-environment]] | Devops Setup Environment | Set up a working environment end-to-end: sync indexes, deploy skills and settings, init env, recreate the DB. |
 | [[id:DBAE601D-183D-4B61-85ED-2823E2AF0EEC][devops-show-services]] | Devops Show Services | Show service fleet status: running, stopped, missing. |
 | [[id:96EBB175-83BD-4DD3-B35C-769C86CB3075][devops-start-services]] | Devops Start Services | Start the service fleet and verify everything came up. |
 | [[id:74D7BEDE-5FEC-45AE-9977-CC9A6C5D47A0][devops-stop-services]] | Devops Stop Services | Stop the service fleet cleanly. |
+| [[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][devops-update-environment]] | devops-update-environment | Bring a worktree fully up to date with main: fetch, detached checkout of the latest commit, sync submodules... |
 
 * Skills (=skill-=)
 

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -142,7 +142,7 @@ Environment, database, services, shell, client, site.
 | [[id:DBAE601D-183D-4B61-85ED-2823E2AF0EEC][devops-show-services]] | Devops Show Services | Show service fleet status: running, stopped, missing. |
 | [[id:96EBB175-83BD-4DD3-B35C-769C86CB3075][devops-start-services]] | Devops Start Services | Start the service fleet and verify everything came up. |
 | [[id:74D7BEDE-5FEC-45AE-9977-CC9A6C5D47A0][devops-stop-services]] | Devops Stop Services | Stop the service fleet cleanly. |
-| [[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][devops-update-environment]] | devops-update-environment | Bring a worktree fully up to date with main: fetch, detached checkout of the latest commit, sync submodules... |
+| [[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][devops-update-environment]] | Update a worktree to latest main | Bring a worktree fully up to date with main: fetch, detached checkout of the latest commit, sync submodules... |
 
 * Skills (=skill-=)
 

--- a/doc/llm/skills/devops-update-environment/SKILL.org
+++ b/doc/llm/skills/devops-update-environment/SKILL.org
@@ -1,0 +1,85 @@
+:PROPERTIES:
+:ID: 4FA1791F-6E6C-4376-A3B9-3BF913F55ACF
+:END:
+#+title: devops-update-environment
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :devops:environment:vcpkg:skills:settings:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+#+begin_export markdown
+---
+name: devops-update-environment
+description: Bring a worktree fully up to date with main: fetch, detached checkout of the latest commit, sync submodules (vcpkg), and rebuild settings and skills.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks to update, sync, or refresh a worktree against
+main — e.g. "update this environment to latest main", "sync my
+checkout", "bring this worktree up to date" — beyond a plain branch
+sync (see pr-sync-branch for that).
+
+* How to use this skill
+
+1.  *Fetch and detach* onto the latest main commit:
+
+    #+begin_src sh
+    git fetch origin main && git checkout --detach origin/main
+    #+end_src
+
+    Check =git status --porcelain= first; stash or commit anything
+    unexpected before checking out.
+
+2.  *Sync the vcpkg submodule* to what main's tree expects:
+
+    #+begin_src sh
+    git submodule update --init vcpkg
+    #+end_src
+
+3.  *Rebuild settings and skills* so the Claude Code harness picks up
+    org-source changes:
+
+    #+begin_src sh
+    ./projects/ores.compass/compass.sh build --direct settings
+    ./projects/ores.compass/compass.sh build --direct skills
+    #+end_src
+
+    Remind the user to =/reload-skills= afterwards.
+
+4.  *Verify* with =compass bearings= — the "Is the environment up?"
+    section flags any remaining =.env=/vcpkg/settings drift.
+
+* Recipes
+
+- [[id:B223B31B-5789-439D-BBA2-5959D82F3D65][How do I update a worktree to latest main?]]
+
+* Reference
+
+- [[id:13209197-CDBD-4807-A8F9-9653AFA96CBF][How do I manage the checkout environment with compass?]]
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/devops-update-environment/SKILL.org
+++ b/doc/llm/skills/devops-update-environment/SKILL.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 4FA1791F-6E6C-4376-A3B9-3BF913F55ACF
 :END:
-#+title: devops-update-environment
+#+title: Update a worktree to latest main
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages

--- a/doc/recipes/compass/how_do_i_update_a_worktree_to_latest_main.org
+++ b/doc/recipes/compass/how_do_i_update_a_worktree_to_latest_main.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: B223B31B-5789-439D-BBA2-5959D82F3D65
+:END:
+#+title: How do I update a worktree to latest main?
+#+description: Bring a worktree fully in sync with origin/main: fetch, detached checkout of the latest commit, sync the vcpkg submodule, and rebuild settings and skills.
+#+type: recipe
+#+level: cross
+#+filetags: :compass:environment:vcpkg:skills:settings:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+Bringing a worktree up to date is more than =git pull=: the vcpkg
+submodule, generated =.claude/settings.json=, and the deployed skills
+bundle all need to move in lockstep with main. =compass bearings=
+surfaces drift in each of these (see "Is the environment up?").
+
+* Question
+
+How do I update a worktree to the latest main, including its vcpkg
+submodule, settings, and skills?
+
+* Answer
+
+#+begin_src sh
+# 1. Fetch latest main and check it out as a detached HEAD — this
+#    checkout tracks a feature branch or task, not main itself, so we
+#    never fast-forward a real branch by surprise.
+git fetch origin main
+git checkout --detach origin/main
+
+# 2. Sync the vcpkg submodule to the commit main's tree records.
+git submodule update --init vcpkg
+
+# 3. Rebuild settings.json from its org source.
+./projects/ores.compass/compass.sh build --direct settings
+
+# 4. Rebuild the deployed skills bundle.
+./projects/ores.compass/compass.sh build --direct skills
+#+end_src
+
+Then, in the Claude Code session, run =/reload-skills= to pick up the
+rebuilt bundle.
+
+Check the result with =compass bearings= — the "Is the environment
+up?" section warns if =.env=, vcpkg, or settings/skills are still
+stale.
+
+* Script
+
+Wrapped end-to-end by the [[id:4FA1791F-6E6C-4376-A3B9-3BF913F55ACF][devops-update-environment]] skill.
+
+* Tested by
+
+Manual smoke test: run the sequence on a worktree with a stale vcpkg
+pointer, confirm =git submodule status vcpkg= matches
+=git rev-parse origin/main:vcpkg= afterwards, and that =compass
+bearings= no longer warns.
+
+* See also
+
+- [[id:13209197-CDBD-4807-A8F9-9653AFA96CBF][How do I manage the checkout environment with compass?]]
+- [[id:E9297D15-F053-4B76-92DF-ED87E7205020][How do I provision a new environment with compass?]]

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1218,6 +1218,31 @@ def _staleness_severity(info):
         return "warn"
     return "ok"
 
+def vcpkg_drift(root):
+    """Compare the checked-out vcpkg submodule commit against what origin/main expects.
+
+    No network call — reads the cached origin/main tree and the submodule's
+    current HEAD only. Returns a dict:
+      current  - vcpkg submodule commit checked out here, or None
+      expected - vcpkg commit that origin/main's tree records, or None
+      error    - None | "no-remote" | "no-submodule"
+    """
+    info = {"current": None, "expected": None, "error": None}
+
+    expected = _git_out("rev-parse", "origin/main:vcpkg", cwd=root)
+    if expected is None:
+        info["error"] = "no-remote"
+        return info
+    info["expected"] = expected
+
+    vcpkg_dir = Path(root) / "vcpkg"
+    if not vcpkg_dir.is_dir():
+        info["error"] = "no-submodule"
+        return info
+    current = _git_out("rev-parse", "HEAD", cwd=vcpkg_dir)
+    info["current"] = current
+    return info
+
 def _age_human(seconds):
     """Convert seconds to a compact label: 30m, 4h, 2d."""
     if seconds is None:
@@ -4943,6 +4968,17 @@ def cmd_bearings(argv):
             elif _current_envver > _required_envver:
                 print(f"  {_C_YELLOW}⚠  .env version v{_current_envver} is newer "
                       f"than required v{_required_envver} — proceeding.{_C_RESET}")
+        except Exception:
+            pass
+        try:
+            _vd = vcpkg_drift(PROJECT_ROOT)
+            if _vd["error"] == "no-submodule":
+                print(f"  {_C_YELLOW}⚠  vcpkg submodule not checked out — "
+                      f"{_ycmd('git submodule update --init vcpkg')}{_C_RESET}")
+            elif _vd["error"] is None and _vd["current"] != _vd["expected"]:
+                print(f"  {_C_YELLOW}⚠  vcpkg is on {_vd['current'][:9]}, "
+                      f"main expects {_vd['expected'][:9]} — "
+                      f"{_ycmd('git submodule update --init vcpkg')}{_C_RESET}")
         except Exception:
             pass
         _info = _cdb.database_info(_env)

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1236,10 +1236,13 @@ def vcpkg_drift(root):
     info["expected"] = expected
 
     vcpkg_dir = Path(root) / "vcpkg"
-    if not vcpkg_dir.is_dir():
+    if not (vcpkg_dir / ".git").exists():
         info["error"] = "no-submodule"
         return info
     current = _git_out("rev-parse", "HEAD", cwd=vcpkg_dir)
+    if current is None:
+        info["error"] = "no-submodule"
+        return info
     info["current"] = current
     return info
 


### PR DESCRIPTION
## Summary

compass bearings now warns when the checked-out vcpkg submodule commit differs from what origin/main expects, mirroring the existing .env staleness check. Also adds a devops-update-environment skill (with a new recipe) that brings a worktree fully in sync with main.

## Changes

- Add vcpkg_drift() helper to compass.py, wired into the bearings 'Is the environment up?' section
- Scaffold devops-update-environment skill + how_do_i_update_a_worktree_to_latest_main recipe via standard skill machinery
- Cross-reference from s1_agent.org function doc; regenerate the skills catalogue
- Verification: syntax-checked compass.py, ran compass bearings against the fleet (silent when in sync, confirmed real drift caught before the fix), rebuilt settings/skills bundles cleanly

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/compass_improvements/story.html) | C816DF00-1E36-4ED7-99E0-854589EF4EF3 |
| Task | [Add vcpkg drift check to bearings and a devops-update-environment skill](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/compass_improvements/task_vcpkg_drift_and_update_environment.html) | 745B765F-BEB2-4CBA-8BA8-852FBDDBA399 |
| Environment | merry_newton | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)