### PR TITLE
[agile] Scaffold badge colour scheme support story

### DIFF
--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/story.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/story.org
@@ -15,7 +15,37 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+Analysis (task 2, done) found the badge system the story assumed
+didn't exist already does: a database-driven
+=badge_severity=/=code_domain=/=badge_definition=/=badge_mapping=
+catalogue in =ores.dq=, a client-side =BadgeCache=, and codegen
+support (=badge_key= column annotation) that generates the delegate
+wiring automatically. Booleans already badge correctly via the same
+=(code_domain, entity_code)= mapping =is_sweepable= uses — no new
+storage design is needed.
+
+The story's remaining scope is four concrete problems, not a
+redesign:
+
+1. An entity that *is* a badge source doesn't badge itself on its own
+   list — only consumers do.
+2. No audit of where else badges should apply but don't (candidates:
+   any FK/soft-FK to an already-badged entity, and any boolean
+   column).
+3. No visual palette review — =badge_definition=/=badge_severity=
+   already have admin UI, but colours render as hex text, not
+   swatches, so misuse of the grey=disabled/green=good/red=bad/
+   yellow=warning convention can't be eyeballed.
+4. =badge_mapping= (the actual linkage data) has no UI at all —
+   invisible, so 1-3 are grep-only today. Fixing this is the
+   highest-leverage single piece of work, since it makes the other
+   three reviewable.
+
+Also folds in: the unmapped-value fallback colour is currently a
+Qt-only hardcoded constant, not a real =badge_definition= row — fixed
+alongside the palette-swatch work so any future client (Wt, out of
+scope to build here, but checked for architectural soundness) inherits
+the same fallback automatically instead of re-hardcoding it.
 
 * Status
 
@@ -23,24 +53,72 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
-| Now           | Not yet started.                       |
+| Now           | Analysis done; 5 follow-on tasks scoped (mapping browser, palette swatch + fallback, badge-source self-annotation, coverage audit, annotation). |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Start the badge_mapping browser UI task (highest leverage, makes the rest reviewable). |
 | Last touched  | 2026-07-15                               |
 
 * Acceptance
 
