### PR TITLE
[agile] Split image-batch story into decision and implementation tasks

### DIFF
--- a/doc/agile/product_backlog/inbox/compress-all-nats-json-messages.org
+++ b/doc/agile/product_backlog/inbox/compress-all-nats-json-messages.org
@@ -5,7 +5,7 @@
 #+description: Raised while scoping the image-batch payload/compression story: every NATS message in this app goes through rfl::json::write/read (ores.service/messaging/handler_helpers.hpp) uncompressed. Images need special-case handling regardless (raw bytes instead of base64-in-JSON, since round-tripping SVGs through JSON encoding just to decode them again is wasted work), but the broader question of whether to add generic compression to the JSON transport layer for all other messages (large list responses, bulk history payloads, etc.) is separate and worth evaluating independently -- likely lower priority since most non-image payloads are far smaller, but worth a look if payload-size complaints recur elsewhere.
 #+type: capture
 #+level: cross
-#+filetags: 
+#+filetags: :nats:messaging:performance:
 #+created: 2026-07-26
 #+updated: 2026-07-26
 

--- a/doc/agile/product_backlog/inbox/compress-all-nats-json-messages.org
+++ b/doc/agile/product_backlog/inbox/compress-all-nats-json-messages.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 4BD63D23-5BB1-455A-92F1-83B6D74EFBD1
+:END:
+#+title: Consider compressing all NATS JSON messages, not just images
+#+description: Raised while scoping the image-batch payload/compression story: every NATS message in this app goes through rfl::json::write/read (ores.service/messaging/handler_helpers.hpp) uncompressed. Images need special-case handling regardless (raw bytes instead of base64-in-JSON, since round-tripping SVGs through JSON encoding just to decode them again is wasted work), but the broader question of whether to add generic compression to the JSON transport layer for all other messages (large list responses, bulk history payloads, etc.) is separate and worth evaluating independently -- likely lower priority since most non-image payloads are far smaller, but worth a look if payload-size complaints recur elsewhere.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-07-26
+#+updated: 2026-07-26
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/story.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :assets:qt:bugfix:performance:sprint_24:v0:
 #+created: 2026-07-22
-#+updated: 2026-07-22
+#+updated: 2026-07-26
 #+environment:
 #+todo: BACKLOG STARTED | DONE ABANDONED
 

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/story.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/story.org
@@ -56,11 +56,23 @@ addressable by key) is arguably a better fit for that same pattern than
 for NATS request-reply: no payload-size ceiling to chunk around at all,
 standard HTTP caching/range-request semantics apply for free, and it
 sidesteps the batching problem entirely rather than tuning around it.
-Whether images should move to =ores_assets_images_tbl= id being S3-object-
-addressable (or reuse the existing storage bucket mechanism directly) vs.
-staying NATS-delivered-but-fixed is a design choice the first task should
-make explicitly, not assume -- weigh against the two other options above
-before committing to an approach.
+
+Leaning towards staying on NATS unless the decision task turns up a good
+reason not to: NATS itself has no issue with binary payloads (a NATS
+message is just an opaque byte array), so there's no inherent transport
+ceiling being fought here. The actual cost stack today is self-inflicted
+by this app's own wire format, not by NATS or by using request-reply:
+every message (including image responses) goes through
+=rfl::json::write=/=read= (=ores.service/messaging/handler_helpers.hpp=),
+so binary SVG data is base64-encoded into a JSON string field -- ~33%
+inflation -- on top of being sent fully uncompressed. Sending raw
+(optionally gzip'd) bytes directly as the NATS payload for image-
+carrying messages, bypassing JSON/base64 for that field, plausibly
+removes most of the overflow risk on its own. The decision task should
+verify this against the synthetic worst case before treating the HTTP-
+transport migration as necessary -- it's a materially bigger change
+(new storage-addressing scheme for images) that should only be taken on
+if NATS-with-compression genuinely can't be made to fit.
 
 * Status
 
@@ -68,10 +80,10 @@ before committing to an approach.
 |---------------+----------------------------------------|
 | State         | BACKLOG                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | Not yet started.                       |
+| Now           | Split into tasks; none started yet.    |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-07-22                               |
+| Next          | Start the decision task.               |
+| Last touched  | 2026-07-26                               |
 
 * Acceptance
 
@@ -95,10 +107,16 @@ before committing to an approach.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:DFE8C121-DDE6-4FE8-891A-0A0DE2B44DFA][Make ImageCache batching byte-size aware, add SVG compression]] | BACKLOG | | | Track cumulative payload size while building each image-fetch batch, not just count; add gzip compression to the image transfer pipeline. |
+| [[id:3BC1C308-9683-48EE-91E1-6F7A3F622F62][Decide: NATS binary+compression vs. HTTP storage-endpoint transport for image delivery]] | BACKLOG | | | Confirm that sending images as raw (non-base64) compressed bytes over NATS resolves the payload-overflow problem on its own, before considering a move to the existing HTTP storage-endpoint transport. Record the decision and rationale. |
+| [[id:BB6947FC-EE92-44E9-984A-BDFFC25A9BCA][Add gzip compression to the image NATS pipeline, send raw bytes instead of base64]] | BACKLOG | | | Server compresses SVG image data before sending; client decompresses on receive. Stop routing binary image data through the JSON/base64 encoding used for the rest of the messaging protocol -- send it as raw bytes on the wire for image-carrying messages, eliminating both the base64 inflation and the missing compression in one pass. |
+| [[id:DF92CC86-8A91-44FE-AA34-5CC78D1B2F12][Make ImageCache batching byte-size aware]] | BACKLOG | | | Track cumulative estimated payload size (post-compression) while building each image-fetch batch, not just image count, so a batch is cut short before it would risk exceeding the NATS payload limit. Backstop for whatever pathological cases remain after compression; revisit MAX_IMAGES_PER_REQUEST once this and the compression task both land. |
+| [[id:DFE8C121-DDE6-4FE8-891A-0A0DE2B44DFA][Make ImageCache batching byte-size aware, add SVG compression]] (ABANDONED -- split above) | ABANDONED | | | Superseded: bundled a design decision with two independent implementation concerns under one task. |
 
 * Decisions
 
 * Out of scope
 
