### PR TITLE
[doc] Term structure/tenor cluster: Pillar, provenance/ladder cleanup

### DIFF
--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
@@ -42,7 +42,7 @@ vol surfaces).
 | Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
 | Now           | First task (tenor type) started; domain-knowledge groundwork done, C++ implementation not yet begun. See task Notes and the * Analysis section below. |
 | Waiting on    | Nothing — [[https://github.com/OreStudio/OreStudio/pull/1409][PR #1409]] ([[id:F4604E72-EF59-4894-A6D4-A68971C793EB][GMM improvements: tidy up synthetic data generation loose ends]], which added =ou_process= and =ores.synthetic.api::domain::validate_process_parameters()=) merged via =4be33f2b4= prior to this branch's rebase. |
-| Next          | Implement the tenor type in =ores.marketdata= against the new [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] knowledge cluster. |
+| Next          | Implement the tenor type in =ores.marketdata= against the new [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] knowledge cluster. |
 | Last touched  | 2026-07-12                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
@@ -136,6 +136,7 @@ which now require the process to expose =P(t,T)=, not just a path of
 | [[id:20D82F58-758D-498A-8B08-AA664408CB8F][Curve Template sub-config (ir_curve_generation_config)]] | BACKLOG | | | New sub-config owned by market_data_generation_config, one per currency+index, configuring the raw instrument grid (deposits, FRAs/futures, swaps). |
 | [[id:E6B7DEF3-F35F-454A-8ECF-CCD9E8E07A83][Tenor-collision/gap validation on the Curve Template]] | BACKLOG | | | Pure, engine-side validator (ores.synthetic.api) rejecting instrument grids where tenors overlap or collide with an active delivery window, using the new tenor type. |
 | [[id:615FD100-BCD9-4CF5-B9DF-197447769AA9][Tick-batch publishing and persistence for curve instruments]] | BACKLOG | | | Each generation step publishes N individual ticks (one per tenor), each its own market_observation row sharing one observation_datetime, point_id set to the tenor label. |
+| [[id:38449685-430E-4AF3-802E-5E02606BF2DA][Term structure/tenor knowledge docs: Pillar, provenance/ladder cleanup]] | DONE | 2026-07-12 | 2026-07-12 | Add a Pillar knowledge doc and rework Curve Point Provenance/Multicurve Management to link rather than duplicate definitions, following Zettelkasten conventions. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_pillar-and-provenance-docs.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_pillar-and-provenance-docs.org
@@ -8,7 +8,7 @@
 #+filetags: :ir-rates-synthetic-generation:sprint_23:v0:
 #+owner: marco
 #+branch: feature/pillar-and-provenance-docs
-#+pr:
+#+pr: 1528
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
@@ -61,7 +61,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1528][#1528]] | [doc] Term structure/tenor cluster: Pillar, provenance/ladder cleanup |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_pillar-and-provenance-docs.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_pillar-and-provenance-docs.org
@@ -1,0 +1,80 @@
+:PROPERTIES:
+:ID: 38449685-430E-4AF3-802E-5E02606BF2DA
+:END:
+#+title: Task: Term structure/tenor knowledge docs: Pillar, provenance/ladder cleanup
+#+description: Add a Pillar knowledge doc and rework Curve Point Provenance/Multicurve Management to link rather than duplicate definitions, following Zettelkasten conventions.
+#+type: task
+#+level: s1
+#+filetags: :ir-rates-synthetic-generation:sprint_23:v0:
+#+owner: marco
+#+branch: feature/pillar-and-provenance-docs
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Extend and tidy the term-structure/tenor knowledge cluster: a dedicated Pillar doc, and provenance/ladder docs that org-roam link to existing definitions instead of restating them.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]] |
+| Now          | Complete.                               |
+| Waiting on   | Nothing.                               |
+| Next         | n/a                                     |
+| Last touched | 2026-07-12                               |
+
+* Acceptance
+
+- Pillar doc exists and is linked wherever 'pillar' is used in the cluster
+- Curve Point Provenance and Multicurve Management link to Data Quality/Interpolation/Extrapolation rather than redefine them
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Added a dedicated Pillar knowledge doc and org-roam linked it wherever
+"pillar" is used across the tenor/term-structure cluster. Reworked Curve
+Point Provenance and Multicurve Management to link to already-defined
+concepts (Data Quality, Interpolation, Extrapolation) rather than restate
+them, and to describe requirements as prose rather than a
+requirements-document format. Also removed an unsourced "observed as
+prior art in another system" claim from Multicurve Management.

--- a/doc/knowledge/domain/broken_dates_and_turn_points.org
+++ b/doc/knowledge/domain/broken_dates_and_turn_points.org
@@ -52,7 +52,70 @@ date]] advances, in contrast to how every other tenor point on the same
 term structure is expressed relative to the horizon date. They require
 special handling in interpolation — a term structure's interpolation
 method must isolate the turn effect's spike so that it does not bleed into
