### PR TITLE
[refdata,sql] Add missing RLS policies for calendars and calendar_types

### DIFF
--- a/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
@@ -717,6 +717,32 @@ with check (
 );
 
 -- -----------------------------------------------------------------------------
+-- Calendar Types
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_calendar_types_tbl enable row level security;
+
+create policy calendar_types_tenant_isolation_policy on ores_refdata_calendar_types_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- Calendars
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_calendars_tbl enable row level security;
+
+create policy calendars_tenant_isolation_policy on ores_refdata_calendars_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
 -- CRM topology configs (codegen-generated table)
 -- -----------------------------------------------------------------------------
 alter table ores_refdata_crm_topology_configs_tbl enable row level security;


### PR DESCRIPTION
## Summary
- `ores_refdata_calendars_tbl` and `ores_refdata_calendar_types_tbl` (added in 88059aa58) have a `tenant_id` column but no registered RLS policy, tripping `validate_schemas.sh`'s `RLS_001` check.
- Adds `calendars_tenant_isolation_policy` and `calendar_types_tenant_isolation_policy` to `refdata_rls_policies_create.sql`, following the `book_purpose_types`/`ledger_feed_types` template.
- Verification: `validate_schemas.sh` now exits 0 with zero warnings; `compass db recreate` runs clean.

Not introduced by any in-flight PR — confirmed identical to `origin/main` before this fix. This is the same recurring class of gap already hit once this sprint for `book_purpose_type`/`ledger_feed_type` (tracked separately as a `codegen_rls_policy_facet` backlog item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)