### PR TITLE
[ores.refdata,ores.codegen] Calendar Regenerate-up-to-year action

### DIFF
--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_calendar-qt-source-editability-and-holidays-browse.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_calendar-qt-source-editability-and-holidays-browse.org
@@ -52,15 +52,15 @@ independent halves:
 
 * Acceptance
 
-- [ ] Calendar's detail dialog shows =source=, =is_editable=, and
+- [X] Calendar's detail dialog shows =source=, =is_editable=, and
   =base_calendar_code= (the last as a dynamic combo over other
   calendars, matching =calendar_rule=/=calendar_exception='s existing
   =calendar_code= combo pattern).
-- [ ] Opening a =source='quantlib'= calendar locks every field in the
+- [X] Opening a =source='quantlib'= calendar locks every field in the
   dialog, not just the fields already locked-after-create -- users
   cannot edit a QuantLib-sourced calendar's own name/type/country via
   the UI, full stop.
-- [ ] A "Regenerate up to <year>" action exists (calendar detail
+- [X] A "Regenerate up to <year>" action exists (calendar detail
   dialog or list-window toolbar) that calls
   =refdata.v1.calendar_dates.regenerate= for the open calendar and
   surfaces success/failure and rows-written to the user.

--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_calendar-qt-source-editability-and-holidays-browse.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_calendar-qt-source-editability-and-holidays-browse.org
@@ -8,7 +8,7 @@
 #+filetags: :calendar-followups:sprint_24:v0:
 #+owner: marco
 #+branch: feature/calendar-qt-source-editability-and-holidays-browse
-#+pr: 1700
+#+pr: 1707
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-25
@@ -92,6 +92,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1707][#1707]] | [ores.refdata,ores.codegen] Calendar Regenerate-up-to-year action |
 | [[https://github.com/OreStudio/OreStudio/pull/1700][#1700]] | [ores.refdata,ores.codegen] Calendar detail dialog: source/editability/base template |
 
 * Review

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -946,10 +946,17 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
             qt_out["has_generate_action"] = any(
                 a.get("action") == "generateAction" for a in qt_out.get("setting_gated_actions", [])
             )
-            # A detail dialog needs a QToolBar iff it hosts either version-nav
-            # actions or the Generate action (both add QAction rows to it).
+            # A detail dialog needs a QToolBar iff it hosts version-nav
+            # actions, the Generate action (both add QAction rows to it),
+            # or the author explicitly asked for one (e.g. to host a
+            # hand-written paste-block action with no dedicated knob of
+            # its own, like calendar's "Regenerate up to <year>") --
+            # an explicit :has_toolbar: true in the drawer must survive
+            # this derivation, not be silently overwritten by it.
             qt_out["has_toolbar"] = bool(
-                qt_out.get("has_version_navigation") or qt_out["has_generate_action"]
+                qt_out.get("has_toolbar")
+                or qt_out.get("has_version_navigation")
+                or qt_out["has_generate_action"]
             )
             res = _section(qt, "Related entity shortcuts")
             if res:

--- a/projects/ores.qt/refdata/include/ores.qt/CalendarDetailDialog.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/CalendarDetailDialog.hpp
@@ -24,8 +24,11 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/DetailDialogBase.hpp"
 #include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/IconUtils.hpp"
 #include "ores.qt/LookupFetcher.hpp"
 #include "ores.refdata.api/domain/calendar.hpp"
+#include <QAction>
+#include <QToolBar>
 #include <vector>
 
 namespace Ui {
@@ -108,6 +111,8 @@ private:
 
     void populateCountryCodeCombo();
 
+    QAction* regenerateAction_{nullptr};
+    void onRegenerateClicked();
 
     Ui::CalendarDetailDialog* ui_;
     ClientManager* clientManager_;
@@ -116,6 +121,8 @@ private:
     bool createMode_{true};
     bool readOnly_{false};
     bool hasChanges_{false};
+
+    QToolBar* toolBar_{nullptr};
 };
 
 }

--- a/projects/ores.qt/refdata/src/CalendarDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CalendarDetailDialog.cpp
@@ -200,6 +200,8 @@ void CalendarDetailDialog::setCreateMode(bool createMode) {
     setProvenanceEnabled(!createMode);
     hasChanges_ = false;
     updateSaveButtonState();
+    if (regenerateAction_)
+        regenerateAction_->setEnabled(!createMode);
 }
 
 void CalendarDetailDialog::markDirty() {

--- a/projects/ores.qt/refdata/src/CalendarDetailDialog.cpp
+++ b/projects/ores.qt/refdata/src/CalendarDetailDialog.cpp
@@ -25,10 +25,13 @@
 #include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
+#include "ores.refdata.api/messaging/calendar_materialisation_protocol.hpp"
 #include "ores.refdata.api/messaging/calendar_protocol.hpp"
 #include "ui_CalendarDetailDialog.h"
 #include <QComboBox>
+#include <QDate>
 #include <QFutureWatcher>
+#include <QInputDialog>
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <algorithm>
@@ -89,6 +92,13 @@ void CalendarDetailDialog::setupUi() {
 
     ui_->closeButton->setIcon(
         IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    if (auto* mainLayout = qobject_cast<QVBoxLayout*>(layout()))
+        mainLayout->insertWidget(0, toolBar_);
 }
 
 void CalendarDetailDialog::setupCombos() {}
@@ -114,6 +124,13 @@ void CalendarDetailDialog::setupConnections() {
             &QComboBox::currentIndexChanged,
             this,
             &CalendarDetailDialog::onFieldChanged);
+    regenerateAction_ = toolBar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::ArrowSync, IconUtils::DefaultIconColor),
+        tr("Regenerate"));
+    regenerateAction_->setToolTip(tr("Regenerate this calendar's holidays up to a chosen year"));
+    regenerateAction_->setEnabled(!createMode_);
+    connect(
+        regenerateAction_, &QAction::triggered, this, &CalendarDetailDialog::onRegenerateClicked);
 }
 
 void CalendarDetailDialog::setClientManager(ClientManager* clientManager) {
@@ -478,5 +495,73 @@ void CalendarDetailDialog::onDeleteClicked() {
     watcher->setFuture(future);
 }
 
+void CalendarDetailDialog::onRegenerateClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(
+            this, "Disconnected", "Cannot regenerate while disconnected from server.");
+        return;
+    }
+
+    bool ok = false;
+    const int currentYear = QDate::currentDate().year();
+    const int endYear = QInputDialog::getInt(this,
+                                             tr("Regenerate Holidays"),
+                                             tr("Regenerate up to year:"),
+                                             currentYear + 10,
+                                             currentYear,
+                                             currentYear + 100,
+                                             1,
+                                             &ok);
+    if (!ok)
+        return;
+
+    const std::string calendarCode = calendar_.code;
+    QPointer<CalendarDetailDialog> self = this;
+
+    struct RegenerateResult {
+        bool success;
+        std::string message;
+        std::uint64_t rows_written;
+    };
+
+    auto task = [self, calendarCode, endYear]() -> RegenerateResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed", 0};
+        }
+
+        refdata::messaging::regenerate_calendar_dates_request request;
+        request.calendar_code = calendarCode;
+        request.end_year = endYear;
+        auto response_result =
+            self->clientManager_->process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server", 0};
+        }
+
+        return {response_result->success, response_result->message, response_result->rows_written};
+    };
+
+    auto* watcher = new QFutureWatcher<RegenerateResult>(self);
+    connect(watcher, &QFutureWatcher<RegenerateResult>::finished, self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+        if (!self)
+            return;
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info)
+                << "Regenerated " << result.rows_written << " calendar_dates rows";
+            emit self->statusMessage(tr("Regenerated %1 holiday row(s)").arg(result.rows_written));
+        } else {
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Regenerate Failed", errorMsg);
+        }
+    });
+
+    QFuture<RegenerateResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
 
 }

