### PR TITLE
[marketdata] Add QuantLib-free tenor type

### DIFF
--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
@@ -131,7 +131,7 @@ which now require the process to expose =P(t,T)=, not just a path of
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:3D39EF0A-585F-4C66-B84F-433CAFA4DEB2][Lightweight QuantLib-free tenor type]] | STARTED | 2026-07-11 | | Parse tenor labels (3M, 2Y, 1W) and support simple std::chrono-based date-window overlap checks, with no business-day calendar machinery and no QuantLib dependency. |
+| [[id:3D39EF0A-585F-4C66-B84F-433CAFA4DEB2][Lightweight QuantLib-free tenor type]] | DONE | 2026-07-11 | 2026-07-12 | Parse tenor labels (3M, 2Y, 1W) and support simple std::chrono-based date-window overlap checks, with no business-day calendar machinery and no QuantLib dependency. |
 | [[id:01143977-5DA2-48AE-B4BE-109585BC4962][Short-rate stochastic process (Hull-White/CIR/Vasicek)]] | BACKLOG | | | New IStochasticProcess implementation for mean-reverting short-rate dynamics, wired into process_factory, mirroring ou_process's shape. |
 | [[id:20D82F58-758D-498A-8B08-AA664408CB8F][Curve Template sub-config (ir_curve_generation_config)]] | BACKLOG | | | New sub-config owned by market_data_generation_config, one per currency+index, configuring the raw instrument grid (deposits, FRAs/futures, swaps). |
 | [[id:E6B7DEF3-F35F-454A-8ECF-CCD9E8E07A83][Tenor-collision/gap validation on the Curve Template]] | BACKLOG | | | Pure, engine-side validator (ores.synthetic.api) rejecting instrument grids where tenors overlap or collide with an active delivery window, using the new tenor type. |

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
@@ -34,11 +34,11 @@ tenor-collision validator task.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]] |
-| Now          | Domain-knowledge groundwork done; C++ implementation not yet started. |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Implement the tenor type in =ores.marketdata= (not =ores.utility= — see Notes) per the =Tenor= knowledge doc. |
+| Next         | Nothing. |
 | Last touched | 2026-07-12                               |
 
 * Acceptance
@@ -101,6 +101,45 @@ implementation should now be written against:
   restated in =pricing_configuration.org=) was replaced with links to
   the new atomic docs.
 
+Implementation, restarted after a branch resync uncovered that the
+locally cached =feature/tenor-type= branch was stale (its remote had
+been deleted on merge, and =compass task start= reused the stale
+local ref instead of resyncing) — =compass pr sync= brought it back
+onto =origin/main= before any new code was written, confirming
+=ores.synthetic='s old =process*= files and a duplicate
+=ores.marketdata.api/domain/i_stochastic_process.hpp= seen earlier in
+the session were artefacts of that stale branch, not real dead code
+on =main=.
+
+=code-add-domain-type='s instructions were themselves stale (hand-written
+JSON models under a =projects/ores.codegen/models/{component}/= that no
+longer exists — the real format is org-mode =entity_org=/etc. docs, per
+=projects/ores.codegen/docs/codegen_input_org_schema.org=, generated via
+=compass codegen generate --model <path> --profile ...=, not
+=run_generator.sh= directly). Fixed the skill doc. Codegen was then
+found not to fit =tenor= regardless: none of its entity-model types
+generate a behaviour-heavy value type (parsing, comparison operators,
+computed methods) with no persistence or UI — they generate flat
+data-carrying structs plus persistence/UI layers. Hand-authored
+instead, following the same precedent already set by
+=ores.analytics.quant='s own domain types (=currency_id=, =ccy_pair=,
+...), which are hand-authored for the identical reason.
+
+Implemented =ores::marketdata::domain::tenor= in
+=ores.marketdata.api= (header =include/ores.marketdata.api/domain/tenor.hpp=,
+source =src/domain/tenor.cpp=): parses O/N, T/N, S/N, S/W, and the
+=<n><D|W|M|Y>= pattern; =end_date()= resolves a tenor to a calendar
+date off a horizon date via =std::chrono= (clamping to the last valid
+day of the month for month/year arithmetic that overflows, e.g. 31 Jan
++ 1M -> 28 Feb); =resolve_window()=/=windows_overlap()= support the
+tenor-collision validator's half-open date-window overlap checks.
+=domain_tenor_tests.cpp=: 10 test cases / 33 assertions, covering
+parsing (valid and malformed labels), ordering, date arithmetic
+(including the month-clamping edge case), and window overlap
+(including the half-open boundary case). Full
+=ores.marketdata.api.tests= suite (110 assertions / 24 test cases)
+passes with no regressions.
+
 * PRs
 
 | PR | Title |
@@ -124,3 +163,19 @@ PR #1517 review round (3 automated passes, issue-level comments, no line comment
 | 5 | "Waiting on PR #1409" note stale — PR #1409 merged into main (4be33f2b4) before this branch's rebase, but story.org still said "still open" | story.org | Fixed | Updated to "Nothing" with a note that #1409 merged prior to this branch's rebase |
 
 * Result
+
+Delivered a QuantLib-free =ores::marketdata::domain::tenor= type in
+=ores.marketdata.api=: parsing of standard tenor labels (short-end
+O/N/T/N/S/N/S/W plus the =<n><D|W|M|Y>= period pattern), calendar-date
+resolution off a horizon date via =std::chrono=, and half-open
+date-window overlap checks — the prerequisite the tenor-collision
+validator task needs. 10 new test cases / 33 assertions; full
+=ores.marketdata.api.tests= suite (110 assertions / 24 cases) green.
+Delivered across two PRs: #1517 (domain-knowledge groundwork —
+Interest Rate Curve Families and Time Structures/Tenor clusters) and
+this task's implementation PR (not yet raised — see PRs table once
+opened). Also fixed stale =code-add-domain-type= skill instructions
+(JSON model path no longer exists; real format is org-mode entity
+docs generated via =compass codegen generate=) discovered while
+confirming codegen wasn't actually the right tool for this value
+type.

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
@@ -8,7 +8,7 @@
 #+filetags: :ir-rates-synthetic-generation:sprint_23:v0:
 #+owner: marco
 #+branch: feature/tenor-type
