### PR TITLE
[agile] Design the as-of lookup codegen facet

### DIFF
--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
@@ -25,11 +25,14 @@ book row), but resolving that code's Name/Description/badge colour
 today uses a current-only lookup, so a since-deleted or since-renamed
 code silently fails to resolve for a perfectly valid historical view.
 
-A hand-written, never-wired precedent already exists
-(=read_at_timepoint= on =currency_repository=/=country_repository=/
-=business_centre_repository=) — dead code, not codegen-generated, no
-service/NATS/UI caller anywhere. This story generalises it into a
-proper facet and applies it broadly, since resolving a historical FK
+A hand-written precedent already exists (=read_at_timepoint= on
+=currency_repository=/=country_repository= — not
+=business_centre_repository=, despite an earlier version of this
+story claiming otherwise): not codegen-generated, and with no
+service/NATS/UI caller, though =ores.cli export --as-of= does call
+it directly on the repository. This story generalises it into a
+proper facet (correcting a boundary bug found along the way — see
+Decisions) and applies it broadly, since resolving a historical FK
 value correctly is a common need, not a book-specific one.
 
 * Status
@@ -38,10 +41,10 @@ value correctly is a common need, not a book-specific one.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | Not yet started.                       |
+| Now           | Design done; implement/pilot next.     |
 | Waiting on    | Nothing.                               |
-| Next          | Design the facet, pilot on book_status/regulatory_book_type. |
-| Last touched  | 2026-07-12                               |
+| Next          | Implement and pilot on book_status/regulatory_book_type. |
+| Last touched  | 2026-07-23                               |
 
 * Acceptance
 
@@ -69,12 +72,37 @@ value correctly is a common need, not a book-specific one.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]] | STARTED | 2026-07-23 | | Design a new codegen facet (candidate flag: :has_as_of_lookup: true) generating a repository-level read_at_timepoint(ctx, as_of[, key]) method and a service-level wrapper, matching the existing hand-written shape on currency_repository/country_repository/business_centre_repository but generated consistently. Decide: NATS protocol surface (new request/response, or reuse an existing one with an optional as_of param), where the flag lives in the .org model (entity-level, since this is about the entity's own bitemporal window, not a parent/child FK relationship), and how/whether to reconcile the 3 existing hand-written methods with the generated one. |
+| [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]] | DONE | 2026-07-23 | 2026-07-23 | Design a new codegen facet (candidate flag: :has_as_of_lookup: true) generating a repository-level read_at_timepoint(ctx, as_of[, key]) method and a service-level wrapper, matching the existing hand-written shape on currency_repository/country_repository/business_centre_repository but generated consistently. Decide: NATS protocol surface (new request/response, or reuse an existing one with an optional as_of param), where the flag lives in the .org model (entity-level, since this is about the entity's own bitemporal window, not a parent/child FK relationship), and how/whether to reconcile the 3 existing hand-written methods with the generated one. |
 | [[id:5DAF8FB2-D665-446F-A458-7612418DC348][Implement and pilot the as-of lookup facet on book_status/regulatory_book_type]] | BACKLOG | | | Add the designed facet to the codegen templates (SQL/repository/service/protocol as scoped). Apply :has_as_of_lookup: true to book_status.org and regulatory_book_type.org (the entities that surfaced this gap), regenerate, and wire it to an actual caller -- at minimum the Book history dialog resolving a historical version's status/type badge correctly, proving the facet isn't dead code like its hand-written predecessor. |
 | [[id:A61D91CC-61A9-4140-8F26-AA76621FBB80][Reconcile existing hand-written read_at_timepoint methods]] | BACKLOG | | | currency_repository/country_repository/business_centre_repository already have a hand-written, unwired read_at_timepoint. Once the codegen facet lands, either replace these with the generated version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept. |
 | [[id:A3A2844A-BE49-4D1C-B5ED-49CA1A07DD1C][Roll out as-of lookup facet to remaining refdata entities]] | BACKLOG | | | Once proven on book_status/regulatory_book_type, apply :has_as_of_lookup: true broadly across refdata lookup/reference entities referenced by FK elsewhere. Deferred follow-on, not required for this story's own completion. |
 
 * Decisions
+
+- Corrected this story's own premise: =read_at_timepoint= is not
+  fully dead code — =ores.cli export currencies/countries --as-of=
+  already calls it directly on the repository.
+  =business_centre_repository= never had the method at all (only
+  =currency=/=country= do); the real gap is service/NATS/UI wiring
+  and test coverage, not "no caller anywhere".
+- The hand-written precedent has a boundary bug: =valid_to >= t=
+  should be =valid_to > t=, per the schema's own
+  =tstzrange(valid_from, valid_to)= exclusion constraint (PostgreSQL
+  default =[valid_from, valid_to)=, exclusive upper) and the
+  documented convention in [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Timestamps]]. The generated facet
+  corrects this rather than reproducing it.
+- Facet is entity-level (=:has_as_of_lookup: true=, not per-column
+  like the existing =list_by_as_of=, which is a different
+  range-overlap shape for composite parent-child versioning and
+  stays untouched by this story).
+- NATS surface: extend the existing =get_..._request=/=response=
+  with an optional =as_of= field rather than minting a new
+  request/response pair — backward compatible, no protocol sprawl.
+- Pilot caller (Book history dialog) resolves a historical book
+  version's status/type badge as-of *that book version's own
+  =valid_from=*, not "now".
+- Full design rationale in [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]]'s =*
+  Plan=.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
@@ -2,12 +2,12 @@
 :ID: 753E984D-94CB-4C99-BE63-D68B77D6BF76
 :END:
 #+title: Story: As-of lookup resolution codegen facet
