### PR TITLE
[refdata,sql] Add missing RLS policy for currency_countries

### DIFF
--- a/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
@@ -743,6 +743,19 @@ with check (
 );
 
 -- -----------------------------------------------------------------------------
+-- Currency Countries
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_currency_countries_tbl enable row level security;
+
+create policy currency_countries_tenant_isolation_policy on ores_refdata_currency_countries_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
 -- CRM topology configs (codegen-generated table)
 -- -----------------------------------------------------------------------------
 alter table ores_refdata_crm_topology_configs_tbl enable row level security;


### PR DESCRIPTION
## Summary
- `ores_refdata_currency_countries_tbl` (added in #1568) has a `tenant_id` column but no registered RLS policy, tripping `validate_schemas.sh`'s `RLS_001` check.
- Adds `currency_countries_tenant_isolation_policy` to `refdata_rls_policies_create.sql`, following the existing template.
- Verification: `validate_schemas.sh` now exits 0 with zero warnings.

Same recurring class of gap as #1574 (calendars/calendar_types) — #1568 landed in the same window before that fix merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)