### PR TITLE
[compass,llm] Deny piped/redirected compass commands via PreToolUse hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 Run `./compass.sh bearings` to orient yourself before acting.
 
+**Never pipe or redirect a `compass` command.** Run it bare — no `|`,
+no `2>&1`, no `>`. Every `compass build`/`deploy`/`site` command that
+produces meaningful output prints its own well-known log file path
+(e.g. `📝 Build output: /tmp/<label>_<target>_build.log`). To watch
+progress, `tail -f`/`tail -n` *that reported file* as a separate,
+standalone command — never by piping the compass invocation itself.
+
 **Memory rule:** All project memories live in `doc/llm/memory/` and must
 be created with `compass add memory`. Never write to the Claude Code
 harness memory system (`~/.claude/projects/*/memory/`). The harness

--- a/doc/agile/versions/v0/sprint_23/compass_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/story.org
@@ -43,6 +43,7 @@ inflating the backlog with one-off stories.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:745B765F-BEB2-4CBA-8BA8-852FBDDBA399][Add vcpkg drift check to bearings and a devops-update-environment skill]] | DONE | 2026-07-12 | 2026-07-12 | Add a vcpkg-vs-main drift warning to compass bearings, and create a new devops-update-environment skill that brings a worktree fully up to date with main (fetch, detached checkout, submodules, settings, skills). |
+| [[id:11FDFC40-E10B-4970-A15E-EEA8D8B7CA82][Improve compass output monitoring]] | BACKLOG | | | Move all compass command output out of ad-hoc /tmp files into a well-known, rotated, per-checkout log directory, and add a services-start concurrency lock so at most 4 environments run services at once. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_23/compass_improvements/task_improve_compass_output_monitoring.org
+++ b/doc/agile/versions/v0/sprint_23/compass_improvements/task_improve_compass_output_monitoring.org
@@ -1,0 +1,132 @@
+:PROPERTIES:
+:ID: 11FDFC40-E10B-4970-A15E-EEA8D8B7CA82
+:END:
+#+title: Task: Improve compass output monitoring
+#+description: Move all compass command output out of ad-hoc /tmp files into a well-known, rotated, per-checkout log directory, and add a services-start concurrency lock so at most 4 environments run services at once.
+#+type: task
+#+level: s1
+#+filetags: :compass:tooling:observability:sprint_23:compass_improvements:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-17
+#+updated: 2026-07-17
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C816DF00-1E36-4ED7-99E0-854589EF4EF3][Compass improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Give every =compass= invocation a "control panel": a well-known,
+project-local, rotated log per command shape, instead of today's
+scattered =/tmp/ores-build.log.<slot>= and =/tmp/<label>_<target>_build.log=
+files — and cap concurrent service fleets host-wide so at most 4
+environments run services at once, with a clear message (and a list
+of who's holding a slot) when a 5th tries.
+
+This grew out of an earlier ad-hoc fix made in-session: =compass
+build= and =compass build --direct <target>= currently print
+a =📝 Build output: <path> (tail -f to follow)= line and write to a
+=/tmp=-rooted path (=_build_log_path=/=_direct_build_log_path= in
+=compass.py=). That was a step in the right direction (a well-known,
+reported path an LLM can =tail= instead of piping the compass
+invocation itself — see CLAUDE.md's "never pipe or redirect a
+compass command" rule and =deny_piped_compass_hook.py=), but it is
+=/tmp=-rooted, one file per command *target* rather than rotated
+history, and doesn't cover every compass command that produces
+meaningful output.
+
+* Requirements
+
+1. *Location*: all compass command output moves from =/tmp= to a
+   project-local =./tmp/compass_output/= directory (gitignored,
+   per-checkout — so concurrent environments on the same host never
+   collide on a filename).
+2. *Naming*: one log-file family per distinct command shape, not per
+   invocation — e.g. =build.log=, =build_site_direct.log=,
+   =build_settings_direct.log=, =build_skills_direct.log=.
+3. *Header*: each fresh log file opens with a line identifying the
+   command and when it ran, e.g. =compass command executed at
+   2026-07-17T19:42:03: ./compass.sh build --direct site=.
+4. *Rotation*: classic logrotate scheme, max 5 kept per command
+   family (current + 4 rotated). On each new run: drop
+   =build.log.4=, shift =.3→.4=, =.2→.3=, =.1→.2=, =build.log→.1=,
+   write a fresh =build.log=.
+5. *Build-lock interaction*: the build-lock file itself stays at
+   =/tmp/ores-build-lock.<slot>= (host-wide by design — shared across
+   every worktree/environment on the box, so it must live outside
+   any one checkout). It no longer writes the build log directly;
+   instead it points at the log's new location under that
+   invocation's own =./tmp/compass_output/= (so
+   =compass build --status= can still find and tail it).
+6. *Retrofit*: apply this to every compass command already migrated
+   to the old =/tmp= scheme (=build=, =build --direct site=,
+   =build --direct settings=, =build --direct skills=, and any other
+   =--direct= target), not just new ones going forward.
+7. *Services-start lock*: a new host-wide lock, independent of the
+   build lock, capping concurrent *running* service fleets at 4
+   environments. Unlike the build lock (released when the command
+   exits), this lock is acquired on =compass services start= and held
+   until the matching =compass services stop= — it tracks "up", not
+   "running the start command". When a 5th environment tries to
+   start with no slots free, =services start= must refuse cleanly:
+   print a clear "no slots left" message plus the list of which
+   environments currently hold a slot (label + since-when), so the
+   user knows which one to bring down.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:C816DF00-1E36-4ED7-99E0-854589EF4EF3][Compass improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Design the rotation/log-family scheme, then implement in compass.py alongside the existing build lock. |
+| Last touched | 2026-07-17                               |
+
+* Acceptance
+
+- Every compass command that produces meaningful output writes to =./tmp/compass_output/<command>.log=, not =/tmp=.
+- Each log file's first line records the command executed and a timestamp.
+- Rotation keeps at most 5 generations per command family (current + =.1= through =.4=), oldest dropped.
+- The build-lock file at =/tmp/ores-build-lock.<slot>= still exists (host-wide coordination unaffected) but now only points at the per-checkout log location; =compass build --status= still works.
+- =compass services start= acquires a host-wide lock capped at 4 concurrently-running environments, held until =compass services stop=.
+- A =services start= attempt with no free slot prints a clear message and lists the environments currently holding a slot.
+- =doc/llm/claude_code_settings.org= / recipes updated if the reported log-path message text changes.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -5,9 +5,9 @@
 #+description: Literate source for .claude/settings.json — permission allow-list and sandbox overrides, generated via org-babel tangle.
 #+type: knowledge
 #+level: cross
-#+filetags: :llm:claude_code:settings:permissions:
+#+filetags: :llm:claude_code:settings:permissions:hooks:
 #+created: 2026-05-22
-#+updated: 2026-07-05
+#+updated: 2026-07-17
 
 * Summary
 
@@ -77,6 +77,9 @@ last section in each array carries no comma.
 <<sandbox-network>>,
 <<sandbox-filesystem>>,
 <<sandbox-excluded>>
+  },
+  "hooks": {
+<<hooks-pretooluse>>
   }
 }
 #+end_src