--- a/projects/ores.refdata/modeling/ores.refdata.calendar.org
+++ b/projects/ores.refdata/modeling/ores.refdata.calendar.org
@@ -315,6 +315,7 @@ drop function if exists ores_refdata_validate_calendar_fn;
 :has_version_navigation:      false
 :changed_event_class:         refdata::eventing::calendar_changed_event
 :changed_event_include:       ores.refdata.api/eventing/calendar_changed_event.hpp
+:has_toolbar:                 true
 :END:
 
 *** Detail fields
@@ -492,6 +493,109 @@ saved.
 
 #+begin_src cpp :name entity_set_load_hook :implements D5A8E2F1-6C4B-4A9D-8E3F-2B7C1A9D4E6F
     setReadOnly(!calendar_.is_editable);
+#+end_src
+
+** Qt: "Regenerate up to <year>" action
+
+A toolbar action (=:has_toolbar: true=, above) that calls the
+=refdata.v1.calendar_dates.regenerate= NATS command
+(=regenerate_calendar_dates_request=, in
+=ores.refdata.api/messaging/calendar_materialisation_protocol.hpp=)
+for the calendar currently open in this dialog, extending its
+materialised
+[[id:875E96F6-3FC7-4E0B-8E3C-2AC0F8BD488F][calendar_dates]] up to a
+user-prompted end year. Available regardless of =is_editable= --
+regenerating derived =calendar_dates= rows is not the same as editing
+the template's own fields, so it isn't gated by the whole-form lock
+above. Disabled in create mode (nothing to regenerate for a row that
+doesn't exist on the server yet).
+
+#+begin_src cpp :name impl_includes :implements 3F8B6C1D-4E2A-4F9B-8C3D-1A5E7F2B9D4C
+#include "ores.refdata.api/messaging/calendar_materialisation_protocol.hpp"
+#include <QDate>
+#include <QInputDialog>
+#+end_src
+
+#+begin_src cpp :name declaration :implements F55CB64E-165A-4E15-A50A-5723C0320E97
+    QAction* regenerateAction_{nullptr};
+    void onRegenerateClicked();
+#+end_src
+
+#+begin_src cpp :name setup_connections_extra :implements B6F2748A-9896-4B9C-BEAC-38436FD1CA79
+    regenerateAction_ = toolBar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::ArrowSync, IconUtils::DefaultIconColor),
+        tr("Regenerate"));
+    regenerateAction_->setToolTip(
+        tr("Regenerate this calendar's holidays up to a chosen year"));
+    regenerateAction_->setEnabled(!createMode_);
+    connect(regenerateAction_, &QAction::triggered,
+            this, &CalendarDetailDialog::onRegenerateClicked);
+#+end_src
+
+#+begin_src cpp :name implementation :implements EC97923E-BC8D-4A50-9970-CBC5CBD4B732
+void CalendarDetailDialog::onRegenerateClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot regenerate while disconnected from server.");
+        return;
+    }
+
+    bool ok = false;
+    const int currentYear = QDate::currentDate().year();
+    const int endYear = QInputDialog::getInt(this, tr("Regenerate Holidays"),
+        tr("Regenerate up to year:"), currentYear + 10,
+        currentYear, currentYear + 100, 1, &ok);
+    if (!ok) return;
+
+    const std::string calendarCode = calendar_.code;
+    QPointer<CalendarDetailDialog> self = this;
+
+    struct RegenerateResult {
+        bool success;
+        std::string message;
+        std::uint64_t rows_written;
+    };
+
+    auto task = [self, calendarCode, endYear]() -> RegenerateResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed", 0};
+        }
+
+        refdata::messaging::regenerate_calendar_dates_request request;
+        request.calendar_code = calendarCode;
+        request.end_year = endYear;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server", 0};
+        }
+
+        return {response_result->success, response_result->message,
+                response_result->rows_written};
+    };
+
+    auto* watcher = new QFutureWatcher<RegenerateResult>(self);
+    connect(watcher, &QFutureWatcher<RegenerateResult>::finished, self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Regenerated " << result.rows_written
+                                      << " calendar_dates rows";
+            emit self->statusMessage(
+                tr("Regenerated %1 holiday row(s)").arg(result.rows_written));
+        } else {
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Regenerate Failed", errorMsg);
+        }
+    });
+
+    QFuture<RegenerateResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
 #+end_src
 
 * See also