-#+description: Resolving what a referenced lookup value (e.g. book_status='x') meant at a historical point in time is a distinct problem from composite parent-child versioning: it needs an as-of point-in-time query against the referenced entity's own bitemporal window (valid_from <= t AND valid_to >= t), not a current-only lookup. A hand-written, unwired precedent already exists on currency_repository/country_repository/business_centre_repository (read_at_timepoint) but is not codegen-generated and has no service/NATS/UI callers -- dead code. Generalise it into a codegen facet (e.g. :has_as_of_lookup: true) generating repository + service (+ protocol where warranted), and apply it broadly since this is a common need across refdata entities, not just book-related ones.
+#+description: Resolving what a referenced lookup value (e.g. book_status='x') meant at a historical point in time is a distinct problem from composite parent-child versioning: it needs an as-of point-in-time query against the referenced entity's own bitemporal window (valid_from <= t AND valid_to > t), not a current-only lookup. A hand-written precedent already exists on currency_repository/country_repository (read_at_timepoint, not business_centre_repository) but is not codegen-generated and has no service/NATS/UI callers, though ores.cli export --as-of does call it directly on the repository. Generalise it into a codegen facet (e.g. :has_as_of_lookup: true) generating repository + service (+ protocol where warranted), correcting a valid_to boundary bug found along the way, and apply it broadly since this is a common need across refdata entities, not just book-related ones.
 #+type: story
 #+level: s2
 #+filetags: :book_data_model_cleanup:sprint_24:v0:codegen:
 #+created: 2026-07-12
-#+updated: 2026-07-21
+#+updated: 2026-07-23
 #+environment: merry_newton
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
@@ -53,17 +53,17 @@ value correctly is a common need, not a book-specific one.
   matching the existing hand-written shape, plus a service-level
   wrapper -- consistently, not hand-added per entity.
 - The facet is actually wired to a caller (NATS request/response
-  and/or a Qt read path) for at least the pilot entities -- no more
-  dead code like the current currency/country/business_centre
-  precedent.
+  and/or a Qt read path) for at least the pilot entities -- the
+  current currency/country precedent has no service/NATS/UI caller,
+  only a direct repository call from ores.cli.
 - Piloted on =book_status= and =regulatory_book_type= (the entities
   that surfaced the gap) and verified: viewing a historical book
   version resolves its status/type badge correctly even after that
   code has since been deleted or renamed.
