### PR TITLE
[hotfix] Fix ores.cli build broken by change_reason(_category) stateless repository migration

### DIFF
--- a/projects/ores.cli/src/app/application.cpp
+++ b/projects/ores.cli/src/app/application.cpp
@@ -511,17 +511,17 @@ void application::export_countries(const config::export_options& cfg) const {
 void application::export_change_reasons(const config::export_options& cfg) const {
     BOOST_LOG_SEV(lg(), debug) << "Exporting change reasons.";
 
-    dq::repository::change_reason_repository repo(context_);
+    dq::repository::change_reason_repository repo;
     std::vector<dq::domain::change_reason> items;
 
     if (!cfg.key.empty()) {
         if (cfg.all_versions) {
-            items = repo.read_all(cfg.key);
+            items = repo.read_all(context_, cfg.key);
         } else {
-            items = repo.read_latest(cfg.key);
+            items = repo.read_latest(context_, cfg.key);
         }
     } else {
-        items = repo.read_latest();
+        items = repo.read_latest(context_);
     }
 
     // Output in the requested format
@@ -546,17 +546,17 @@ void application::export_change_reasons(const config::export_options& cfg) const
 void application::export_change_reason_categories(const config::export_options& cfg) const {
     BOOST_LOG_SEV(lg(), debug) << "Exporting change reason categories.";
 
-    dq::repository::change_reason_category_repository repo(context_);
+    dq::repository::change_reason_category_repository repo;
     std::vector<dq::domain::change_reason_category> items;
 
     if (!cfg.key.empty()) {
         if (cfg.all_versions) {
-            items = repo.read_all(cfg.key);
+            items = repo.read_all(context_, cfg.key);
         } else {
-            items = repo.read_latest(cfg.key);
+            items = repo.read_latest(context_, cfg.key);
         }
     } else {
-        items = repo.read_latest();
+        items = repo.read_latest(context_);
     }
 
     // Output in the requested format
@@ -997,16 +997,16 @@ void application::delete_country(const config::delete_options& cfg) const {
 
 void application::delete_change_reason(const config::delete_options& cfg) const {
     BOOST_LOG_SEV(lg(), debug) << "Deleting change reason: " << cfg.key;
-    dq::repository::change_reason_repository repo(context_);
-    repo.remove(cfg.key);
+    dq::repository::change_reason_repository repo;
+    repo.remove(context_, cfg.key);
     output_stream_ << "Change reason deleted successfully: " << cfg.key << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Deleted change reason: " << cfg.key;
 }
 
 void application::delete_change_reason_category(const config::delete_options& cfg) const {
     BOOST_LOG_SEV(lg(), debug) << "Deleting change reason category: " << cfg.key;
-    dq::repository::change_reason_category_repository repo(context_);
-    repo.remove(cfg.key);
+    dq::repository::change_reason_category_repository repo;
+    repo.remove(context_, cfg.key);
     output_stream_ << "Change reason category deleted successfully: " << cfg.key << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Deleted change reason category: " << cfg.key;
 }
@@ -1333,8 +1333,8 @@ void application::add_change_reason(const config::add_change_reason_options& cfg
     if (cfg.change_commentary)
         record.change_commentary = *cfg.change_commentary;
 
-    dq::repository::change_reason_repository repo(context_);
-    repo.write({record});
+    dq::repository::change_reason_repository repo;
+    repo.write(context_, {record});
 
     output_stream_ << "Successfully added change reason: " << cfg.code << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Added change reason: " << cfg.code;
@@ -1354,8 +1354,8 @@ void application::add_change_reason_category(
     if (cfg.change_commentary)
         record.change_commentary = *cfg.change_commentary;
 
-    dq::repository::change_reason_category_repository repo(context_);
-    repo.write({record});
+    dq::repository::change_reason_category_repository repo;
+    repo.write(context_, {record});
 
     output_stream_ << "Successfully added change reason category: " << cfg.code << std::endl;
     BOOST_LOG_SEV(lg(), info) << "Added change reason category: " << cfg.code;


### PR DESCRIPTION
## Summary
- **main is currently broken**: PRs #1647 (change_reason_category) and #1651 (change_reason) converted `change_reason_repository`/`change_reason_category_repository` from stateful (constructor-injected context) to the standard stateless (context per call) shape, but the caller sweep in both PRs covered `ores.qt*`/`ores.dq`/`ores.shell` and never checked `ores.cli`.
- `ores.cli/src/app/application.cpp` used the old API directly in 6 places (export/delete/add for both entities), breaking `main`'s CI (`linux-clang-release`, `linux-gcc-debug`, `linux-gcc-release` all failing to compile `ores.cli.lib` since PR #1651 merged, confirmed via `gh run view` on the last 3 scheduled `Continuous Linux` runs).
- Fixed all 6 call sites to the stateless shape (`repo;` construction, `context_` passed as first arg to `read_all`/`read_latest`/`write`/`remove`).

## Test plan
- [x] `compass build ores.cli.lib` -- clean
- [x] `compass build test_ores.cli.tests` -- 382 assertions/119 cases, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)