@@ -557,6 +560,97 @@ invocation forms from the permission grant are mirrored here.
       "./projects/ores.compass/compass.sh *",
       "projects/ores.compass/compass.sh *",
       "git *"
+    ]
+#+end_src
+
+* Hooks
+
+** Deny piped or redirected compass invocations
+
+Permission allow/deny rules cannot express this rule: they evaluate a
+compound command /per subcommand/ (see the Shell utilities rationale
+above), so a pipeline like =./compass.sh build --direct site | tail
+-30= is checked as two independent, individually-authorised pieces
+(=compass.sh build ...= and =tail -30=) — there is no way for a glob
+rule to see "compass, piped into tail" as a single shape to deny, nor
+to distinguish it from an unrelated, perfectly fine =tail -f
+/tmp/some.log=. A =PreToolUse= hook is the only mechanism that
+inspects the full command string as written, so it is what enforces
+CLAUDE.md's "never pipe or redirect a compass command" rule: every
+=compass= command that produces meaningful output prints its own
+well-known log-file path (=📝 Build output: /tmp/<label>_<target>_build.log
+(tail -f to follow)=; see [[proj:projects/ores.compass/src/compass.py][=compass.py='s =_build_log_path=/=_direct_build_log_path=]]) —
+watching that reported file with a separate, standalone =tail= is the
+supported way to follow progress.
+
+The hook fires on every =Bash= tool call, matches the command against
+all four invocation forms compass is granted under (see [[id:2D83251F-0E24-4B97-B736-08F710316634][Compass]]
+above) plus the raw script name, and denies (exit code 2, message on
+stderr) only when that same command string also contains a pipe
+(=|=) or a redirect (=>=, which also matches =2>&1= and =>>=). A
+denial's stderr becomes the tool result the agent sees, so the
+message doubles as the correction: it names the rule and repeats what
+to do instead, rather than the agent having to infer that from a bare
+rejection.
+
+#+begin_src python :tangle ../../projects/ores.compass/src/deny_piped_compass_hook.py :mkdirp yes :shebang "#!/usr/bin/env python3"
+"""PreToolUse hook: deny compass.sh invocations that pipe or redirect
+their output. See CLAUDE.md's "Never pipe or redirect a compass
+command" rule and doc/llm/claude_code_settings.org's Hooks section.
+
+Compass build/deploy commands print their own well-known log-file
+path for exactly this purpose; tailing that file separately is the
+supported way to follow progress instead.
+"""
+import json
+import re
+import sys
+
+COMPASS_RE = re.compile(
+    r"(?:^|[\s&;(])(?:\./)?(?:projects/ores\.compass/)?compass\.sh(?:\s|$)"
+)
+REDIRECT_RE = re.compile(r"\||>")
+
+DENIAL_MESSAGE = (
+    "Never pipe or redirect a compass command (no `|`, no `>`, no "
+    "`2>&1`) -- run it bare. Compass build/deploy commands print their "
+    "own well-known log-file path (e.g. \"\U0001F4DD Build output: "
+    "/tmp/<label>_<target>_build.log (tail -f to follow)\"). To watch "
+    "progress, tail THAT reported file as a separate, standalone "
+    "command (e.g. `tail -f <path>`) -- never by piping the compass "
+    "invocation itself. See CLAUDE.md.\n"
+)
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if data.get("tool_name") != "Bash":
+        return 0
+    command = data.get("tool_input", {}).get("command", "")
+    if COMPASS_RE.search(command) and REDIRECT_RE.search(command):
+        sys.stderr.write(DENIAL_MESSAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+#+end_src
+
+#+begin_src json :tangle no :noweb-ref hooks-pretooluse
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 projects/ores.compass/src/deny_piped_compass_hook.py"
+          }
+        ]
+      }
     ]
 #+end_src
 

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -593,6 +593,36 @@ message doubles as the correction: it names the rule and repeats what
 to do instead, rather than the agent having to infer that from a bare
 rejection.
 