--
+- A =badge_mapping= browser exists (System > Configuration), grouped/
+  filterable by =code_domain=, with a colour swatch per mapped badge.
+- =badge_definition=/=badge_severity= admin UI renders colours as
+  swatches (not hex text), with a colour picker in the detail dialog.
+- The unmapped-value fallback is a real, reserved =badge_definition=
+  row, resolved through =BadgeCache= like any other badge, visually
+  distinct from a legitimate grey/inactive badge.
+- At least one badge-source entity (e.g. =book_status=) badges itself
+  on its own list, via an explicit codegen model annotation (not DB
+  introspection).
+- A written coverage audit exists (FK-to-badged-entity and boolean
+  columns across all =domain_entity= models), split into
+  ready-to-annotate vs needs-new-badge-definition-data.
+- Every audit candidate is either annotated and regenerated, or has a
+  one-line documented reason it was skipped.
+- No regression to any currently-working badge rendering (existing
+  entities' generated files stay zero-diff except where this story
+  deliberately changes them).
 
 * Tasks
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:20EA48C7-C375-446E-A006-9D51D5BCD117][Scaffold story: Improve badge colour scheme support]] | STARTED | 2026-07-15 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:D8A976B3-993F-48A9-87DC-1D3D7461223F][Analyze current badge colour determination and design improved storage]] | STARTED | 2026-07-15 | | Initial task for: Improve badge colour scheme support |
+| [[id:20EA48C7-C375-446E-A006-9D51D5BCD117][Scaffold story: Improve badge colour scheme support]] | DONE | 2026-07-15 | 2026-07-15 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:D8A976B3-993F-48A9-87DC-1D3D7461223F][Analyze current badge colour determination and design improved storage]] | DONE | 2026-07-15 | 2026-07-15 | Initial task for: Improve badge colour scheme support |
+| [[id:98AC38DD-E800-4961-A6BE-9F018097DAB2][Add a badge_mapping browser UI]] | BACKLOG | | | badge_mapping (the actual code_domain->entity_code->badge_definition linkage) has no UI at all today -- populated via seed scripts only. Add a read-only browser, grouped/filterable by code_domain, showing entity_code -> badge_definition with a colour swatch. This is the highest-leverage single piece of work: it makes badge source self-use, coverage gaps, and colour-semantic misuse all reviewable instead of grep-only. |
+| [[id:FFD9EFC2-AB60-4008-BC2A-FED99C7B09AD][Badge palette swatch rendering + data-driven fallback badge]] | BACKLOG | | | Badge Definitions/Severities admin UI shows colours as plain hex text, so semantic misuse (grey/green/red/yellow used for something other than their reserved meaning) can't be eyeballed. Add a colour-swatch delegate (and ideally a colour-picker in the detail dialog) to the badge_definition list/detail views. Separately, replace the hardcoded Qt-only fallback constant (color_constants::badge_fallback) with a real, reserved badge_definition row so any future client inherits the same fallback automatically instead of re-hardcoding it, and so the fallback is visually distinct from a legitimate grey/inactive badge. |
+| [[id:5BAE2E27-7C8A-4C3E-B65C-5D6F631528C7][Badge sources should badge their own list too]] | BACKLOG | | | An entity that IS a code_domain (e.g. book_status, whose code column other entities' badge_key columns reference) doesn't badge itself on its own list -- only consumers do. Add a codegen mechanism (explicit model annotation, not DB introspection) so a badge-source entity's own code/name column also gets badge_key wired to its own code_domain. |
+| [[id:712AA40D-67D2-4234-ABD2-1D006F63673B][Audit badge adoption coverage across domain_entity models]] | BACKLOG | | | Only 10 of 108 domain_entity models use badge_key today. Audit candidates: any column that is a foreign key (soft or real) to an entity already used as a badge source elsewhere (we know both ends), and any boolean column (is_sweepable is the established pattern). Produce a list of candidate columns/entities not yet badged, cross-referenced against existing code_domain/badge_definition rows (already-covered vs needs-new-badge-definition), to drive follow-up annotation work -- this task is the audit/list, not annotating all of them. |
+| [[id:08547F5A-B07C-4429-9EA5-022ACDC882C9][Annotate audited entities with badge_key and regenerate]] | BACKLOG | | | Consume the coverage audit's list: add badge_key to the identified FK/boolean columns, author any missing badge_definition/badge_mapping rows the audit flagged as needed, and regenerate. Depends on the coverage audit task's output. |
 
 * Decisions
 
+- *Do not move badge colour onto each "table enum type"'s own row*
+  (the story's original hypothesis). The current normalised
+  =(code_domain, entity_code) -> badge_definition= mapping's whole
+  value is letting many entity types share one badge definition
+  (=active=/=inactive= alone is reused by =book_status=,
+  =regulatory_book_type=, =is_sweepable=, =tenant_status=,
+  =workspace_status=, ...); per-table colour columns would fragment
+  that reuse and lose the single catalogue the admin UI manages. Keep
+  the architecture, close the visibility/adoption/self-use gaps
+  instead.
+- *=badge_mapping= browser first, ahead of the audit/annotation
+  work*, because it's the tool that makes the audit and the
+  colour-semantic review possible in the first place, not just a
+  nice-to-have alongside them.
+- *Wt is explicitly out of scope* for this story's tasks (user
+  instruction), but the data/protocol layer was checked for
+  architectural soundness first: =badge_definition= already carries
+  both raw hex colours and an unused =css_class= Wt hint, so a future
+  Wt client isn't blocked by anything here — only the fallback-colour
+  hardcoding needed fixing to keep that promise, which this story
+  does as part of the palette-swatch task.
+
 * Out of scope
 
--
+- Wt-side badge rendering (=account_list_widget.cpp= still hardcodes
+  Bootstrap CSS classes directly) — real, confirmed gap, but explicit
+  user instruction to ignore it for this story.
+- Moving badge colour storage onto individual lookup tables — see
+  Decisions above.

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/story.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/story.org
@@ -1,0 +1,46 @@
+:PROPERTIES:
+:ID: 1744E882-3141-4EAE-ABC0-C79CD3DA0767
+:END:
+#+title: Story: Improve badge colour scheme support
+#+description: Analyze how badge colours are currently determined across the codebase (hardcoded in Qt model/table code vs data-driven) and design a path to store badge colour schemes properly -- for table-enum-type-backed entities potentially alongside the enum's own row data, and for other cases (e.g. booleans) as a system-level property/setting.
+#+type: story
+#+level: s2
+#+filetags: :qt:badges:ui:design:refdata:sprint_23:v0:
+#+created: 2026-07-15
+#+updated: 2026-07-15
+#+environment: bright_faraday
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:341C071C-3042-4386-BC14-0D52CE8E6250][Sprint 23]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-07-15                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:20EA48C7-C375-446E-A006-9D51D5BCD117][Scaffold story: Improve badge colour scheme support]] | STARTED | 2026-07-15 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:D8A976B3-993F-48A9-87DC-1D3D7461223F][Analyze current badge colour determination and design improved storage]] | STARTED | 2026-07-15 | | Initial task for: Improve badge colour scheme support |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_annotate-audited-entities-with-badges.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_annotate-audited-entities-with-badges.org
@@ -1,41 +1,44 @@
 :PROPERTIES:
