### PR TITLE
[marketdata] Salvage tenor_period runtime value type from PR #1522

### DIFF
--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.org
@@ -131,7 +131,7 @@ which now require the process to expose =P(t,T)=, not just a path of
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:3D39EF0A-585F-4C66-B84F-433CAFA4DEB2][Lightweight QuantLib-free tenor type]] | STARTED | 2026-07-11 | | Parse tenor labels (3M, 2Y, 1W) and support simple std::chrono-based date-window overlap checks, with no business-day calendar machinery and no QuantLib dependency. |
+| [[id:3D39EF0A-585F-4C66-B84F-433CAFA4DEB2][Lightweight QuantLib-free tenor type]] | DONE | 2026-07-11 | 2026-07-13 | Parse tenor labels (3M, 2Y, 1W) and support simple std::chrono-based date-window overlap checks, with no business-day calendar machinery and no QuantLib dependency. |
 | [[id:01143977-5DA2-48AE-B4BE-109585BC4962][Short-rate stochastic process (Hull-White/CIR/Vasicek)]] | BACKLOG | | | New IStochasticProcess implementation for mean-reverting short-rate dynamics, wired into process_factory, mirroring ou_process's shape. |
 | [[id:20D82F58-758D-498A-8B08-AA664408CB8F][Curve Template sub-config (ir_curve_generation_config)]] | BACKLOG | | | New sub-config owned by market_data_generation_config, one per currency+index, configuring the raw instrument grid (deposits, FRAs/futures, swaps). |
 | [[id:E6B7DEF3-F35F-454A-8ECF-CCD9E8E07A83][Tenor-collision/gap validation on the Curve Template]] | BACKLOG | | | Pure, engine-side validator (ores.synthetic.api) rejecting instrument grids where tenors overlap or collide with an active delivery window, using the new tenor type. |

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :ir-rates-synthetic-generation:sprint_23:v0:
 #+owner: marco
-#+branch: feature/tenor-type
-#+pr: 1517
+#+branch: feature/tenor-runtime-value-type
+#+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
@@ -34,12 +34,12 @@ tenor-collision validator task.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                                   |
 | Parent story | [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]] |
-| Now          | Domain-knowledge groundwork done; C++ implementation not yet started. |
+| Now          | Complete.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Implement the tenor type in =ores.marketdata= (not =ores.utility= — see Notes) per the =Tenor= knowledge doc. |
-| Last touched | 2026-07-12                               |
+| Next         | Nothing.                                |
+| Last touched | 2026-07-13                               |
 
 * Acceptance
 
@@ -101,12 +101,30 @@ implementation should now be written against:
   restated in =pricing_configuration.org=) was replaced with links to
   the new atomic docs.
 