--
+- Compressing NATS messages generically (the =rfl::json= transport used
+  by every other message type, not just images) -- separate, broader
+  question, filed as a backlog capture:
+  [[id:4BD63D23-5BB1-455A-92F1-83B6D74EFBD1][Consider compressing all NATS JSON messages, not just images]].

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-batching.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-batching.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: DF92CC86-8A91-44FE-AA34-5CC78D1B2F12
+:END:
+#+title: Task: Make ImageCache batching byte-size aware
+#+description: Track cumulative estimated payload size (post-compression) while building each image-fetch batch, not just image count, so a batch is cut short before it would risk exceeding the NATS payload limit. Backstop for whatever pathological cases remain after compression; revisit MAX_IMAGES_PER_REQUEST once this and the compression task both land.
+#+type: task
+#+level: s1
+#+filetags: :fix-image-batch-payload-and-compression:sprint_24:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-26
+#+updated: 2026-07-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-26                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-batching.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-batching.org
@@ -20,7 +20,22 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Make =ImageCache='s batch-fetch logic track cumulative estimated
+payload size while building each batch, not just image count, so a
+batch is cut short before adding an image that would risk exceeding
+NATS's max payload -- rather than relying solely on
+=MAX_IMAGES_PER_REQUEST= as a count-based proxy for size. This is the
+remaining backstop after the compression task lands: compression
+removes most of the overflow risk, but a byte-size-aware cap makes the
+guarantee hold regardless of how images happen to cluster in a given
+request. Depends on the decision task confirming NATS (not HTTP
+transport) is the chosen path, and should land after (or alongside)
+the compression task, since the safe-size threshold is computed
+against post-compression payload size.
+
+Revisit =MAX_IMAGES_PER_REQUEST= once this lands: raise it back up,
+remove it, or reinterpret it as a soft cap now that byte size is the
+real constraint being enforced.
 
 * Status
 

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-image-batching.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-image-batching.org
@@ -37,12 +37,12 @@ regardless of how many or how large the images in a given request are.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] |
-| Now          | Not yet started.                       |
+| Now          | Superseded -- split into three tasks.  |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-22                               |
+| Next         | See the three replacement tasks below. |
+| Last touched | 2026-07-26                               |
 
 * Acceptance
 
@@ -65,6 +65,17 @@ are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
 
 * Notes