-:ID: 20EA48C7-C375-446E-A006-9D51D5BCD117
+:ID: 08547F5A-B07C-4429-9EA5-022ACDC882C9
 :END:
-#+title: Task: Scaffold story: Improve badge colour scheme support
-#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+title: Task: Annotate audited entities with badge_key and regenerate
+#+description: Consume the coverage audit's list: add badge_key to the identified FK/boolean columns, author any missing badge_definition/badge_mapping rows the audit flagged as needed, and regenerate. Depends on the coverage audit task's output.
 #+type: task
 #+level: s1
 #+filetags: :badge-colour-scheme-support:sprint_23:v0:
 #+owner: marco
-#+branch: feature/badge-colour-scheme-support
+#+branch: feature/annotate-audited-entities-with-badges
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
 #+updated: 2026-07-15
-#+environment: bright_faraday
+#+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Every column the audit flagged as a badge candidate either renders as a badge, or has an explicit, documented reason it doesn't (e.g. too many distinct values for a badge to be useful).
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE                              |
+| State        | BACKLOG                              |
 | Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
-| Now          | Nothing. |
+| Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing. |
+| Next         | Begin implementation.                  |
 | Last touched | 2026-07-15                               |
 
 * Acceptance
 
--
+- Every 'ready-to-annotate' entry from the audit gets badge_key added to its model and is regenerated.
+- Every 'needs new badge_definition data' entry gets its badge_definition/badge_mapping rows authored, following the established colour-semantic convention (grey=disabled/no, green=good, red=bad, yellow=warning).
+- Any audit entry deliberately skipped has a one-line reason recorded in this task's Result.
+- Zero diff on entities not touched by this task; build clean; existing badge-related tests still pass.
 
 * Plan
 
@@ -69,8 +72,3 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
-
-Story, sprint wiring, and 6 tasks scaffolded (this scaffold task,
-the analysis task, and 5 follow-on implementation tasks scoped after
-the analysis surfaced the real, narrower problem — see the story's
-own Goal/Decisions for the corrected scope).

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-adoption-coverage-audit.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-adoption-coverage-audit.org
@@ -1,41 +1,43 @@
 :PROPERTIES:
-:ID: 20EA48C7-C375-446E-A006-9D51D5BCD117
+:ID: 712AA40D-67D2-4234-ABD2-1D006F63673B
 :END:
-#+title: Task: Scaffold story: Improve badge colour scheme support
-#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+title: Task: Audit badge adoption coverage across domain_entity models
+#+description: Only 10 of 108 domain_entity models use badge_key today. Audit candidates: any column that is a foreign key (soft or real) to an entity already used as a badge source elsewhere (we know both ends), and any boolean column (is_sweepable is the established pattern). Produce a list of candidate columns/entities not yet badged, cross-referenced against existing code_domain/badge_definition rows (already-covered vs needs-new-badge-definition), to drive follow-up annotation work -- this task is the audit/list, not annotating all of them.
 #+type: task
 #+level: s1
 #+filetags: :badge-colour-scheme-support:sprint_23:v0:
 #+owner: marco