-#+pr: 1517
+#+pr: 1522
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
@@ -144,6 +144,7 @@ passes with no regressions.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1522][#1522]] | [marketdata] Add QuantLib-free tenor type |
 | [[https://github.com/OreStudio/OreStudio/pull/1517][#1517]] | [doc] Establish IR curve-family and time-structure/tenor knowledge clusters |
 | [[https://github.com/OreStudio/OreStudio/pull/1411][#1411]] | [agile] Raise IR Rates synthetic data generation story |
 

--- a/doc/knowledge/domain/broken_dates_and_turn_points.org
+++ b/doc/knowledge/domain/broken_dates_and_turn_points.org
@@ -52,7 +52,70 @@ date]] advances, in contrast to how every other tenor point on the same
 term structure is expressed relative to the horizon date. They require
 special handling in interpolation — a term structure's interpolation
 method must isolate the turn effect's spike so that it does not bleed into
-the value of adjacent, structurally ordinary tenor points.
+the value of adjacent, structurally ordinary tenor points. A turn point
+also differs from a broken date in kind, not just in calendar behaviour: it
+"nudges" the rates around it rather than defining a tradeable maturity in
+its own right — see the three-way classification below.
+
+** Three-way tenor classification
+
+Every entry on a curve's tenor ladder is classified as exactly one of
+three kinds, and the system tracks which throughout the entry's lifetime
+(see [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]]
+for how that classification is recorded and why it never changes):
+
+- *Standard*: a normal named [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  (=O/N=, =1M=, =1Y=, and so on).
+- *Broken date*: a non-standard, interpolated maturity added explicitly
+  (e.g. 47 days), tracked distinctly from the standard tenors around it —
+  this document's "broken dates (odd dates)" section above.
+- *Turn*: a fixed-calendar-date discontinuity, potentially spanning
+  multiple days, which nudges rates around it rather than defining a
+  tradeable maturity — this document's "turn points" section above.
+
+** Entry and display
+
+How a broken date is added to and shown on a curve's tenor ladder follows
+several conventions, all specific to broken dates rather than to standard
+tenors:
+
+- A broken date can be added or removed directly on the ladder — a user is
+  not limited to the pre-defined standard tenor set.
+- It can be entered either as an absolute *date* or as a *tenor label*
+  where applicable — the same date-vs-tenor duality used for other
+  single-instrument date fields (e.g. an option's expiry).
+- As part of supporting broken-date and forward-forward analysis, the
+  system must provide an isolated calculation surface, separate from the
+  live term structure, on which a user can price an arbitrary
+  forward-forward relationship (e.g. "the rate 3M in 6M") or an arbitrary
+  bespoke maturity before deciding whether it is worth adding as a real
+  broken date. This is necessary because such exploration is inherently
+  speculative — a user comparing several hypothetical structures needs to
+  try many of them without any one attempt mutating the curve every other
+  part of the system reads from. To satisfy this, the surface must: (a)
+  use the same [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  resolution and interpolation machinery the live term structure uses, so
+  a result is a faithful preview of what adding the point for real would
+  produce, not an approximation; (b) read the live curve's current state
+  to ground its calculations in real market levels, without ever writing
+  a result back into that curve's point set; and (c) leave no
+  [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] trace on the
+  live curve — an explored-but-discarded hypothesis must be exactly as if
+  it had never been tried, consistent with provenance's "no promotion"
+  rule applying only to points that were actually added, not to
+  speculative ones that never were.
+- A broken date is not necessarily purely interpolated: each tenor entry,
+  including a broken date, can carry its own market data feed, so a broken
+  date can in principle be directly quoted rather than derived.
+- The [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][hub]]'s deferred "Out Of"
+  convention (Out of Today / Out of Tomorrow / Out of Spot) affects broken
+  dates the same way it affects standard tenors: when a non-standard
+  basis is selected, affected tenors — broken dates included — must be
+  visually distinguished so the user knows they are not on the
+  conventional spot basis.
+- On volatility surfaces specifically, a separate toggle controls whether
+  *interpolated* tenors are displayed at all — a distinct control from the
+  FX forward ladder's broken-date handling described above.
 
 * See also
 
@@ -60,3 +123,18 @@ the value of adjacent, structurally ordinary tenor points.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard labels a broken date falls between.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — where an interpolation method is specified.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete interpolation methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how the three-way classification is recorded and tracked over a point's lifetime.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions a broken date's position determines.
+
+** Further reading: terminology verification
+
+"Broken date"/"odd date" and "the turn"/"turn effect" were checked against
+independent market sources (not this notebook) to confirm they are real,
+standard industry terminology rather than local naming:
+
+- [[https://www.poems.com.sg/glossary/investment/broken-date/][Broken Date: Meaning, Impact & Fundamentals in Financial Markets]]
+- [[https://www.bestx.co.uk/publications/bestx-fx-forward-methodology-on-broken-dates][BestX FX Forward Methodology on Broken Dates]]
+- [[https://thefullfx.com/ncfx-extends-fx-forward-benchmarks-to-broken-dates/][NCFX Extends FX Forward Benchmarks to Broken Dates]]
+- [[https://www.cmegroup.com/education/articles-and-reports/understanding-and-analyzing-year-end-effects-in-the-fx-swap-market.html][Understanding and Analyzing Year-End Effects in the FX Swap Market (CME Group)]]
+- [[https://www.lseg.com/en/insights/fx/the-case-for-turn-impact-adjusted-fx-forward-curves][The case for turn impact-adjusted FX forward curves (LSEG)]]
+- [[https://www.clarusft.com/year-end-turn-rates/][Year End Turn Rates (Clarus FT)]]

--- a/doc/knowledge/domain/broken_dates_and_turn_points.org
+++ b/doc/knowledge/domain/broken_dates_and_turn_points.org
@@ -107,12 +107,12 @@ tenors:
 - A broken date is not necessarily purely interpolated: each tenor entry,
   including a broken date, can carry its own market data feed, so a broken
   date can in principle be directly quoted rather than derived.
-- The [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][hub]]'s deferred "Out Of"
-  convention (Out of Today / Out of Tomorrow / Out of Spot) affects broken
-  dates the same way it affects standard tenors: when a non-standard
-  basis is selected, affected tenors — broken dates included — must be
-  visually distinguished so the user knows they are not on the
-  conventional spot basis.
+- The [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]]
+  (Out of Today / Out of Tomorrow / Out of Spot) affects broken dates the
+  same way it affects standard tenors: when a non-standard basis is
+  selected, affected tenors — broken dates included — must be visually
+  distinguished so the user knows they are not on the conventional spot
+  basis.
 - On volatility surfaces specifically, a separate toggle controls whether
   *interpolated* tenors are displayed at all — a distinct control from the
   FX forward ladder's broken-date handling described above.
@@ -122,9 +122,10 @@ tenors:
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard labels a broken date falls between.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — where an interpolation method is specified.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete interpolation methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the concrete methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how the three-way classification is recorded and tracked over a point's lifetime.
-- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions a broken date's position determines.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ranges a broken date's position falls within.
+- [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] — the quoting-basis convention that also governs visual flagging for broken dates.
 
 ** Further reading: terminology verification
 

--- a/doc/knowledge/domain/curve_point_provenance.org
+++ b/doc/knowledge/domain/curve_point_provenance.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 573F9165-C20B-463C-B0B3-F324AFE4E81F
+:END:
+#+title: Curve Point Provenance
+#+description: The metadata tracked per term-structure point (rejected, interpolated, back-filled, overridden) and why a broken date is never promoted into a standard tenor.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+Every point on a [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
+structure]] carries provenance metadata alongside its value: whether it
+was rejected by a consensus provider, whether it is interpolated, whether
+it is back-filled (and if so, its age), and whether it has been
+overridden. This provenance is what lets a user interface distinguish a
+directly-quoted standard pillar from a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] or an
+interpolated point at a glance, rather than presenting every point as
+equally authoritative. One consequence of tracking provenance this way,
+rather than mutating a point's classification over time, is that a broken
+date is never "promoted" into a standard tenor: once added, it remains
+tracked as a broken date indefinitely.
+
+* Detail
+
+** The provenance fields
+
+Each curve point's metadata records:
+
+- Whether it was *rejected* by a consensus data provider.
+- Whether it is *interpolated* (derived from surrounding points, see
+  [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for
+  the interpolate/extrapolate/flatten regions this applies within).
+- Whether it is *back-filled*, and if so, its age — how long ago the value
+  it now shows was actually current.
+- Whether it has been *overridden* — replaced by a manual value rather
+  than the value a feed or interpolation would otherwise produce.
+
+This is the same underlying mechanism that lets a user interface
+colour-code or otherwise visually flag broken dates and interpolated
+points as distinct from directly-quoted standard tenors — the visual
+treatment is a presentation of the provenance metadata, not a separate
+tracking mechanism.
+
+** No promotion over time
+
+A [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] is added to a
+term structure as, and remains tracked as, a broken date — there is no
+mechanism by which repeated use or the passage of time converts it into a
+standard tenor indistinguishable from the pillars around it. The
+provenance record is what makes this durable: a point's classification
+(standard / broken date / turn, see
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s three-way classification) is a stored fact about that point,
+not a derived judgement that could drift as the point ages.
+
+** Related: illiquid cut times
+
+A related but distinct provenance-adjacent problem appears for option
+expiries rather than term-structure tenors: a barrier option expiring at a
+non-standard, illiquid cut time is risk-managed by placing a *Date Shift
+Reserve* against the nearest *liquid* cut time, rather than by sourcing
+market data for the illiquid cut directly. This is the closest analogue to
+"mapping an illiquid point to the nearest liquid one" outside the tenor
+domain proper — it operates on option cut times, not on a term structure's
+own tenor ladder, and is recorded here only as a cross-reference, not
+elaborated further in this cluster.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification this provenance record supports.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions provenance distinguishes between.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series each point with provenance belongs to.

--- a/doc/knowledge/domain/extrapolation.org
+++ b/doc/knowledge/domain/extrapolation.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2
+:END:
+#+title: Extrapolation
+#+description: Why a term structure needs a defined policy before its first pillar and beyond its last, and why flattening, not extrapolating, is the default beyond the end.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+Where [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]] fills a
+gap *between* two known [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
+structure]] points, *extrapolation* answers a request for a date *outside*
+the range those points cover altogether — before the first pillar, or
+beyond the last. A defined policy for both directions is necessary because
+a term structure's pillar range is finite by construction (see
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for how
+far it goes by curve type), while requests for a value can, in principle,
+fall anywhere. The two directions are treated asymmetrically: before the
+start, genuine extrapolation is used; beyond the end, the system flattens
+— holds the last known value constant — rather than extrapolating, and
+only extrapolates beyond the end in rare, explicitly justified cases.
+
+* Detail
+
+** Why a policy is needed at all
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is
+constructed from a finite set of pillar points and has no market-observed
+value outside that range. Left undefined, a request for such a value would
+either fail outright or silently return an arbitrary result depending on
+whichever code path happened to handle it. Neither is acceptable: the
+system must have an explicit, documented answer for "what happens if
+someone asks for a point before the curve starts, or after it ends" —
+the same way [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]]
+gives an explicit answer for a point falling between two known ones.
+
+** Before the start: extrapolate
+
+For a date earlier than the term structure's first pillar, the convention
+is to extrapolate — derive a value by continuing the curve's near-end
+behaviour backward. This is the more permissive of the two directions,
+reflecting that requests for very-near-term values (e.g. today, or a date
+just before the first liquid pillar) are routine rather than exceptional.
+
+** Beyond the end: flatten, not extrapolate
+
+For a date beyond the term structure's last pillar, the default is to
+*flatten* — hold the last known value constant — rather than to
+extrapolate. Genuine extrapolation beyond the end is reserved for rare,
+explicitly justified cases, not applied by default. This asymmetry is
+deliberate: extrapolating forward from a curve's long end would
+manufacture a value with no basis in any observed point, which is a
+materially different risk from extending near-term behaviour backward by
+a short distance. Flattening does not fail the request and does not
+fabricate a trend — it is the conservative middle ground between refusing
+to answer and inventing an answer. See
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for the
+concrete curve-type-specific ceilings (30Y for interest rate curves, a 5Y
+default for volatility surfaces, open-ended for CDS) this policy applies
+beyond.
+
+** Tracking which regime applies
+
+Whether a given point was interpolated, extrapolated, or flattened is part
+of that point's [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] —
+the same mechanism that tracks whether a point was rejected, back-filled,
+or overridden. A consumer reading a curve value can, and should, be able
+to tell which of the three regimes produced it, rather than treating every
+returned value as equally observed.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ceilings this policy applies beyond.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series whose finite range makes this policy necessary.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how a point is flagged as interpolated, extrapolated, or flattened.

--- a/doc/knowledge/domain/imm_dates.org
+++ b/doc/knowledge/domain/imm_dates.org
@@ -34,7 +34,9 @@ fixed set, not an arithmetic offset.
 
 ** Uses
 
-- As an alternative bucketing scheme for position reporting.
+- As an alternative bucketing scheme for position reporting, alongside
+  standard monthly [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  buckets.
 - As the underlying schedule for Eurodollar / Short Sterling futures used
   in USD curve bootstrapping — see
   [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]'s

--- a/doc/knowledge/domain/interest_rate_curves.org
+++ b/doc/knowledge/domain/interest_rate_curves.org
@@ -2,18 +2,20 @@
 :ID: E808F432-2FDA-47E8-B003-1E8B908870FE
 :END:
 #+title: Interest Rate Curves
-#+description: Day-count conventions, discount factors, bootstrapping from deposits/FRAs/IRS/OIS, and interpolation methods for interest rate curves used in FX and rates pricing.
+#+description: Day-count conventions, discount factors, and bootstrapping from deposits/FRAs/IRS/OIS for interest rate curves used in FX and rates pricing.
 #+type: knowledge
 #+level: cross
 #+filetags: :knowledge:domain:finance:rates:curves:ore:
 #+created: 2026-05-25
-#+updated: 2026-05-25
+#+updated: 2026-07-12
 
 Interest rate curves are a core market data input in [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]].
 [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] uses them as discount and projection curves throughout valuation. This
-document covers day-count conventions, the bootstrapping process, and
-interpolation for a *single* curve. For how several curves compose into a
-funding/projection family for one currency, see
+document covers day-count conventions and the bootstrapping process for a
+*single* curve; for how the resulting pillars are interpolated between and
+extrapolated beyond, see [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]]
+and [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]]. For how several
+curves compose into a funding/projection family for one currency, see
 [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]]. For
 tenor labels and settlement conventions see
 [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
@@ -197,47 +199,6 @@ us what future floating fixings are expected to be. A system maintains multiple
 projection curves per currency — one for each floating tenor (3M LIBOR, 6M
 LIBOR, etc.) — because basis spreads mean 3M and 6M projections diverge. All
 projected cashflows are discounted using the funding (discount) curve.
-
-* Interpolation Methods
-
-A bootstrapped curve is defined only at its pillar tenors. Interpolation is
-required for any date between pillars.
-
-** Local Methods
-
-Local methods use only the immediately bracketing pillars; changing one pillar
-does not affect distant tenors.
-
-- *Log-Linear (Linear in log-DF)*: Discount factor changes by a constant ratio
-  every day within an interval. Daily forward rates are constant within each
-  interval. Simple and stable; the industry default for the short end.
-
-- *Zero-Linear (Linear in zero rate)*: Linear in $-\ln(DF)/t$. Daily forward
-  rates change at a constant rate within each interval.
-
-Both perform well in low-curvature regimes.
-
-** Non-Local Methods
-
-Non-local methods take into account the full shape of the curve, producing
-smoother results but introducing the risk that changing one pillar affects
-distant tenors.
-
-- *Cubic Spline*: Piecewise cubic polynomial fitted globally. Produces smooth
-  forward curves but can generate oscillations and negative forward rates in
-  extreme cases.
-
-- *Monotone Spline*: A shape-preserving variant of the cubic spline that
-  prevents oscillations while maintaining smoothness.
-
-A single curve may use different interpolation methods at different tenor
-ranges (e.g. log-linear at the short end, cubic spline beyond =2Y=). A /curve
-split tenor/ (typically =5Y=) separates the short-end and long-end spline
-segments, preventing changes at one end from propagating to the other.
-
-It is critical that all systems consuming the same curve agree on the
-interpolation method; different methods will produce different forward rates at
-off-pillar dates.
 
 * ORE Studio Notes
 

--- a/doc/knowledge/domain/interpolation.org
+++ b/doc/knowledge/domain/interpolation.org
@@ -1,0 +1,94 @@
+:PROPERTIES:
+:ID: 85B48CF7-3858-44C8-97AA-91D21C634A9D
+:END:
+#+title: Interpolation
+#+description: Why a term structure needs interpolation between pillars, and the local vs non-local method families used to provide it.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is only
+directly observed at its own pillar [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+points — a bootstrapped curve has no market-quoted value for a date that
+falls *between* two pillars, yet a consumer (a cash flow landing on an
+off-pillar date, a [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken
+date]] a user adds) still needs a value there. *Interpolation* is the rule
+that manufactures that value from the surrounding known points. Two
+families of interpolation method exist — local and non-local — trading off
+stability against smoothness, and the choice matters beyond aesthetics:
+different methods produce different forward rates at the same off-pillar
+date, so every system consuming a given curve must agree on which method
+that curve uses.
+
+* Detail
+
+** Why interpolation is needed
+
+A [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]] curve fixes a
+discount factor (or rate) at each of its pillar tenors and nowhere else.
+Anything that needs a value elsewhere *within* the pillar range — pricing
+a cash flow on an arbitrary date, resolving a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] a user has added
+to the ladder — must derive it from the pillars bracketing it. This is
+distinct from asking for a value *outside* the pillar range altogether,
+which is [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][extrapolation]], a
+related but separate concept with its own conventions.
+
+** Local methods
+
+Local methods use only the immediately bracketing pillars; changing one
+pillar does not affect distant tenors.
+
+- *Log-linear (linear in log-DF)*: the discount factor changes by a
+  constant ratio every day within an interval, so daily forward rates are
+  constant within each interval. Simple and stable; the industry default
+  for the short end.
+- *Zero-linear (linear in zero rate)*: linear in $-\ln(DF)/t$. Daily
+  forward rates change at a constant rate within each interval.
+
+Both perform well in low-curvature regimes.
+
+** Non-local methods
+
+Non-local methods take into account the full shape of the curve, producing
+smoother results but introducing the risk that changing one pillar affects
+distant tenors.
+
+- *Cubic spline*: a piecewise cubic polynomial fitted globally. Produces
+  smooth forward curves but can generate oscillations and negative forward
+  rates in extreme cases.
+- *Monotone spline*: a shape-preserving variant of the cubic spline that
+  prevents oscillations while maintaining smoothness.
+
+** Mixing methods and the curve split tenor
+
+A single curve may use different interpolation methods at different tenor
+ranges — e.g. log-linear at the short end, cubic spline beyond =2Y=. A
+*curve split tenor* (typically =5Y=) separates the short-end and long-end
+spline segments, preventing a change at one end from propagating to the
+other. The same split-tenor idea recurs on the volatility side: a
+volatility surface's default 5-year extent, described in
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]], is
+conventionally reused as its own curve split tenor.
+
+** Agreement across consuming systems
+
+It is critical that every system consuming the same curve agree on the
+interpolation method: different methods produce different forward rates
+at off-pillar dates, so a mismatch between, say, a pricer and a risk
+engine reading the same nominal curve produces silently inconsistent
+results rather than an error.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the sister concept for values outside the pillar range entirely.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series interpolation fills in the gaps of.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a curve's pillar range extends by curve type.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the entries on a ladder that interpolation, or a direct feed, resolves.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how an interpolated point is flagged as such.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — where these methods are applied to a concrete bootstrapped curve.

--- a/doc/knowledge/domain/multi_curve_grid_ui.org
+++ b/doc/knowledge/domain/multi_curve_grid_ui.org
@@ -47,9 +47,9 @@ responsible for assembling the family.
 *Requirement 2 — separation of review from construction.* Reviewing a
 curve family is a distinct concern from constructing one. Bootstrapping —
 selecting pillar instruments, resolving day-count conventions, choosing an
-interpolation method (see
-[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]) — is a
-separate workflow with its own inputs and its own failure modes. A review
+interpolation method (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
+Rate Curves]] and [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]])
+— is a separate workflow with its own inputs and its own failure modes. A review
 surface presents curves that already exist; it must not conflate the two
 responsibilities into one screen, since doing so would couple a read-only
 concern to a stateful, error-prone one.