-the value of adjacent, structurally ordinary tenor points.
+the value of adjacent, structurally ordinary tenor points. A turn point
+also differs from a broken date in kind, not just in calendar behaviour: it
+"nudges" the rates around it rather than defining a tradeable maturity in
+its own right — see the three-way classification below.
+
+** Three-way tenor classification
+
+Every entry on a curve's tenor ladder is classified as exactly one of
+three kinds, and the system tracks which throughout the entry's lifetime
+(see [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]]
+for how that classification is recorded and why it never changes):
+
+- *Standard*: a normal named [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  (=O/N=, =1M=, =1Y=, and so on).
+- *Broken date*: a non-standard, interpolated maturity added explicitly
+  (e.g. 47 days), tracked distinctly from the standard tenors around it —
+  this document's "broken dates (odd dates)" section above.
+- *Turn*: a fixed-calendar-date discontinuity, potentially spanning
+  multiple days, which nudges rates around it rather than defining a
+  tradeable maturity — this document's "turn points" section above.
+
+** Entry and display
+
+How a broken date is added to and shown on a curve's tenor ladder follows
+several conventions, all specific to broken dates rather than to standard
+tenors:
+
+- A broken date can be added or removed directly on the ladder — a user is
+  not limited to the pre-defined standard tenor set.
+- It can be entered either as an absolute *date* or as a *tenor label*
+  where applicable — the same date-vs-tenor duality used for other
+  single-instrument date fields (e.g. an option's expiry).
+- As part of supporting broken-date and forward-forward analysis, the
+  system must provide an isolated calculation surface, separate from the
+  live term structure, on which a user can price an arbitrary
+  forward-forward relationship (e.g. "the rate 3M in 6M") or an arbitrary
+  bespoke maturity before deciding whether it is worth adding as a real
+  broken date. This is necessary because such exploration is inherently
+  speculative — a user comparing several hypothetical structures needs to
+  try many of them without any one attempt mutating the curve every other
+  part of the system reads from. To satisfy this, the surface must: (a)
+  use the same [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  resolution and interpolation machinery the live term structure uses, so
+  a result is a faithful preview of what adding the point for real would
+  produce, not an approximation; (b) read the live curve's current state
+  to ground its calculations in real market levels, without ever writing
+  a result back into that curve's point set; and (c) leave no
+  [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] trace on the
+  live curve — an explored-but-discarded hypothesis must be exactly as if
+  it had never been tried, consistent with provenance's "no promotion"
+  rule applying only to points that were actually added, not to
+  speculative ones that never were.
+- A broken date is not necessarily purely interpolated: each tenor entry,
+  including a broken date, can carry its own market data feed, so a broken
+  date can in principle be directly quoted rather than derived.
+- The [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][hub]]'s deferred "Out Of"
+  convention (Out of Today / Out of Tomorrow / Out of Spot) affects broken
+  dates the same way it affects standard tenors: when a non-standard
+  basis is selected, affected tenors — broken dates included — must be
+  visually distinguished so the user knows they are not on the
+  conventional spot basis.
+- On volatility surfaces specifically, a separate toggle controls whether
+  *interpolated* tenors are displayed at all — a distinct control from the
+  FX forward ladder's broken-date handling described above.
 
 * See also
 
@@ -60,3 +123,18 @@ the value of adjacent, structurally ordinary tenor points.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard labels a broken date falls between.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — where an interpolation method is specified.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete interpolation methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how the three-way classification is recorded and tracked over a point's lifetime.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions a broken date's position determines.
+
+** Further reading: terminology verification
+
+"Broken date"/"odd date" and "the turn"/"turn effect" were checked against
+independent market sources (not this notebook) to confirm they are real,
+standard industry terminology rather than local naming:
+
+- [[https://www.poems.com.sg/glossary/investment/broken-date/][Broken Date: Meaning, Impact & Fundamentals in Financial Markets]]
+- [[https://www.bestx.co.uk/publications/bestx-fx-forward-methodology-on-broken-dates][BestX FX Forward Methodology on Broken Dates]]
+- [[https://thefullfx.com/ncfx-extends-fx-forward-benchmarks-to-broken-dates/][NCFX Extends FX Forward Benchmarks to Broken Dates]]
+- [[https://www.cmegroup.com/education/articles-and-reports/understanding-and-analyzing-year-end-effects-in-the-fx-swap-market.html][Understanding and Analyzing Year-End Effects in the FX Swap Market (CME Group)]]
+- [[https://www.lseg.com/en/insights/fx/the-case-for-turn-impact-adjusted-fx-forward-curves][The case for turn impact-adjusted FX forward curves (LSEG)]]
+- [[https://www.clarusft.com/year-end-turn-rates/][Year End Turn Rates (Clarus FT)]]

--- a/doc/knowledge/domain/broken_dates_and_turn_points.org
+++ b/doc/knowledge/domain/broken_dates_and_turn_points.org
@@ -14,7 +14,7 @@
 Two distinct irregularities complicate an otherwise clean
 [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] grid: a *broken date* is
 a bespoke maturity that does not correspond to a standard tenor label and
-must be interpolated between the surrounding pillars, while a *turn point*
+must be interpolated between the surrounding [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillars]], while a *turn point*
 is a fixed-calendar-time discontinuity (most commonly year-end) that must
 be prevented from bleeding into the interpolation of adjacent tenors. Both
 matter to how a [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
@@ -59,10 +59,12 @@ its own right — see the three-way classification below.
 
 ** Three-way tenor classification
 
-Every entry on a curve's tenor ladder is classified as exactly one of
-three kinds, and the system tracks which throughout the entry's lifetime
-(see [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]]
-for how that classification is recorded and why it never changes):
+Every entry on a [[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward
+ladder]] is one of exactly three kinds, and the system must track which
+throughout the entry's lifetime (see
+[[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] for
+the proposed fields this classification would be recorded in, and why it
+should never change once recorded):
 
 - *Standard*: a normal named [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
   (=O/N=, =1M=, =1Y=, and so on).
@@ -75,63 +77,71 @@ for how that classification is recorded and why it never changes):
 
 ** Entry and display
 
-How a broken date is added to and shown on a curve's tenor ladder follows
-several conventions, all specific to broken dates rather than to standard
-tenors:
+Managing broken dates places several requirements on the
+[[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward ladder]] they are
+entered through, all specific to broken dates rather than to standard
+tenors.
 
-- A broken date can be added or removed directly on the ladder — a user is
-  not limited to the pre-defined standard tenor set.
-- It can be entered either as an absolute *date* or as a *tenor label*
-  where applicable — the same date-vs-tenor duality used for other
-  single-instrument date fields (e.g. an option's expiry).
-- As part of supporting broken-date and forward-forward analysis, the
-  system must provide an isolated calculation surface, separate from the
-  live term structure, on which a user can price an arbitrary
-  forward-forward relationship (e.g. "the rate 3M in 6M") or an arbitrary
-  bespoke maturity before deciding whether it is worth adding as a real
-  broken date. This is necessary because such exploration is inherently
-  speculative — a user comparing several hypothetical structures needs to
-  try many of them without any one attempt mutating the curve every other
-  part of the system reads from. To satisfy this, the surface must: (a)
-  use the same [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
-  resolution and interpolation machinery the live term structure uses, so
-  a result is a faithful preview of what adding the point for real would
-  produce, not an approximation; (b) read the live curve's current state
-  to ground its calculations in real market levels, without ever writing
-  a result back into that curve's point set; and (c) leave no
-  [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] trace on the
-  live curve — an explored-but-discarded hypothesis must be exactly as if
-  it had never been tried, consistent with provenance's "no promotion"
-  rule applying only to points that were actually added, not to
-  speculative ones that never were.
-- A broken date is not necessarily purely interpolated: each tenor entry,
-  including a broken date, can carry its own market data feed, so a broken
-  date can in principle be directly quoted rather than derived.
-- The [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]]
-  (Out of Today / Out of Tomorrow / Out of Spot) affects broken dates the
-  same way it affects standard tenors: when a non-standard basis is
-  selected, affected tenors — broken dates included — must be visually
-  distinguished so the user knows they are not on the conventional spot
-  basis.
-- On volatility surfaces specifically, a separate toggle controls whether
-  *interpolated* tenors are displayed at all — a distinct control from the
-  FX forward ladder's broken-date handling described above.
+The system must let a user add or remove a broken date directly on the
+ladder, rather than limiting entry to the pre-defined standard tenor set,
+and must accept a broken date entered either as an absolute date or as a
+tenor label where applicable — the same date-vs-tenor duality needed for
+other single-instrument date fields, such as an option's expiry.
+
+In order to support broken-date and forward-forward analysis, the system
+must provide an isolated calculation surface, separate from the live
+[[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]], on which a
+user can price an arbitrary forward-forward relationship (e.g. "the rate
+3M in 6M") or an arbitrary bespoke maturity before deciding whether it is
+worth adding as a real broken date. This is necessary because such
+exploration is inherently speculative — a user comparing several
+hypothetical structures needs to try many of them without any one attempt
+mutating the term structure every other part of the system reads from. To
+satisfy this, the calculation surface must use the same
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] resolution and
+interpolation machinery the live term structure uses, so a result is a
+faithful preview of what adding the point for real would produce rather
+than an approximation; it must read the live term structure's current
+state to ground its calculations in real market levels, without ever
+writing a result back into its point set; and it must leave no
+[[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] trace on the live
+term structure, so an explored-but-discarded hypothesis is exactly as if
+it had never been tried — consistent with provenance's "no promotion"
+rule applying only to points that were actually added, not to speculative
+ones that never were.
+
+The system must also let a broken date carry its own market data feed, the
+same as any standard tenor entry on the ladder, since a broken date is not
+necessarily purely interpolated — it must be possible for one to be
+directly quoted rather than derived.
+
+Because the [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]]
+(Out of Today / Out of Tomorrow / Out of Spot) affects broken dates the
+same way it affects standard tenors, the system must visually distinguish
+any ladder entry — broken date or standard tenor alike — that is not on
+the conventional spot basis whenever a non-standard basis is selected.
+
+On volatility surfaces specifically, the system must offer a separate
+toggle controlling whether interpolated tenors are displayed on the ladder
+at all, distinct from the broken-date handling described above.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard labels a broken date falls between.
+- [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — the quoted points a broken date falls between, as distinct from tenor labels in general.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — where an interpolation method is specified.
 - [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the concrete methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how the three-way classification is recorded and tracked over a point's lifetime.
 - [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ranges a broken date's position falls within.
 - [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] — the quoting-basis convention that also governs visual flagging for broken dates.
+- [[id:CE15D83D-6400-4596-8878-3A78D8298A85][Forward Ladder]] — the entry/display surface broken dates are managed through, distinct from the term structure it presents.
 
 ** Further reading: terminology verification
 
 "Broken date"/"odd date" and "the turn"/"turn effect" were checked against
-independent market sources (not this notebook) to confirm they are real,
-standard industry terminology rather than local naming:
+independent market sources to confirm they are real, standard industry
+terminology rather than local naming:
 
 - [[https://www.poems.com.sg/glossary/investment/broken-date/][Broken Date: Meaning, Impact & Fundamentals in Financial Markets]]
 - [[https://www.bestx.co.uk/publications/bestx-fx-forward-methodology-on-broken-dates][BestX FX Forward Methodology on Broken Dates]]

--- a/doc/knowledge/domain/broken_dates_and_turn_points.org
+++ b/doc/knowledge/domain/broken_dates_and_turn_points.org
@@ -107,12 +107,12 @@ tenors:
 - A broken date is not necessarily purely interpolated: each tenor entry,
   including a broken date, can carry its own market data feed, so a broken
   date can in principle be directly quoted rather than derived.
-- The [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][hub]]'s deferred "Out Of"
-  convention (Out of Today / Out of Tomorrow / Out of Spot) affects broken
-  dates the same way it affects standard tenors: when a non-standard
-  basis is selected, affected tenors — broken dates included — must be
-  visually distinguished so the user knows they are not on the
-  conventional spot basis.
+- The [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]]
+  (Out of Today / Out of Tomorrow / Out of Spot) affects broken dates the
+  same way it affects standard tenors: when a non-standard basis is
+  selected, affected tenors — broken dates included — must be visually
+  distinguished so the user knows they are not on the conventional spot
+  basis.
 - On volatility surfaces specifically, a separate toggle controls whether
   *interpolated* tenors are displayed at all — a distinct control from the
   FX forward ladder's broken-date handling described above.
@@ -122,9 +122,10 @@ tenors:
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard labels a broken date falls between.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — where an interpolation method is specified.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete interpolation methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the concrete methods (log-linear, zero-linear, cubic spline, monotone spline) this document assumes.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how the three-way classification is recorded and tracked over a point's lifetime.
-- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions a broken date's position determines.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ranges a broken date's position falls within.
+- [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] — the quoting-basis convention that also governs visual flagging for broken dates.
 
 ** Further reading: terminology verification
 

--- a/doc/knowledge/domain/curve_point_provenance.org
+++ b/doc/knowledge/domain/curve_point_provenance.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 573F9165-C20B-463C-B0B3-F324AFE4E81F
+:END:
+#+title: Curve Point Provenance
+#+description: The metadata tracked per term-structure point (rejected, interpolated, back-filled, overridden) and why a broken date is never promoted into a standard tenor.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+Every point on a [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
+structure]] carries provenance metadata alongside its value: whether it
+was rejected by a consensus provider, whether it is interpolated, whether
+it is back-filled (and if so, its age), and whether it has been
+overridden. This provenance is what lets a user interface distinguish a
+directly-quoted standard pillar from a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] or an
+interpolated point at a glance, rather than presenting every point as
+equally authoritative. One consequence of tracking provenance this way,
+rather than mutating a point's classification over time, is that a broken
+date is never "promoted" into a standard tenor: once added, it remains
+tracked as a broken date indefinitely.
+
+* Detail
+
+** The provenance fields
+
+Each curve point's metadata records:
+
+- Whether it was *rejected* by a consensus data provider.
+- Whether it is *interpolated* (derived from surrounding points, see
+  [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for
+  the interpolate/extrapolate/flatten regions this applies within).
+- Whether it is *back-filled*, and if so, its age — how long ago the value
+  it now shows was actually current.
+- Whether it has been *overridden* — replaced by a manual value rather
+  than the value a feed or interpolation would otherwise produce.
+
+This is the same underlying mechanism that lets a user interface
+colour-code or otherwise visually flag broken dates and interpolated
+points as distinct from directly-quoted standard tenors — the visual
+treatment is a presentation of the provenance metadata, not a separate
+tracking mechanism.
+
+** No promotion over time
+
+A [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] is added to a
+term structure as, and remains tracked as, a broken date — there is no
+mechanism by which repeated use or the passage of time converts it into a
+standard tenor indistinguishable from the pillars around it. The
+provenance record is what makes this durable: a point's classification
+(standard / broken date / turn, see
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s three-way classification) is a stored fact about that point,
+not a derived judgement that could drift as the point ages.
+
+** Related: illiquid cut times
+
+A related but distinct provenance-adjacent problem appears for option
+expiries rather than term-structure tenors: a barrier option expiring at a
+non-standard, illiquid cut time is risk-managed by placing a *Date Shift
+Reserve* against the nearest *liquid* cut time, rather than by sourcing
+market data for the illiquid cut directly. This is the closest analogue to
+"mapping an illiquid point to the nearest liquid one" outside the tenor
+domain proper — it operates on option cut times, not on a term structure's
+own tenor ladder, and is recorded here only as a cross-reference, not
+elaborated further in this cluster.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification this provenance record supports.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions provenance distinguishes between.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series each point with provenance belongs to.

--- a/doc/knowledge/domain/curve_point_provenance.org
+++ b/doc/knowledge/domain/curve_point_provenance.org
@@ -2,7 +2,7 @@
 :ID: 573F9165-C20B-463C-B0B3-F324AFE4E81F
 :END:
 #+title: Curve Point Provenance
-#+description: The metadata tracked per term-structure point (rejected, interpolated, back-filled, overridden) and why a broken date is never promoted into a standard tenor.
+#+description: What provenance and lineage mean for a market-data curve point specifically, why market data needs more than the standard reference-data provenance fields, and the fields that satisfy that need.
 #+type: knowledge
 #+level: cross
 #+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
@@ -11,51 +11,76 @@
 
 * Summary
 
-Every point on a [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
-structure]] carries provenance metadata alongside its value: whether it
-was rejected by a consensus provider, whether it is interpolated, whether
-it is back-filled (and if so, its age), and whether it has been
-overridden. This provenance is what lets a user interface distinguish a
-directly-quoted standard pillar from a
-[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] or an
-interpolated point at a glance, rather than presenting every point as
-equally authoritative. One consequence of tracking provenance this way,
-rather than mutating a point's classification over time, is that a broken
-date is never "promoted" into a standard tenor: once added, it remains
-tracked as a broken date indefinitely.
+[[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data Quality]] is the
+authoritative definition of *provenance*, *lineage*, and the *Record
+Provenance Fields* every reference data entity in ORE Studio already
+carries — this document does not redefine any of that. It exists because
+those standard fields, designed for reference data (currencies, day-count
+conventions, and the like), answer a *change-management* question (who
+last touched this record, when, and why) that is not the question a
+market-data consumer actually needs answered. A
+[[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] point needs a
+*trustworthiness* answer instead — was this specific value actually
+quoted by the market right now, or is it synthesised, stale, or someone's
+manual correction? Answering that needs a different, additional set of
+fields, proposed below and not yet implemented.
 
 * Detail
 
-** The provenance fields
+** Why market data needs more than the standard fields
 
-Each curve point's metadata records:
+A term structure point changes constantly (every tick, potentially), and
+unlike a reference-data record, its *trustworthiness at the moment it is
+read* is exactly as important as who last touched it — arguably more so,
+since it feeds directly into pricing and risk. Knowing that a value was
+last modified by a particular user at a particular time (the standard
+fields) does not tell a consumer what they actually need to know before
+relying on it:
 
-- Whether it was *rejected* by a consensus data provider.
-- Whether it is *interpolated* (derived from surrounding points, see
-  [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for
-  the interpolate/extrapolate/flatten regions this applies within).
-- Whether it is *back-filled*, and if so, its age — how long ago the value
-  it now shows was actually current.
-- Whether it has been *overridden* — replaced by a manual value rather
-  than the value a feed or interpolation would otherwise produce.
+- Was this value *actually quoted* by the market, or is it a manufactured
+  value — [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolated]],
+  [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][extrapolated]], or flattened
+  (see [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure
+  Extent]] for the regions each of those applies within)? A pricer relying
+  on an interpolated value where it assumed a live quote is relying on
+  something structurally different from what it thinks it has.
+- Was it *rejected* by a consensus data provider's own quality checks
+  before it ever reached the system? A rejected value that nonetheless
+  made it onto a curve is a data-quality incident, not a normal quote.
+- Is it *stale* — a back-filled value standing in for one that failed to
+  arrive — and if so, how stale? A value that is merely a few seconds old
+  is a different risk than one that is hours old, and a consumer cannot
+  tell the difference without an explicit age.
+- Has it been *manually overridden*, replacing whatever the feed or
+  interpolation would otherwise have produced? Knowing *that* an override
+  happened is what a market-data consumer needs first; [[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data
+  Quality]]'s existing fields already cover explaining who and why once
+  that fact is known.
 
-This is the same underlying mechanism that lets a user interface
-colour-code or otherwise visually flag broken dates and interpolated
-points as distinct from directly-quoted standard tenors — the visual
-treatment is a presentation of the provenance metadata, not a separate
-tracking mechanism.
+** Proposed fields
 
-** No promotion over time
+The following fields would satisfy the trustworthiness need above,
+alongside — not replacing — [[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data
+Quality]]'s existing Record Provenance Fields. None of this is
+implemented yet — this is a proposal, not a description of existing
+behaviour:
 
-A [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] is added to a
-term structure as, and remains tracked as, a broken date — there is no
-mechanism by which repeated use or the passage of time converts it into a
-standard tenor indistinguishable from the pillars around it. The
-provenance record is what makes this durable: a point's classification
-(standard / broken date / turn, see
-[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
-Points]]'s three-way classification) is a stored fact about that point,
-not a derived judgement that could drift as the point ages.
+- *Rejected*: whether the value was flagged by a consensus data
+  provider's own quality checks before reaching the system.
+- *Derivation kind*: which of directly-quoted, interpolated,
+  extrapolated, flattened, or overridden produced this value — the single
+  field a consumer would check first to know what kind of value they are
+  looking at. This also carries the classification
+  [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+  Points]]' three-way tenor classification depends on: a point's standard
+  / broken date / turn classification is a stored fact recorded once
+  alongside this field, not a derived judgement re-computed on every
+  read — which is why a broken date is never "promoted" into a standard
+  tenor over time; there is no mechanism that re-evaluates a point's
+  classification after the fact.
+- *Back-filled, and age*: whether the value stands in for one that failed
+  to arrive, and how long ago the value it now shows was actually
+  current.
 
 ** Related: illiquid cut times
 
@@ -66,12 +91,15 @@ Reserve* against the nearest *liquid* cut time, rather than by sourcing
 market data for the illiquid cut directly. This is the closest analogue to
 "mapping an illiquid point to the nearest liquid one" outside the tenor
 domain proper — it operates on option cut times, not on a term structure's
-own tenor ladder, and is recorded here only as a cross-reference, not
-elaborated further in this cluster.
+own [[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward ladder]], and is
+recorded here only as a cross-reference, not elaborated further in this
+cluster.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
-- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification this provenance record supports.
-- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions provenance distinguishes between.
-- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series each point with provenance belongs to.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
+- [[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data Quality]] — the general provenance/lineage definitions and the standard reference-data provenance fields this document extends.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification the proposed derivation-kind field records.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the interpolate/extrapolate/flatten regions the proposed derivation-kind field distinguishes between.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series each point needing provenance belongs to.
+- [[id:CE15D83D-6400-4596-8878-3A78D8298A85][Forward Ladder]] — the entry/display surface provenance would ultimately be shown through.

--- a/doc/knowledge/domain/date_rolling_and_business_day_calendars.org
+++ b/doc/knowledge/domain/date_rolling_and_business_day_calendars.org
@@ -68,7 +68,7 @@ holiday calendar sits as part of a term structure's metadata.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:267DD5E8-F095-47C1-B42B-733565306776][FX spot date and settlement]] — the canonical business day / settlement day definition.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the dates this rolling process is applied to.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — irregular dates that interact with rolling and interpolation together.

--- a/doc/knowledge/domain/extrapolation.org
+++ b/doc/knowledge/domain/extrapolation.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2
+:END:
+#+title: Extrapolation
+#+description: Why a term structure needs a defined policy before its first pillar and beyond its last, and why flattening, not extrapolating, is the default beyond the end.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+Where [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]] fills a
+gap *between* two known [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
+structure]] points, *extrapolation* answers a request for a date *outside*
+the range those points cover altogether — before the first pillar, or
+beyond the last. A defined policy for both directions is necessary because
+a term structure's pillar range is finite by construction (see
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for how
+far it goes by curve type), while requests for a value can, in principle,
+fall anywhere. The two directions are treated asymmetrically: before the
+start, genuine extrapolation is used; beyond the end, the system flattens
+— holds the last known value constant — rather than extrapolating, and
+only extrapolates beyond the end in rare, explicitly justified cases.
+
+* Detail
+
+** Why a policy is needed at all
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is
+constructed from a finite set of pillar points and has no market-observed
+value outside that range. Left undefined, a request for such a value would
+either fail outright or silently return an arbitrary result depending on
+whichever code path happened to handle it. Neither is acceptable: the
+system must have an explicit, documented answer for "what happens if
+someone asks for a point before the curve starts, or after it ends" —
+the same way [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]]
+gives an explicit answer for a point falling between two known ones.
+
+** Before the start: extrapolate
+
+For a date earlier than the term structure's first pillar, the convention
+is to extrapolate — derive a value by continuing the curve's near-end
+behaviour backward. This is the more permissive of the two directions,
+reflecting that requests for very-near-term values (e.g. today, or a date
+just before the first liquid pillar) are routine rather than exceptional.
+
+** Beyond the end: flatten, not extrapolate
+
+For a date beyond the term structure's last pillar, the default is to
+*flatten* — hold the last known value constant — rather than to
+extrapolate. Genuine extrapolation beyond the end is reserved for rare,
+explicitly justified cases, not applied by default. This asymmetry is
+deliberate: extrapolating forward from a curve's long end would
+manufacture a value with no basis in any observed point, which is a
+materially different risk from extending near-term behaviour backward by
+a short distance. Flattening does not fail the request and does not
+fabricate a trend — it is the conservative middle ground between refusing
+to answer and inventing an answer. See
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for the
+concrete curve-type-specific ceilings (30Y for interest rate curves, a 5Y
+default for volatility surfaces, open-ended for CDS) this policy applies
+beyond.
+
+** Tracking which regime applies
+
+Whether a given point was interpolated, extrapolated, or flattened is part
+of that point's [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] —
+the same mechanism that tracks whether a point was rejected, back-filled,
+or overridden. A consumer reading a curve value can, and should, be able
+to tell which of the three regimes produced it, rather than treating every
+returned value as equally observed.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ceilings this policy applies beyond.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series whose finite range makes this policy necessary.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how a point is flagged as interpolated, extrapolated, or flattened.

--- a/doc/knowledge/domain/extrapolation.org
+++ b/doc/knowledge/domain/extrapolation.org
@@ -14,7 +14,7 @@
 Where [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]] fills a
 gap *between* two known [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
 structure]] points, *extrapolation* answers a request for a date *outside*
-the range those points cover altogether — before the first pillar, or
+the range those points cover altogether — before the first [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillar]], or
 beyond the last. A defined policy for both directions is necessary because
 a term structure's pillar range is finite by construction (see
 [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for how
@@ -65,17 +65,18 @@ beyond.
 
 ** Tracking which regime applies
 
-Whether a given point was interpolated, extrapolated, or flattened is part
-of that point's [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] —
-the same mechanism that tracks whether a point was rejected, back-filled,
-or overridden. A consumer reading a curve value can, and should, be able
-to tell which of the three regimes produced it, rather than treating every
-returned value as equally observed.
+Whether a given point was interpolated, extrapolated, or flattened should
+be part of that point's [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][provenance]] —
+the same proposed record that would also track whether a point was
+rejected, back-filled, or overridden. A consumer reading a curve value
+should be able to tell which of the three regimes produced it, rather than
+treating every returned value as equally observed.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
+- [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — what a pillar is, and how it differs from a tenor in general.
 - [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the curve-type-specific ceilings this policy applies beyond.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series whose finite range makes this policy necessary.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how a point is flagged as interpolated, extrapolated, or flattened.

--- a/doc/knowledge/domain/forward_ladder.org
+++ b/doc/knowledge/domain/forward_ladder.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: CE15D83D-6400-4596-8878-3A78D8298A85
+:END:
+#+title: Forward Ladder
+#+description: The structured, tabular presentation of quotes across the standard tenors, distinct from the term structure it presents -- a display/entry surface, not the underlying data structure.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A *forward ladder* (also /tenor ladder/) is the structured, row-per-tenor
+presentation of quotes — one row per
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]], typically ordered from
+shortest to longest — that a trader reads and edits directly. It is
+distinct from a [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term
+structure]]: a term structure is the abstract, ordered series of tenor
+points a curve *is*; a forward ladder is the concrete, tabular surface a
+user *reads and edits it through*. The distinction matters because
+requirements framed against "the ladder" are about entry and display
+behaviour — what a user can add, remove, or see — while requirements
+framed against "the term structure" are about the underlying data and its
+mathematical properties (interpolation, extrapolation, provenance).
+
+* Detail
+
+** Definition
+
+A forward ladder presents quotes across the standard tenor set as a table:
+one row per tenor, ordered shortest to longest, each row holding whatever
+value that tenor carries (an outright rate, a forward point, a discount
+factor — the specific quantity depends on context). This is the surface a
+professional trader reads to reference or compare quotes across time
+horizons at a glance, and — where the system supports editing — the
+surface through which individual entries are added, removed, or amended.
+
+** Ladder vs. term structure
+
+- A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is the
+  data: an ordered series of tenor points plus its metadata (holiday
+  calendars, interpolation method). It exists whether or not any user is
+  looking at it.
+- A forward ladder is the presentation: a row-per-tenor view onto that
+  same data, plus (where supported) the interaction surface for changing
+  it.
+
+A single term structure can in principle be presented through more than
+one ladder-like surface — see
+[[id:A26CFA71-21C0-4E98-ABC4-25F0EAD517E3][Multicurve Management]] for the
+related tenor × curve-identity grid, which presents an entire
+[[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][curve family]] rather than one
+curve's ladder alone.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the underlying data a ladder presents.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the individual labels a ladder has one row per.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the entry/display requirements a ladder must satisfy for non-standard entries.
+- [[id:A26CFA71-21C0-4E98-ABC4-25F0EAD517E3][Multicurve Management]] — the related tenor x curve-identity grid for an entire curve family.

--- a/doc/knowledge/domain/fx_deliverability_and_ndf.org
+++ b/doc/knowledge/domain/fx_deliverability_and_ndf.org
@@ -2,12 +2,12 @@
 :ID: CD3E82C6-AE56-4D06-B949-0B3A5CE7A5FC
 :END:
 #+title: Deliverability and non-deliverable instruments
-#+description: Deliverable vs non-deliverable currencies, NDFs and NDOs, onshore/offshore bifurcation (KRW, CNY/CNH), and pseudo currency codes.
+#+description: Deliverable vs non-deliverable currencies, NDFs and NDOs, onshore/offshore bifurcation (KRW, CNY/CNH), pseudo currency codes, deal-level deliverability, counterparty/booking restrictions, the ISO boundary at the ledger, and the Offshore Forward Report.
 #+type: knowledge
 #+level: cross
 #+filetags: :marketdata:fx:crm:domain:
 #+created: 2026-07-04
-#+updated: 2026-07-04
+#+updated: 2026-07-12
 
 * Summary
 
@@ -93,6 +93,64 @@ Consequences that must stay visible downstream:
 4. *Visibility*: trades valued with pseudo-code market data should be
    highlighted in relevant reports.
 
+** Deliverability at the deal level
+
+Deliverability is not only a currency-level property; it also determines
+how a given deal is settled once booked. Where a currency pair nets two
+amounts and one side is non-deliverable, the deal is deliverable by
+convention: the two legs net down to a single amount in the deliverable
+currency, leaving nothing to settle in the non-deliverable one. Where a
+currency is genuinely both deliverable, onshore, and non-deliverable,
+offshore, the convention that marks a particular deal as the deliverable
+kind is a blank *fixing date* — the same fixing date that, when present,
+identifies an NDF or NDO (see above). Deliverability is therefore encoded
+directly in the deal's own fields, not inferred from the currency alone.
+
+** Counterparty and booking restrictions
+
+Because the split between an onshore and an offshore market is a
+jurisdictional one, it constrains not only which curve or spot rate
+applies but also who may transact and where a trade may be booked. An
+onshore entity — a genuine local trading presence rather than a nominal
+one — trades only with counterparties within the same country, including
+internally: the [[id:9E364BEF-12EE-42F8-902C-B1E68A3095B8][back-to-back
+risk-routing]] mechanism otherwise available to a foreign office without a
+proper local trading presence is precisely what a genuine onshore entity
+cannot use to move its risk elsewhere, since doing so would defeat the
+jurisdictional restriction the split exists to enforce. At the book
+level, the same restriction rules out an onshore book holding both the
+deliverable and non-deliverable sides of one currency (a =KRW= trade
+alongside a =KR1= trade, say) at once, since the two require different
+regulatory treatment. See [[id:D215AB01-8BE4-4E2B-930C-17AC80491C9D][Book
+and the ledger]] for the entity/business-unit hierarchy this eligibility
+is ultimately derived from.
+
+** The ISO boundary at the ledger
+
+A pseudo currency code is legitimate everywhere upstream of settlement —
+booking, market data, Greeks — precisely because those layers need to
+distinguish an onshore market from its offshore counterpart. The general
+ledger and settlement systems are the point past which that distinction
+must disappear: every profit-and-loss and present-value figure crossing
+into the ledger is expressed in the underlying ISO currency, never in the
+pseudo code that produced it. Maintaining this boundary depends on two
+things happening correctly upstream: the deal itself must already carry
+its onshore/offshore classification through booking eligibility, and the
+market data used to value it must be correctly tagged onshore or
+offshore, so that Greeks and any bump-and-reset revaluation are computed
+against the right market before the pseudo code's job is done and the
+figure crosses into the ledger.
+
+** Offshore Forward Report
+
+A deal whose counterparty is domiciled offshore carries a reporting
+obligation distinct from ordinary onshore activity, captured in a
+dedicated Offshore Forward Report. This report is a consequence of the
+same jurisdictional split underlying everything else in this document: a
+regulator's interest in offshore activity in a given currency is a
+separate concern from its interest in that currency's domestic market,
+and the report exists to keep the two visible independently.
+
 * See also
 
 - [[id:48F6FD8D-56C7-4FF7-A369-CD13D08A6057][Cross-rates matrix (CRM)]] — the hub.
@@ -101,3 +159,5 @@ Consequences that must stay visible downstream:
   constraint.
 - [[id:CC6D86D8-33FC-41D6-AC27-F35FA942F436][Currency pair and currency entity fields]] — where =deliverable= and
   =settlement_currency= live on the entity.
+- [[id:9E364BEF-12EE-42F8-902C-B1E68A3095B8][Wash books and risk routing]] — the back-to-back mechanism a genuine onshore entity is restricted from using.
+- [[id:D215AB01-8BE4-4E2B-930C-17AC80491C9D][Book and the ledger]] — the entity/business-unit hierarchy behind booking eligibility, and the ISO boundary at the ledger.

--- a/doc/knowledge/domain/fx_spot_date_and_settlement.org
+++ b/doc/knowledge/domain/fx_spot_date_and_settlement.org
@@ -64,7 +64,7 @@ holiday.
 * See also
 
 - [[id:48F6FD8D-56C7-4FF7-A369-CD13D08A6057][Cross-rates matrix (CRM)]] — the structure that depends on this convention.
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — settlement conventions, tenors, date rolling.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — settlement conventions, tenors, date rolling.
 - [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and timestamps]] — the system-wide date/time conventions.
 - [[id:5DD9A309-91E0-4CAB-BD9D-6ECB3B5EB58E][Currency pairs]] — the pair-as-entity companion hub.
 - [[id:CD3E82C6-AE56-4D06-B949-0B3A5CE7A5FC][Deliverability and non-deliverable instruments]] — NDF fixing-date

--- a/doc/knowledge/domain/fx_valuation_spot_date_and_overnight.org
+++ b/doc/knowledge/domain/fx_valuation_spot_date_and_overnight.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :marketdata:fx:crm:domain:
 #+created: 2026-07-04
-#+updated: 2026-07-04
+#+updated: 2026-07-12
 
 * Summary
 
@@ -37,6 +37,17 @@ tomorrow, which is what drives theta on settled cash positions.
   desks prefer overnight rates for intraday positions; Finance prefers
   spot rates for official end-of-day valuation.
 
+** The pre-spot region
+
+For currencies with a T+2 spot lag, there is a two-day region before spot:
+today → tomorrow (=O/N=) and tomorrow → spot (=T/N=). For currencies with a
+T+1 spot lag (e.g. USD/CAD, USD/TRY) this region collapses to a single day,
+since there is no separate tomorrow-to-spot leg to price. This is why the
+outright formulas below take a different shape for T+1 vs. T+2 currencies:
+a T+1 currency only ever needs to strip out one leg (O/N) to move from
+spot back to today, while a T+2 currency needs to strip out both legs
+(T/N, then O/N).
+
 ** Outright formulas
 
 For a currency with T+1 settlement (e.g. USD):
@@ -51,6 +62,9 @@ $$\text{Outright tomorrow} = \text{Spot} - \text{T/N points} \times \text{pip fa
 These formulas tie the short end of the forward curve to spot and are the
 basis for theta calculations on settled cash positions; the pip factor is
 covered in [[id:F40E2871-BF6C-4552-B936-09427688EBE8][Pip, tick size, and pip factor]].
+The =T/N= point used here is a date-window input to this formula only —
+for Tom/Next's own dual role as both a settlement convention and a
+funding mechanism, see [[id:5CC47697-2655-4ECD-B04D-C6C08FF620D5][Tom/Next]].
 
 * See also
 
@@ -58,3 +72,4 @@ covered in [[id:F40E2871-BF6C-4552-B936-09427688EBE8][Pip, tick size, and pip fa
 - [[id:267DD5E8-F095-47C1-B42B-733565306776][FX spot date and settlement]] — the plain spot date this normalises.
 - [[id:F40E2871-BF6C-4552-B936-09427688EBE8][Pip, tick size, and pip factor]] — the pip factor used in the outright
   formulas.
+- [[id:5CC47697-2655-4ECD-B04D-C6C08FF620D5][Tom/Next]] — Tom/Next's dual role beyond its use as an outright-formula input.

--- a/doc/knowledge/domain/horizon_date.org
+++ b/doc/knowledge/domain/horizon_date.org
@@ -56,7 +56,7 @@ being performed."
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the labels this date anchors.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the structure a horizon date belongs to.
 - [[id:85526DCE-31B2-4D46-BA3F-564876397BE2][Valuation spot date and overnight]] — reval date, spot date, and valuation spot date.

--- a/doc/knowledge/domain/imm_dates.org
+++ b/doc/knowledge/domain/imm_dates.org
@@ -34,7 +34,9 @@ fixed set, not an arithmetic offset.
 
 ** Uses
 
-- As an alternative bucketing scheme for position reporting.
+- As an alternative bucketing scheme for position reporting, alongside
+  standard monthly [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+  buckets.
 - As the underlying schedule for Eurodollar / Short Sterling futures used
   in USD curve bootstrapping — see
   [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]'s

--- a/doc/knowledge/domain/imm_dates.org
+++ b/doc/knowledge/domain/imm_dates.org
@@ -49,6 +49,6 @@ fixed set, not an arithmetic offset.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the Credit/CDS Curves convention built on IMM roll dates.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — STIR futures bootstrapping off the nearest IMM contract.

--- a/doc/knowledge/domain/interest_rate_curves.org
+++ b/doc/knowledge/domain/interest_rate_curves.org
@@ -18,7 +18,7 @@ and [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]]. For how several
 curves compose into a funding/projection family for one currency, see
 [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]]. For
 tenor labels and settlement conventions see
-[[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+[[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
 
 * Overview
 
@@ -103,7 +103,7 @@ be compared and combined consistently.
 
 * Input Instruments
 
-The instruments used to build a curve are called /pillar instruments/. Each
+The instruments used to build a curve are called /[[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillar]] instruments/. Each
 instrument fixes one point on the curve. The bootstrapped curve must reprice
 every pillar instrument at its observed market rate.
 

--- a/doc/knowledge/domain/interest_rate_curves.org
+++ b/doc/knowledge/domain/interest_rate_curves.org
@@ -2,18 +2,20 @@
 :ID: E808F432-2FDA-47E8-B003-1E8B908870FE
 :END:
 #+title: Interest Rate Curves
-#+description: Day-count conventions, discount factors, bootstrapping from deposits/FRAs/IRS/OIS, and interpolation methods for interest rate curves used in FX and rates pricing.
+#+description: Day-count conventions, discount factors, and bootstrapping from deposits/FRAs/IRS/OIS for interest rate curves used in FX and rates pricing.
 #+type: knowledge
 #+level: cross
 #+filetags: :knowledge:domain:finance:rates:curves:ore:
 #+created: 2026-05-25
-#+updated: 2026-05-25
+#+updated: 2026-07-12
 
 Interest rate curves are a core market data input in [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]].
 [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] uses them as discount and projection curves throughout valuation. This
-document covers day-count conventions, the bootstrapping process, and
-interpolation for a *single* curve. For how several curves compose into a
-funding/projection family for one currency, see
+document covers day-count conventions and the bootstrapping process for a
+*single* curve; for how the resulting pillars are interpolated between and
+extrapolated beyond, see [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]]
+and [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]]. For how several
+curves compose into a funding/projection family for one currency, see
 [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]]. For
 tenor labels and settlement conventions see
 [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
@@ -197,47 +199,6 @@ us what future floating fixings are expected to be. A system maintains multiple
 projection curves per currency — one for each floating tenor (3M LIBOR, 6M
 LIBOR, etc.) — because basis spreads mean 3M and 6M projections diverge. All
 projected cashflows are discounted using the funding (discount) curve.
-
-* Interpolation Methods
-
-A bootstrapped curve is defined only at its pillar tenors. Interpolation is
-required for any date between pillars.
-
-** Local Methods
-
-Local methods use only the immediately bracketing pillars; changing one pillar
-does not affect distant tenors.
-
-- *Log-Linear (Linear in log-DF)*: Discount factor changes by a constant ratio
-  every day within an interval. Daily forward rates are constant within each
-  interval. Simple and stable; the industry default for the short end.
-
-- *Zero-Linear (Linear in zero rate)*: Linear in $-\ln(DF)/t$. Daily forward
-  rates change at a constant rate within each interval.
-
-Both perform well in low-curvature regimes.
-
-** Non-Local Methods
-
-Non-local methods take into account the full shape of the curve, producing
-smoother results but introducing the risk that changing one pillar affects
-distant tenors.
-
-- *Cubic Spline*: Piecewise cubic polynomial fitted globally. Produces smooth
-  forward curves but can generate oscillations and negative forward rates in
-  extreme cases.
-
-- *Monotone Spline*: A shape-preserving variant of the cubic spline that
-  prevents oscillations while maintaining smoothness.
-
-A single curve may use different interpolation methods at different tenor
-ranges (e.g. log-linear at the short end, cubic spline beyond =2Y=). A /curve
-split tenor/ (typically =5Y=) separates the short-end and long-end spline
-segments, preventing changes at one end from propagating to the other.
-
-It is critical that all systems consuming the same curve agree on the
-interpolation method; different methods will produce different forward rates at
-off-pillar dates.
 
 * ORE Studio Notes
 

--- a/doc/knowledge/domain/interpolation.org
+++ b/doc/knowledge/domain/interpolation.org
@@ -1,0 +1,94 @@
+:PROPERTIES:
+:ID: 85B48CF7-3858-44C8-97AA-91D21C634A9D
+:END:
+#+title: Interpolation
+#+description: Why a term structure needs interpolation between pillars, and the local vs non-local method families used to provide it.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is only
+directly observed at its own pillar [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+points — a bootstrapped curve has no market-quoted value for a date that
+falls *between* two pillars, yet a consumer (a cash flow landing on an
+off-pillar date, a [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken
+date]] a user adds) still needs a value there. *Interpolation* is the rule
+that manufactures that value from the surrounding known points. Two
+families of interpolation method exist — local and non-local — trading off
+stability against smoothness, and the choice matters beyond aesthetics:
+different methods produce different forward rates at the same off-pillar
+date, so every system consuming a given curve must agree on which method
+that curve uses.
+
+* Detail
+
+** Why interpolation is needed
+
+A [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]] curve fixes a
+discount factor (or rate) at each of its pillar tenors and nowhere else.
+Anything that needs a value elsewhere *within* the pillar range — pricing
+a cash flow on an arbitrary date, resolving a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] a user has added
+to the ladder — must derive it from the pillars bracketing it. This is
+distinct from asking for a value *outside* the pillar range altogether,
+which is [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][extrapolation]], a
+related but separate concept with its own conventions.
+
+** Local methods
+
+Local methods use only the immediately bracketing pillars; changing one
+pillar does not affect distant tenors.
+
+- *Log-linear (linear in log-DF)*: the discount factor changes by a
+  constant ratio every day within an interval, so daily forward rates are
+  constant within each interval. Simple and stable; the industry default
+  for the short end.
+- *Zero-linear (linear in zero rate)*: linear in $-\ln(DF)/t$. Daily
+  forward rates change at a constant rate within each interval.
+
+Both perform well in low-curvature regimes.
+
+** Non-local methods
+
+Non-local methods take into account the full shape of the curve, producing
+smoother results but introducing the risk that changing one pillar affects
+distant tenors.
+
+- *Cubic spline*: a piecewise cubic polynomial fitted globally. Produces
+  smooth forward curves but can generate oscillations and negative forward
+  rates in extreme cases.
+- *Monotone spline*: a shape-preserving variant of the cubic spline that
+  prevents oscillations while maintaining smoothness.
+
+** Mixing methods and the curve split tenor
+
+A single curve may use different interpolation methods at different tenor
+ranges — e.g. log-linear at the short end, cubic spline beyond =2Y=. A
+*curve split tenor* (typically =5Y=) separates the short-end and long-end
+spline segments, preventing a change at one end from propagating to the
+other. The same split-tenor idea recurs on the volatility side: a
+volatility surface's default 5-year extent, described in
+[[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]], is
+conventionally reused as its own curve split tenor.
+
+** Agreement across consuming systems
+
+It is critical that every system consuming the same curve agree on the
+interpolation method: different methods produce different forward rates
+at off-pillar dates, so a mismatch between, say, a pricer and a risk
+engine reading the same nominal curve produces silently inconsistent
+results rather than an error.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the sister concept for values outside the pillar range entirely.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series interpolation fills in the gaps of.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a curve's pillar range extends by curve type.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the entries on a ladder that interpolation, or a direct feed, resolves.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how an interpolated point is flagged as such.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — where these methods are applied to a concrete bootstrapped curve.

--- a/doc/knowledge/domain/interpolation.org
+++ b/doc/knowledge/domain/interpolation.org
@@ -12,7 +12,7 @@
 * Summary
 
 A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is only
-directly observed at its own pillar [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+directly observed at its own [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillar]] [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
 points — a bootstrapped curve has no market-quoted value for a date that
 falls *between* two pillars, yet a consumer (a cash flow landing on an
 off-pillar date, a [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken
@@ -33,7 +33,8 @@ discount factor (or rate) at each of its pillar tenors and nowhere else.
 Anything that needs a value elsewhere *within* the pillar range — pricing
 a cash flow on an arbitrary date, resolving a
 [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] a user has added
-to the ladder — must derive it from the pillars bracketing it. This is
+to the [[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward ladder]] — must
+derive it from the pillars bracketing it. This is
 distinct from asking for a value *outside* the pillar range altogether,
 which is [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][extrapolation]], a
 related but separate concept with its own conventions.
@@ -85,8 +86,9 @@ results rather than an error.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the sister concept for values outside the pillar range entirely.
+- [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — what a pillar is, and how it differs from a tenor in general.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series interpolation fills in the gaps of.
 - [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a curve's pillar range extends by curve type.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the entries on a ladder that interpolation, or a direct feed, resolves.

--- a/doc/knowledge/domain/multi_curve_construction.org
+++ b/doc/knowledge/domain/multi_curve_construction.org
@@ -11,7 +11,7 @@
 
 * Summary
 
-Before 2008, a single curve (typically LIBOR) served both roles: it
+Before 2008, a single curve (typically [[id:5170B17B-188B-45CA-A1B6-1F27A97E1CF8][LIBOR]]) served both roles: it
 projected expected floating fixings *and* discounted every cash flow,
 because the LIBOR/OIS basis was small enough to ignore. The 2008 financial
 crisis widened that basis to a level that could no longer be ignored,

--- a/doc/knowledge/domain/multi_curve_grid_ui.org
+++ b/doc/knowledge/domain/multi_curve_grid_ui.org
@@ -47,9 +47,9 @@ responsible for assembling the family.
 *Requirement 2 — separation of review from construction.* Reviewing a
 curve family is a distinct concern from constructing one. Bootstrapping —
 selecting pillar instruments, resolving day-count conventions, choosing an
-interpolation method (see
-[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]) — is a
-separate workflow with its own inputs and its own failure modes. A review
+interpolation method (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
+Rate Curves]] and [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]])
+— is a separate workflow with its own inputs and its own failure modes. A review
 surface presents curves that already exist; it must not conflate the two
 responsibilities into one screen, since doing so would couple a read-only
 concern to a stateful, error-prone one.

--- a/doc/knowledge/domain/multi_curve_grid_ui.org
+++ b/doc/knowledge/domain/multi_curve_grid_ui.org
@@ -92,7 +92,7 @@ field. This distinction matters for the same reason a
 mathematical surface: curve identity is a discrete, enumerable label, not a
 second continuous axis alongside tenor. For reviewing a single curve
 rather than a whole family, the same idea reduces to a plain tenor-indexed
-table with one (Date, Rate) column, the degenerate case of the grid below.
+table with one (Date, Rate) column, the degenerate case of the grid above.
 
 The family's curves populate the grid's columns, so reviewing the family
 is reviewing one screen rather than a sequence of screens — joint

--- a/doc/knowledge/domain/multi_curve_grid_ui.org
+++ b/doc/knowledge/domain/multi_curve_grid_ui.org
@@ -2,7 +2,7 @@
 :ID: A26CFA71-21C0-4E98-ABC4-25F0EAD517E3
 :END:
 #+title: Multicurve Management
-#+description: The domain requirement for reviewing an entire curve family at once, and the tenor x curve-identity lookup grid attested elsewhere as one solution to it — documented as a design reference, not as functionality ORE Studio currently implements.
+#+description: What reviewing an entire curve family at once entails, and a tenor x curve-identity lookup grid as one way of organising that review.
 #+type: knowledge
 #+level: cross
 #+filetags: :knowledge:domain:finance:rates:curves:ore:ui:
@@ -17,68 +17,58 @@ Funding Curve and its dependent Projection Curves exist, a user still needs
 a way to *inspect* them as a coherent whole, rather than navigating to each
 constituent curve individually and losing sight of how they relate. This
 document states that inspection need as a domain requirement, independent
-of any particular implementation, and records one attested solution to
+of any particular implementation, and records one candidate solution to
 it — a tenor-by-curve-identity lookup grid, referred to here as the *Multi
-Curve Grid* — observed as prior art in another system. ORE Studio does not
-currently implement this pattern; it is documented here as a design
-reference for whichever interface eventually takes on curve-family review,
-so that the requirement and one known solution to it are not lost between
-the domain analysis captured in this cluster and the UI work that will
-eventually consume it.
+Curve Grid*.
 
 * Detail
 
-** The requirement, stated independently of any screen
+** Reviewing a curve family as a whole
 
 A currency's full interest-rate picture is a
 [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][curve family]]: one Funding
 Curve and a discrete set of Projection Curves, each independently
-[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]]. Whatever
-interface is responsible for presenting this family to a user must satisfy
-four requirements, stated here prior to any question of layout or widget
-choice.
+[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]]. Reviewing such
+a family is a distinct activity from constructing one, and it has its own
+character, independent of how any particular interface might realise it.
 
-*Requirement 1 — joint visibility.* Every curve belonging to one family
-must be visible together, in a single view. A user reviewing a currency's
-rates must not be required to reconstruct the family mentally by visiting
-each constituent curve in turn; the interface, not the user, is
-responsible for assembling the family.
+Central to that activity is joint visibility: every curve belonging to one
+family is examined together, in a single view, rather than reconstructed
+mentally by visiting each constituent curve in turn. Reviewing is also
+kept apart from constructing. Bootstrapping — selecting pillar
+instruments, resolving day-count conventions, choosing an interpolation
+method (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate
+Curves]] and [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]])
+— is a separate activity with its own inputs and its own failure modes; a
+review of curves that already exist is a read-only concern, and conflating
+it with the stateful, error-prone business of construction would blur two
+activities that are better kept distinct.
 
-*Requirement 2 — separation of review from construction.* Reviewing a
-curve family is a distinct concern from constructing one. Bootstrapping —
-selecting pillar instruments, resolving day-count conventions, choosing an
-interpolation method (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
-Rate Curves]] and [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]])
-— is a separate workflow with its own inputs and its own failure modes. A review
-surface presents curves that already exist; it must not conflate the two
-responsibilities into one screen, since doing so would couple a read-only
-concern to a stateful, error-prone one.
+Because a party typically holds curve families for many currencies at
+once, review also extends one level above the family itself: families are
+grouped for display — by desk, region, or similar operational criteria —
+without altering the internal structure of any individual family. This
+grouping concerns *families*, not the curves within a family, and is
+therefore orthogonal to how any one family is itself presented.
 