-#+branch: feature/badge-colour-scheme-support
+#+branch: feature/badge-adoption-coverage-audit
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
 #+updated: 2026-07-15
-#+environment: bright_faraday
+#+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+A written list of every domain_entity column that is a plausible badge candidate (FK to an already-badged entity, or boolean) but currently lacks badge_key, split into 'code_domain/badge_definition already exists, just needs badge_key' vs 'needs new badge_definition rows authored too'.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE                              |
+| State        | BACKLOG                              |
 | Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
-| Now          | Nothing. |
+| Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing. |
+| Next         | Begin implementation.                  |
 | Last touched | 2026-07-15                               |
 
 * Acceptance
 
--
+- Enumerate all domain_entity FK/soft-FK columns pointing at an entity already referenced via badge_key elsewhere, and all boolean columns, across all 108 models.
+- Cross-reference each candidate against existing code_domain rows to split the list into ready-to-annotate vs needs-new-badge-definition-data.
+- Written up in this task's Result as a concrete, actionable list (entity, column, code_domain, ready|needs-data) -- not fixed in this task.
 
 * Plan
 
@@ -69,8 +71,3 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
-
-Story, sprint wiring, and 6 tasks scaffolded (this scaffold task,
-the analysis task, and 5 follow-on implementation tasks scoped after
-the analysis surfaced the real, narrower problem — see the story's
-own Goal/Decisions for the corrected scope).

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-mapping-browser-ui.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-mapping-browser-ui.org
@@ -1,41 +1,43 @@
 :PROPERTIES:
-:ID: 20EA48C7-C375-446E-A006-9D51D5BCD117
+:ID: 98AC38DD-E800-4961-A6BE-9F018097DAB2
 :END:
-#+title: Task: Scaffold story: Improve badge colour scheme support
-#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+title: Task: Add a badge_mapping browser UI
+#+description: badge_mapping (the actual code_domain->entity_code->badge_definition linkage) has no UI at all today -- populated via seed scripts only. Add a read-only browser, grouped/filterable by code_domain, showing entity_code -> badge_definition with a colour swatch. This is the highest-leverage single piece of work: it makes badge source self-use, coverage gaps, and colour-semantic misuse all reviewable instead of grep-only.
 #+type: task
 #+level: s1
 #+filetags: :badge-colour-scheme-support:sprint_23:v0:
 #+owner: marco
-#+branch: feature/badge-colour-scheme-support
+#+branch: feature/badge-mapping-browser-ui
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
 #+updated: 2026-07-15
-#+environment: bright_faraday
+#+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+A user can open a screen (System > Configuration, alongside Badge Definitions/Severities) and see every (code_domain, entity_code) -> badge mapping, grouped by code_domain, with each badge rendered as an actual colour swatch -- not just hex text.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE                              |
+| State        | BACKLOG                              |
 | Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
-| Now          | Nothing. |
+| Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing. |
+| Next         | Begin implementation.                  |
 | Last touched | 2026-07-15                               |
 
 * Acceptance
 
--
+- New read-only list window shows all badge_mapping rows grouped/filterable by code_domain_code, each row showing entity_code and its resolved badge_definition (label + colour swatch).
+- Wired into the System > Configuration menu alongside the existing Badge Definitions/Severities windows.
+- Manual QA: opening the screen for a known code_domain (e.g. book_status) shows the same mappings seeded in dq_badge_system_populate.sql.
 
 * Plan
 
