### PR TITLE
[history] Add history_handler and single-subject registrar

### DIFF
--- a/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
+++ b/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
@@ -71,5 +71,11 @@ via its "Verifies task" field.
 | 2 | dispatch_registry not thread-safe (cf. event_channel_registry mutex) | dispatch_registry.hpp | Declined | Scaffolding increment; registration happens at startup before dispatch, no concurrent access yet. Revisit when real providers are wired |
 | 3 | dispatch_registry copyable/movable by default | dispatch_registry.hpp | Declined | Minor; not an issue at current scope, no single-owned-instance requirement yet |
 | 4 | get_entity_history_response field order differs from workflow_query_protocol.hpp sibling | history_protocol.hpp | Declined | Cosmetic, not house-style-mandated |
+| 5 | decode failure leaves the caller hanging (no error_reply) | history_handler.hpp | Accepted | Added error_reply(bad_request) on the decode-failure path, matching every other handler in the codebase |
+| 6 | dispatch_registry parameter/member could be const& (only const dispatch() is called) | history_handler.hpp, registrar.hpp/.cpp | Accepted | Tightened to const service::dispatch_registry& throughout |
+| 7 | no auth/tenant-scoping on the generic handler; history_provider has no context parameter | history_handler.hpp, dispatch_registry.hpp | Declined for this increment | No service registers a real provider yet, so this is inert. Tracked as design work for the "wire real per-entity providers" increment — history_provider's signature will need a context/tenant parameter before any provider touches per-tenant data |
+| 8 | no unit tests for history_handler/registrar | history_handler.hpp, registrar.cpp | Declined | Matches existing convention — no other component's NATS handler/registrar pairs are unit-tested directly (need a live client); covered by dispatch_registry's own tests plus future integration tests |
+| 9 | registrar is a free function returning one subscription, unlike the class + vector<subscription> shape used elsewhere | registrar.hpp/.cpp | Declined | Deliberate: there is exactly one shared subject, not N per-entity ones |
+| 10 | messaging namespace reopened twice in the PlantUML diagram | ores.history.puml | Accepted | Merged into a single namespace block |
 
 * Result