-- Existing =currency_repository=/=country_repository=/
-  =business_centre_repository= hand-written =read_at_timepoint=
-  methods are either replaced by the generated facet or explicitly
-  reconciled with it (not left as a second, inconsistent
+- Existing =currency_repository=/=country_repository= hand-written
+  =read_at_timepoint= methods (including their =valid_to >= t=
+  boundary bug) are either replaced by the generated facet or
+  explicitly reconciled with it (not left as a second, inconsistent
   implementation).
 - Rollout to the remaining refdata lookup entities is scoped as a
   follow-on, not required for this story's completion.
@@ -74,7 +74,7 @@ value correctly is a common need, not a book-specific one.
 |------+-------+-------+-----+-------------|
 | [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]] | DONE | 2026-07-23 | 2026-07-23 | Design a new codegen facet (candidate flag: :has_as_of_lookup: true) generating a repository-level read_at_timepoint(ctx, as_of[, key]) method and a service-level wrapper, matching the existing hand-written shape on currency_repository/country_repository/business_centre_repository but generated consistently. Decide: NATS protocol surface (new request/response, or reuse an existing one with an optional as_of param), where the flag lives in the .org model (entity-level, since this is about the entity's own bitemporal window, not a parent/child FK relationship), and how/whether to reconcile the 3 existing hand-written methods with the generated one. |
 | [[id:5DAF8FB2-D665-446F-A458-7612418DC348][Implement and pilot the as-of lookup facet on book_status/regulatory_book_type]] | BACKLOG | | | Add the designed facet to the codegen templates (SQL/repository/service/protocol as scoped). Apply :has_as_of_lookup: true to book_status.org and regulatory_book_type.org (the entities that surfaced this gap), regenerate, and wire it to an actual caller -- at minimum the Book history dialog resolving a historical version's status/type badge correctly, proving the facet isn't dead code like its hand-written predecessor. |
-| [[id:A61D91CC-61A9-4140-8F26-AA76621FBB80][Reconcile existing hand-written read_at_timepoint methods]] | BACKLOG | | | currency_repository/country_repository/business_centre_repository already have a hand-written, unwired read_at_timepoint. Once the codegen facet lands, either replace these with the generated version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept. |
+| [[id:A61D91CC-61A9-4140-8F26-AA76621FBB80][Reconcile existing hand-written read_at_timepoint methods]] | BACKLOG | | | currency_repository/country_repository already have a hand-written read_at_timepoint (not business_centre_repository), unwired to any service/NATS/UI caller and with a valid_to >= t boundary bug versus the documented valid_to > t convention. Once the codegen facet lands, either replace these with the generated (corrected) version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept. |
 | [[id:A3A2844A-BE49-4D1C-B5ED-49CA1A07DD1C][Roll out as-of lookup facet to remaining refdata entities]] | BACKLOG | | | Once proven on book_status/regulatory_book_type, apply :has_as_of_lookup: true broadly across refdata lookup/reference entities referenced by FK elsewhere. Deferred follow-on, not required for this story's own completion. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.org
@@ -8,7 +8,7 @@
 #+filetags: :book_data_model_cleanup:sprint_24:v0:codegen:
 #+created: 2026-07-12
 #+updated: 2026-07-21
-#+environment:
+#+environment: merry_newton
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -36,7 +36,7 @@ value correctly is a common need, not a book-specific one.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -69,7 +69,7 @@ value correctly is a common need, not a book-specific one.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]] | BACKLOG | | | Design a new codegen facet (candidate flag: :has_as_of_lookup: true) generating a repository-level read_at_timepoint(ctx, as_of[, key]) method and a service-level wrapper, matching the existing hand-written shape on currency_repository/country_repository/business_centre_repository but generated consistently. Decide: NATS protocol surface (new request/response, or reuse an existing one with an optional as_of param), where the flag lives in the .org model (entity-level, since this is about the entity's own bitemporal window, not a parent/child FK relationship), and how/whether to reconcile the 3 existing hand-written methods with the generated one. |
+| [[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]] | STARTED | 2026-07-23 | | Design a new codegen facet (candidate flag: :has_as_of_lookup: true) generating a repository-level read_at_timepoint(ctx, as_of[, key]) method and a service-level wrapper, matching the existing hand-written shape on currency_repository/country_repository/business_centre_repository but generated consistently. Decide: NATS protocol surface (new request/response, or reuse an existing one with an optional as_of param), where the flag lives in the .org model (entity-level, since this is about the entity's own bitemporal window, not a parent/child FK relationship), and how/whether to reconcile the 3 existing hand-written methods with the generated one. |
 | [[id:5DAF8FB2-D665-446F-A458-7612418DC348][Implement and pilot the as-of lookup facet on book_status/regulatory_book_type]] | BACKLOG | | | Add the designed facet to the codegen templates (SQL/repository/service/protocol as scoped). Apply :has_as_of_lookup: true to book_status.org and regulatory_book_type.org (the entities that surfaced this gap), regenerate, and wire it to an actual caller -- at minimum the Book history dialog resolving a historical version's status/type badge correctly, proving the facet isn't dead code like its hand-written predecessor. |
 | [[id:A61D91CC-61A9-4140-8F26-AA76621FBB80][Reconcile existing hand-written read_at_timepoint methods]] | BACKLOG | | | currency_repository/country_repository/business_centre_repository already have a hand-written, unwired read_at_timepoint. Once the codegen facet lands, either replace these with the generated version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept. |
 | [[id:A3A2844A-BE49-4D1C-B5ED-49CA1A07DD1C][Roll out as-of lookup facet to remaining refdata entities]] | BACKLOG | | | Once proven on book_status/regulatory_book_type, apply :has_as_of_lookup: true broadly across refdata lookup/reference entities referenced by FK elsewhere. Deferred follow-on, not required for this story's own completion. |

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :codegen:sprint_24:v0:as_of_lookup_resolution:
 #+owner: marco
-#+branch:
+#+branch: feature/design-as-of-lookup-facet
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
 #+updated: 2026-07-21
-#+environment:
+#+environment: merry_newton
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:753E984D-94CB-4C99-BE63-D68B77D6BF76][As-of lookup resolution codegen facet]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:753E984D-94CB-4C99-BE63-D68B77D6BF76][As-of lookup resolution codegen facet]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
-#+updated: 2026-07-21
+#+updated: 2026-07-23
 #+environment: merry_newton
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -37,7 +37,7 @@ sibling implement/pilot task for that.
 | Now          | Nothing. |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