+A follow-up modeling review concluded a tenor also needs to be a
+persisted, orderable reference-data entity (users manage the standard
+tenor set and its per-convention resolution rules), not only an
+in-process value type. That redesign shipped separately as
+=ores.marketdata.tenor=/=tenor_anchor=/=tenor_convention=/
+=tenor_convention_resolution= codegen entity models (SQL, domain,
+repository, service, protocol, Qt UI). The original hand-authored
+=ores.marketdata::domain::tenor= value type from PR #1522 was salvaged
+onto a fresh branch and renamed =tenor_period= (parse()/end_date()/
+resolve_window()/windows_overlap()) to avoid colliding with the new
+persisted =domain::tenor= entity — it remains the runtime date-arithmetic
+companion the tenor-collision validator task needs, which the entity
+model alone does not provide. PR #1522 itself was closed unmerged: its
+knowledge-doc changes were superseded by #1528 (already merged), and its
+code is what this task now ships instead.
+
 * PRs
 
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/1517][#1517]] | [doc] Establish IR curve-family and time-structure/tenor knowledge clusters |
 | [[https://github.com/OreStudio/OreStudio/pull/1411][#1411]] | [agile] Raise IR Rates synthetic data generation story |
+| [[https://github.com/OreStudio/OreStudio/pull/1522][#1522]] | [marketdata] Add QuantLib-free tenor type (closed unmerged; docs superseded by #1528, code salvaged into this task) |
+| [[https://github.com/OreStudio/OreStudio/pull/1528][#1528]] | [doc] Term structure/tenor cluster: Pillar, provenance/ladder cleanup |
 
 * Review
 
@@ -124,3 +142,12 @@ PR #1517 review round (3 automated passes, issue-level comments, no line comment
 | 5 | "Waiting on PR #1409" note stale — PR #1409 merged into main (4be33f2b4) before this branch's rebase, but story.org still said "still open" | story.org | Fixed | Updated to "Nothing" with a note that #1409 merged prior to this branch's rebase |
 
 * Result
+
+Shipped as two parts: (1) the persisted, orderable tenor-as-entity
+redesign (=ores.marketdata.tenor=/=tenor_anchor=/=tenor_convention=/
+=tenor_convention_resolution=, full codegen layers including Qt UI,
+raised separately as part of the DQ dataset task); (2) the runtime
+=tenor_period= value type (parse/end_date/resolve_window/windows_overlap,
+10 test cases/33 assertions, salvaged and renamed from PR #1522 to avoid
+colliding with the persisted entity). PR #1522 closed unmerged; its docs
+were superseded by #1528, its code lives on here instead.

--- a/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
+++ b/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.org
@@ -8,7 +8,7 @@
 #+filetags: :ir-rates-synthetic-generation:sprint_23:v0:
 #+owner: marco
 #+branch: feature/tenor-runtime-value-type
-#+pr:
+#+pr: 1535
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-03
@@ -121,6 +121,7 @@ code is what this task now ships instead.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1535][#1535]] | [marketdata] Salvage tenor_period runtime value type from PR #1522 |
 | [[https://github.com/OreStudio/OreStudio/pull/1517][#1517]] | [doc] Establish IR curve-family and time-structure/tenor knowledge clusters |
 | [[https://github.com/OreStudio/OreStudio/pull/1411][#1411]] | [agile] Raise IR Rates synthetic data generation story |
 | [[https://github.com/OreStudio/OreStudio/pull/1522][#1522]] | [marketdata] Add QuantLib-free tenor type (closed unmerged; docs superseded by #1528, code salvaged into this task) |

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/domain/tenor_period.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/domain/tenor_period.hpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_MARKETDATA_API_DOMAIN_TENOR_PERIOD_HPP
+#define ORES_MARKETDATA_API_DOMAIN_TENOR_PERIOD_HPP
+
+#include "ores.marketdata.api/export.hpp"
+#include <chrono>
+#include <compare>
+#include <string>
+#include <string_view>
+
+namespace ores::marketdata::domain {
+
+/**
+ * @brief The unit a tenor::count is expressed in.
+ */
+enum class tenor_period_unit { days, weeks, months, years };
+
+/**
+ * @brief A lightweight, QuantLib-free tenor period: a label identifying a point in
+ * time relative to a horizon date (see
+ * doc/knowledge/domain/tenor.org and doc/knowledge/domain/horizon_date.org).
+ *
+ * Deliberately does not model business-day calendars or holiday rolling —
+ * that level of precision belongs to actual curve bootstrapping, which is
+ * out of scope here (see doc/knowledge/domain/date_rolling_and_business_day_calendars.org).
+ * The short-end labels (O/N, T/N, S/N, S/W) are approximated as fixed day
+ * counts from the horizon date rather than resolved against real
+ * spot-lag/holiday conventions.
+ */
+class ORES_MARKETDATA_API_EXPORT tenor_period final {
+public:
+    tenor_period() = default;
+    tenor_period(tenor_period_unit unit, int count) : unit_(unit), count_(count) {}
+
+    /**
+     * @brief Parses a standard tenor label (O/N, T/N, S/N, S/W, or the
+     * "<n><D|W|M|Y>" pattern, e.g. "1W", "3M", "2Y") into a tenor.
+     *
+     * @param label The tenor label to parse.
+     * @throws std::invalid_argument if the label is not a recognised tenor.
+     */
+    static tenor_period parse(std::string_view label);
+
+    tenor_period_unit unit() const { return unit_; }
+    int count() const { return count_; }
+
+    /**
+     * @brief Approximate length in calendar days, used only to order and
+     * compare tenors against one another (not for date arithmetic).
+     */
+    int approx_days() const;
+
+    /**
+     * @brief Resolves this tenor to an end date relative to a horizon date,
+     * using std::chrono calendar arithmetic (no business-day adjustment).
+     */
+    std::chrono::year_month_day end_date(std::chrono::year_month_day horizon) const;
+
+    std::strong_ordering operator<=>(const tenor_period& other) const {
+        return approx_days() <=> other.approx_days();
+    }
+    bool operator==(const tenor_period& other) const = default;
+
+private:
+    tenor_period_unit unit_{tenor_period_unit::days};
+    int count_{0};
+};
+
+/**
+ * @brief A half-open date window [start, end) anchored to a horizon date and
+ * a tenor.
+ */
+struct tenor_period_window final {
+    std::chrono::year_month_day start;
+    std::chrono::year_month_day end;
+};
+
+/**
+ * @brief Resolves a (horizon, tenor) pair into its [start, end) date window,
+ * where start is the horizon date itself.
+ */
+ORES_MARKETDATA_API_EXPORT tenor_period_window
+resolve_window(std::chrono::year_month_day horizon, const tenor_period& t);
+
+/**
+ * @brief Whether two half-open date windows [a.start, a.end) and
+ * [b.start, b.end) overlap.
+ */
+ORES_MARKETDATA_API_EXPORT bool windows_overlap(const tenor_period_window& a, const tenor_period_window& b);
+
+}
+
+#endif

--- a/projects/ores.marketdata/api/src/domain/tenor_period.cpp
+++ b/projects/ores.marketdata/api/src/domain/tenor_period.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.marketdata.api/domain/tenor_period.hpp"
+#include <charconv>
+#include <stdexcept>
+
+namespace ores::marketdata::domain {
+
+namespace {
+
+// Short-end labels are approximated as fixed day counts from the horizon
+// date, rather than resolved against real spot-lag/holiday conventions
+// (out of scope here — see class comment).
+constexpr int overnight_days = 1;
+constexpr int tom_next_days = 2;
+constexpr int spot_next_days = 3;
+constexpr int spot_week_days = 9; // spot (day 2) + one week.
+
+int days_per_unit(tenor_period_unit unit) {
+    switch (unit) {
+    case tenor_period_unit::days: return 1;
+    case tenor_period_unit::weeks: return 7;
+    case tenor_period_unit::months: return 30;
+    case tenor_period_unit::years: return 365;
+    }
+    throw std::invalid_argument("Unrecognised tenor_period_unit");
+}
+
+}
+
+tenor_period tenor_period::parse(std::string_view label) {
+    if (label == "O/N") return tenor_period(tenor_period_unit::days, overnight_days);
+    if (label == "T/N") return tenor_period(tenor_period_unit::days, tom_next_days);
+    if (label == "S/N") return tenor_period(tenor_period_unit::days, spot_next_days);
+    if (label == "S/W") return tenor_period(tenor_period_unit::days, spot_week_days);
+
+    if (label.size() < 2)
+        throw std::invalid_argument("Tenor label too short: " + std::string(label));
+
+    const char unitChar = label.back();
+    tenor_period_unit unit;
+    switch (unitChar) {
+    case 'D': unit = tenor_period_unit::days; break;
+    case 'W': unit = tenor_period_unit::weeks; break;
+    case 'M': unit = tenor_period_unit::months; break;
+    case 'Y': unit = tenor_period_unit::years; break;
+    default:
+        throw std::invalid_argument("Unrecognised tenor label: " + std::string(label));
+    }
+
+    const auto digits = label.substr(0, label.size() - 1);
+    int count = 0;
+    const auto result = std::from_chars(digits.data(), digits.data() + digits.size(), count);
+    if (result.ec != std::errc() || result.ptr != digits.data() + digits.size() || count <= 0)
+        throw std::invalid_argument("Unrecognised tenor label: " + std::string(label));
+
+    return tenor_period(unit, count);
+}
+
+int tenor_period::approx_days() const { return count_ * days_per_unit(unit_); }
+
+std::chrono::year_month_day tenor_period::end_date(std::chrono::year_month_day horizon) const {
+    using namespace std::chrono;
+
+    switch (unit_) {
+    case tenor_period_unit::days:
+        return year_month_day(sys_days(horizon) + days(count_));
+    case tenor_period_unit::weeks:
+        return year_month_day(sys_days(horizon) + weeks(count_));
+    case tenor_period_unit::months: {
+        auto shifted = horizon + months(count_);
+        if (!shifted.ok())
+            shifted = year_month_day_last(shifted.year() / shifted.month() / last);
+        return shifted;
+    }
+    case tenor_period_unit::years: {
+        auto shifted = horizon + years(count_);
+        if (!shifted.ok())
+            shifted = year_month_day_last(shifted.year() / shifted.month() / last);
+        return shifted;
+    }
+    }
+    throw std::invalid_argument("Unrecognised tenor_period_unit");
+}
+
+tenor_period_window resolve_window(std::chrono::year_month_day horizon, const tenor_period& t) {
+    return tenor_period_window{horizon, t.end_date(horizon)};
+}
+
+bool windows_overlap(const tenor_period_window& a, const tenor_period_window& b) {
+    return a.start < b.end && b.start < a.end;
+}
+
+}

--- a/projects/ores.marketdata/api/tests/domain_tenor_period_tests.cpp
+++ b/projects/ores.marketdata/api/tests/domain_tenor_period_tests.cpp
@@ -1,0 +1,168 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.marketdata.api/domain/tenor_period.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+const std::string tags("[tenor_period]");
+
+}
+
+TEST_CASE("tenor_period_parse_recognises_short_end_labels", tags) {
+    using ores::marketdata::domain::tenor_period;
+    using ores::marketdata::domain::tenor_period_unit;
+
+    auto on = tenor_period::parse("O/N");
+    CHECK(on.unit() == tenor_period_unit::days);
+    CHECK(on.count() == 1);
+
+    auto tn = tenor_period::parse("T/N");
+    CHECK(tn.unit() == tenor_period_unit::days);
+    CHECK(tn.count() == 2);
+
+    auto sn = tenor_period::parse("S/N");
+    CHECK(sn.unit() == tenor_period_unit::days);
+
+    auto sw = tenor_period::parse("S/W");
+    CHECK(sw.unit() == tenor_period_unit::days);
+}
+
+TEST_CASE("tenor_period_parse_recognises_period_labels", tags) {
+    using ores::marketdata::domain::tenor_period;
+    using ores::marketdata::domain::tenor_period_unit;
+
+    auto oneWeek = tenor_period::parse("1W");
+    CHECK(oneWeek.unit() == tenor_period_unit::weeks);
+    CHECK(oneWeek.count() == 1);
+
+    auto threeMonths = tenor_period::parse("3M");
+    CHECK(threeMonths.unit() == tenor_period_unit::months);
+    CHECK(threeMonths.count() == 3);
+
+    auto twoYears = tenor_period::parse("2Y");
+    CHECK(twoYears.unit() == tenor_period_unit::years);
+    CHECK(twoYears.count() == 2);
+
+    auto tenDays = tenor_period::parse("10D");
+    CHECK(tenDays.unit() == tenor_period_unit::days);
+    CHECK(tenDays.count() == 10);
+}
+
+TEST_CASE("tenor_period_parse_rejects_malformed_labels", tags) {
+    using ores::marketdata::domain::tenor_period;
+
+    CHECK_THROWS_AS(tenor_period::parse(""), std::invalid_argument);
+    CHECK_THROWS_AS(tenor_period::parse("X"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor_period::parse("3Q"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor_period::parse("M3"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor_period::parse("-1Y"), std::invalid_argument);
+    CHECK_THROWS_AS(tenor_period::parse("0M"), std::invalid_argument);
+}
+
+TEST_CASE("tenor_period_orders_by_approximate_length", tags) {
+    using ores::marketdata::domain::tenor_period;
+
+    CHECK(tenor_period::parse("O/N") < tenor_period::parse("1W"));
+    CHECK(tenor_period::parse("1W") < tenor_period::parse("1M"));
+    CHECK(tenor_period::parse("1M") < tenor_period::parse("1Y"));
+    CHECK(tenor_period::parse("3M") < tenor_period::parse("6M"));
+    CHECK(tenor_period::parse("12M") == tenor_period::parse("12M"));
+}
+
+TEST_CASE("tenor_period_end_date_adds_days_and_weeks", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor_period;
+
+    const year_month_day horizon{year(2026), month(1), day(15)};
+
+    auto oneWeekEnd = tenor_period::parse("1W").end_date(horizon);
+    CHECK(oneWeekEnd == year_month_day{year(2026), month(1), day(22)});
+
+    auto tenDaysEnd = tenor_period::parse("10D").end_date(horizon);
+    CHECK(tenDaysEnd == year_month_day{year(2026), month(1), day(25)});
+}
+
+TEST_CASE("tenor_period_end_date_adds_months_and_years", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor_period;
+
+    const year_month_day horizon{year(2026), month(1), day(15)};
+
+    auto threeMonthsEnd = tenor_period::parse("3M").end_date(horizon);
+    CHECK(threeMonthsEnd == year_month_day{year(2026), month(4), day(15)});
+
+    auto oneYearEnd = tenor_period::parse("1Y").end_date(horizon);
+    CHECK(oneYearEnd == year_month_day{year(2027), month(1), day(15)});
+}
+
+TEST_CASE("tenor_period_end_date_clamps_to_last_valid_day_of_month", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::tenor_period;
+
+    // 31 Jan + 1M has no 31 Feb: must clamp to the last day of February.
+    const year_month_day horizon{year(2026), month(1), day(31)};
+
+    auto oneMonthEnd = tenor_period::parse("1M").end_date(horizon);
+    CHECK(oneMonthEnd == year_month_day{year(2026), month(2), day(28)});
+}
+
+TEST_CASE("windows_overlap_detects_overlapping_windows", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor_period;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    // A 3M deposit window and a 2M-3M FRA-like window overlap.
+    auto deposit = resolve_window(horizon, tenor_period::parse("3M"));
+    auto overlapping = resolve_window(horizon + months(2), tenor_period::parse("3M"));
+
+    CHECK(ores::marketdata::domain::windows_overlap(deposit, overlapping));
+}
+
+TEST_CASE("windows_overlap_returns_false_for_disjoint_windows", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor_period;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    auto first = resolve_window(horizon, tenor_period::parse("1M"));
+    auto secondStart = horizon + months(2);
+    auto second = resolve_window(secondStart, tenor_period::parse("1M"));
+
+    CHECK_FALSE(ores::marketdata::domain::windows_overlap(first, second));
+}
+
+TEST_CASE("windows_overlap_treats_windows_as_half_open", tags) {
+    using namespace std::chrono;
+    using ores::marketdata::domain::resolve_window;
+    using ores::marketdata::domain::tenor_period;
+
+    const year_month_day horizon{year(2026), month(1), day(1)};
+
+    // Second window starts exactly where the first ends: half-open windows
+    // must not count that as an overlap.
+    auto first = resolve_window(horizon, tenor_period::parse("1M"));
+    auto second = resolve_window(first.end, tenor_period::parse("1M"));
+
+    CHECK_FALSE(ores::marketdata::domain::windows_overlap(first, second));
+}


### PR DESCRIPTION
## Summary

Carries forward the tested parse/end_date/resolve_window/windows_overlap logic from PR #1522 (which is being closed unmerged, its docs already superseded by #1528), renamed tenor -> tenor_period to avoid colliding with the newly-added persisted domain::tenor reference-data entity.

## Changes

- New: ores.marketdata.api domain::tenor_period value type (parse, end_date, resolve_window, windows_overlap)
- Renamed from PR #1522's tenor/tenor_unit/tenor_window to tenor_period/tenor_period_unit/tenor_period_window to avoid a class-name collision with the separately-added persisted tenor entity
- Closes out task 'Lightweight QuantLib-free tenor type' (DONE)
- Verification: local build clean (linux-clang-debug-make); 10/10 tenor_period test cases (33 assertions) passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [IR Rates synthetic data generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/story.html) | 3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98 |
| Task | [Lightweight QuantLib-free tenor type](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ir-rates-synthetic-generation/task_tenor-type.html) | 3D39EF0A-585F-4C66-B84F-433CAFA4DEB2 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)