--- a/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
+++ b/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
@@ -28,10 +28,10 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs onto HistoryDialogBase]] |
-| Now          | Not yet started.                       |
+| Now          | history_handler + register_history_handlers wired (single history.v1.get subject); no service registers real providers yet. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-11                               |
+| Next         | Wire real per-entity providers (repository + codegen'd render_{entity}_fields()) into a dispatch_registry per service, and remove the old per-entity get_<entity>_history subjects as each entity migrates. |
+| Last touched | 2026-07-12                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
+++ b/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.org
@@ -8,7 +8,7 @@
 #+filetags: :consolidate_history_dialogs:sprint_23:v0:
 #+owner: marco
 #+branch: feature/generic-history-subject
-#+pr: 1521
+#+pr: 1523
 #+blocked_on: 5C873944-1152-4A79-9C92-C24AEB65834A
 #+blocked_since:
 #+created: 2026-07-11
@@ -60,6 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1523][#1523]] | [history] Add history_handler and single-subject registrar |
 | [[https://github.com/OreStudio/OreStudio/pull/1521][#1521]] | [history] Add ores.history component with dispatch registry |
 
 * Review

--- a/projects/ores.history/include/ores.history/messaging/history_handler.hpp
+++ b/projects/ores.history/include/ores.history/messaging/history_handler.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_HISTORY_MESSAGING_HISTORY_HANDLER_HPP
+#define ORES_HISTORY_MESSAGING_HISTORY_HANDLER_HPP
+
+#include "ores.history/export.hpp"
+#include "ores.history/messaging/history_protocol.hpp"
+#include "ores.history/service/dispatch_registry.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+
+namespace ores::history::messaging {
+
+namespace {
+
+inline auto& history_handler_lg() {
+    static auto instance = ores::logging::make_logger("ores.history.messaging.history_handler");
+    return instance;
+}
+
+} // namespace
+
+/**
+ * @brief NATS handler for the one generic history subject.
+ *
+ * Decodes a get_entity_history_request, delegates to the injected
+ * dispatch_registry (which never throws — see its dispatch() doc), and
+ * replies with the resulting response. The registry itself owns all
+ * per-entity dispatch logic; this class is purely the NATS decode/reply
+ * glue shared by every entity, replacing what would otherwise be N
+ * near-identical per-entity history() methods.
+ */
+class ORES_HISTORY_EXPORT history_handler final {
+public:
+    history_handler(ores::nats::service::client& nats, service::dispatch_registry& registry)
+        : nats_(nats), registry_(registry) {}
+
+    void history(ores::nats::message msg) const {
+        using ores::service::messaging::decode;
+        using ores::service::messaging::log_handler_entry;
+        using ores::service::messaging::reply;
+        using namespace ores::logging;
+
+        [[maybe_unused]] const auto correlation_id = log_handler_entry(history_handler_lg(), msg);
+        auto req = decode<get_entity_history_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(history_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            return;
+        }
+        const auto resp = registry_.dispatch(*req);
+        BOOST_LOG_SEV(history_handler_lg(), debug) << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    service::dispatch_registry& registry_;
+};
+
+}
+
+#endif

--- a/projects/ores.history/include/ores.history/messaging/history_handler.hpp
+++ b/projects/ores.history/include/ores.history/messaging/history_handler.hpp
@@ -51,11 +51,12 @@ inline auto& history_handler_lg() {
  */
 class ORES_HISTORY_EXPORT history_handler final {
 public:
-    history_handler(ores::nats::service::client& nats, service::dispatch_registry& registry)
+    history_handler(ores::nats::service::client& nats, const service::dispatch_registry& registry)
         : nats_(nats), registry_(registry) {}
 
     void history(ores::nats::message msg) const {
         using ores::service::messaging::decode;
+        using ores::service::messaging::error_reply;
         using ores::service::messaging::log_handler_entry;
         using ores::service::messaging::reply;
         using namespace ores::logging;
@@ -64,6 +65,7 @@ public:
         auto req = decode<get_entity_history_request>(msg);
         if (!req) {
             BOOST_LOG_SEV(history_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
             return;
         }
         const auto resp = registry_.dispatch(*req);
@@ -73,7 +75,7 @@ public:
 
 private:
     ores::nats::service::client& nats_;
-    service::dispatch_registry& registry_;
+    const service::dispatch_registry& registry_;
 };
 
 }

--- a/projects/ores.history/include/ores.history/messaging/registrar.hpp
+++ b/projects/ores.history/include/ores.history/messaging/registrar.hpp
@@ -37,7 +37,7 @@ namespace ores::history::messaging {
  */
 ORES_HISTORY_EXPORT ores::nats::service::subscription
 register_history_handlers(ores::nats::service::client& nats,
-                          service::dispatch_registry& registry,
+                          const service::dispatch_registry& registry,
                           std::string_view queue_group);
 
 }

--- a/projects/ores.history/include/ores.history/messaging/registrar.hpp
+++ b/projects/ores.history/include/ores.history/messaging/registrar.hpp
@@ -1,0 +1,45 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_HISTORY_MESSAGING_REGISTRAR_HPP
+#define ORES_HISTORY_MESSAGING_REGISTRAR_HPP
+
+#include "ores.history/export.hpp"
+#include "ores.history/service/dispatch_registry.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.nats/service/subscription.hpp"
+
+namespace ores::history::messaging {
+
+/**
+ * @brief Subscribes the one generic history subject (history.v1.get) to a
+ * history_handler backed by @p registry, under the given queue group.
+ *
+ * Call once per service process, after registering that service's own
+ * entities' providers on @p registry. Owns no state itself: registry must
+ * outlive the returned subscription.
+ */
+ORES_HISTORY_EXPORT ores::nats::service::subscription
+register_history_handlers(ores::nats::service::client& nats,
+                          service::dispatch_registry& registry,
+                          std::string_view queue_group);
+
+}
+
+#endif

--- a/projects/ores.history/modeling/component_overview.org
+++ b/projects/ores.history/modeling/component_overview.org
@@ -55,11 +55,21 @@ crosses the wire for history; every frontend renders the same shape.
 - =include/ores.history/service/dispatch_registry.hpp= — the
   server-side registry: =register_history_provider(entity_type, fn)=
   and =dispatch(entity_type, entity_id)=.
+- =include/ores.history/messaging/history_handler.hpp= — the NATS
+  decode/dispatch/reply glue shared by every entity.
+- =include/ores.history/messaging/registrar.hpp= —
+  =register_history_handlers(nats, registry, queue_group)=, subscribing
+  the single =history.v1.get= subject to a =history_handler= backed by
+  a caller-owned =dispatch_registry=. Call once per service process,
+  after registering that service's own entities' providers.
 
 * Dependencies
 
 - [[id:45754809-C069-41D4-A7E4-23CC686FE8E4][ores.diff]] — =field_value=/=diff_result= embedded in
   =entity_history_version=.
+- =ores.nats= / =ores.service= / =ores.logging= — the NATS
+  subscribe/decode/reply plumbing used by =history_handler= and
+  =registrar=.
 - std and =rfl= only beyond that — deliberately a leaf so every domain
   service depends on it without cycles, matching =ores.diff='s
   dependency discipline.

--- a/projects/ores.history/modeling/ores.history.puml
+++ b/projects/ores.history/modeling/ores.history.puml
@@ -49,6 +49,13 @@ namespace ores #F2F2F2 {
             get_entity_history_response o-- entity_history_version
             entity_history_version ..> ores::diff::domain::field_value : renders
             entity_history_version ..> ores::diff::domain::diff_result : diffs
+
+            class history_handler <<class>> {
+                +history(msg) : void
+            }
+            history_handler --> service::dispatch_registry : dispatches via
+            history_handler ..> get_entity_history_request : decodes
+            history_handler ..> get_entity_history_response : replies with
         }
         namespace service #FEFECE {
             class dispatch_registry <<class>> {
@@ -59,14 +66,6 @@ namespace ores #F2F2F2 {
             }
             dispatch_registry ..> messaging::get_entity_history_request : consumes
             dispatch_registry ..> messaging::get_entity_history_response : produces
-        }
-        namespace messaging #FEFECE {
-            class history_handler <<class>> {
-                +history(msg) : void
-            }
-            history_handler --> service::dispatch_registry : dispatches via
-            history_handler ..> get_entity_history_request : decodes
-            history_handler ..> get_entity_history_response : replies with
         }
     }
 }

--- a/projects/ores.history/modeling/ores.history.puml
+++ b/projects/ores.history/modeling/ores.history.puml
@@ -60,7 +60,21 @@ namespace ores #F2F2F2 {
             dispatch_registry ..> messaging::get_entity_history_request : consumes
             dispatch_registry ..> messaging::get_entity_history_response : produces
         }