-| Last touched | 2026-07-12                               |
+| Last touched | 2026-07-23                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
@@ -20,28 +20,180 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Design a codegen facet generating a repository-level
+=read_at_timepoint(ctx, as_of[, key])= method and a service-level
+wrapper, matching (and correcting) the existing hand-written shape
+on =currency_repository=/=country_repository=, plus decide the NATS
+protocol surface and where the flag lives in the =.org= model. Output
+of this task is a written design (this =* Plan=), not code — see the
+sibling implement/pilot task for that.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:753E984D-94CB-4C99-BE63-D68B77D6BF76][As-of lookup resolution codegen facet]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-12                               |
 
 * Acceptance
 
--
+- Written design covering: facet flag name and placement, generated
+  repository/service method shapes, the boundary-condition
+  correction versus the hand-written precedent, and the NATS
+  protocol surface decision.
+- Existing hand-written precedent re-examined against the schema's
+  own bitemporal range semantics, not assumed correct as-is.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+** Correction to the story's premise: not fully dead code
+
+The story's framing ("dead code, no service/NATS/UI caller
+anywhere") is half right. =currency_repository::read_at_timepoint=
+and =country_repository::read_at_timepoint= *do* have a real caller:
+=ores.cli export currencies/countries --as-of <t>=
+(=projects/ores.cli/src/app/application.cpp=, =export_currencies=/
+=export_countries=). =business_centre_repository= does *not* have
+=read_at_timepoint= at all, despite the story listing it as a third
+precedent. What's genuinely missing is a *service/NATS/UI* caller —
+no Qt dialog or NATS handler resolves an as-of lookup today, and
+there is no test coverage of =read_at_timepoint='s SQL behaviour
+itself (only CLI arg-parsing tests exist).
+
+** A boundary bug in the hand-written precedent
+
+Both hand-written methods use:
+#+begin_src cpp
+where("valid_from"_c <= ts.value() && "valid_to"_c >= ts.value());
+#+end_src
+
+But the schema's own exclusion constraint
+(=ores.sql.schema.domain_entity_create.org=:
+=tstzrange(valid_from, valid_to) WITH &&=) uses PostgreSQL's default
+=[valid_from, valid_to)= range — inclusive lower, *exclusive* upper.
+Version-close triggers confirm this in practice: closing an old row
+sets =valid_to = current_timestamp()=/=clock_timestamp()=, the exact
+instant the successor row's =valid_from= takes on. The documented
+convention in [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Timestamps: Architecture and Conventions]]
+(=* Repository WHERE Clauses=) agrees: =valid_from <= t AND valid_to
+> t= (strict upper). The hand-written =>== is therefore an
+off-by-one against both the schema and the documented convention —
+at the exact instant a version closes, it would spuriously still
+match alongside its successor. Narrow in practice (nobody queries at
+microsecond precision matching a close), but real, and not something
+the generated facet should reproduce. *The generated method uses
+=valid_to > t=, not the hand-written =valid_to >= t=.*
+
+** Relationship to two other "as-of"-flavoured things already in the codebase
+
+- =list_by_as_of= (existing facet, per-FK-column,
+  =ores.cpp.repository.repository_impl.org=): generates
+  =read_by_{{column}}_as_of(ctx, {{column}}, valid_from_bound,
+  valid_to_bound)= — a *range-overlap* query
+  (=valid_from < vt AND valid_to > vf=) filtered by a parent FK
+  column, used for temporal composite entity versioning (e.g.
+  =book::read_by_parent_portfolio_id_as_of=,
+  =party_identifier::read_by_party_id_as_of=). This is a *different*
+  shape (range overlap, not a single-timestamp point test) serving a
+  *different* problem (all child versions overlapping a parent's
+  validity window), and this story is explicitly not about that —
+  see the story's own goal text distinguishing itself from composite
+  parent-child versioning.
+- Story [[id:F15A8480-C61A-4FC3-87FD-C880A1407F11][Generalize as-of and as-of-bucket queries across
+  repositories]]: cross-row-family snapshot reconstruction
+  (=DISTINCT ON (key) ... ORDER BY key, time DESC=), a third,
+  unrelated shape. Kept as a separate story per discussion — no
+  overlap in generated code or facet flag.
+
+So there are now three distinct "as-of" shapes in play; this facet
+is specifically the single-entity, single-timestamp,
+own-primary-key-or-natural-key point lookup — "what did this code
+mean at time t", nothing else.
+
+** Facet design
+
+*** Flag placement
+
+Entity-level boolean, alongside the existing =:has_batch_remove:
+true= convention (=* C++ > ** Flags= section in the =.org= model):
+
+#+begin_src org
+** Flags
+:PROPERTIES:
+:subcomponent:       api
+:has_batch_remove:   true
+:has_as_of_lookup:   true
+:END:
+#+end_src
+
+Entity-level (not per-column, unlike =list_by_as_of=) because this
+is about the entity's *own* bitemporal window, not a parent/child FK
+relationship — matches the story's own framing.
+
+*** Repository layer
+
+Two overloads mirroring =read_latest='s existing shape (see
+=ores.cpp.repository.repository_impl.org= ~line 71/108), gated by
+=has_as_of_lookup=:
+
+#+begin_src cpp
+std::vector<domain::{{entity_singular}}>
+{{entity_singular}}_repository::read_at_timepoint(context ctx, const std::string& as_of);
+
+std::vector<domain::{{entity_singular}}>
+{{entity_singular}}_repository::read_at_timepoint(
+    context ctx, const std::string& as_of, const std::string& {{primary_key.column}});
+#+end_src
+
+WHERE clause: =tenant_id"_c == tid && "valid_from"_c <= ts.value() &&
+"valid_to"_c > ts.value()= (plus the primary-key predicate on the
+keyed overload) — same tenant/workspace-filtering variants
+=read_latest= already generates (system vs. tenant-scoped,
+workspace-aware or not).
+
+*** Service layer
+
+=list_{{entity_plural}}_at_timepoint(ctx, as_of[, key])= wrapper,
+mirroring the existing =list_{{entity_plural}}= naming pattern.
+
+*** NATS protocol surface
+
+*Reuse the existing =get_{{entity_plural}}_request=/=response=* with
+an added optional =as_of= field (empty string = current/latest,
+matching =ores.cli='s own =cfg.as_of.empty()= convention already in
+=application.cpp=), rather than minting a new request/response pair
+per entity. Backward compatible (existing callers send no =as_of=,
+behaviour unchanged) and keeps the protocol surface from sprawling —
+consistent with how =get_..._request= already carries
+=offset=/=limit= as optional-with-defaults fields. The handler
+branches to =read_at_timepoint= when =as_of= is non-empty, else the
+existing =read_latest= path.
+
+*** Reconciliation of the hand-written precedent
+
+Once generated, =currency_repository=/=country_repository='s
+hand-written =read_at_timepoint= are *replaced* by the generated
+version (fixing the boundary bug as a side effect) — not left as a
+second, diverging implementation. =ores.cli/application.cpp='s call
+sites are unaffected (same method name/signature). Tracked by the
+sibling [[id:A61D91CC-61A9-4140-8F26-AA76621FBB80][Reconcile existing hand-written read_at_timepoint methods]]
+task, not this one.
+
+*** Pilot wiring (book_status / regulatory_book_type)
+
+The pilot's proof-of-not-dead-code caller is the Book history
+dialog: when displaying a historical book version, resolve its
+status/type badge using an as-of lookup anchored on *that book
+version's own =valid_from=* (the instant this book version became
+active) — not "now" — so the resolved status name/description/badge
+reflects what the code meant contemporaneously, not its current
+(possibly renamed/deleted) definition. Tracked by the sibling
+[[id:5DAF8FB2-D665-446F-A458-7612418DC348][Implement and pilot the as-of lookup facet on book_status/regulatory_book_type]]
+task.
 
 * Notes
 