--- a/doc/knowledge/domain/out_of_convention.org
+++ b/doc/knowledge/domain/out_of_convention.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 8582E7E9-D975-46D5-B61B-93B9EA3DECC0
+:END:
+#+title: Out Of Convention
+#+description: The reference point a forward rate ladder is quoted off (spot, tomorrow, or today), and why non-standard bases must be visually distinguished.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A forward rate ladder does not have one fixed reference point it is
+measured from — it can be expressed *out of* spot, tomorrow, or today, and
+which basis is in effect changes what a given
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] label actually resolves
+to. *Out of Spot* is the market default and the convention already assumed
+throughout [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s
+spot/forward curve conventions; *Out of Tomorrow* and *Out of Today* are
+non-standard alternatives that must be visually distinguished wherever
+they appear, since a tenor label under a non-standard basis silently means
+a different date than the same label would under the default.
+
+* Detail
+
+** The three bases
+
+A forward rate ladder can be expressed starting from different reference
+points:
+
+- *Out of Spot* (standard): rates beyond =S/N= are computed off spot —
+  this is the market default, and the convention
+  [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s "spot/forward
+  curves" section describes without further qualification.
+- *Out of Tomorrow*: rates beyond =T/N= are computed off tomorrow instead
+  of spot.
+- *Out of Today*: all rates are computed off today. Tenors in this mode
+  are non-standard and must be visually distinguished (e.g. highlighted)
+  to alert a user they are not reading the conventional spot-basis ladder.
+
+** Why the distinction matters
+
+Because a tenor label is only meaningful relative to a
+[[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][horizon date]], changing the
+basis a ladder is quoted *out of* changes what every tenor beyond the
+short end actually resolves to, even though the labels themselves (=1W=,
+=1M=, ...) do not change. A user reading =1M= on an Out of Today ladder
+and assuming the market-default Out of Spot basis would misread the
+maturity by however many days separate today from spot. Flagging a
+non-default basis visually is therefore not a cosmetic nicety — it is what
+prevents a silent misreading of every tenor on the ladder.
+
+** Where this applies beyond the FX forward ladder
+
+The basis distinction is not confined to the FX forward ladder it was
+first documented against: it applies identically wherever a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] is entered — a
+broken date added under a non-standard basis must be visually
+distinguished the same way a standard tenor under that basis would be, per
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s entry and display conventions.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the spot/forward curve convention this document's default basis matches.
+- [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every basis (spot, tomorrow, today) is itself a reference point relative to.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — where non-standard-basis visual flagging also applies, to broken dates specifically.

--- a/doc/knowledge/domain/tenor.org
+++ b/doc/knowledge/domain/tenor.org
@@ -27,23 +27,54 @@ but separate concept.
 ** Standard tenor labels
 
 The short end of the curve uses named tenors; the long end uses period
-notation.
+notation. The table below is the *union* of every tenor label attested
+across the source material this cluster draws on, in ascending order. No
+single curve necessarily carries every one of these as a live pillar —
+which subset is actually quoted (as opposed to filled in by interpolation)
+depends on the curve type and the liquidity of the underlying instrument
+at that point (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
+Rate Curves]] for the instrument-to-pillar mapping).
 