-*Requirement 3 — groupability across currencies.* Because a party
-typically holds curve families for many currencies at once, the interface
-must also support grouping families for display — by desk, region, or
-similar operational criteria — without altering the internal structure of
-any individual family. This requirement operates one level above the
-family itself: it groups *families*, not the curves within a family.
-
-*Requirement 4 — inspectable provenance.* Each curve's provenance must
-remain inspectable. This has two parts: first, the specific set of
-instruments and parameters used to bootstrap the curve — its *curve
-template*, the same pillar-instrument selection introduced in
+Finally, each curve's provenance remains inspectable throughout review.
+This has two parts. The first is the specific set of instruments and
+parameters used to bootstrap the curve — its *curve template*, the same
+pillar-instrument selection introduced in
 [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]'s
 discussion of pillar instruments and bootstrapping segments, here
 considered a named, inspectable artefact rather than a one-off input to a
-bootstrapping run; second, the curve's full revision history, including
-time-travel to a prior state and diff-against-previous-version comparison.
-Without both parts, a user can see a curve's current values but not
-account for why they take those values or how they have changed.
+bootstrapping run. The second is the curve's full revision history,
+including time-travel to a prior state and diff-against-previous-version
+comparison. Absent either part, a reviewer can see a curve's current
+values but cannot account for why they take those values or how they have
+changed.
 