@@ -69,8 +71,3 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
-
-Story, sprint wiring, and 6 tasks scaffolded (this scaffold task,
-the analysis task, and 5 follow-on implementation tasks scoped after
-the analysis surfaced the real, narrower problem — see the story's
-own Goal/Decisions for the corrected scope).

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-palette-swatch-and-fallback.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-palette-swatch-and-fallback.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: FFD9EFC2-AB60-4008-BC2A-FED99C7B09AD
+:END:
+#+title: Task: Badge palette swatch rendering + data-driven fallback badge
+#+description: Badge Definitions/Severities admin UI shows colours as plain hex text, so semantic misuse (grey/green/red/yellow used for something other than their reserved meaning) can't be eyeballed. Add a colour-swatch delegate (and ideally a colour-picker in the detail dialog) to the badge_definition list/detail views. Separately, replace the hardcoded Qt-only fallback constant (color_constants::badge_fallback) with a real, reserved badge_definition row so any future client inherits the same fallback automatically instead of re-hardcoding it, and so the fallback is visually distinct from a legitimate grey/inactive badge.
+#+type: task
+#+level: s1
+#+filetags: :badge-colour-scheme-support:sprint_23:v0:
+#+owner: marco
+#+branch: feature/badge-palette-swatch-and-fallback
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-15
+#+updated: 2026-07-15
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-15                               |
+
+* Acceptance
+
+- BadgeDefinitionMdiWindow's background_colour/text_colour columns render as colour swatches.
+- BadgeDefinitionDetailDialog's colour fields use a QColorDialog-backed picker instead of a raw text field.
+- A reserved badge_definition row (e.g. code=__unmapped__ or an is_fallback flag) replaces color_constants::badge_fallback; BadgeCache/delegates resolve it the same way as any other badge instead of hardcoding it.
+- The fallback's visual treatment (e.g. dashed/hatched border, or distinct from any real grey badge in use) is visibly different from a legitimate inactive/disabled badge.
+- Manual QA: temporarily remove a badge_mapping row, confirm the affected badge renders as the new fallback style, not a colour indistinguishable from 'inactive'.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-source-self-annotation.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_badge-source-self-annotation.org
@@ -1,41 +1,44 @@
 :PROPERTIES:
-:ID: 20EA48C7-C375-446E-A006-9D51D5BCD117
+:ID: 5BAE2E27-7C8A-4C3E-B65C-5D6F631528C7
 :END:
-#+title: Task: Scaffold story: Improve badge colour scheme support
-#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+title: Task: Badge sources should badge their own list too
+#+description: An entity that IS a code_domain (e.g. book_status, whose code column other entities' badge_key columns reference) doesn't badge itself on its own list -- only consumers do. Add a codegen mechanism (explicit model annotation, not DB introspection) so a badge-source entity's own code/name column also gets badge_key wired to its own code_domain.
 #+type: task
 #+level: s1
 #+filetags: :badge-colour-scheme-support:sprint_23:v0:
 #+owner: marco
-#+branch: feature/badge-colour-scheme-support
+#+branch: feature/badge-source-self-annotation
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
 #+updated: 2026-07-15
-#+environment: bright_faraday
+#+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Opening a badge-source entity's own list window (e.g. Book Status) shows its own code column rendered as a badge, using the same code_domain other entities already reference it by.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DONE                              |
+| State        | BACKLOG                              |
 | Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
-| Now          | Nothing. |
+| Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
-| Next         | Nothing. |
+| Next         | Begin implementation.                  |
 | Last touched | 2026-07-15                               |
 
 * Acceptance
 
--
+- New model annotation (e.g. #+badge_source_domain: <code_domain>, or reuse badge_key on the entity's own key column) drives codegen to badge_key-wire the entity's own list column to its own code_domain.
+- Piloted on at least book_status (or another entity already referenced via badge_key elsewhere) -- regenerated, its own list now shows badges matching the same colours consumers already show.
+- No change to consumer entities' existing badge rendering (zero diff on their generated files).
+- Manual QA: open the pilot entity's own list window, confirm badges render and match the colours seen when the same values are badged elsewhere (e.g. Book's Status column).
 
 * Plan
 
@@ -69,8 +72,3 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
-
-Story, sprint wiring, and 6 tasks scaffolded (this scaffold task,
-the analysis task, and 5 follow-on implementation tasks scoped after
-the analysis surfaced the real, narrower problem — see the story's
-own Goal/Decisions for the corrected scope).

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
@@ -8,7 +8,7 @@
 #+filetags: :badge-colour-scheme-support:sprint_23:v0:
 #+owner: marco
 #+branch: feature/implement-badge-colour-scheme-support