+        namespace messaging #FEFECE {
+            class history_handler <<class>> {
+                +history(msg) : void
+            }
+            history_handler --> service::dispatch_registry : dispatches via
+            history_handler ..> get_entity_history_request : decodes
+            history_handler ..> get_entity_history_response : replies with
+        }
     }
 }
+
+note right of ores::history::messaging::history_handler
+  register_history_handlers(nats, registry, queue_group)
+  subscribes the single history.v1.get subject to a
+  history_handler backed by the caller-owned registry.
+end note
 
 @enduml

--- a/projects/ores.history/src/CMakeLists.txt
+++ b/projects/ores.history/src/CMakeLists.txt
@@ -38,6 +38,9 @@ target_include_directories(${lib_target_name} PUBLIC
 
 target_link_libraries(${lib_target_name}
     PUBLIC
-        ores.diff.lib)
+        ores.diff.lib
+        ores.nats.lib
+        ores.service.lib
+        ores.logging.lib)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.history/src/messaging/registrar.cpp
+++ b/projects/ores.history/src/messaging/registrar.cpp
@@ -26,7 +26,7 @@ namespace ores::history::messaging {
 
 ores::nats::service::subscription
 register_history_handlers(ores::nats::service::client& nats,
-                          service::dispatch_registry& registry,
+                          const service::dispatch_registry& registry,
                           std::string_view queue_group) {
     auto handler = std::make_shared<history_handler>(nats, registry);
     return nats.queue_subscribe(

--- a/projects/ores.history/src/messaging/registrar.cpp
+++ b/projects/ores.history/src/messaging/registrar.cpp
@@ -1,0 +1,38 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.history/messaging/registrar.hpp"
+#include "ores.history/messaging/history_handler.hpp"
+#include "ores.history/messaging/history_protocol.hpp"
+#include <memory>
+
+namespace ores::history::messaging {
+
+ores::nats::service::subscription
+register_history_handlers(ores::nats::service::client& nats,
+                          service::dispatch_registry& registry,
+                          std::string_view queue_group) {
+    auto handler = std::make_shared<history_handler>(nats, registry);
+    return nats.queue_subscribe(
+        get_entity_history_request::nats_subject, queue_group, [handler](ores::nats::message msg) {
+            handler->history(std::move(msg));
+        });
+}
+
+}


### PR DESCRIPTION
## Summary

Second increment of the generic history.v1.get subject work: a history_handler bridging NATS decode/reply to dispatch_registry, and register_history_handlers() subscribing the one shared subject under a caller-given queue group.

## Changes

- history_handler: decodes get_entity_history_request, dispatches via dispatch_registry, replies
- register_history_handlers(nats, registry, queue_group): subscribes history.v1.get to a history_handler backed by the given registry
- No service registers real per-entity providers yet; removing old per-entity get_<entity>_history subjects is the next increment
- Verification: local build clean (linux-clang-debug-make); ctest 69/71 passed (2 pre-existing unrelated failures: ores.iam.core.tests, ores.analytics.quant.tests); ores.history.tests 7/7 passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Consolidate history dialogs onto HistoryDialogBase](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/story.html) | 037B474D-84ED-4888-9054-D58AB1FB10D2 |
| Task | [Generic history.v1.get NATS subject and server-side dispatch registry](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/consolidate_history_dialogs/task_generic-history-subject.html) | 15CFB0BE-C411-4B12-B733-974F6F5A44A5 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)