-| Tenor | Common Name  | Description                                                             |
-|-------+--------------+--------------------------------------------------------------------------|
-| =O/N= | Overnight    | From today to the next business day. The earliest possible tenor.       |
-| =T/N= | Tom/Next     | From tomorrow to the day after (i.e. from next business day to spot).  |
-| =S/N= | Spot/Next    | From spot to the next business day after spot.                          |
-| =S/W= | Spot/Week    | From spot to one week after spot (by convention, for rate curves).      |
-| =1W=  | One Week     | One week. For rate curves this is spot + 1W; for vol surfaces today + 1W. |
-| =1M=  | One Month    | One calendar month off spot (rates) or today (vols).                   |
-| =3M=  | Three Months | Three calendar months off spot.                                         |
-| =6M=  | Six Months   | Six calendar months off spot.                                           |
-| =1Y=  | One Year     | Twelve calendar months off spot.                                        |
+| Tenor | Common Name | Notes |
+|-------+-------------+-------|
+| =O/N= | Overnight | Today to next business day. Earliest possible tenor. |
+| =T/N= | Tom/Next | Next business day to spot. |
+| =S/N= | Spot/Next | Spot to spot + 1 business day. |
+| =S/W= | Spot/Week | Spot to spot + 1 week; also written =WK1= or =1W=. |
+| =1D=, =2D=, =3D= | Daily tenors | Used mainly on granular option-map/bucketing screens, not on bootstrapped curves. |
+| =1W=, =2W=, =3W=, =4W= | Weekly tenors | =1W= is a standard pillar everywhere; =2W=/=3W=/=4W= appear on consensus/IPV expiry ladders. |
+| =1M= | One Month | Standard short-end pillar (deposits/LIBOR). |
+| =2M= | Two Months | Appears on consensus/vol expiry ladders. |
+| =3M= | Three Months | Standard pillar; FRA/futures region begins here. |
+| =4M=, =5M= | Four/Five Months | Occasional intermediate points; not universal pillars. |
+| =6M= | Six Months | Standard pillar; short-end deposits may extend this far. |
+| =7M=, =8M= | Seven/Eight Months | Rare, mostly interpolated. |
+| =9M= | Nine Months | Standard pillar on consensus/vol expiry ladders. |
+| =12M= | Twelve Months | Equivalent to =1Y=; both labels appear depending on context (money-market vs. swap convention). |
+| =18M= | Eighteen Months | Explicit odd pillar between =1Y= and =2Y=, bootstrapped off a 3M fixed IRS. |
+| =2Y=-=10Y= | Annual pillars | =2Y=, =3Y=, =4Y=, =5Y=, =6Y=, =7Y=, =8Y=, =9Y=, =10Y=; bootstrapped from 3M-reset IRS. Not every consensus/vol provider supplies every one of these by design (e.g. =6Y=, =8Y=, =9Y= are commonly unsupported gaps, filled by interpolation). |
+| =12Y= | Twelve Years | Appears on consensus/vol expiry ladders between =10Y= and =15Y=. |
+| =15Y= | Fifteen Years | Standard long-end IRS pillar. |
+| =20Y= | Twenty Years | Standard long-end IRS pillar. |
+| =25Y= | Twenty-Five Years | Standard long-end IRS pillar. |
+| =30Y= | Thirty Years | Standard long-end IRS pillar — see [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for why this is the ceiling for interest rate curves specifically. |
 
 Longer tenors follow the pattern =nM= (months) or =nY= (years). Odd tenors
 between liquid points are [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken
 dates]].