+
+This task bundled a design decision (batching vs. compression vs.
+HTTP transport) with two independent implementation concerns
+(byte-aware batching, compression) under one heading. Split on
+2026-07-26 into:
+
+- [[id:3BC1C308-9683-48EE-91E1-6F7A3F622F62][Decide: NATS binary+compression vs. HTTP storage-endpoint transport
+  for image delivery]]
+- [[id:BB6947FC-EE92-44E9-984A-BDFFC25A9BCA][Add gzip compression to the image NATS pipeline, send raw bytes
+  instead of base64]]
+- [[id:DF92CC86-8A91-44FE-AA34-5CC78D1B2F12][Make ImageCache batching byte-size aware]]
 
 * Test Scenarios
 

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-image-batching.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_byte-size-aware-image-batching.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-22
-#+updated: 2026-07-22
+#+updated: 2026-07-26
 #+environment:
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_compress-image-nats-payload.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_compress-image-nats-payload.org
@@ -1,0 +1,88 @@
+:PROPERTIES:
+:ID: BB6947FC-EE92-44E9-984A-BDFFC25A9BCA
+:END:
+#+title: Task: Add gzip compression to the image NATS pipeline, send raw bytes instead of base64
+#+description: Server compresses SVG image data before sending; client decompresses on receive. Stop routing binary image data through the JSON/base64 encoding used for the rest of the messaging protocol -- send it as raw bytes on the wire for image-carrying messages, eliminating both the base64 inflation and the missing compression in one pass.
+#+type: task
+#+level: s1
+#+filetags: :fix-image-batch-payload-and-compression:sprint_24:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-26
+#+updated: 2026-07-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two distinct mechanisms, both scoped to image-carrying messages only
+(the rest of the messaging protocol's JSON/=rfl::json= transport is out
+of scope for this task -- see the "Consider compressing all NATS JSON
+messages" backlog capture for that broader, separate question):
+
+1. Stop round-tripping SVG bytes through base64-inside-JSON just to
+   decode them straight back out again on the other end. Image data
+   should travel as raw bytes on the wire, not as a base64 string field
+   the receiver immediately decodes -- that encode/decode step is pure
+   overhead with no benefit for this payload.
+2. Compress those raw bytes (gzip) before sending; decompress on
+   receive. This is what actually shrinks the payload -- the base64
+   removal alone only recovers the ~33% encoding inflation, whereas
+   gzip on SVG text typically saves 70-80% on top of that.
+
+Together these should make image responses small enough that
+=MAX_IMAGES_PER_REQUEST= is no longer the binding constraint (see the
+sibling byte-size-aware-batching task for the remaining backstop).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-26                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_decide-nats-compression-vs-http-transport.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_decide-nats-compression-vs-http-transport.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 3BC1C308-9683-48EE-91E1-6F7A3F622F62
+:END:
+#+title: Task: Decide: NATS binary+compression vs. HTTP storage-endpoint transport for image delivery
+#+description: Confirm that sending images as raw (non-base64) compressed bytes over NATS resolves the payload-overflow problem on its own, before considering a move to the existing HTTP storage-endpoint transport. Record the decision and rationale.
+#+type: task
+#+level: s1
+#+filetags: :fix-image-batch-payload-and-compression:sprint_24:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-26
+#+updated: 2026-07-26
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:EFFEEFAC-0406-4FF3-AAFB-075EB0324DB1][Fix image-batch NATS payload overflow, add SVG compression]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-26                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_decide-nats-compression-vs-http-transport.org
+++ b/doc/agile/versions/v0/sprint_24/fix-image-batch-payload-and-compression/task_decide-nats-compression-vs-http-transport.org
@@ -20,7 +20,21 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Confirm, before either implementation task starts, that staying on
+NATS request-reply with raw (non-base64) compressed bytes for image
+payloads is sufficient to eliminate the overflow -- rather than
+defaulting to it and discovering mid-implementation that it isn't.
+
+Estimate the worst-case compressed payload size for a batch of the
+largest known SVGs (e.g. Norfolk Island, CEFTA) after removing the
+base64 layer and applying gzip, and compare against NATS's max
+payload. If the estimate comfortably clears the limit (with the
+byte-size-aware batching task as the remaining backstop), record that
+as the decision and rationale in this task's =* Plan=, then distil it
+into the parent story's =* Decisions= at close. Only escalate to the
+HTTP storage-endpoint transport migration (a materially bigger change:
+new storage-addressing scheme for images) if the estimate shows
+compression alone isn't enough.
 
 * Status
 


### PR DESCRIPTION
## Summary
- Doc-only: rework the task breakdown for "Fix image-batch NATS payload overflow, add SVG compression" -- the single bundled task conflated a design decision with two independent implementation concerns.
- Split into a decision task (NATS-byte-aware-batching+compression vs. HTTP storage-endpoint transport) plus two implementation tasks (compression + raw-byte wire encoding, byte-size-aware batching); old task marked ABANDONED with a pointer to the split.
- Recorded the NATS-vs-HTTP-transport leaning and the base64-in-JSON root cause (rfl::json wire format, not a NATS limitation) in the story.
- Filed the broader "compress all NATS JSON messages" question as a separate backlog capture rather than folding it into this story's scope.

## Test plan
- [x] Doc-only change, no code touched -- no build/test applicable.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>