@@ -69,3 +221,24 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Design complete (see =* Plan=). Key outcomes:
+
+- Corrected the story's own premise: =read_at_timepoint= has a real
+  caller (=ores.cli export --as-of=), just no service/NATS/UI one;
+  =business_centre_repository= doesn't have the method at all.
+- Found and will fix a genuine boundary bug in the hand-written
+  precedent: =valid_to >= t= should be =valid_to > t= per the
+  schema's own =[valid_from, valid_to)= range-exclusion constraint
+  and the documented convention in Time and Timestamps.
+- Disambiguated three distinct "as-of" shapes now in the codebase
+  (this facet's single-entity point lookup; the existing
+  =list_by_as_of= range-overlap facet for composite versioning;
+  story F15A8480's cross-row-family snapshot reconstruction) so the
+  implement task doesn't conflate them.
+- Facet: entity-level =:has_as_of_lookup: true=, generating
+  =read_at_timepoint= (repository) + =list_..._at_timepoint=
+  (service), reusing the existing =get_..._request=/=response= with
+  an added optional =as_of= field rather than a new protocol pair.
+- Pilot caller: Book history dialog resolves a historical version's
+  status/type badge as-of that book version's own =valid_from=.

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
@@ -218,7 +218,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Stale pre-correction claims (business_centre_repository, valid_to >= t) left in story.org's description/Acceptance/Tasks table and the reconcile task's own description | story.org, task_reconcile_existing_read_at_timepoint.org | Accepted | Fixed in 42ded6e81 |
+| 2 | #+updated/Last touched not bumped on story.org and this task file | story.org, task_design_as_of_lookup_facet.org | Accepted | Fixed in 42ded6e81 |
+| 3 | Unclear whether the boundary-bug fix is backported to hand-written methods independently or bundled with reconciliation | task_reconcile_existing_read_at_timepoint.org | Accepted | Clarified in 42ded6e81: bundled with the replacement, not backported separately |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.org
@@ -8,7 +8,7 @@
 #+filetags: :codegen:sprint_24:v0:as_of_lookup_resolution:
 #+owner: marco
 #+branch: feature/design-as-of-lookup-facet
-#+pr:
+#+pr: 1675
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
@@ -212,7 +212,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1675][#1675]] | [agile] Design the as-of lookup codegen facet |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_reconcile_existing_read_at_timepoint.org
+++ b/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_reconcile_existing_read_at_timepoint.org
@@ -2,7 +2,7 @@
 :ID: A61D91CC-61A9-4140-8F26-AA76621FBB80
 :END:
 #+title: Task: Reconcile existing hand-written read_at_timepoint methods
-#+description: currency_repository/country_repository/business_centre_repository already have a hand-written, unwired read_at_timepoint. Once the codegen facet lands, either replace these with the generated version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept.
+#+description: currency_repository/country_repository already have a hand-written read_at_timepoint (not business_centre_repository), unwired to any service/NATS/UI caller and with a valid_to >= t boundary bug versus the documented valid_to > t convention. Once the codegen facet lands, either replace these with the generated (corrected) version or explicitly document why they diverge -- don't leave two parallel implementations of the same concept.
 #+type: task
 #+level: s1
 #+filetags: :codegen:sprint_24:v0:as_of_lookup_resolution:
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-12
-#+updated: 2026-07-21
+#+updated: 2026-07-23
 #+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -20,7 +20,14 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Replace =currency_repository=/=country_repository='s hand-written
+=read_at_timepoint= with the generated (corrected) facet method — see
+[[id:002A916C-2D83-4408-8B74-05CEA44CCB06][Design the as-of lookup codegen facet]]. The =valid_to >= t= boundary
+bug is *not* backported to the hand-written methods independently —
+it's fixed as part of this reconciliation replacing them outright,
+not as a standalone earlier patch, so there's no window where a
+known-buggy hand-written version is deliberately left live longer
+than the replacement takes to land.
 
 * Status
 


### PR DESCRIPTION
## Summary

Design task for the As-of lookup resolution codegen facet story: an entity-level facet resolving what a referenced lookup value meant at a historical point in time, correcting a boundary bug found in the existing hand-written precedent along the way.

## Changes

- Corrected the story's own premise: read_at_timepoint has a real CLI caller (ores.cli export --as-of), and business_centre_repository never had the method at all
- Found and will fix a boundary bug: the hand-written precedent's valid_to greater-or-equal-t should be strict greater-than-t, per the schema's own tstzrange exclusion constraint and the documented Time and Timestamps convention
- Disambiguated this facet from two other as-of-flavoured shapes already in the codebase: list_by_as_of's range-overlap composite-versioning facet, and the separately-tracked as-of-bucket snapshot-reconstruction story
- Facet design: entity-level has_as_of_lookup flag, reusing the existing get request/response with an optional as_of field rather than a new protocol pair
- Docs-only change, no build/test impact

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [As-of lookup resolution codegen facet](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/story.html) | 753E984D-94CB-4C99-BE63-D68B77D6BF76 |
| Task | [Design the as-of lookup codegen facet](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/as_of_lookup_resolution/task_design_as_of_lookup_facet.html) | 002A916C-2D83-4408-8B74-05CEA44CCB06 |
| Environment | merry_newton | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)