-** An attested solution: the tenor x curve-identity grid
+** A tenor x curve-identity grid
 
-One solution to the requirement above, observed as prior art rather than
-as something ORE Studio builds today, arranges a curve family as a
-two-dimensional lookup grid — [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][tenor]]
-on one axis, curve identity on the other:
+A grid such as the following provides the necessary structure: a
+two-dimensional lookup with [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][tenor]]
+on one axis and curve identity on the other:
 
 #+BEGIN_EXAMPLE
 ┌───────┬──────────────────────┬─────────────────────────┬─────────────┬─────┐
@@ -100,37 +90,24 @@ columns, so the grid is properly a *lookup* structure, not a continuous
 field. This distinction matters for the same reason a
 [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][curve family]] itself is not a
 mathematical surface: curve identity is a discrete, enumerable label, not a
-second continuous axis alongside tenor. In the prior art this pattern is
-drawn from, it sits alongside a simpler single-curve wireframe — a plain
-tenor-indexed table — used when only one curve, rather than a whole family,
-needs review.
+second continuous axis alongside tenor. For reviewing a single curve
+rather than a whole family, the same idea reduces to a plain tenor-indexed
+table with one (Date, Rate) column, the degenerate case of the grid below.
 
-** Where this pattern satisfies the requirement
-
-Mapped back onto the four requirements stated above, the grid pattern
-satisfies each as follows.
-
-It satisfies *joint visibility* by construction: the family's curves are
-the grid's columns, so reviewing the family is reviewing one screen rather
-than a sequence of screens.
-
-It satisfies *separation of review from construction* by scope exclusion.
-The pattern, as attested, exposes no editing or bootstrapping affordance of
-its own; construction, where it is reachable at all from a review surface
-built on this pattern, sits behind a separate, dedicated workflow rather
-than behind an editable cell in the grid.
-
-It satisfies *groupability across currencies* one level up from the grid
-itself: families for multiple currencies are grouped for display — by
-desk, region, or similar criteria — independently of how any single
-family's grid is laid out, so the grouping mechanism and the grid layout
-do not need to know about each other.
-
-It satisfies *inspectable provenance* by attaching a curve template and a
-full revision history to each curve the grid displays, rather than to the
-grid as a whole — provenance is a property of a curve, and the grid's role
-is only to make that per-curve property reachable from a family-level
-view.
+The family's curves populate the grid's columns, so reviewing the family
+is reviewing one screen rather than a sequence of screens — joint
+visibility follows from the layout itself. The grid, as such, exposes no
+editing or bootstrapping affordance of its own; construction, where it is
+reachable at all from a surface built on this pattern, sits behind a
+separate, dedicated workflow rather than behind an editable cell in the
+grid, keeping review and construction apart. Grouping families for display
+by desk, region, or similar criteria operates one level above any single
+family's grid, independently of how that grid is laid out, so the two
+concerns do not need to know about each other. And a curve template and a
+full revision history attach to each curve the grid displays, rather than
+to the grid as a whole, since provenance is a property of a curve — the
+grid's role is only to make that per-curve property reachable from a
+family-level view.
 
 * See also
 

