### PR TITLE
[agile] Rescope DQ-publish task to the two unblocked junctions

### DIFF
--- a/doc/agile/versions/v0/sprint_23/calendar-reference-data/story.org
+++ b/doc/agile/versions/v0/sprint_23/calendar-reference-data/story.org
@@ -84,7 +84,7 @@ placeholder text field.
 | [[id:78A340FA-94F0-49F4-B521-89950A32B1F1][Build ORE's comma-joined calendar string only at the XML export boundary]] | BACKLOG | | | ores.ore's conventions_mapper (or successor) should build ORE's comma-joined calendar-name string from the FK relationship(s) only when exporting to XML — the domain model itself never stores the joined string. |
 | [[id:1D064DDB-0C57-43C6-B17C-07003BC644C1][Holiday-aware date picker widget]] | BACKLOG | | | A reusable Qt date-picker widget that takes one or more calendars as input, highlights their holidays (with a tooltip naming the source calendar), and is used everywhere a date sensitive to holidays needs to be picked. |
 | [[id:C6107A93-1639-4EEB-B00F-FF01CDA321FB][Model a currency-country junction]] | DONE | 2026-07-14 | 2026-07-14 | Model a many-to-many currency_country junction linking currency to the existing country entity, since a currency can span multiple countries (e.g. EUR -> DE, FR, IT, ...) and calendar.country_code needs a country to FK against. |
-| [[id:E34B34F0-DE82-4CD2-AA7C-A15527ECCA59][DQ-publish the calendar reference data]] | BACKLOG | | | Wire calendar, calendar_type, currency_country, currency_calendar, and currency_pair_convention_calendar into the DQ bundle publication pipeline (artefact tables + publish-from-dq functions + NATS handlers), following the existing hand-written pattern used for currency_pairs. |
+| [[id:E34B34F0-DE82-4CD2-AA7C-A15527ECCA59][DQ-publish the calendar reference data]] | BACKLOG | | | Wire currency_country and currency_calendar into the DQ bundle publication pipeline (artefact tables + publish-from-dq functions + NATS handlers); calendar/calendar_type already have this from task 1. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_23/calendar-reference-data/task_dq-publish-calendar-reference-data.org
+++ b/doc/agile/versions/v0/sprint_23/calendar-reference-data/task_dq-publish-calendar-reference-data.org
@@ -2,17 +2,17 @@
 :ID: E34B34F0-DE82-4CD2-AA7C-A15527ECCA59
 :END:
 #+title: Task: DQ-publish the calendar reference data
-#+description: Wire calendar, calendar_type, currency_country, currency_calendar, and currency_pair_convention_calendar into the DQ bundle publication pipeline (artefact tables + publish-from-dq functions + NATS handlers), following the existing hand-written pattern used for currency_pairs.
+#+description: Wire currency_country, currency_calendar, and currency_pair_convention_calendar into the DQ bundle publication pipeline (artefact tables + publish-from-dq functions + NATS handlers), following the existing hand-written pattern used for calendar/calendar_type (delivered in task 1) and currency_pairs.
 #+type: task
 #+level: s1
 #+filetags: :calendar-reference-data:sprint_23:v0:
 #+owner: marco
 #+branch:
 #+pr:
-#+blocked_on: 1F43998E-BD20-4CBC-8C05-509F1ABF0E0C, C6107A93-1639-4EEB-B00F-FF01CDA321FB
-#+blocked_since: 2026-07-13
+#+blocked_on:
+#+blocked_since:
 #+created: 2026-07-13
-#+updated: 2026-07-13
+#+updated: 2026-07-15
 #+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -20,17 +20,28 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Wire the new calendar reference-data tables — =calendar=,
-=calendar_type=, =currency_country=, =currency_calendar=, and
+Wire the remaining calendar-adjacent reference-data tables —
+=currency_country=, =currency_calendar=, and
 =currency_pair_convention_calendar= — into the DQ bundle publication
 pipeline (see [[id:F05B779F-769B-49D5-B369-D2AAC029B36D][DQ Bundle
 Publication Pipeline]]), so this data reaches target services as
 dataset bundle publications, the same way =currency_pairs= is
-published today. Since the =publish_from_dq= codegen facet described
-in [[id:1CAA4761-AF7A-4264-8A41-C514083A4FA9][the open capture]] has
-not been built yet, this follows the existing hand-written pattern:
-artefact table(s), =publish-from-dq= SQL function(s), and NATS
-handler wiring, per entity.
+published today. =calendar= and =calendar_type= already have this
+support, delivered early as part of
+[[id:1F43998E-BD20-4CBC-8C05-509F1ABF0E0C][Model the calendar entity
+for codegen]] (=refdata.v1.calendar-types.publish-from-dq=,
+=refdata.v1.calendars.publish-from-dq=) — leaving both junction tables
+without a DQ publish path was flagged during
+[[id:30563983-1E0E-44D2-8D9D-9BBE7086BF68][the currency-calendar FK
+task]]'s review as a gap that shouldn't be left unaddressed: every
+other reference-data table in this story is DQ-publishable, and the
+junctions inheriting "no DQ publish" from each other rather than from
+the fully-supported =calendar= pattern is not something to let stand.
+Since the =publish_from_dq= codegen facet described in
+[[id:1CAA4761-AF7A-4264-8A41-C514083A4FA9][the open capture]] has not
+been built yet, this follows the existing hand-written pattern:
+artefact table(s), =publish-from-dq= SQL function(s), and NATS handler
+wiring, per entity.
 
 * Status
 
@@ -39,29 +50,34 @@ handler wiring, per entity.
 | State        | BACKLOG                              |
 | Parent story | [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model calendars as proper ORE Studio reference data]] |
 | Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
+| Waiting on   | Nothing — both currency_country and currency_calendar have landed. |
 | Next         | Begin implementation.                  |
-| Last touched | 2026-07-13                               |
+| Last touched | 2026-07-15                               |
 
 * Acceptance
 
-- [ ] Artefact tables and =publish-from-dq= SQL functions exist for
-  =calendar=, =currency_country=, =currency_calendar=, and
-  =currency_pair_convention_calendar= (junction tables published
-  alongside their owning entity where that matches the existing
-  pattern; =calendar_type=, being a small static aux-type table, is
-  evaluated for whether it needs its own artefact or can ship as part
-  of =calendar='s bundle).
-- [ ] NATS handler wiring and workflow orchestration registered for
-  each new artefact type, matching =currency_pairs='s existing wiring.
+- [ ] Artefact tables (and matching drop scripts) exist for
+  =currency_country= and =currency_calendar=, mirroring
+  =dq_calendars_artefact_tbl='s shape.
+- [ ] =publish-from-dq= SQL functions exist for both junctions in
+  =refdata_publish_from_dq_create.sql=, supporting the same
+  upsert/insert_only/replace_all mode contract as every other
+  publish-from-dq function.
+- [ ] Both are registered as NATS subjects
+  (=refdata.v1.currency-countries.publish-from-dq=,
+  =refdata.v1.currency-calendars.publish-from-dq=) in
+  =registrar.cpp=.
+- [ ] Both artefact types are registered in
+  =dq_artefact_types_populate.sql=.
+- [ ] =currency_pair_convention_calendar= is evaluated separately: it
+  does not yet exist as a table (calendars are still attached to
+  =currency_pair_convention.advance_calendar= as free text, per
+  [[id:F348285C-7ECE-4D59-9CD1-13931D2C90DE][the pending advance_calendar
+  migration task]]) — DQ publish for it is out of scope here and
+  belongs with that migration once the column becomes a real
+  relationship.
 - [ ] Published bundles are visible and consumable via the Librarian
   UI.
-- [ ] Blocked on tasks
-  [[id:1F43998E-BD20-4CBC-8C05-509F1ABF0E0C][Model the calendar entity
-  for codegen]] and
-  [[id:C6107A93-1639-4EEB-B00F-FF01CDA321FB][Model a currency-country
-  junction]] landing first (the tables must exist before they can be
-  published).
 
 * Plan
 


### PR DESCRIPTION
## Summary
- Doc-only: rescopes the existing "DQ-publish the calendar reference data" task now that its blockers (calendar entity, currency_country junction) have landed.
- calendar/calendar_type already have DQ publish support (delivered early in task 1); currency_country and currency_calendar landed without it, flagged during review as a gap that shouldn't stand.
- Clears the now-satisfied blockers and splits currency_pair_convention_calendar out since that table doesn't exist yet (belongs with its own migration task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)