-#+pr:
+#+pr: 1593
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
@@ -147,7 +147,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1593][#1593]] | [agile] Scaffold badge colour scheme support story |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
@@ -20,28 +20,115 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Determine how badge colours are currently determined across the
+codebase, and whether/how to move toward storing colour schemes in
+the database — either alongside a "table enum type"'s own row data,
+or as a system-level property for cases like booleans, per the
+story's framing.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-15                               |
 
 * Acceptance
 
--
+- Establishes, with evidence (grep/file references, not guesswork),
+  whether badge colours are currently hardcoded or data-driven.
+- If a data-driven mechanism already exists, assesses how complete its
+  rollout is (adoption coverage, remaining hardcoded stragglers,
+  Qt-vs-Wt parity) rather than assuming it needs to be built from
+  scratch.
+- Produces a concrete recommendation: either a design for new storage,
+  or a scoped list of gaps to close in an already-adequate design —
+  written into this task's =* Result= and reflected in the story's
+  =* Decisions=/=* Tasks=.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+1. Searched for any existing badge-related infrastructure before
+   assuming none exists — found a full, already-implemented,
+   database-driven badge system, designed in
+   =doc/plans/2026-03-28-badge-system-design.org= (2026-03-28) and
+   substantially built out since: four =ores.dq= entities
+   (=badge_severity=, =code_domain=, =badge_definition=,
+   =badge_mapping=), a client-side =BadgeCache= (loaded once at
+   startup, synchronous =resolve(code_domain, entity_code)=), and
+   codegen support (a =badge_key= column annotation that generates the
+   delegate wiring automatically — see
+   =ores.cpp.qt.mdi_window_impl.org='s =\{\{#is_badge\}\}= section).
+2. Verified the design doc's own success criteria against the current
+   tree rather than trusting the doc alone:
+   - =BadgeColors.hpp= is gone; =ColorConstants.hpp= no longer has a
+     =badge_colors= struct — Phase 3 cleanup of the *old* hardcoded
+     path is done.
+   - Sampled every file =grep= found still calling
+     =set_badge_color_resolver= (the delegate API, ~19 files:
+     =BookMdiWindow.cpp=, =TenantMdiWindow.cpp=,
+     =ComputeConsoleWindow.cpp=, =WorkspaceMdiWindow.cpp=, others) —
+     every one of them resolves through =BadgeCache::resolve()=
+     already; none hardcode a colour inline. The Phase-2 delegate
+     migration described in the design doc is, as far as this sample
+     shows, complete for the entities that have adopted badges at all.
+   - Confirmed =BookMdiWindow.cpp='s badge wiring
+     (=set_badge_color_resolver(...)= calling
+     =cache->resolve("book_status", ...)=,
+     =cache->resolve("is_sweepable", ...)=, etc.) is =\{\{#is_badge\}\}=
+     *codegen output*, not hand-written — matches the =badge_key=
+     column annotation on =ores.refdata.book.org=.
+3. *Directly tested the story's own hypothesis* ("for booleans it is a
+   system property"): =is_sweepable= (a boolean column) already
+   renders as a badge, via the *exact same* =(code_domain,
+   entity_code)= mapping mechanism as any enum — =code_domain =
+   "is_sweepable"=, =entity_code = "true"/"false"=, seeded as two
+   ordinary =badge_mapping= rows
+   (=dq_badge_system_populate.sql:502,504=), reusing the shared
+   =active=/=inactive= badge definitions. There is *no* separate
+   "system property" mechanism for booleans, and no gap here — the
+   hypothesis in the story's own framing turned out to be already
+   answered, just not the way it assumed. A code comment at
+   =dq_badge_system_populate.sql:725= documents this as a repeatable
+   convention ("same convention as =is_sweepable="), so it is not a
+   one-off hack either.
+4. Checked adoption breadth, not just depth: =badge_key= is used in
+   only *10 of 108* =domain_entity= models
+   (=book=, =currency=, =currency_pair=, =currency_pair_convention=,
+   =calendar=, =tenor=, =instrument_code=, =crm_topology_config=,
+   =crm_driver_pair=, =crm_enabled_derived_pair=). 58 badge
+   definitions are already seeded. This says the *infrastructure* is
+   done but *rollout* is early — most status/enum/boolean columns
+   elsewhere in the codebase presumably still render as plain text,
+   not badges, simply because nobody has annotated their model yet
+   (a rollout/toil gap, not a design gap).
+5. Checked Wt parity, since the design doc's own "Open Questions"
+   flagged this as unscoped: =projects/ores.wt.service/src/app/
+   account_list_widget.cpp= is the only Wt file touching badges at
+   all, and it hardcodes Bootstrap =css_class= strings
+   (="badge bg-danger"=/="badge bg-success"=/="badge bg-secondary"=)
+   directly in C++ — it does *not* go through =badge_definition=/
+   =css_class= from the DB at all. This is a real, confirmed gap: Wt
+   badge rendering was never actually migrated to the data-driven
+   system the design doc planned for it.
+6. Evaluated the story's other implicit hypothesis — storing colour
+   directly on a "table enum type"'s own row (e.g. a =colour= column
+   on =book_status=) instead of the current normalised
+   =(code_domain, entity_code) -> badge_definition= indirection.
+   *Recommend against changing this*: the current design's whole
+   point is that many entity types share one =badge_definition= (e.g.
+   =active=/=inactive= is reused by =book_status=,
+   =regulatory_book_type=, =is_sweepable=, =tenant_status=,
+   =workspace_status=, ...) — moving colour onto each lookup table
+   would fragment that reuse, force every table to duplicate colour
+   choices, and lose the central catalogue (58 definitions, one
+   source of truth) the =BadgeSeverityMdiWindow=/
+   =BadgeDefinitionMdiWindow= admin UI already manages. The existing
+   architecture is the right one; it just needs wider adoption.
 
 * Notes
 
@@ -69,3 +156,53 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+*Badge colours are already database-driven, not hardcoded* — a
+complete system (=badge_severity=/=code_domain=/=badge_definition=/
+=badge_mapping= in =ores.dq=, a client-side =BadgeCache=, and codegen
+support via a =badge_key= column annotation) was designed
+2026-03-28 and has since been substantially built and rolled out for
+every entity that uses it. Sampled ~19 files still calling the
+delegate's =set_badge_color_resolver= API and every one resolves
+through =BadgeCache= — no hardcoded stragglers found. The story's own
+"booleans need a system property" hypothesis is already answered by
+the existing =(code_domain, entity_code)= mapping (=is_sweepable= is a
+live example, documented as a repeatable convention) — no new storage
+design needed there.
+
+Confirmed real gaps instead of a from-scratch design (full writeup in
+the conversation that produced this task; distilled into the story's
+=* Decisions= and the four follow-on tasks below):
+
+1. An entity that *is* a badge source (e.g. =book_status=) doesn't
+   badge itself on its own list — only consumers do.
+2. Adoption is narrow (10/108 =domain_entity= models use =badge_key=)
+   with no audit of where else it should apply.
+3. No visual palette review: =badge_definition=/=badge_severity= have
+   list/detail UI (System > Configuration, =AdminPlugin.cpp:182=)
+   but colours render as plain hex text, not swatches — misuse of
+   the greyy/green/red/yellow semantic convention can't be eyeballed.
+4. =badge_mapping= (the actual linkage data) has no UI at all — "no
+   management UI, populated via seed scripts" was true then and still
+   is. This is the single highest-leverage gap: a mapping browser
+   would make 1, 2, and 3 reviewable instead of grep-only.
+5. The unmapped-value fallback colour
+   (=color_constants::badge_fallback=, orange) is a Qt-only hardcoded
+   constant, indistinguishable in principle from a legitimate grey
+   "inactive" badge, and would need re-duplicating in any future
+   non-Qt client rather than being inherited from the shared data
+   model.
+
+Explicitly recommend *against* moving colour storage onto each "table
+enum type"'s own row — the current normalised mapping's whole value
+is letting many entity types share one badge definition; per-table
+colour columns would fragment that and lose the central catalogue.
+Keep the architecture, close the gaps above.
+
+Wt support is explicitly out of scope for the follow-on tasks (per
+explicit instruction) but was checked for architectural soundness:
+the data/protocol layer is genuinely client-agnostic already
+(=badge_definition= carries both raw hex and an unused =css_class=
+Wt hint); the one piece that wasn't was the fallback colour (#5
+above), folded into its own task so any future client inherits it
+automatically instead of re-hardcoding it.

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: D8A976B3-993F-48A9-87DC-1D3D7461223F
+:END:
+#+title: Task: Analyze current badge colour determination and design improved storage
+#+description: Initial task for: Improve badge colour scheme support
+#+type: task
+#+level: s1
+#+filetags: :badge-colour-scheme-support:sprint_23:v0:
+#+owner: marco
+#+branch: feature/implement-badge-colour-scheme-support
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-15
+#+updated: 2026-07-15
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-15                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_scaffold_badge-colour-scheme-support.org
+++ b/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_scaffold_badge-colour-scheme-support.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 20EA48C7-C375-446E-A006-9D51D5BCD117
+:END:
+#+title: Task: Scaffold story: Improve badge colour scheme support
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :badge-colour-scheme-support:sprint_23:v0:
+#+owner: marco
+#+branch: feature/badge-colour-scheme-support
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-15
+#+updated: 2026-07-15
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-15                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_23/sprint.org
+++ b/doc/agile/versions/v0/sprint_23/sprint.org
@@ -82,6 +82,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 |-------+-------+-------+-----+-------------|
 | [[id:C4755E35-7E5D-4276-8AAE-53FA8557FAEF][Hotfix: Windows Clang CI compiler-launcher wrapper]] | DONE | 2026-07-11 | 2026-07-11 | windows-clang-debug-ninja and windows-clang-release-ninja fail to configure because the clang preset's environment launcher (a .sh wrapper) leaks into CMake's project()-time compiler detection on Windows. |
 | [[id:14F24665-6CB0-4DAB-895E-1D5D1360E507][Hotfix: ores.iam.core build fails, missing ores.eventing.core include dependency]] | DONE | 2026-07-14 | 2026-07-14 | party_cache.hpp includes ores.eventing.core/service/cache/partitioned_cache.hpp but ores.iam.core's CMakeLists.txt doesn't depend on ores.eventing.core, so the include path is missing and the build fails. |
+| [[id:1744E882-3141-4EAE-ABC0-C79CD3DA0767][Improve badge colour scheme support]] | BACKLOG | | | Analyze how badge colours are currently determined across the codebase (hardcoded in Qt model/table code vs data-driven) and design a path to store badge colour schemes properly -- for table-enum-type-backed entities potentially alongside the enum's own row data, and for other cases (e.g. booleans) as a system-level property/setting. |
 
 * Achievements
 


### PR DESCRIPTION
## Summary

Scaffold the 'Improve badge colour scheme support' story and complete its analysis task. Found the badge system the story assumed didn't exist already does (database-driven badge_severity/code_domain/badge_definition/badge_mapping + BadgeCache + codegen badge_key support) and rescoped the story around 4 real, confirmed gaps instead of a redesign.

## Changes

- Scaffold story, sprint wiring, and the analysis task
- Analysis: badge colours are already DB-driven and booleans already badge correctly (is_sweepable); recommend against moving colour storage onto lookup tables
- Scope 5 follow-on tasks: badge_mapping browser UI, palette swatch + data-driven fallback, badge-source self-annotation, coverage audit, annotate-audited-entities
- Doc-only change (org files); no C++/codegen touched in this PR, nothing to build/test locally

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Improve badge colour scheme support](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/story.html) | 1744E882-3141-4EAE-ABC0-C79CD3DA0767 |
| Task | [Analyze current badge colour determination and design improved storage](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_23/badge-colour-scheme-support/task_implement_badge-colour-scheme-support.html) | D8A976B3-993F-48A9-87DC-1D3D7461223F |
| Environment | bright_faraday | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)