### PR TITLE
[iam] Fix ores.iam.core build: link ores.eventing.core.lib

### DIFF
--- a/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/story.org
+++ b/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/story.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 14F24665-6CB0-4DAB-895E-1D5D1360E507
+:END:
+#+title: Story: Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency
+#+description: party_cache.hpp includes ores.eventing.core/service/cache/partitioned_cache.hpp but ores.iam.core's CMakeLists.txt doesn't depend on ores.eventing.core, so the include path is missing and the build fails.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:iam:sprint_23:v0:
+#+created: 2026-07-14
+#+updated: 2026-07-14
+#+environment: solid_dirac
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore a green build for =ores.iam.core=, broken by PR #1557
+("Migrate party to the generated nats-event-cache"): its generated
+=party_cache.hpp= includes a header from =ores.eventing.core= that the
+component's =CMakeLists.txt= never declared a dependency on.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                   |
+| Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
+| Now           | Nothing.                               |
+| Waiting on    | Nothing.                               |
+| Next          | Raise PR.                              |
+| Last touched  | 2026-07-14                               |
+
+* Acceptance
+
+- =cmake --build= succeeds past =ores.iam.core.lib='s
+  =messaging/registrar.cpp.o= (and the rest of =ores.iam.core=).
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:D649F9BE-9AEF-4983-AD0E-57756D4262E6][Scaffold story: Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] | DONE | 2026-07-14 | 2026-07-14 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:B920D05D-A5FD-405D-B80F-39AD437CE4CE][Implement Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] | DONE | 2026-07-14 | 2026-07-14 | Initial task for: Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency |
+
+* Decisions
+
+- Root cause: PR #1557's generated =party_cache.hpp= introduced an
+  include on =ores.eventing.core= that its consuming component's
+  =CMakeLists.txt= never declared as a link dependency (only the
+  sibling =ores.eventing.api= was linked). One-line fix:
+  =target_link_libraries(... PUBLIC ... ores.eventing.core.lib)=.
+- Confirms a gap in that PR's verification: no vcpkg-based build was
+  available in the sandbox that authored it, so a missing CMake
+  dependency wasn't caught until a real build environment hit it.
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_implement_ores_iam_core_missing_eventing_core_include.org
+++ b/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_implement_ores_iam_core_missing_eventing_core_include.org
@@ -1,0 +1,105 @@
+:PROPERTIES:
+:ID: B920D05D-A5FD-405D-B80F-39AD437CE4CE
+:END:
+#+title: Task: Implement Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency
+#+description: Initial task for: Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency
+#+type: task
+#+level: s1
+#+filetags: :ores_iam_core_missing_eventing_core_include:sprint_23:v0:
+#+owner: marco
+#+branch: feature/implement-ores-iam-core-missing-eventing-core-include
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-14
+#+updated: 2026-07-14
+#+environment: solid_dirac
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix the =ores.iam.core= build failure: it now includes
+=ores.eventing.core/service/cache/partitioned_cache.hpp= (via the
+generated =party_cache.hpp=, PR #1557) but its =CMakeLists.txt= never
+declared a dependency on =ores.eventing.core.lib= — only on
+=ores.eventing.api.lib=, a different target — so the include path was
+never propagated and the compiler can't find the header.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                |
+| Parent story | [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] |
+| Now          | Nothing. |
+| Waiting on   | User to re-run the build (no vcpkg toolchain in this environment to verify locally). |
+| Next         | Nothing. |
+| Last touched | 2026-07-14                               |
+
+* Acceptance
+
+- =ores.iam.core.lib= links =ores.eventing.core.lib= so
+  =partitioned_cache.hpp='s include path resolves.
+- User confirms =cmake --build= succeeds past
+  =projects/ores.iam/core/src/messaging/registrar.cpp.o=.
+
+* Plan
+
+1. Confirm the target name: =ores.eventing.core/src/CMakeLists.txt=
+   sets =name = "ores.eventing.core"=, =lib_target_name =
+   ${name}.lib= → =ores.eventing.core.lib=.
+2. Add =ores.eventing.core.lib= to =ores.iam.core/src/CMakeLists.txt='s
+   =target_link_libraries(... PUBLIC ...)=, alongside the existing
+   =ores.eventing.api.lib= — PUBLIC because the include appears in
+   =ores.iam.core='s public headers (=party_cache.hpp=, pulled in by
+   =account_handler.hpp=/=auth_handler.hpp=/=bootstrap_handler.hpp=).
+3. Check =ores.iam.core/tests= for any direct include of the same
+   headers requiring its own CMake change — none found; tests link
+   =ores.iam.core.lib= and inherit the PUBLIC dependency transitively.
+4. Ask the user to re-run the build, since this environment has no
+   vcpkg toolchain to verify locally.
+
+* Notes
+
+Root cause: PR #1557 ("Migrate party to the generated
+nats-event-cache") added =ores.iam.core/service/cache/party_cache.hpp=
+including =ores.eventing.core/.../partitioned_cache.hpp=, but that PR
+was verified by static/template review only (no vcpkg-based build
+available in that sandbox) and missed that =ores.iam.core='s
+=CMakeLists.txt= had never needed =ores.eventing.core= before (only
+its sibling =ores.eventing.api=, a distinct target with a distinct
+include root). One-line fix: add the missing =target_link_libraries=
+entry.
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Added =ores.eventing.core.lib= to
+=projects/ores.iam/core/src/CMakeLists.txt='s PUBLIC
+=target_link_libraries=, alongside the existing
+=ores.eventing.api.lib=. User confirmed the build now passes past
+=registrar.cpp.o=.