+
+*** A distinct convention: cash/position bucketing
+
+Beyond the individually named labels above, positions and cash balances
+are sometimes bucketed using a coarser, purely calendar-based scheme
+instead of the curve-pillar ladder: =Nostro=, =Today=, =Tomorrow=,
+=Spot=, =1W=, then monthly buckets out to 24 months, or alternatively
+[[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM]]-date buckets. This is a
+*reporting/aggregation* convention, distinct in purpose from the
+curve-construction pillar ladder above, even where individual labels
+coincide — a position-bucketing =1W= is not being used to construct a
+term structure. Elaborating this bucketing scheme's own conventions is
+out of scope for this cluster, which is concerned with curve construction.
 
 ** Rates vs. vols convention
 
@@ -117,3 +148,23 @@ curve. A common disambiguation convention appends the roll quarter: e.g.
 - [[id:DF9EFAF9-1340-48F2-BFD9-1F4ED0ADBC76][Date Rolling and Business-Day Calendars]] — how a tenor date is adjusted onto a valid business day.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — odd tenors and fixed-calendar-time discontinuities.
 - [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM Dates]] — the quarterly roll dates behind the CDS tenor convention.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a curve built from these labels actually extends, by curve type.
+
+** Further reading: external references
+
+The short-end labels and the =<n><D|W|M|Y>= period pattern are not local
+convention — they are checked here against independent, citable technical
+sources rather than this cluster's own notebooks:
+
+- [[https://strata.opengamma.io/apidocs/com/opengamma/strata/basics/date/MarketTenor.html][OpenGamma Strata: MarketTenor]] — an open-source, industry-used quant
+  library's API documentation, defining =ON=/=TN=/=SN=/=SW= in terms
+  matching this document's almost exactly (=ON=: today to tomorrow, spot
+  lag 0; =TN=: tomorrow to the next day, spot lag 1; =SN=: spot to spot+1,
+  conventional spot lag; =SW=: one week from spot), and confirming
+  standard regular tenors (=2W=, =1M=, =1Y=, ...) are measured from spot
+  under the conventional spot lag.
+- [[https://www.fpml.org/spec/fpml-5-6-5-rec-1/html/confirmation/fpml-5-6-intro-6.html][FpML 5.6: Interest Rate Derivative Product Architecture]] — confirms the
+  =<n><D|W|M|Y>= pattern this document uses (=periodMultiplier= combined
+  with a =period= code, e.g. =6M=, =5Y=) is the actual ISDA/FpML standard
+  representation for a tenor, not an ad hoc parsing convention invented
+  for this codebase.

--- a/doc/knowledge/domain/term_structure.org
+++ b/doc/knowledge/domain/term_structure.org
@@ -38,9 +38,8 @@ date]], and carries metadata beyond the raw (tenor, value) pairs:
   non-deliverable instruments]]).
 - An interpolation method, used to derive values at dates falling between
   the term structure's own tenor points (see
-  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
-  concrete interpolation methods used for interest rate curves
-  specifically).
+  [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] for why this
+  is needed and the concrete local/non-local method families).
 
 One [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]] interest
 rate curve is one term structure; a
@@ -84,5 +83,8 @@ one value or a tenor-indexed series of values.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the individual points a term structure orders.
 - [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every term structure's tenor points are relative to.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete bootstrapping and interpolation mechanics for one interest rate term structure.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete bootstrapping mechanics for one interest rate term structure.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the concrete methods this document's interpolation-method metadata refers to.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the policy for values outside the term structure's own range entirely.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a term structure's own range extends, by curve type.
 - [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][Funding and Projection Curves]] — several term structures related by a discounting dependency, not one larger term structure.