--- a/doc/knowledge/domain/out_of_convention.org
+++ b/doc/knowledge/domain/out_of_convention.org
@@ -11,8 +11,9 @@
 
 * Summary
 
-A forward rate ladder does not have one fixed reference point it is
-measured from — it can be expressed *out of* spot, tomorrow, or today, and
+A [[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward ladder]] does not have
+one fixed reference point it is measured from — it can be expressed *out
+of* spot, tomorrow, or today, and
 which basis is in effect changes what a given
 [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] label actually resolves
 to. *Out of Spot* is the market default and the convention already assumed
@@ -63,7 +64,8 @@ Points]]'s entry and display conventions.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the spot/forward curve convention this document's default basis matches.
 - [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every basis (spot, tomorrow, today) is itself a reference point relative to.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — where non-standard-basis visual flagging also applies, to broken dates specifically.
+- [[id:CE15D83D-6400-4596-8878-3A78D8298A85][Forward Ladder]] — the presentation surface a quoting basis applies to.

--- a/doc/knowledge/domain/out_of_convention.org
+++ b/doc/knowledge/domain/out_of_convention.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 8582E7E9-D975-46D5-B61B-93B9EA3DECC0
+:END:
+#+title: Out Of Convention
+#+description: The reference point a forward rate ladder is quoted off (spot, tomorrow, or today), and why non-standard bases must be visually distinguished.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A forward rate ladder does not have one fixed reference point it is
+measured from — it can be expressed *out of* spot, tomorrow, or today, and
+which basis is in effect changes what a given
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] label actually resolves
+to. *Out of Spot* is the market default and the convention already assumed
+throughout [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s
+spot/forward curve conventions; *Out of Tomorrow* and *Out of Today* are
+non-standard alternatives that must be visually distinguished wherever
+they appear, since a tenor label under a non-standard basis silently means
+a different date than the same label would under the default.
+
+* Detail
+
+** The three bases
+
+A forward rate ladder can be expressed starting from different reference
+points:
+
+- *Out of Spot* (standard): rates beyond =S/N= are computed off spot —
+  this is the market default, and the convention
+  [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s "spot/forward
+  curves" section describes without further qualification.
+- *Out of Tomorrow*: rates beyond =T/N= are computed off tomorrow instead
+  of spot.
+- *Out of Today*: all rates are computed off today. Tenors in this mode
+  are non-standard and must be visually distinguished (e.g. highlighted)
+  to alert a user they are not reading the conventional spot-basis ladder.
+
+** Why the distinction matters
+
+Because a tenor label is only meaningful relative to a
+[[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][horizon date]], changing the
+basis a ladder is quoted *out of* changes what every tenor beyond the
+short end actually resolves to, even though the labels themselves (=1W=,
+=1M=, ...) do not change. A user reading =1M= on an Out of Today ladder
+and assuming the market-default Out of Spot basis would misread the
+maturity by however many days separate today from spot. Flagging a
+non-default basis visually is therefore not a cosmetic nicety — it is what
+prevents a silent misreading of every tenor on the ladder.
+
+** Where this applies beyond the FX forward ladder
+
+The basis distinction is not confined to the FX forward ladder it was
+first documented against: it applies identically wherever a
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken date]] is entered — a
+broken date added under a non-standard basis must be visually
+distinguished the same way a standard tenor under that basis would be, per
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s entry and display conventions.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the spot/forward curve convention this document's default basis matches.
+- [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every basis (spot, tomorrow, today) is itself a reference point relative to.
+- [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — where non-standard-basis visual flagging also applies, to broken dates specifically.

--- a/doc/knowledge/domain/pillar.org
+++ b/doc/knowledge/domain/pillar.org
@@ -1,0 +1,79 @@
+:PROPERTIES:
+:ID: D5FAFA10-333D-44BC-B993-4B5C4C4D803F
+:END:
+#+title: Pillar
+#+description: The subset of a term structure's tenor points that are actually quoted/bootstrapped inputs, as distinct from a tenor label in general.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A *pillar* is a [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] point
+that is actually used to build a
+[[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] — a maturity
+at which a real instrument is quoted and bootstrapped into the curve,
+rather than merely a label from the standard tenor set. Every pillar is a
+tenor, but not every tenor is a pillar for a given curve: which subset of
+the standard tenor labels is actually quoted (and therefore a pillar) as
+opposed to filled in by [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolation]]
+depends on the curve type and the liquidity of the underlying instrument
+at that point.
+
+* Detail
+
+** Pillar vs. tenor
+
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] is the more general
+term: a symbolic label (=O/N=, =1M=, =5Y=) identifying a point in time
+relative to a horizon date, independent of whether any curve actually
+carries a quoted value there. Pillar is narrower and curve-specific: it
+names the tenors that are *live inputs* to a particular
+[[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]]'s
+construction — the points a bootstrapping routine consumes directly,
+rather than the points it produces by
+[[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][interpolating]] between them.
+=6Y=, =8Y=, and =9Y= are standard tenor labels, for example, but on many
+curves they are not pillars at all — no instrument is quoted at those
+maturities, and their value is obtained purely by interpolating between
+the =5Y=, =7Y=, and =10Y= pillars that are (see
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s standard tenor
+labels table for further examples of this gap).
+
+** Why the distinction matters
+
+Conflating "tenor" and "pillar" obscures a real structural fact about a
+curve: which points are *observed* and which are *derived*. A pricer or
+risk system that treats every tenor point as equally quoted is blind to
+the difference between a value that came directly from the market and one
+that is a mathematical consequence of the interpolation method chosen —
+the same distinction
+[[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]]'s
+proposed *derivation kind* field would make explicit and persistent per
+point. Pillar is the term for identifying that subset in general
+discussion; provenance is the mechanism for recording it per point once
+implemented.
+
+** Pillar range and count
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]]'s pillars
+are bounded by the curve's [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term
+Structure Extent]] — the finite range within which pillars can exist at
+all, beyond which the curve is filled by
+[[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][extrapolation]] or flattening
+rather than by any further quoted point. The specific pillars within that
+range differ by curve family — see
+[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
+concrete instrument-to-pillar mapping used for interest rate curves.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the general label; pillar is the subset of tenors actually quoted for a given curve.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series a curve's pillars are bootstrapped into.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — how non-pillar tenor points between pillars are filled in.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — the range within which a curve's pillars fall.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — the proposed per-point field that would record whether a point is a pillar or a derived value.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete instrument-to-pillar mapping for interest rate curves.

--- a/doc/knowledge/domain/risk_reporting.org
+++ b/doc/knowledge/domain/risk_reporting.org
@@ -255,7 +255,7 @@ specific tenors.
 
 *Measures*: Forward outright rates at each tenor; optionally swap/forward
 points. Aggregation can be "Out of Today", "Out of Tomorrow", or "Out of Spot"
-(see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]).
+(see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]]).
 
 ** Spot Greeks Report
 