--- a/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_implement_ores_iam_core_missing_eventing_core_include.org
+++ b/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_implement_ores_iam_core_missing_eventing_core_include.org
@@ -8,7 +8,7 @@
 #+filetags: :ores_iam_core_missing_eventing_core_include:sprint_23:v0:
 #+owner: marco
 #+branch: feature/implement-ores-iam-core-missing-eventing-core-include
-#+pr:
+#+pr: 1561
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-14
@@ -88,7 +88,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1561][#1561]] | [iam] Fix ores.iam.core build: link ores.eventing.core.lib |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_scaffold_ores_iam_core_missing_eventing_core_include.org
+++ b/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_scaffold_ores_iam_core_missing_eventing_core_include.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: D649F9BE-9AEF-4983-AD0E-57756D4262E6
+:END:
+#+title: Task: Scaffold story: Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :ores_iam_core_missing_eventing_core_include:sprint_23:v0:
+#+owner: marco
+#+branch: hotfix/ores-iam-core-missing-eventing-core-include
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-14
+#+updated: 2026-07-14
+#+environment: solid_dirac
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-14                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Story/task docs scaffolded and wired into sprint 23's =* Stories=
+section; rides the same PR as the implementation task rather than a
+separate scaffold-only PR.

--- a/doc/agile/versions/v0/sprint_23/sprint.org
+++ b/doc/agile/versions/v0/sprint_23/sprint.org
@@ -79,6 +79,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:C4755E35-7E5D-4276-8AAE-53FA8557FAEF][Hotfix: Windows Clang CI compiler-launcher wrapper]] | DONE | 2026-07-11 | 2026-07-11 | windows-clang-debug-ninja and windows-clang-release-ninja fail to configure because the clang preset's environment launcher (a .sh wrapper) leaks into CMake's project()-time compiler detection on Windows. |
+| [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] | DONE | 2026-07-14 | 2026-07-14 | party_cache.hpp includes ores.eventing.core/service/cache/partitioned_cache.hpp but ores.iam.core's CMakeLists.txt doesn't depend on ores.eventing.core, so the include path is missing and the build fails. |
 
 * Achievements
 

--- a/projects/ores.iam/core/src/CMakeLists.txt
+++ b/projects/ores.iam/core/src/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(${lib_target_name}
         ores.database.lib
         ores.dq.api.lib
         ores.eventing.api.lib
+        ores.eventing.core.lib
         ores.geo.lib
         ores.platform.lib
         ores.security.lib


### PR DESCRIPTION
## Summary

Hotfix: party_cache.hpp (generated by the nats-event-cache facet, PR #1557) includes ores.eventing.core/service/cache/partitioned_cache.hpp, but ores.iam.core's CMakeLists.txt only linked the sibling ores.eventing.api.lib -- a distinct target with a distinct include root -- so the include path was never propagated and the build failed.

## Changes

- Added ores.eventing.core.lib to ores.iam.core/src/CMakeLists.txt's PUBLIC target_link_libraries, alongside the existing ores.eventing.api.lib
- Verification: user confirmed locally (cmake --build) that the build now passes past ores.iam.core.lib's registrar.cpp.o and the rest of the target; no vcpkg toolchain available in this environment to re-verify

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/story.html) | 14F24665-6CB0-4DAB-895E-1D5D1360E507 |
| Task | [Implement Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/ores_iam_core_missing_eventing_core_include/task_implement_ores_iam_core_missing_eventing_core_include.html) | B920D05D-A5FD-405D-B80F-39AD437CE4CE |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)