--- a/doc/knowledge/domain/term_structure_extent.org
+++ b/doc/knowledge/domain/term_structure_extent.org
@@ -1,0 +1,86 @@
+:PROPERTIES:
+:ID: 6FFD22D7-5E83-405A-8069-52B96B9AF606
+:END:
+#+title: Term Structure Extent
+#+description: How far a term structure extends by curve type (30Y for IR, 5Y-default/30Y-available for vol, open-ended for CDS), and the flatten-beyond-the-end convention.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is defined by
+its constituent [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] points,
+but nothing in that definition says how *far* the series extends before
+stopping — that extent is itself a convention, and it differs materially by
+curve type: interest rate curves stop at a fixed 30-year ceiling,
+volatility surfaces default to a much shorter 5 years while remaining
+*able* to quote out to 30, and CDS curves have no fixed ceiling at all,
+running instead to whatever the longest live trade in the portfolio
+happens to be. A term structure's behaviour for a request *beyond* its own
+last point is a second, related convention — flatten, not extrapolate — a
+deliberate, explicit choice rather than a failure mode.
+
+* Detail
+
+** Interest rate curves: a fixed 30-year ceiling
+
+For interest rate (discount/projection) curves, the long end is
+consistently *30Y* — =15Y=, =20Y=, =25Y=, =30Y= are named together as the
+standard long-end IRS pillars (see
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s standard label table),
+and the consensus-provider expiry list likewise terminates at 30 years.
+Where a curve genuinely has no tenor beyond its last pillar, the system
+does not silently fail a request past that point; it applies the
+beyond-the-end convention below. If asked whether an interest rate curve
+should extend to 30Y or 50Y, the answer is unambiguously 30Y — 50Y does
+not appear as a curve length anywhere in the source material this cluster
+draws on.
+
+** Volatility surfaces: a practical default, not a hard ceiling
+
+For [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX volatility surfaces]],
+data normally extends only to *5Y*, and that same 5Y point is
+conventionally reused as the surface's short-end/long-end *curve split
+tenor* for interpolation purposes. This is a *practical default*, not a
+structural limit: it must remain possible to view or quote a vol surface
+out to 30Y on request. Beyond the liquid ATM region, a common quoting
+convention applies a Zero Delta Straddle (delta-neutral straddle) out to
+10Y, then an ATM Forward from 12Y through 30Y — a different quoting basis
+for the illiquid long end, not an extension of the same liquid-region
+convention.
+
+** CDS curves: open-ended, portfolio-driven
+
+CDS/credit exposure has no fixed maximum tenor at all. Rather than a
+pillar-based ceiling, it runs "up to the longest maturity of the
+portfolio" — open-ended, and determined by whichever live trade happens to
+be longest, not by a fixed curve length the way IR and vol curves are.
+
+** Beyond the end: flatten, not extrapolate
+
+Three distinct regions exist relative to a term structure's known points:
+
+- *Between* two known points: interpolate. Log-linear is the preferred
+  method; polynomial methods are best avoided for this purpose (see
+  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
+  full local/non-local interpolation method comparison).
+- *Before* the start of the curve: extrapolate.
+- *Beyond* the end of the curve: the convention is to *flatten* — hold the
+  last known value constant — and extrapolate only in rare, explicitly
+  justified cases. This is the deliberate resolution of "what happens past
+  30Y (IR) / past 5Y (vol, if not quoting out further) / past the
+  portfolio's longest CDS trade": the system does not silently fail, and
+  it does not default to extrapolation, which would manufacture a value
+  with no basis. It holds the curve flat instead.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series this document states the extent of.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard long-end labels (15Y-30Y) that define the IR ceiling.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how interpolated/extrapolated/flattened points are tracked and distinguished from directly-quoted ones.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the interpolation methods used between known points.
+- [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the 5Y default extent and curve-split tenor in its native context.

--- a/doc/knowledge/domain/term_structure_extent.org
+++ b/doc/knowledge/domain/term_structure_extent.org
@@ -61,26 +61,24 @@ be longest, not by a fixed curve length the way IR and vol curves are.
 
 ** Beyond the end: flatten, not extrapolate
 
-Three distinct regions exist relative to a term structure's known points:
-
-- *Between* two known points: interpolate. Log-linear is the preferred
-  method; polynomial methods are best avoided for this purpose (see
-  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
-  full local/non-local interpolation method comparison).
-- *Before* the start of the curve: extrapolate.
-- *Beyond* the end of the curve: the convention is to *flatten* — hold the
-  last known value constant — and extrapolate only in rare, explicitly
-  justified cases. This is the deliberate resolution of "what happens past
-  30Y (IR) / past 5Y (vol, if not quoting out further) / past the
-  portfolio's longest CDS trade": the system does not silently fail, and
-  it does not default to extrapolation, which would manufacture a value
-  with no basis. It holds the curve flat instead.
+What happens past 30Y (IR) / past 5Y (vol, if not quoting out further) /
+past the portfolio's longest CDS trade is governed by
+[[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]]'s general
+beyond-the-end policy: the system does not silently fail, and it does not
+default to extrapolation, which would manufacture a value with no basis —
+it holds the curve flat instead. See
+[[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] for the full
+policy, including the asymmetry with the before-the-start case, and
+[[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] for how the
+region *between* known points is handled instead.
 
 * See also
 
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series this document states the extent of.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard long-end labels (15Y-30Y) that define the IR ceiling.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the general before-the-start/beyond-the-end policy this document's curve-type-specific ceilings feed into.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how interpolated/extrapolated/flattened points are tracked and distinguished from directly-quoted ones.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the interpolation methods used between known points.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — where these methods are applied to a concrete bootstrapped curve.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the 5Y default extent and curve-split tenor in its native context.

--- a/doc/knowledge/domain/time_structures_and_tenors.org
+++ b/doc/knowledge/domain/time_structures_and_tenors.org
@@ -65,6 +65,14 @@ for vol surface tenors see
   Point Provenance]] (rejected/interpolated/back-filled/overridden
   metadata, and why a broken date is never promoted into a standard
   tenor).
+- *Filling the gaps* → [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]]
+  (local vs. non-local methods, the curve split tenor) and
+  [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] (before the
+  start vs. flattening beyond the end).
+- *Which reference point a ladder is quoted off* →
+  [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] (Out of
+  Spot, Tomorrow, or Today, and why non-default bases must be visually
+  flagged).
 
 ** Where these concepts are consumed
 
@@ -80,11 +88,18 @@ Families]]. For the equivalent tenor concept on the volatility side, see
 
 ** Deferred: FX short-end forward conventions
 
-The following FX-specific conventions were part of this document's
-previous, monolithic form and are preserved here verbatim rather than
-atomized, since they are out of scope for the current interest-rate work
-and it would be premature to design their final home before returning to
-them.
+The following FX-settlement-specific conventions were part of this
+document's previous, monolithic form and are preserved here verbatim
+rather than atomized, since they are out of scope for the current
+interest-rate work and it would be premature to design their final home
+before returning to them. The *"Out Of" convention* that used to sit
+alongside these has since been promoted to its own atomic doc,
+[[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]], rather than
+staying deferred here — unlike the two conventions below, it is not
+FX-settlement-specific: it is a general spot/forward-curve quoting-basis
+convention already load-bearing for
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s entry and display rules.
 
 *** Spot days and the pre-spot region
 
@@ -102,16 +117,6 @@ must be adjusted by the short-end rates:
 - *T+2 spot currencies*:
   - Outright today = Spot rate − T/N points × scaling factor − O/N points × scaling factor
   - Outright tomorrow = Spot rate − T/N points × scaling factor
-
-*** The "Out Of" convention on forward ladders
-
-A forward rate ladder can be expressed starting from different reference
-points:
-
-- *Out of Spot* (standard): rates beyond =S/N= are computed off spot.
-- *Out of Tomorrow*: rates beyond =T/N= are computed off tomorrow.
-- *Out of Today*: all rates are computed off today. Tenors in this mode are
-  non-standard and should be visually distinguished to alert users.
 
 *** Tom/Next and funding
 

--- a/doc/knowledge/domain/time_structures_and_tenors.org
+++ b/doc/knowledge/domain/time_structures_and_tenors.org
@@ -52,9 +52,19 @@ for vol surface tenors see
   standard rolling conventions).
 - *Irregular dates* → [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken
   Dates and Turn Points]] (bespoke maturities vs. fixed-calendar-time
-  discontinuities) and [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM
-  Dates]] (the fixed quarterly roll schedule CDS and STIR futures use
-  instead of horizon-relative tenor arithmetic).
+  discontinuities, the three-way tenor classification, and how broken
+  dates are entered/displayed) and
+  [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM Dates]] (the fixed
+  quarterly roll schedule CDS and STIR futures use instead of
+  horizon-relative tenor arithmetic).
+- *How far a curve goes* → [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term
+  Structure Extent]] (30Y for interest rate curves, 5Y-default/30Y-available
+  for vol surfaces, open-ended for CDS, and the flatten-beyond-the-end
+  convention).
+- *Tracking a point's history* → [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve
+  Point Provenance]] (rejected/interpolated/back-filled/overridden
+  metadata, and why a broken date is never promoted into a standard
+  tenor).
 
 ** Where these concepts are consumed
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -59,7 +59,7 @@ Finance concepts the codebase relies on, grouped by topic.
 ** Rates and curves
 
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — day-count conventions, discount factors,
-  bootstrapping, and interpolation methods for rate curves.
+  and bootstrapping for rate curves.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — hub note for how a currency's
   curves compose beyond a single curve: funding/projection families,
   multi-curve build order, storage grouping, the review UI, and

--- a/doc/llm/skills/code-add-domain-type/SKILL.org
+++ b/doc/llm/skills/code-add-domain-type/SKILL.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :llm:skill:skills:claude_code:domain:codegen:
 #+created: 2024-09-01
-#+updated: 2026-06-06
+#+updated: 2026-07-12
 
 #+begin_export markdown
 ---
@@ -27,18 +27,41 @@ support. This is the mandatory first step before any exposure layer
 
 * How to use this skill
 
-Codegen is the primary path. Manual creation is a last resort and must
-be justified in the file header.
+Codegen is the primary path for a *persisted, data-carrying* entity
+(one with SQL storage, and usually a UI). Manual creation is
+appropriate — not a last resort — for a behaviour-heavy value type
+(parsing, comparison operators, computed methods) with no persistence
+or generated UI: none of codegen's entity-model types generate that
+shape, they generate flat data-carrying structs plus persistence/UI
+layers. See e.g. =ores.analytics.quant='s own domain types
+(=currency_id=, =ccy_pair=, ...), which are hand-authored for exactly
+this reason — no codegen banner, not listed in
+=compass codegen entity list=. Justify the choice in the file header
+either way.
 