--- a/doc/knowledge/domain/risk_reporting.org
+++ b/doc/knowledge/domain/risk_reporting.org
@@ -255,7 +255,7 @@ specific tenors.
 
 *Measures*: Forward outright rates at each tenor; optionally swap/forward
 points. Aggregation can be "Out of Today", "Out of Tomorrow", or "Out of Spot"
-(see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]]).
+(see [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]]).
 
 ** Spot Greeks Report
 

--- a/doc/knowledge/domain/tenor.org
+++ b/doc/knowledge/domain/tenor.org
@@ -29,7 +29,8 @@ but separate concept.
 The short end of the curve uses named tenors; the long end uses period
 notation. The table below is the *union* of every tenor label attested
 across the source material this cluster draws on, in ascending order. No
-single curve necessarily carries every one of these as a live pillar —
+single curve necessarily carries every one of these as a live
+[[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillar]] —
 which subset is actually quoted (as opposed to filled in by interpolation)
 depends on the curve type and the liquidity of the underlying instrument
 at that point (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
@@ -67,11 +68,12 @@ dates]].
 
 Beyond the individually named labels above, positions and cash balances
 are sometimes bucketed using a coarser, purely calendar-based scheme
-instead of the curve-pillar ladder: =Nostro=, =Today=, =Tomorrow=,
-=Spot=, =1W=, then monthly buckets out to 24 months, or alternatively
-[[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM]]-date buckets. This is a
-*reporting/aggregation* convention, distinct in purpose from the
-curve-construction pillar ladder above, even where individual labels
+instead of the curve-construction
+[[id:CE15D83D-6400-4596-8878-3A78D8298A85][forward ladder]]: =Nostro=,
+=Today=, =Tomorrow=, =Spot=, =1W=, then monthly buckets out to 24 months,
+or alternatively [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM]]-date
+buckets. This is a *reporting/aggregation* convention, distinct in purpose
+from the curve-construction ladder above, even where individual labels
 coincide — a position-bucketing =1W= is not being used to construct a
 term structure. Elaborating this bucketing scheme's own conventions is
 out of scope for this cluster, which is concerned with curve construction.
@@ -142,7 +144,8 @@ curve. A common disambiguation convention appends the roll quarter: e.g.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
+- [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — the subset of tenors actually quoted as live inputs to a given curve.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the ordered series a tenor is one point of.
 - [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the reference date every tenor is relative to.
 - [[id:DF9EFAF9-1340-48F2-BFD9-1F4ED0ADBC76][Date Rolling and Business-Day Calendars]] — how a tenor date is adjusted onto a valid business day.
@@ -154,7 +157,7 @@ curve. A common disambiguation convention appends the roll quarter: e.g.
 
 The short-end labels and the =<n><D|W|M|Y>= period pattern are not local
 convention — they are checked here against independent, citable technical
-sources rather than this cluster's own notebooks:
+sources:
 
 - [[https://strata.opengamma.io/apidocs/com/opengamma/strata/basics/date/MarketTenor.html][OpenGamma Strata: MarketTenor]] — an open-source, industry-used quant
   library's API documentation, defining =ON=/=TN=/=SN=/=SW= in terms

--- a/doc/knowledge/domain/tenor.org
+++ b/doc/knowledge/domain/tenor.org
@@ -27,23 +27,54 @@ but separate concept.
 ** Standard tenor labels
 
 The short end of the curve uses named tenors; the long end uses period
-notation.
+notation. The table below is the *union* of every tenor label attested
+across the source material this cluster draws on, in ascending order. No
+single curve necessarily carries every one of these as a live pillar —
+which subset is actually quoted (as opposed to filled in by interpolation)
+depends on the curve type and the liquidity of the underlying instrument
+at that point (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest
+Rate Curves]] for the instrument-to-pillar mapping).
 
-| Tenor | Common Name  | Description                                                             |
-|-------+--------------+--------------------------------------------------------------------------|
-| =O/N= | Overnight    | From today to the next business day. The earliest possible tenor.       |
-| =T/N= | Tom/Next     | From tomorrow to the day after (i.e. from next business day to spot).  |
-| =S/N= | Spot/Next    | From spot to the next business day after spot.                          |
-| =S/W= | Spot/Week    | From spot to one week after spot (by convention, for rate curves).      |
-| =1W=  | One Week     | One week. For rate curves this is spot + 1W; for vol surfaces today + 1W. |
-| =1M=  | One Month    | One calendar month off spot (rates) or today (vols).                   |
-| =3M=  | Three Months | Three calendar months off spot.                                         |
-| =6M=  | Six Months   | Six calendar months off spot.                                           |
-| =1Y=  | One Year     | Twelve calendar months off spot.                                        |
+| Tenor | Common Name | Notes |
+|-------+-------------+-------|
+| =O/N= | Overnight | Today to next business day. Earliest possible tenor. |
+| =T/N= | Tom/Next | Next business day to spot. |
+| =S/N= | Spot/Next | Spot to spot + 1 business day. |
+| =S/W= | Spot/Week | Spot to spot + 1 week; also written =WK1= or =1W=. |
+| =1D=, =2D=, =3D= | Daily tenors | Used mainly on granular option-map/bucketing screens, not on bootstrapped curves. |
+| =1W=, =2W=, =3W=, =4W= | Weekly tenors | =1W= is a standard pillar everywhere; =2W=/=3W=/=4W= appear on consensus/IPV expiry ladders. |
+| =1M= | One Month | Standard short-end pillar (deposits/LIBOR). |
+| =2M= | Two Months | Appears on consensus/vol expiry ladders. |
+| =3M= | Three Months | Standard pillar; FRA/futures region begins here. |
+| =4M=, =5M= | Four/Five Months | Occasional intermediate points; not universal pillars. |
+| =6M= | Six Months | Standard pillar; short-end deposits may extend this far. |
+| =7M=, =8M= | Seven/Eight Months | Rare, mostly interpolated. |
+| =9M= | Nine Months | Standard pillar on consensus/vol expiry ladders. |
+| =12M= | Twelve Months | Equivalent to =1Y=; both labels appear depending on context (money-market vs. swap convention). |
+| =18M= | Eighteen Months | Explicit odd pillar between =1Y= and =2Y=, bootstrapped off a 3M fixed IRS. |
+| =2Y=-=10Y= | Annual pillars | =2Y=, =3Y=, =4Y=, =5Y=, =6Y=, =7Y=, =8Y=, =9Y=, =10Y=; bootstrapped from 3M-reset IRS. Not every consensus/vol provider supplies every one of these by design (e.g. =6Y=, =8Y=, =9Y= are commonly unsupported gaps, filled by interpolation). |
+| =12Y= | Twelve Years | Appears on consensus/vol expiry ladders between =10Y= and =15Y=. |
+| =15Y= | Fifteen Years | Standard long-end IRS pillar. |
+| =20Y= | Twenty Years | Standard long-end IRS pillar. |
+| =25Y= | Twenty-Five Years | Standard long-end IRS pillar. |
+| =30Y= | Thirty Years | Standard long-end IRS pillar — see [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] for why this is the ceiling for interest rate curves specifically. |
 
 Longer tenors follow the pattern =nM= (months) or =nY= (years). Odd tenors
 between liquid points are [[id:4DF1F49A-9AB4-4B56-B170-808490071799][broken
 dates]].
+
+*** A distinct convention: cash/position bucketing
+
+Beyond the individually named labels above, positions and cash balances
+are sometimes bucketed using a coarser, purely calendar-based scheme
+instead of the curve-pillar ladder: =Nostro=, =Today=, =Tomorrow=,
+=Spot=, =1W=, then monthly buckets out to 24 months, or alternatively
+[[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM]]-date buckets. This is a
+*reporting/aggregation* convention, distinct in purpose from the
+curve-construction pillar ladder above, even where individual labels
+coincide — a position-bucketing =1W= is not being used to construct a
+term structure. Elaborating this bucketing scheme's own conventions is
+out of scope for this cluster, which is concerned with curve construction.
 
 ** Rates vs. vols convention
 
@@ -117,3 +148,23 @@ curve. A common disambiguation convention appends the roll quarter: e.g.
 - [[id:DF9EFAF9-1340-48F2-BFD9-1F4ED0ADBC76][Date Rolling and Business-Day Calendars]] — how a tenor date is adjusted onto a valid business day.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — odd tenors and fixed-calendar-time discontinuities.
 - [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM Dates]] — the quarterly roll dates behind the CDS tenor convention.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a curve built from these labels actually extends, by curve type.
+
+** Further reading: external references
+
+The short-end labels and the =<n><D|W|M|Y>= period pattern are not local
+convention — they are checked here against independent, citable technical
+sources rather than this cluster's own notebooks:
+
+- [[https://strata.opengamma.io/apidocs/com/opengamma/strata/basics/date/MarketTenor.html][OpenGamma Strata: MarketTenor]] — an open-source, industry-used quant
+  library's API documentation, defining =ON=/=TN=/=SN=/=SW= in terms
+  matching this document's almost exactly (=ON=: today to tomorrow, spot
+  lag 0; =TN=: tomorrow to the next day, spot lag 1; =SN=: spot to spot+1,
+  conventional spot lag; =SW=: one week from spot), and confirming
+  standard regular tenors (=2W=, =1M=, =1Y=, ...) are measured from spot
+  under the conventional spot lag.
+- [[https://www.fpml.org/spec/fpml-5-6-5-rec-1/html/confirmation/fpml-5-6-intro-6.html][FpML 5.6: Interest Rate Derivative Product Architecture]] — confirms the
+  =<n><D|W|M|Y>= pattern this document uses (=periodMultiplier= combined
+  with a =period= code, e.g. =6M=, =5Y=) is the actual ISDA/FpML standard
+  representation for a tenor, not an ad hoc parsing convention invented
+  for this codebase.

--- a/doc/knowledge/domain/term_structure.org
+++ b/doc/knowledge/domain/term_structure.org
@@ -38,9 +38,8 @@ date]], and carries metadata beyond the raw (tenor, value) pairs:
   non-deliverable instruments]]).
 - An interpolation method, used to derive values at dates falling between
   the term structure's own tenor points (see