--- a/projects/ores.refdata/modeling/ores.refdata.calendar.org
+++ b/projects/ores.refdata/modeling/ores.refdata.calendar.org
@@ -508,7 +508,18 @@ user-prompted end year. Available regardless of =is_editable= --
 regenerating derived =calendar_dates= rows is not the same as editing
 the template's own fields, so it isn't gated by the whole-form lock
 above. Disabled in create mode (nothing to regenerate for a row that
-doesn't exist on the server yet).
+doesn't exist on the server yet) -- its initial state is set once in
+=setupConnections()= (below) while =createMode_= still holds its
+constructor default, but the real caller-driven state only lands
+later via =setCreateMode()=, so that seam must also re-sync the
+action's enabled state, or it stays permanently disabled for every
+existing calendar opened through the normal view/edit flow (the one
+path this feature exists for).
+
+#+begin_src cpp :name set_create_mode_extra :implements 9A719585-3AB1-47DE-B0B0-99AFDFE7180E
+    if (regenerateAction_)
+        regenerateAction_->setEnabled(!createMode);
+#+end_src
 
 #+begin_src cpp :name impl_includes :implements 3F8B6C1D-4E2A-4F9B-8C3D-1A5E7F2B9D4C
 #include "ores.refdata.api/messaging/calendar_materialisation_protocol.hpp"


### PR DESCRIPTION
## Summary

Progress on Calendar Qt UI: source/editability display, regenerate button, browse-holidays view. Adds a Regenerate-up-to-year toolbar action on Calendar's detail dialog, wired to the existing (already server-side complete) refdata.v1.calendar_dates.regenerate NATS command.

## Changes

- Add regenerateAction_ toolbar action to CalendarDetailDialog, prompting for an end year and calling regenerate_calendar_dates_request; surfaces success/rows-written or failure to the user
- Hand-authored via existing paste-block extension seams (has_toolbar, private members, setupConnections, implementation body) -- a one-off entity-specific NATS call, not worth a new generic codegen knob
- Fix codegen: has_toolbar is derived (version-nav or Generate action) and unconditionally overwrote an entity's own explicit :has_toolbar: true drawer value, discarding it. Now ORs the raw drawer value in; no other entity currently sets it explicitly, so this is a no-op everywhere else
- Verification: local build clean (linux-clang-debug-make); ctest 73/74 passed -- the one failure (ores.refdata.core.tests) is pre-existing DB schema drift on this environment, not a regression

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/story.html) | 16162B5B-1EDA-4CA7-9AB6-E5AD37D21426 |
| Task | [Calendar Qt UI: source/editability display, regenerate button, browse-holidays view](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/task_calendar-qt-source-editability-and-holidays-browse.html) | B2888D7D-9D16-48DE-AE4C-48FF610841AA |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)