+*Fail open, not closed, if the script is missing.* The hook is a
+project-tracked file — it can legitimately be absent on a given
+=git checkout= (an older branch predating this task, a worktree mid
+rebase, this same PR's own commit not yet checked out). Claude Code
+treats a hook *command that itself fails to execute* (e.g. =python3=
+reporting "No such file or directory") as a hard block of the
+=Bash= tool entirely — every subsequent command, compass or not,
+gets denied with no way to self-correct, since the correcting action
+itself requires a =Bash= call. That is a materially worse failure
+mode than "the piping rule goes briefly unenforced," so the actual
+hook invocation is wrapped in a shell guard that checks the script
+exists before running it, exiting 0 (allow) if it doesn't rather than
+letting the missing-file error propagate as a block:
+
+#+begin_example
+sh -c 'f=projects/ores.compass/src/deny_piped_compass_hook.py; if [ -f "$f" ]; then python3 "$f"; else exit 0; fi'
+#+end_example
+
+Deliberately an =if=/=then=/=else=, not the shorter =[ -f "$f" ] &&
+python3 "$f" || exit 0=: in an =A && B || C= chain, =C= runs if
+/either/ =A= or =B= fails, so a genuine deny (=python3= exiting 2)
+would also satisfy =|| exit 0= and get silently swallowed into an
+allow — the exact bug this guard exists to avoid, just moved one
+level up. With =if=/=then=/=else=, the compound command's exit
+status is whatever the taken branch's last command produced:
+=python3 "$f"='s own 0/2 when the file exists, or the explicit
+=exit 0= only when the =[ -f ]= test itself is what failed. The
+literal string tangled into =.claude/settings.json= (below) is this
+same guard, JSON-escaped.
+
 #+begin_src python :tangle ../../projects/ores.compass/src/deny_piped_compass_hook.py :mkdirp yes :shebang "#!/usr/bin/env python3"
 """PreToolUse hook: deny compass.sh invocations that pipe or redirect
 their output. See CLAUDE.md's "Never pipe or redirect a compass
@@ -647,7 +677,7 @@ if __name__ == "__main__":
         "hooks": [
           {
             "type": "command",
-            "command": "python3 projects/ores.compass/src/deny_piped_compass_hook.py"
+            "command": "sh -c 'f=projects/ores.compass/src/deny_piped_compass_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
           }
         ]
       }

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -639,7 +639,12 @@ import sys
 COMPASS_RE = re.compile(
     r"(?:^|[\s&;(])(?:\./)?(?:projects/ores\.compass/)?compass\.sh(?:\s|$)"
 )
-REDIRECT_RE = re.compile(r"\||>")
+# A lone "|" (pipe) not adjacent to another "|" -- excludes the "||"
+# logical-OR operator (e.g. `compass.sh build || echo failed`, a normal
+# error-handling idiom that pipes nothing) while still catching a real
+# single-pipe pipeline. Any ">" is a redirect (">", ">>", "2>&1" all
+# contain it) and has no equivalent non-redirect meaning to exclude.
+REDIRECT_RE = re.compile(r"(?<!\|)\|(?!\|)|>")
 
 DENIAL_MESSAGE = (
     "Never pipe or redirect a compass command (no `|`, no `>`, no "
@@ -657,7 +662,7 @@ def main() -> int:
         data = json.load(sys.stdin)
     except (ValueError, json.JSONDecodeError):
         return 0
-    if data.get("tool_name") != "Bash":
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
         return 0
     command = data.get("tool_input", {}).get("command", "")
     if COMPASS_RE.search(command) and REDIRECT_RE.search(command):
@@ -668,6 +673,101 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+#+end_src
+
+#+begin_src python :tangle ../../projects/ores.compass/tests/test_deny_piped_compass_hook.py :mkdirp yes
+"""
+Tests for the piped/redirected-compass PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_piped_compass_hook.py -v
+No live database or file system access required.
+"""
+
+import io
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_piped_compass_hook as hook
+
+
+def run(command, tool_name="Bash", monkeypatch=None):
+    """Drive hook.main() with a synthetic PreToolUse payload on stdin,
+    returning (exit_code, stderr_text)."""
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    import json
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr)
+    return hook.main(), stderr.getvalue()
+
+
+def test_bare_compass_allowed(monkeypatch):
+    code, _ = run("./compass.sh build --direct site", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_piped_compass_denied(monkeypatch):
+    code, msg = run("./compass.sh build --direct site 2>&1 | tail -30",
+                     monkeypatch=monkeypatch)
+    assert code == 2
+    assert "Never pipe or redirect" in msg
+
+
+def test_redirected_compass_denied(monkeypatch):
+    code, _ = run("./compass.sh build > out.log", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_logical_or_compass_allowed(monkeypatch):
+    """`||` is error handling, not a pipe -- must not be denied."""
+    code, _ = run("./compass.sh build --direct site || echo failed",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_all_four_invocation_forms_denied_when_piped(monkeypatch):
+    for prefix in (
+        "./compass.sh",
+        "compass.sh",
+        "./projects/ores.compass/compass.sh",
+        "projects/ores.compass/compass.sh",
+    ):
+        code, _ = run(f"{prefix} build | tail", monkeypatch=monkeypatch)
+        assert code == 2, prefix
+
+
+def test_unrelated_pipe_allowed(monkeypatch):
+    code, _ = run("git log --oneline | head -5", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_unrelated_logical_or_allowed(monkeypatch):
+    code, _ = run("git fetch || echo failed", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_bash_tool_allowed(monkeypatch):
+    code, _ = run("./compass.sh build | tail", tool_name="Read",
+                  monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_dict_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[1, 2, 3]"))
+    assert hook.main() == 0
+
+
+def test_null_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("null"))
+    assert hook.main() == 0
+
+
+def test_malformed_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
 #+end_src
 
 #+begin_src json :tangle no :noweb-ref hooks-pretooluse

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -5532,6 +5532,15 @@ EMACS_BUILD_SCRIPTS = {
 _EMACS_LISP_DIR = Path("projects") / "ores.lisp" / "src"
 
 
+def _direct_build_log_path(target: str) -> Path:
+    """Well-known output-log path for a `--direct` emacs build target, for
+    `tail -f` — named <environment-label>_<target>_build.log so it's easy
+    to tell apart from another worktree's build running concurrently."""
+    env_label = _read_env_map().get("ORES_CHECKOUT_LABEL", "") or "direct"
+    friendly = target.removeprefix("deploy_")
+    return Path(f"/tmp/{env_label}_{friendly}_build.log")
+
+
 def _run_emacs_target(target: str, dry_run: bool = False) -> int:
     """Run a single emacs build script directly, bypassing cmake."""
     script = EMACS_BUILD_SCRIPTS.get(target)
@@ -5548,7 +5557,10 @@ def _run_emacs_target(target: str, dry_run: bool = False) -> int:
     print(f"🔨 emacs -Q --script {_EMACS_LISP_DIR / script}")
     if dry_run:
         return 0
-    return subprocess.run(cmd, cwd=PROJECT_ROOT).returncode
+    log_path = _direct_build_log_path(target)
+    print(f"📝 Build output: {log_path} (tail -f to follow)")
+    with open(log_path, "w") as log:
+        return _run_logged(cmd, PROJECT_ROOT, log)
 
 
 def cmd_site(argv):

--- a/projects/ores.compass/src/deny_piped_compass_hook.py
+++ b/projects/ores.compass/src/deny_piped_compass_hook.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: deny compass.sh invocations that pipe or redirect
+their output. See CLAUDE.md's "Never pipe or redirect a compass
+command" rule and doc/llm/claude_code_settings.org's Hooks section.
+
+Compass build/deploy commands print their own well-known log-file
+path for exactly this purpose; tailing that file separately is the
+supported way to follow progress instead.
+"""
+import json
+import re
+import sys
+
+COMPASS_RE = re.compile(
+    r"(?:^|[\s&;(])(?:\./)?(?:projects/ores\.compass/)?compass\.sh(?:\s|$)"
+)
+REDIRECT_RE = re.compile(r"\||>")
+
+DENIAL_MESSAGE = (
+    "Never pipe or redirect a compass command (no `|`, no `>`, no "
+    "`2>&1`) -- run it bare. Compass build/deploy commands print their "
+    "own well-known log-file path (e.g. \"\U0001F4DD Build output: "
+    "/tmp/<label>_<target>_build.log (tail -f to follow)\"). To watch "
+    "progress, tail THAT reported file as a separate, standalone "
+    "command (e.g. `tail -f <path>`) -- never by piping the compass "
+    "invocation itself. See CLAUDE.md.\n"
+)
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if data.get("tool_name") != "Bash":
+        return 0
+    command = data.get("tool_input", {}).get("command", "")
+    if COMPASS_RE.search(command) and REDIRECT_RE.search(command):
+        sys.stderr.write(DENIAL_MESSAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/ores.compass/src/deny_piped_compass_hook.py
+++ b/projects/ores.compass/src/deny_piped_compass_hook.py
@@ -14,7 +14,12 @@ import sys
 COMPASS_RE = re.compile(
     r"(?:^|[\s&;(])(?:\./)?(?:projects/ores\.compass/)?compass\.sh(?:\s|$)"
 )
-REDIRECT_RE = re.compile(r"\||>")
+# A lone "|" (pipe) not adjacent to another "|" -- excludes the "||"
+# logical-OR operator (e.g. `compass.sh build || echo failed`, a normal
+# error-handling idiom that pipes nothing) while still catching a real
+# single-pipe pipeline. Any ">" is a redirect (">", ">>", "2>&1" all
+# contain it) and has no equivalent non-redirect meaning to exclude.
+REDIRECT_RE = re.compile(r"(?<!\|)\|(?!\|)|>")
 
 DENIAL_MESSAGE = (
     "Never pipe or redirect a compass command (no `|`, no `>`, no "
@@ -32,7 +37,7 @@ def main() -> int:
         data = json.load(sys.stdin)
     except (ValueError, json.JSONDecodeError):
         return 0
-    if data.get("tool_name") != "Bash":
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
         return 0
     command = data.get("tool_input", {}).get("command", "")
     if COMPASS_RE.search(command) and REDIRECT_RE.search(command):

--- a/projects/ores.compass/tests/test_deny_piped_compass_hook.py
+++ b/projects/ores.compass/tests/test_deny_piped_compass_hook.py
@@ -1,0 +1,92 @@
+"""
+Tests for the piped/redirected-compass PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_piped_compass_hook.py -v
+No live database or file system access required.
+"""
+
+import io
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_piped_compass_hook as hook
+
+
+def run(command, tool_name="Bash", monkeypatch=None):
+    """Drive hook.main() with a synthetic PreToolUse payload on stdin,
+    returning (exit_code, stderr_text)."""
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    import json
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr)
+    return hook.main(), stderr.getvalue()
+
+
+def test_bare_compass_allowed(monkeypatch):
+    code, _ = run("./compass.sh build --direct site", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_piped_compass_denied(monkeypatch):
+    code, msg = run("./compass.sh build --direct site 2>&1 | tail -30",
+                     monkeypatch=monkeypatch)
+    assert code == 2
+    assert "Never pipe or redirect" in msg
+
+
+def test_redirected_compass_denied(monkeypatch):
+    code, _ = run("./compass.sh build > out.log", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_logical_or_compass_allowed(monkeypatch):
+    """`||` is error handling, not a pipe -- must not be denied."""
+    code, _ = run("./compass.sh build --direct site || echo failed",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_all_four_invocation_forms_denied_when_piped(monkeypatch):
+    for prefix in (
+        "./compass.sh",
+        "compass.sh",
+        "./projects/ores.compass/compass.sh",
+        "projects/ores.compass/compass.sh",
+    ):
+        code, _ = run(f"{prefix} build | tail", monkeypatch=monkeypatch)
+        assert code == 2, prefix
+
+
+def test_unrelated_pipe_allowed(monkeypatch):
+    code, _ = run("git log --oneline | head -5", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_unrelated_logical_or_allowed(monkeypatch):
+    code, _ = run("git fetch || echo failed", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_bash_tool_allowed(monkeypatch):
+    code, _ = run("./compass.sh build | tail", tool_name="Read",
+                  monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_dict_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[1, 2, 3]"))
+    assert hook.main() == 0
+
+
+def test_null_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("null"))
+    assert hook.main() == 0
+
+
+def test_malformed_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0


### PR DESCRIPTION
## Summary
- Add a PreToolUse hook (`deny_piped_compass_hook.py`) that blocks any Bash command invoking `compass.sh` (any of its 4 granted forms) when the same command string also contains a pipe or redirect. Permission allow/deny rules can't express this — they evaluate compound commands per-subcommand, so a pipeline's `compass.sh ...` and `| tail` pieces are each independently authorised with no way to see "compass piped into tail" as a shape to deny.
- Give `compass build --direct <target>` (site/settings/skills/...) the same well-known, reported log-path treatment `compass build`'s cmake path already had (`📝 Build output: <path> (tail -f to follow)`), instead of silently swallowing emacs batch-mode output.
- Document the rule prominently in CLAUDE.md (read at the start of every session) so it's durable across sessions, not just this one.
- File the follow-up task under the "Compass improvements" story: move all compass output from ad-hoc `/tmp` files into a rotated, per-checkout `./tmp/compass_output/` directory (log rotation, command-executed header, build-lock pointing at the new location), plus a new services-start lock capping concurrent running environments at 4. Not implemented in this PR — this PR only lays the groundwork (the hook + the reported-log-path pattern) that task will build on.

## Test plan
- [x] `python3 -m py_compile` on both changed/added Python files.
- [x] `./compass.sh build --direct settings` regenerates `.claude/settings.json` cleanly with the new `hooks` key.
- [x] Hook script exercised directly against representative bare/piped/redirected commands, confirming allow/deny behavior and that unrelated pipes (`git log | head`) and standalone `tail -f <logfile>` are unaffected.
- [x] Docs-only additions (task/story wiring) re-indexed via `compass index --org-roam-db-sync` with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)