-  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
-  concrete interpolation methods used for interest rate curves
-  specifically).
+  [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] for why this
+  is needed and the concrete local/non-local method families).
 
 One [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]] interest
 rate curve is one term structure; a
@@ -84,5 +83,8 @@ one value or a tenor-indexed series of values.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the individual points a term structure orders.
 - [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every term structure's tenor points are relative to.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete bootstrapping and interpolation mechanics for one interest rate term structure.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete bootstrapping mechanics for one interest rate term structure.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the concrete methods this document's interpolation-method metadata refers to.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the policy for values outside the term structure's own range entirely.
+- [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term Structure Extent]] — how far a term structure's own range extends, by curve type.
 - [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][Funding and Projection Curves]] — several term structures related by a discounting dependency, not one larger term structure.

--- a/doc/knowledge/domain/term_structure.org
+++ b/doc/knowledge/domain/term_structure.org
@@ -11,7 +11,7 @@
 
 * Summary
 
-A *term structure* (also /time structure/ or /curve/) is an ordered series
+A *term structure* (also /curve/) is an ordered series
 of [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] points representing
 the time profile of a quantity — a rate, a price, a volatility — across a
 series of future dates, together with the metadata needed to interpret
@@ -80,7 +80,7 @@ one value or a tenor-indexed series of values.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the individual points a term structure orders.
 - [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon Date]] — the anchor every term structure's tenor points are relative to.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the concrete bootstrapping mechanics for one interest rate term structure.

--- a/doc/knowledge/domain/term_structure_extent.org
+++ b/doc/knowledge/domain/term_structure_extent.org
@@ -1,0 +1,86 @@
+:PROPERTIES:
+:ID: 6FFD22D7-5E83-405A-8069-52B96B9AF606
+:END:
+#+title: Term Structure Extent
+#+description: How far a term structure extends by curve type (30Y for IR, 5Y-default/30Y-available for vol, open-ended for CDS), and the flatten-beyond-the-end convention.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:tenors:ore:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+A [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structure]] is defined by
+its constituent [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]] points,
+but nothing in that definition says how *far* the series extends before
+stopping — that extent is itself a convention, and it differs materially by
+curve type: interest rate curves stop at a fixed 30-year ceiling,
+volatility surfaces default to a much shorter 5 years while remaining
+*able* to quote out to 30, and CDS curves have no fixed ceiling at all,
+running instead to whatever the longest live trade in the portfolio
+happens to be. A term structure's behaviour for a request *beyond* its own
+last point is a second, related convention — flatten, not extrapolate — a
+deliberate, explicit choice rather than a failure mode.
+
+* Detail
+
+** Interest rate curves: a fixed 30-year ceiling
+
+For interest rate (discount/projection) curves, the long end is
+consistently *30Y* — =15Y=, =20Y=, =25Y=, =30Y= are named together as the
+standard long-end IRS pillars (see
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s standard label table),
+and the consensus-provider expiry list likewise terminates at 30 years.
+Where a curve genuinely has no tenor beyond its last pillar, the system
+does not silently fail a request past that point; it applies the
+beyond-the-end convention below. If asked whether an interest rate curve
+should extend to 30Y or 50Y, the answer is unambiguously 30Y — 50Y does
+not appear as a curve length anywhere in the source material this cluster
+draws on.
+
+** Volatility surfaces: a practical default, not a hard ceiling
+
+For [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX volatility surfaces]],
+data normally extends only to *5Y*, and that same 5Y point is
+conventionally reused as the surface's short-end/long-end *curve split
+tenor* for interpolation purposes. This is a *practical default*, not a
+structural limit: it must remain possible to view or quote a vol surface
+out to 30Y on request. Beyond the liquid ATM region, a common quoting
+convention applies a Zero Delta Straddle (delta-neutral straddle) out to
+10Y, then an ATM Forward from 12Y through 30Y — a different quoting basis
+for the illiquid long end, not an extension of the same liquid-region
+convention.
+
+** CDS curves: open-ended, portfolio-driven
+
+CDS/credit exposure has no fixed maximum tenor at all. Rather than a
+pillar-based ceiling, it runs "up to the longest maturity of the
+portfolio" — open-ended, and determined by whichever live trade happens to
+be longest, not by a fixed curve length the way IR and vol curves are.
+
+** Beyond the end: flatten, not extrapolate
+
+Three distinct regions exist relative to a term structure's known points:
+
+- *Between* two known points: interpolate. Log-linear is the preferred
+  method; polynomial methods are best avoided for this purpose (see
+  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
+  full local/non-local interpolation method comparison).
+- *Before* the start of the curve: extrapolate.
+- *Beyond* the end of the curve: the convention is to *flatten* — hold the
+  last known value constant — and extrapolate only in rare, explicitly
+  justified cases. This is the deliberate resolution of "what happens past
+  30Y (IR) / past 5Y (vol, if not quoting out further) / past the
+  portfolio's longest CDS trade": the system does not silently fail, and
+  it does not default to extrapolation, which would manufacture a value
+  with no basis. It holds the curve flat instead.
+
+* See also
+
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series this document states the extent of.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard long-end labels (15Y-30Y) that define the IR ceiling.
+- [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how interpolated/extrapolated/flattened points are tracked and distinguished from directly-quoted ones.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the interpolation methods used between known points.
+- [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the 5Y default extent and curve-split tenor in its native context.

--- a/doc/knowledge/domain/term_structure_extent.org
+++ b/doc/knowledge/domain/term_structure_extent.org
@@ -61,26 +61,24 @@ be longest, not by a fixed curve length the way IR and vol curves are.
 
 ** Beyond the end: flatten, not extrapolate
 
-Three distinct regions exist relative to a term structure's known points:
-
-- *Between* two known points: interpolate. Log-linear is the preferred
-  method; polynomial methods are best avoided for this purpose (see
-  [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] for the
-  full local/non-local interpolation method comparison).
-- *Before* the start of the curve: extrapolate.
-- *Beyond* the end of the curve: the convention is to *flatten* — hold the
-  last known value constant — and extrapolate only in rare, explicitly
-  justified cases. This is the deliberate resolution of "what happens past
-  30Y (IR) / past 5Y (vol, if not quoting out further) / past the
-  portfolio's longest CDS trade": the system does not silently fail, and
-  it does not default to extrapolation, which would manufacture a value
-  with no basis. It holds the curve flat instead.
+What happens past 30Y (IR) / past 5Y (vol, if not quoting out further) /
+past the portfolio's longest CDS trade is governed by
+[[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]]'s general
+beyond-the-end policy: the system does not silently fail, and it does not
+default to extrapolation, which would manufacture a value with no basis —
+it holds the curve flat instead. See
+[[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] for the full
+policy, including the asymmetry with the before-the-start case, and
+[[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] for how the
+region *between* known points is handled instead.
 
 * See also
 
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series this document states the extent of.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard long-end labels (15Y-30Y) that define the IR ceiling.
+- [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the general before-the-start/beyond-the-end policy this document's curve-type-specific ceilings feed into.
+- [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how interpolated/extrapolated/flattened points are tracked and distinguished from directly-quoted ones.
-- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the interpolation methods used between known points.
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — where these methods are applied to a concrete bootstrapped curve.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the 5Y default extent and curve-split tenor in its native context.

--- a/doc/knowledge/domain/term_structure_extent.org
+++ b/doc/knowledge/domain/term_structure_extent.org
@@ -29,7 +29,7 @@ deliberate, explicit choice rather than a failure mode.
 
 For interest rate (discount/projection) curves, the long end is
 consistently *30Y* — =15Y=, =20Y=, =25Y=, =30Y= are named together as the
-standard long-end IRS pillars (see
+standard long-end IRS [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillars]] (see
 [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]]'s standard label table),
 and the consensus-provider expiry list likewise terminates at 30 years.
 Where a curve genuinely has no tenor beyond its last pillar, the system
@@ -74,11 +74,12 @@ region *between* known points is handled instead.
 
 * See also
 
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — the hub.
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series this document states the extent of.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the standard long-end labels (15Y-30Y) that define the IR ceiling.
 - [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the general before-the-start/beyond-the-end policy this document's curve-type-specific ceilings feed into.
 - [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — the sister concept for values between known pillars.
+- [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — what a pillar is, and how it differs from a tenor in general.
 - [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — how interpolated/extrapolated/flattened points are tracked and distinguished from directly-quoted ones.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — where these methods are applied to a concrete bootstrapped curve.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the 5Y default extent and curve-split tenor in its native context.

--- a/doc/knowledge/domain/term_structures_and_tenors.org
+++ b/doc/knowledge/domain/term_structures_and_tenors.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 1427C01C-17C0-4D7E-AE55-BF16C414FD58
 :END:
-#+title: Time Structures and Tenors
+#+title: Term Structures and Tenors
 #+description: Hub note for the time-dependence of market data: scalar vs tenor vs term structure, and the atomic docs covering tenor labels, horizon date, date rolling, broken dates/turn points, and IMM dates.
 #+type: knowledge
 #+level: cross
@@ -39,14 +39,19 @@ for vol surface tenors see
   and [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] (the
   latter also covers the *scalar* contrast — a market value with no tenor
   dimension at all).
+- *A quoted tenor, specifically* → [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]]
+  (the subset of tenors that are live inputs to a curve, as distinct from
+  tenor labels in general).
 - *The anchor date* → [[id:6857871D-CFDE-4D9F-A83A-4A84CD3F4448][Horizon
   Date]] (what every tenor calculation starts from, and how it differs
   from the reval date it usually, but not always, coincides with).
 - *Settlement timing* (companion cluster) →
   [[id:267DD5E8-F095-47C1-B42B-733565306776][FX spot date and
-  settlement]] (spot days, the =T+2= max-of-two rule) and
+  settlement]] (spot days, the =T+2= max-of-two rule),
   [[id:85526DCE-31B2-4D46-BA3F-564876397BE2][Valuation spot date and
-  overnight]] (reval date, valuation spot date, O/N/T/N outrights).
+  overnight]] (reval date, valuation spot date, the pre-spot region, and
+  O/N/T/N outrights), and [[id:5CC47697-2655-4ECD-B04D-C6C08FF620D5][Tom/Next]]
+  (its dual role as settlement convention and funding mechanism).
 - *Landing on a valid date* → [[id:DF9EFAF9-1340-48F2-BFD9-1F4ED0ADBC76][Date
   Rolling and Business-Day Calendars]] (Modified Following and the other
   standard rolling conventions).
@@ -78,54 +83,13 @@ for vol surface tenors see
 
 For how a tenor and a term structure appear in a concrete,
 [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][bootstrapped]] interest rate
-curve — day-count conventions, pillar instruments, interpolation — see
+curve — day-count conventions, [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][pillar]] instruments, interpolation — see
 [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]. For how
 several such curves compose into a
 [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][curve family]] for one currency,
 see [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve
 Families]]. For the equivalent tenor concept on the volatility side, see
 [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]].
-
-** Deferred: FX short-end forward conventions
-
-The following FX-settlement-specific conventions were part of this
-document's previous, monolithic form and are preserved here verbatim
-rather than atomized, since they are out of scope for the current
-interest-rate work and it would be premature to design their final home
-before returning to them. The *"Out Of" convention* that used to sit
-alongside these has since been promoted to its own atomic doc,
-[[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]], rather than
-staying deferred here — unlike the two conventions below, it is not
-FX-settlement-specific: it is a general spot/forward-curve quoting-basis
-convention already load-bearing for
-[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
-Points]]'s entry and display rules.
-
-*** Spot days and the pre-spot region
-
-For currencies with a T+2 spot lag, there is a two-day region before spot:
-today → tomorrow (=O/N=) and tomorrow → spot (=T/N=). For currencies with a
-T+1 spot lag (e.g. USD/CAD, USD/TRY) this region collapses to a single day.
-
-To value an FX position as of /today/ rather than /spot/, the spot rate
-must be adjusted by the short-end rates:
-
-- *T+1 spot currencies*:
-  - Outright today = Spot rate − O/N points × scaling factor
-  - Outright tomorrow = Spot rate
-
-- *T+2 spot currencies*:
-  - Outright today = Spot rate − T/N points × scaling factor − O/N points × scaling factor
-  - Outright tomorrow = Spot rate − T/N points × scaling factor
-
-*** Tom/Next and funding
-
-Tom/Next serves a dual role:
-
-1. *A time reference*: the standard settlement convention for rolling an
-   open spot position to the next business day.
-2. *A funding mechanism*: interest accrues on accumulated cash up to the
-   Tom/Next date.
 
 * See also
 