-1. /Create a JSON model/ in =projects/ores.codegen/models/{component}/=
-   following the =*_domain_entity.json= or =*_junction.json= naming
-   convention. See [[id:08FBD248-257A-A474-DD43-DB08949978F1][ORE Studio Codegen]] for the model schema and
-   available fields. Type mappings are in [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]]§"Type
-   mappings".
+1. /Create an org-mode entity model/ under the target component's
+   =modeling/= directory (co-located org models — see the
+   =component_catalogue.org='s =modeling_dir= column), following the
+   =ores.codegen.entity= (full entity: C++ + SQL + Qt),
+   =ores.codegen.lookup_entity= (SQL-only reference table),
+   =ores.codegen.field_group= (flat C++ struct fragment composed into
+   a parent entity), =ores.codegen.table=, or =ores.codegen.junction=
+   schema — see [[id:2A2E8B6D-179D-452C-9169-04E6BB46CC07][Codegen input org-file schema reference]] for the
+   authoritative frontmatter keywords and section hierarchy per type.
+   (The legacy =*_domain_entity.json=/=models/{component}/= format
+   this step used to reference no longer exists in the repo — org-mode
+   entity models superseded it.) Scaffold via =compass add --type
+   entity_org ...= (or =field_group=/=table=/=junction=/
+   =lookup_entity= as appropriate) per [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with
+   compass?]], then fill in the sections by hand.
 