--- a/doc/knowledge/domain/time_structures_and_tenors.org
+++ b/doc/knowledge/domain/time_structures_and_tenors.org
@@ -65,6 +65,14 @@ for vol surface tenors see
   Point Provenance]] (rejected/interpolated/back-filled/overridden
   metadata, and why a broken date is never promoted into a standard
   tenor).
+- *Filling the gaps* → [[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]]
+  (local vs. non-local methods, the curve split tenor) and
+  [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] (before the
+  start vs. flattening beyond the end).
+- *Which reference point a ladder is quoted off* →
+  [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] (Out of
+  Spot, Tomorrow, or Today, and why non-default bases must be visually
+  flagged).
 
 ** Where these concepts are consumed
 
@@ -80,11 +88,18 @@ Families]]. For the equivalent tenor concept on the volatility side, see
 
 ** Deferred: FX short-end forward conventions
 
-The following FX-specific conventions were part of this document's
-previous, monolithic form and are preserved here verbatim rather than
-atomized, since they are out of scope for the current interest-rate work
-and it would be premature to design their final home before returning to
-them.
+The following FX-settlement-specific conventions were part of this
+document's previous, monolithic form and are preserved here verbatim
+rather than atomized, since they are out of scope for the current
+interest-rate work and it would be premature to design their final home
+before returning to them. The *"Out Of" convention* that used to sit
+alongside these has since been promoted to its own atomic doc,
+[[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]], rather than
+staying deferred here — unlike the two conventions below, it is not
+FX-settlement-specific: it is a general spot/forward-curve quoting-basis
+convention already load-bearing for
+[[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn
+Points]]'s entry and display rules.
 
 *** Spot days and the pre-spot region
 
@@ -102,16 +117,6 @@ must be adjusted by the short-end rates:
 - *T+2 spot currencies*:
   - Outright today = Spot rate − T/N points × scaling factor − O/N points × scaling factor
   - Outright tomorrow = Spot rate − T/N points × scaling factor
-
-*** The "Out Of" convention on forward ladders
-
-A forward rate ladder can be expressed starting from different reference
-points:
-
-- *Out of Spot* (standard): rates beyond =S/N= are computed off spot.
-- *Out of Tomorrow*: rates beyond =T/N= are computed off tomorrow.
-- *Out of Today*: all rates are computed off today. Tenors in this mode are
-  non-standard and should be visually distinguished to alert users.
 
 *** Tom/Next and funding
 

--- a/doc/knowledge/domain/time_structures_and_tenors.org
+++ b/doc/knowledge/domain/time_structures_and_tenors.org
@@ -52,9 +52,19 @@ for vol surface tenors see
   standard rolling conventions).
 - *Irregular dates* → [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken
   Dates and Turn Points]] (bespoke maturities vs. fixed-calendar-time
-  discontinuities) and [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM
-  Dates]] (the fixed quarterly roll schedule CDS and STIR futures use
-  instead of horizon-relative tenor arithmetic).
+  discontinuities, the three-way tenor classification, and how broken
+  dates are entered/displayed) and
+  [[id:013BC5B0-9461-4AD4-A55E-374BCF34D8A4][IMM Dates]] (the fixed
+  quarterly roll schedule CDS and STIR futures use instead of
+  horizon-relative tenor arithmetic).
+- *How far a curve goes* → [[id:6FFD22D7-5E83-405A-8069-52B96B9AF606][Term
+  Structure Extent]] (30Y for interest rate curves, 5Y-default/30Y-available
+  for vol surfaces, open-ended for CDS, and the flatten-beyond-the-end
+  convention).
+- *Tracking a point's history* → [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve
+  Point Provenance]] (rejected/interpolated/back-filled/overridden
+  metadata, and why a broken date is never promoted into a standard
+  tenor).
 
 ** Where these concepts are consumed
 

--- a/doc/knowledge/domain/tom_next_funding.org
+++ b/doc/knowledge/domain/tom_next_funding.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 5CC47697-2655-4ECD-B04D-C6C08FF620D5
+:END:
+#+title: Tom/Next
+#+description: What Tom/Next (T/N) is, and its dual role as both a settlement convention for rolling an open spot position and a funding mechanism accruing interest on cash held overnight.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:fx:crm:
+#+created: 2026-07-12
+#+updated: 2026-07-12
+
+* Summary
+
+*Tom/Next* (=T/N=) is the short-end [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][tenor]]
+spanning the next business day to spot. Unlike most other short-end
+tenors, it carries two distinct roles rather than one: as a *time
+reference* it is the standard settlement convention for rolling an open
+spot position forward to the next business day; as a *funding mechanism*
+it is the period over which interest accrues on cash held overnight. Both
+roles matter together — a Tom/Next roll is not a simple date relabelling,
+it has a real funding cost or benefit attached to it.
+
+* Detail
+
+** What Tom/Next is
+
+Tom/Next is one of the standard short-end tenor labels (alongside =O/N=
+and =S/N=), covering the window from the next business day to spot. See
+[[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] for how it fits among
+the other standard labels, and
+[[id:85526DCE-31B2-4D46-BA3F-564876397BE2][Valuation spot date and
+overnight]] for the O/N/T/N outright formulas that use it as a date-window
+input to price spot today or tomorrow.
+
+** Dual role
+
+- *A time reference*: the standard settlement convention for rolling an
+  open spot position to the next business day, once a spot trade has not
+  yet delivered by end of day.
+- *A funding mechanism*: interest accrues on accumulated cash up to the
+  Tom/Next date. This is distinct from Tom/Next's use as a date-window
+  input to the O/N/T/N outright formulas: those formulas use T/N to price
+  a rate; the funding role is about what happens economically over the
+  T/N window itself, independent of any one outright calculation.
+
+** Why both roles matter together
+
+A position rolled on a Tom/Next basis is not simply relabelled to a new
+date — the funding role means the roll has a real economic cost or
+benefit, since interest genuinely accrues on the cash over that window.
+Treating Tom/Next purely as a settlement-convention date label, without
+its funding role, would miss why an open spot position held overnight
+carries a funding charge or credit at all.
+
+* See also
+
+- [[id:5DD9A309-91E0-4CAB-BD9D-6ECB3B5EB58E][Currency pairs]] — the FX/CRM hub.
+- [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — T/N among the other standard short-end tenor labels.
+- [[id:85526DCE-31B2-4D46-BA3F-564876397BE2][Valuation spot date and overnight]] — the O/N/T/N outright formulas Tom/Next is also an input to.
+- [[id:8582E7E9-D975-46D5-B61B-93B9EA3DECC0][Out Of Convention]] — the quoting basis a Tom/Next-rolled ladder is still subject to.
+- [[id:CE15D83D-6400-4596-8878-3A78D8298A85][Forward Ladder]] — the entry/display surface a Tom/Next roll is reflected on.

--- a/doc/knowledge/domain/trade_blotter.org
+++ b/doc/knowledge/domain/trade_blotter.org
@@ -494,7 +494,7 @@ Non-Deliverable Options require:
 3. Fix the NDF.
 
 The NDF fixing date is shown alongside the NDO; it is normally today but can
-differ due to holiday calendars (see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]).
+differ due to holiday calendars (see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]]).
 
 ** Undo
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -64,7 +64,7 @@ Finance concepts the codebase relies on, grouped by topic.
   curves compose beyond a single curve: funding/projection families,
   multi-curve build order, storage grouping, the review UI, and
   onshore/offshore namespacing.
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — hub note for scalar/tenor/term-structure
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — hub note for scalar/tenor/term-structure
   concepts: tenor labels, horizon date, date rolling, IMM dates, and
   broken dates/turn points.
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -59,7 +59,7 @@ Finance concepts the codebase relies on, grouped by topic.
 ** Rates and curves
 
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — day-count conventions, discount factors,
-  bootstrapping, and interpolation methods for rate curves.
+  and bootstrapping for rate curves.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — hub note for how a currency's
   curves compose beyond a single curve: funding/projection families,
   multi-curve build order, storage grouping, the review UI, and

--- a/doc/llm/skills/code-add-domain-type/SKILL.org
+++ b/doc/llm/skills/code-add-domain-type/SKILL.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :llm:skill:skills:claude_code:domain:codegen:
 #+created: 2024-09-01
-#+updated: 2026-06-06
+#+updated: 2026-07-12
 
 #+begin_export markdown
 ---
@@ -27,18 +27,41 @@ support. This is the mandatory first step before any exposure layer
 
 * How to use this skill
 
-Codegen is the primary path. Manual creation is a last resort and must
-be justified in the file header.
+Codegen is the primary path for a *persisted, data-carrying* entity
+(one with SQL storage, and usually a UI). Manual creation is
+appropriate — not a last resort — for a behaviour-heavy value type
+(parsing, comparison operators, computed methods) with no persistence
+or generated UI: none of codegen's entity-model types generate that
+shape, they generate flat data-carrying structs plus persistence/UI
+layers. See e.g. =ores.analytics.quant='s own domain types
+(=currency_id=, =ccy_pair=, ...), which are hand-authored for exactly
+this reason — no codegen banner, not listed in
+=compass codegen entity list=. Justify the choice in the file header
+either way.
 
-1. /Create a JSON model/ in =projects/ores.codegen/models/{component}/=
-   following the =*_domain_entity.json= or =*_junction.json= naming
-   convention. See [[id:08FBD248-257A-A474-DD43-DB08949978F1][ORE Studio Codegen]] for the model schema and
-   available fields. Type mappings are in [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]]§"Type
-   mappings".
+1. /Create an org-mode entity model/ under the target component's
+   =modeling/= directory (co-located org models — see the
+   =component_catalogue.org='s =modeling_dir= column), following the
+   =ores.codegen.entity= (full entity: C++ + SQL + Qt),
+   =ores.codegen.lookup_entity= (SQL-only reference table),
+   =ores.codegen.field_group= (flat C++ struct fragment composed into
+   a parent entity), =ores.codegen.table=, or =ores.codegen.junction=
+   schema — see [[id:2A2E8B6D-179D-452C-9169-04E6BB46CC07][Codegen input org-file schema reference]] for the
+   authoritative frontmatter keywords and section hierarchy per type.
+   (The legacy =*_domain_entity.json=/=models/{component}/= format
+   this step used to reference no longer exists in the repo — org-mode
+   entity models superseded it.) Scaffold via =compass add --type
+   entity_org ...= (or =field_group=/=table=/=junction=/
+   =lookup_entity= as appropriate) per [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with
+   compass?]], then fill in the sections by hand.
 
-2. /Generate all C++ artefacts/ (files written directly to the project
-   tree — no copy step):
-   =cd projects/ores.codegen && ./run_generator.sh models/{component}/{entity}_domain_entity.json --profile all-cpp=
+2. /Generate the C++ artefacts/ via compass, not the generator script
+   directly:
+   =compass codegen generate --model <path/to/model.org> --profile all-cpp=
+   (=compass codegen entity generate <entity>= regenerates an
+   already-modelled entity's applicable profiles;
+   =compass codegen entity list= / =show= / =diff= inspect what
+   exists and whether it's stale).
 
 3. /Build and verify/: use [[id:654D4A70-E63D-4C18-B5A5-886066E36314][cmake-runner]] to confirm the component
    library compiles cleanly.

--- a/projects/modeling/system_model_domain.org
+++ b/projects/modeling/system_model_domain.org
@@ -147,7 +147,7 @@ Related documents:
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — yield curve structure, interpolation, and storage
   model.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — vol surface design and calibration data model.
-- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] — tenor conventions and time structure model used
+- [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — tenor conventions and term structure model used
   throughout market data.
 
 ** ores.synthetic


### PR DESCRIPTION
## Summary

Extends the term-structure/tenor knowledge cluster: renames the hub to Term Structures and Tenors, splits Interpolation/Extrapolation/Out Of Convention/Forward Ladder/Tom-Next into their own docs, adds a Pillar doc distinguishing quoted curve inputs from tenor labels, and reworks Curve Point Provenance and Multicurve Management to link to already-defined concepts and describe requirements as prose rather than a requirements-document format.

## Changes

- New: Pillar, Forward Ladder, Tom/Next, Interpolation, Extrapolation, Out Of Convention knowledge docs
- Renamed Time Structures and Tenors -> Term Structures and Tenors (not attested terminology)
- Curve Point Provenance and Multicurve Management reworked to org-roam link rather than duplicate definitions
- Docs-only change; no code

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [IR Rates synthetic data generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.html) | 3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98 |
| Task | [Term structure/tenor knowledge docs: Pillar, provenance/ladder cleanup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_pillar-and-provenance-docs.html) | 38449685-430E-4AF3-802E-5E02606BF2DA |
| Environment | eager-maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)