-2. /Generate all C++ artefacts/ (files written directly to the project
-   tree — no copy step):
-   =cd projects/ores.codegen && ./run_generator.sh models/{component}/{entity}_domain_entity.json --profile all-cpp=
+2. /Generate the C++ artefacts/ via compass, not the generator script
+   directly:
+   =compass codegen generate --model <path/to/model.org> --profile all-cpp=
+   (=compass codegen entity generate <entity>= regenerates an
+   already-modelled entity's applicable profiles;
+   =compass codegen entity list= / =show= / =diff= inspect what
+   exists and whether it's stale).
 
 3. /Build and verify/: use [[id:654D4A70-E63D-4C18-B5A5-886066E36314][cmake-runner]] to confirm the component
    library compiles cleanly.

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/domain/tenor.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/domain/tenor.hpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_MARKETDATA_API_DOMAIN_TENOR_HPP
+#define ORES_MARKETDATA_API_DOMAIN_TENOR_HPP
+
+#include "ores.marketdata.api/export.hpp"
+#include <chrono>
+#include <compare>
+#include <string>
+#include <string_view>
+
+namespace ores::marketdata::domain {
+
+/**
+ * @brief The unit a tenor::count is expressed in.
+ */
+enum class tenor_unit { days, weeks, months, years };
+
+/**
+ * @brief A lightweight, QuantLib-free tenor: a label identifying a point in
+ * time relative to a horizon date (see
+ * doc/knowledge/domain/tenor.org and doc/knowledge/domain/horizon_date.org).
+ *
+ * Deliberately does not model business-day calendars or holiday rolling —
+ * that level of precision belongs to actual curve bootstrapping, which is
+ * out of scope here (see doc/knowledge/domain/date_rolling_and_business_day_calendars.org).
+ * The short-end labels (O/N, T/N, S/N, S/W) are approximated as fixed day
+ * counts from the horizon date rather than resolved against real
+ * spot-lag/holiday conventions.
+ */
+class ORES_MARKETDATA_API_EXPORT tenor final {
+public:
+    tenor() = default;
+    tenor(tenor_unit unit, int count) : unit_(unit), count_(count) {}
+
+    /**
+     * @brief Parses a standard tenor label (O/N, T/N, S/N, S/W, or the
+     * "<n><D|W|M|Y>" pattern, e.g. "1W", "3M", "2Y") into a tenor.
+     *
+     * @param label The tenor label to parse.
+     * @throws std::invalid_argument if the label is not a recognised tenor.
+     */
+    static tenor parse(std::string_view label);
+
+    tenor_unit unit() const { return unit_; }
+    int count() const { return count_; }
+
+    /**
+     * @brief Approximate length in calendar days, used only to order and
+     * compare tenors against one another (not for date arithmetic).
+     */
+    int approx_days() const;
+
+    /**
+     * @brief Resolves this tenor to an end date relative to a horizon date,
+     * using std::chrono calendar arithmetic (no business-day adjustment).
+     */
+    std::chrono::year_month_day end_date(std::chrono::year_month_day horizon) const;
+
+    std::strong_ordering operator<=>(const tenor& other) const {
+        return approx_days() <=> other.approx_days();
+    }
+    bool operator==(const tenor& other) const = default;
+
+private:
+    tenor_unit unit_{tenor_unit::days};
+    int count_{0};
+};
+
+/**
+ * @brief A half-open date window [start, end) anchored to a horizon date and
+ * a tenor.
+ */
+struct tenor_window final {
+    std::chrono::year_month_day start;
+    std::chrono::year_month_day end;
+};
+
+/**
+ * @brief Resolves a (horizon, tenor) pair into its [start, end) date window,
+ * where start is the horizon date itself.
+ */
+ORES_MARKETDATA_API_EXPORT tenor_window
+resolve_window(std::chrono::year_month_day horizon, const tenor& t);
+
+/**
+ * @brief Whether two half-open date windows [a.start, a.end) and
+ * [b.start, b.end) overlap.
+ */
+ORES_MARKETDATA_API_EXPORT bool windows_overlap(const tenor_window& a, const tenor_window& b);
+
+}
+
+#endif

--- a/projects/ores.marketdata/api/src/domain/tenor.cpp
+++ b/projects/ores.marketdata/api/src/domain/tenor.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.marketdata.api/domain/tenor.hpp"
+#include <charconv>
+#include <stdexcept>
+
+namespace ores::marketdata::domain {
+
+namespace {
+
+// Short-end labels are approximated as fixed day counts from the horizon
+// date, rather than resolved against real spot-lag/holiday conventions
+// (out of scope here — see class comment).
+constexpr int overnight_days = 1;
+constexpr int tom_next_days = 2;
+constexpr int spot_next_days = 3;
+constexpr int spot_week_days = 9; // spot (day 2) + one week.
+
+int days_per_unit(tenor_unit unit) {
+    switch (unit) {
+    case tenor_unit::days: return 1;
+    case tenor_unit::weeks: return 7;
+    case tenor_unit::months: return 30;
+    case tenor_unit::years: return 365;
+    }
+    throw std::invalid_argument("Unrecognised tenor_unit");
+}
+
+}
+
+tenor tenor::parse(std::string_view label) {
+    if (label == "O/N") return tenor(tenor_unit::days, overnight_days);
+    if (label == "T/N") return tenor(tenor_unit::days, tom_next_days);
+    if (label == "S/N") return tenor(tenor_unit::days, spot_next_days);
+    if (label == "S/W") return tenor(tenor_unit::days, spot_week_days);
+
+    if (label.size() < 2)
+        throw std::invalid_argument("Tenor label too short: " + std::string(label));
+
+    const char unitChar = label.back();
+    tenor_unit unit;
+    switch (unitChar) {
+    case 'D': unit = tenor_unit::days; break;
+    case 'W': unit = tenor_unit::weeks; break;
+    case 'M': unit = tenor_unit::months; break;
+    case 'Y': unit = tenor_unit::years; break;
+    default:
+        throw std::invalid_argument("Unrecognised tenor label: " + std::string(label));
+    }
+
+    const auto digits = label.substr(0, label.size() - 1);
+    int count = 0;
+    const auto result = std::from_chars(digits.data(), digits.data() + digits.size(), count);
+    if (result.ec != std::errc() || result.ptr != digits.data() + digits.size() || count <= 0)
+        throw std::invalid_argument("Unrecognised tenor label: " + std::string(label));
+
+    return tenor(unit, count);
+}
+
+int tenor::approx_days() const { return count_ * days_per_unit(unit_); }
+
+std::chrono::year_month_day tenor::end_date(std::chrono::year_month_day horizon) const {
+    using namespace std::chrono;
+
+    switch (unit_) {
+    case tenor_unit::days:
+        return year_month_day(sys_days(horizon) + days(count_));
+    case tenor_unit::weeks:
+        return year_month_day(sys_days(horizon) + weeks(count_));
+    case tenor_unit::months: {
+        auto shifted = horizon + months(count_);
+        if (!shifted.ok())
+            shifted = year_month_day_last(shifted.year() / shifted.month() / last);
+        return shifted;
+    }
+    case tenor_unit::years: {
+        auto shifted = horizon + years(count_);
+        if (!shifted.ok())
+            shifted = year_month_day_last(shifted.year() / shifted.month() / last);
+        return shifted;
+    }
+    }
+    throw std::invalid_argument("Unrecognised tenor_unit");
+}
+
+tenor_window resolve_window(std::chrono::year_month_day horizon, const tenor& t) {
+    return tenor_window{horizon, t.end_date(horizon)};
+}
+
+bool windows_overlap(const tenor_window& a, const tenor_window& b) {
+    return a.start < b.end && b.start < a.end;
+}
+
+}

--- a/projects/ores.marketdata/api/tests/domain_tenor_tests.cpp
+++ b/projects/ores.marketdata/api/tests/domain_tenor_tests.cpp
@@ -1,0 +1,168 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.marketdata.api/domain/tenor.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+const std::string tags("[tenor]");
+
+}
+
+TEST_CASE("tenor_parse_recognises_short_end_labels", tags) {
+    using ores::marketdata::domain::tenor;
+    using ores::marketdata::domain::tenor_unit;
+
+    auto on = tenor::parse("O/N");
+    CHECK(on.unit() == tenor_unit::days);
+    CHECK(on.count() == 1);
+
+    auto tn = tenor::parse("T/N");
+    CHECK(tn.unit() == tenor_unit::days);
+    CHECK(tn.count() == 2);
+
+    auto sn = tenor::parse("S/N");
+    CHECK(sn.unit() == tenor_unit::days);
+
+    auto sw = tenor::parse("S/W");
+    CHECK(sw.unit() == tenor_unit::days);
+}
+
+TEST_CASE("tenor_parse_recognises_period_labels", tags) {
+    using ores::marketdata::domain::tenor;
+    using ores::marketdata::domain::tenor_unit;
+
+    auto oneWeek = tenor::parse("1W");
+    CHECK(oneWeek.unit() == tenor_unit::weeks);
+    CHECK(oneWeek.count() == 1);
+
+    auto threeMonths = tenor::parse("3M");
+    CHECK(threeMonths.unit() == tenor_unit::months);
+    CHECK(threeMonths.count() == 3);
+
+    auto twoYears = tenor::parse("2Y");
+    CHECK(twoYears.unit() == tenor_unit::years);
+    CHECK(twoYears.count() == 2);
+
+    auto tenDays = tenor::parse("10D");
+    CHECK(tenDays.unit() == tenor_unit::days);
+    CHECK(tenDays.count() == 10);
+}
+
+TEST_CASE("tenor_parse_rejects_malformed_labels", tags) {
+    using ores::marketdata::domain::tenor;
+
+    CHECK_THROWS_AS(tenor::parse(""), std::invalid_argument);
+    CHECK_THROWS_AS(tenor::parse("X"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor::parse("3Q"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor::parse("M3"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor::parse("-1Y"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor::parse("0M"), std::invalid_argument);
+}
+
+TEST_CASE("tenor_orders_by_approximate_length", tags) {
+    using ores::marketdata::domain::tenor;
+
+    CHECK(tenor::parse("O/N") < tenor::parse("1W"));
+    CHECK(tenor::parse("1W") < tenor::parse("1M"));
+    CHECK(tenor::parse("1M") < tenor::parse("1Y"));
+    CHECK(tenor::parse("3M") < tenor::parse("6M"));
+    CHECK(tenor::parse("12M") == tenor::parse("12M"));
+}
+
+TEST_CASE("tenor_end_date_adds_days_and_weeks", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor;
+
+    const year_month_day horizon{year(2026), month(1), day(15)};
+
+    auto oneWeekEnd = tenor::parse("1W").end_date(horizon);
+    CHECK(oneWeekEnd == year_month_day{year(2026), month(1), day(22)});
+
+    auto tenDaysEnd = tenor::parse("10D").end_date(horizon);
+    CHECK(tenDaysEnd == year_month_day{year(2026), month(1), day(25)});
+}
+
+TEST_CASE("tenor_end_date_adds_months_and_years", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor;
+
+    const year_month_day horizon{year(2026), month(1), day(15)};
+
+    auto threeMonthsEnd = tenor::parse("3M").end_date(horizon);
+    CHECK(threeMonthsEnd == year_month_day{year(2026), month(4), day(15)});
+
+    auto oneYearEnd = tenor::parse("1Y").end_date(horizon);
+    CHECK(oneYearEnd == year_month_day{year(2027), month(1), day(15)});
+}
+
+TEST_CASE("tenor_end_date_clamps_to_last_valid_day_of_month", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor;
+
+    // 31 Jan + 1M has no 31 Feb: must clamp to the last day of February.
+    const year_month_day horizon{year(2026), month(1), day(31)};
+
+    auto oneMonthEnd = tenor::parse("1M").end_date(horizon);
+    CHECK(oneMonthEnd == year_month_day{year(2026), month(2), day(28)});
+}
+
+TEST_CASE("windows_overlap_detects_overlapping_windows", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    // A 3M deposit window and a 2M-3M FRA-like window overlap.
+    auto deposit = resolve_window(horizon, tenor::parse("3M"));
+    auto overlapping = resolve_window(horizon + months(2), tenor::parse("3M"));
+
+    CHECK(ores::marketdata::domain::windows_overlap(deposit, overlapping));
+}
+
+TEST_CASE("windows_overlap_returns_false_for_disjoint_windows", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    auto first = resolve_window(horizon, tenor::parse("1M"));
+    auto secondStart = horizon + months(2);
+    auto second = resolve_window(secondStart, tenor::parse("1M"));
+
+    CHECK_FALSE(ores::marketdata::domain::windows_overlap(first, second));
+}
+
+TEST_CASE("windows_overlap_treats_windows_as_half_open", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    // Second window starts exactly where the first ends: half-open windows
+    // must not count that as an overlap.
+    auto first = resolve_window(horizon, tenor::parse("1M"));
+    auto second = resolve_window(first.end, tenor::parse("1M"));
+
+    CHECK_FALSE(ores::marketdata::domain::windows_overlap(first, second));
+}


### PR DESCRIPTION
## Summary

Completes the tenor-type task: parses standard tenor labels, resolves them to calendar dates off a horizon date, and supports half-open date-window overlap checks -- the prerequisite for the tenor-collision validator task. Hand-authored in ores.marketdata.api (not ores.utility, not codegen -- see task Notes).

## Changes

- ores::marketdata::domain::tenor: parses O/N, T/N, S/N, S/W, and <n><D|W|M|Y>; end_date() via std::chrono with month/year-overflow clamping; resolve_window()/windows_overlap() for date-window overlap checks
- 10 test cases / 33 assertions; full ores.marketdata.api.tests suite (110 assertions / 24 cases) green
- Fixed stale code-add-domain-type skill instructions (JSON model path no longer exists; real format is org-mode entity docs via compass codegen generate), discovered while confirming codegen wasn't the right tool for this value type
- Verification: local build clean (linux-clang-debug-make); ores.marketdata.api.tests 110/110 assertions passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [IR Rates synthetic data generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.html) | 3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98 |
| Task | [Lightweight QuantLib-free tenor type](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.html) | 3D39EF0A-585F-4C66-B84F-433CAFA4DEB2 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)