### PR TITLE
[refdata,codegen] Generate calendar_date messaging layer, fix date-column validation in service templates

### DIFF
--- a/doc/agile/versions/v0/sprint_24/calendar-followups/story.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/story.org
@@ -46,7 +46,7 @@ Pick up three follow-ups beyond [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model
 | [[id:35F743BF-F513-4976-B294-D4E8DB975906][Add codegen Qt facet for paginated read-only junction-scoped lists]] | DONE | | 2026-07-25 | Extend ores.codegen's Qt facet with a new shape for junction-backed, read-only, server-paginated lists scoped to a parent key -- a client model + list dialog (no detail dialog, nothing to edit), reusable for calendar_dates and future large materialised/derived datasets. Closer to the existing History dialog shape (read-only, parent-scoped) than to the relationship-assignment-widget pattern (CalendarAssignmentWidget) used by every existing small many-to-many junction today. |
 | [[id:B2888D7D-9D16-48DE-AE4C-48FF610841AA][Calendar Qt UI: source/editability display, regenerate button, browse-holidays view]] | DONE | 2026-07-26 | 2026-07-27 | Remaining step 6 pieces: Calendar detail dialog shows source/is_editable/base_calendar_code and locks the form for source=quantlib rows; a Regenerate-up-to-year button wired to the calendar_dates regenerate NATS command; a Browse Holidays view backed by the paginated read-only junction-list codegen facet (blocked on that facet existing). |
 | [[id:3282E378-74C0-43B4-B952-544FCEADE66A][Codegen: extend junction repository/service templates with paginated list_by filter]] | DONE | 2026-07-27 | 2026-07-27 | Add the same list_by/pagination knob that domain_entity foreign_keys already have (read_latest_by_COLUMN with offset/limit through repository and service) to the junction repository/service mustache templates, so a junction like calendar_dates can expose a paginated, filtered by-left-or-right-column list method. |
-| [[id:3E688A38-757A-4DE6-A7D2-9CA9B1EC2255][Codegen: generate calendar_date service/protocol/nats-handler layers using extra_list_requests]] | BACKLOG | | | First real consumer of the existing but never-exercised extra_list_requests knob: generate calendar_date's service, protocol, and nats-handler layers with a paginated list-by-calendar_code request/response, once the junction list_by pagination knob exists. Validates the extra_list_requests mechanism end to end for the first time. |
+| [[id:3E688A38-757A-4DE6-A7D2-9CA9B1EC2255][Codegen: generate calendar_date service/protocol/nats-handler layers using extra_list_requests]] | DONE | 2026-07-27 | 2026-07-28 | First real consumer of the existing but never-exercised extra_list_requests knob: generate calendar_date's service, protocol, and nats-handler layers with a paginated list-by-calendar_code request/response, once the junction list_by pagination knob exists. Validates the extra_list_requests mechanism end to end for the first time. |
 | [[id:1C673C53-9ED0-4C02-B856-EF031A1CC95F][Codegen: design and implement Qt parent-scoping for has_readonly_paginated_list]] | BACKLOG | | | The Qt cpp.qt facet has a has_readonly_paginated_list knob but no way to scope a generated list window's get-request to an owning parent key (e.g. a calendar's calendar_code). Design and implement a parent_key_field/parent_key_param-style knob in the client_model/controller/mdi_window templates so a paginated read-only list can be opened for a specific parent and pass that key on every request. |
 | [[id:F081079A-312E-46C5-91AB-2C83310DA8F0][Generate calendar_dates Qt facet and wire Browse Holidays action]] | BACKLOG | | | Once the junction pagination knob, calendar_date messaging layer, and Qt parent-scoping knob all exist: generate calendar_date's Qt facet (has_readonly_paginated_list, scoped by calendar_code) and add a Browse Holidays action to Calendar's detail dialog that opens it for the selected calendar. Closes the deferred acceptance item from task B2888D7D. |
 
@@ -57,6 +57,25 @@ Pick up three follow-ups beyond [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model
   tasks: added an analysis task first to scope each item, surface
   design decisions and risks, and produce an implementation plan
   before committing to any of the three.
+
+- =extra_list_requests= turned out to be domain_entity-only (every
+  facet using it declares =#+model_types: domain_entity schema=, and
+  the mustache sections are wrapped in
+  =\{\{#domain_entity\}\}...\{\{/domain_entity\}\}=), so
+  =calendar_date='s messaging layer instead got a parallel, deliberately
+  minimal =\{\{#junction\}\}= section added to the service/protocol/
+  nats-handler/nats-registrar templates -- covering only the
+  paginated read-only list a browse view needs, not full CRUD.
+  Verified via =--diff= against another junction (no =list_by= set)
+  that this adds zero regression risk to existing entities.
+
+- Fixed a latent codegen bug surfaced by this task: primary-key/
+  junction-key validation in the service templates only branched on
+  =is_uuid= vs. a string-only =.empty()= fallback, with no case for
+  the =is_date= flag that already existed in the data model. Any
+  future entity with a non-string, non-UUID key column (e.g. a date)
+  would hit the same compile error =calendar_date= did. Fixed at the
+  template, not the generated file, and regenerated for real.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_codegen-generate-calendar-date-messaging.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_codegen-generate-calendar-date-messaging.org
@@ -8,7 +8,7 @@
 #+filetags: :calendar-followups:sprint_24:v0:
 #+owner: marco
 #+branch: feature/codegen-generate-calendar-date-messaging
-#+pr:
+#+pr: 1714
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-27
@@ -115,7 +115,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1714][#1714]] | [refdata,codegen] Generate calendar_date messaging layer, fix date-column validation in service templates |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_codegen-generate-calendar-date-messaging.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_codegen-generate-calendar-date-messaging.org
@@ -7,41 +7,96 @@
 #+level: s1
 #+filetags: :calendar-followups:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/codegen-generate-calendar-date-messaging
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-27
 #+updated: 2026-07-27
-#+environment:
+#+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:16162B5B-1EDA-4CA7-9AB6-E5AD37D21426][Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+=calendar_date= currently has only domain/SQL/repository layers
+generated. This task applies the =list_by= knob added in
+[[id:3282E378-74C0-43B4-B952-544FCEADE66A][Codegen: extend junction repository/service templates with paginated list_by filter]]
+(repository + service, regenerated for real this time, not just
+dry-run diffed) and generates a protocol/nats-handler layer via the
+=extra_list_requests= knob -- the first real consumer of that
+mechanism -- so a paginated, filtered-by-calendar_code NATS request
+exists for the Qt Browse Holidays view to call in the follow-on task.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:16162B5B-1EDA-4CA7-9AB6-E5AD37D21426][Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-27                               |
 
 * Acceptance
 
--
+- [X] calendar_date's repository/service files regenerate for real
+  (not dry-run) with the paginated list_by-by-calendar_code method.
+- [X] calendar_date gets a protocol layer with a paginated,
+  calendar_code-filtered get_calendar_dates_.../request/response pair
+  via extra_list_requests.
+- [X] calendar_date gets a nats-handler layer wiring that request to
+  the service's paginated list method, registered on a NATS subject.
+- [X] Build is clean and calendar_date's new messaging code compiles
+  and links.
 
 * Plan
 
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+*Correction to the Goal's premise*: =extra_list_requests= turned out
+to be a domain_entity-only mechanism -- =protocol_header.org=,
+=nats_handler_header.org=, and =nats_registrar_{header,implementation}.org=
+are each wrapped entirely in =\{\{#domain_entity\}\}...\{\{/domain_entity\}\}=,
+with no junction path at all. Deeper still: all four facets
+(=ores.cpp.service=, =ores.cpp.protocol=, =ores.cpp.nats-handler=,
+=ores.cpp.nats-sub-registrar=) declare
+=#+model_types: domain_entity schema= -- junction models are excluded
+at the facet-applicability level, so even the =\{\{#junction\}\}=
+section already added to =service_header/impl.org= in the prior task
+was unreachable dead code until this task added =junction= to that
+list.
+
+Rather than reusing =extra_list_requests= verbatim, added a parallel,
+deliberately minimal =\{\{#junction\}\}= section to each of the four
+templates, covering only what a read-only paginated browse view
+needs (no save/delete/history/CRUD -- junctions don't have a uniform
+CRUD shape the way domain entities do):
+- =protocol_header.org=: =get_<name>_by_<column>_request/response=
+  gated by =left.list_by=/=right.list_by=, same shape as the
+  domain_entity =extra_list_requests= block.
+- =nats_handler_header.org=: a handler class with one
+  =list_by_<column>= method per flagged side, calling the service's
+  paginated =list_<name_short>_by_<column>= + count methods.
+- =nats_registrar_{header,implementation}.org=: constructor + one
+  subject subscription per flagged side.
+- =service.org=: added =junction= to =#+model_types:= so the
+  service-layer =list_by= section from the prior task actually fires.
+
+Verified via =--diff= against =currency_calendar= (no =list_by= set)
+that all four facets now generate a minimal-but-valid skeleton (empty
+handler/registrar, base service methods) with zero regression risk to
+existing entities -- these files aren't checked in for any junction
+except =calendar_date=, so nothing else's build is affected.
+
+Wired =calendar_date_registrar= into
+=ores.refdata.core/src/messaging/registrar.cpp= (hand-maintained
+composition point, not itself generated) alongside the other
+alphabetically-ordered =register_*_handlers= calls.
 
 * Notes
 
@@ -69,3 +124,23 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Shipped =calendar_date='s full messaging layer (service, protocol,
+nats-handler, nats-registrar) via a new =\{\{#junction\}\}= path added
+to all four generating templates, and wired
+=calendar_date_registrar= into the hand-maintained
+=ores.refdata.core/src/messaging/registrar.cpp=.
+
+Build broke on first attempt: the generated
+=save_calendar_date= validation called =.empty()= on
+=calendar_date.date= (a =std::chrono::year_month_day=, which has no
+=.empty()=) -- a latent bug in =cpp_service.cpp.mustache= /
+=ores.cpp.service.service_impl.org=, which only distinguished
+=is_uuid= vs. a string-only =.empty()= fallback for primary-key/
+junction-key validation, with no branch for the =is_date= flag that
+already existed in the codegen data model (used elsewhere, e.g. SQL
+templates). Fixed both templates to check =is_date= first
+(=!x.ok()=) before falling back to =.empty()=, then regenerated
+=calendar_date_service.\{hpp,cpp\}= for real from the corrected
+template rather than hand-patching the generated output. Full build
+is green.

--- a/projects/ores.codegen/library/templates/cpp_nats_handler.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_nats_handler.hpp.mustache
@@ -380,6 +380,130 @@ private:
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_HANDLER_HPP
+#define ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.{{component_include}}/messaging/{{name_singular}}_protocol.hpp"
+#include "ores.{{component_core}}/service/{{name_singular}}_service.hpp"
+
+namespace ores::{{component}}::messaging {
+
+namespace {
+inline auto& {{name_singular}}_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.{{component}}.messaging.{{name_singular}}_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for {{name_words}} operations.
+ */
+class {{name_singular}}_handler {
+public:
+    {{name_singular}}_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+{{#left.list_by}}
+    void list_by_{{left.column_short}}(ores::nats::message msg) {
+        BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::{{name_singular}}_service svc(req_ctx);
+        if (auto req = decode<get_{{name}}_by_{{left.column_short}}_request>(msg)) {
+            get_{{name}}_by_{{left.column_short}}_response resp;
+            try {
+                resp.{{name}} = svc.list_{{name_short}}_by_{{left.column_short}}(
+                    req->{{left.column}}, req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(
+                    svc.get_total_{{name_singular_short}}_count_by_{{left.column_short}}(req->{{left.column}}));
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV({{name_singular}}_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, resp);
+        } else {
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+{{/left.list_by}}
+{{#right.list_by}}
+    void list_by_{{right.column_short}}(ores::nats::message msg) {
+        BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::{{name_singular}}_service svc(req_ctx);
+        if (auto req = decode<get_{{name}}_by_{{right.column_short}}_request>(msg)) {
+            get_{{name}}_by_{{right.column_short}}_response resp;
+            try {
+                resp.{{name}} = svc.list_{{name_short}}_by_{{right.column_short}}(
+                    req->{{right.column}}, req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(
+                    svc.get_total_{{name_singular_short}}_count_by_{{right.column_short}}(req->{{right.column}}));
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV({{name_singular}}_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, resp);
+        } else {
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+{{/right.list_by}}
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::{{component}}::messaging
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_HANDLER_HPP
 #define ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_HANDLER_HPP

--- a/projects/ores.codegen/library/templates/cpp_nats_registrar.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_nats_registrar.cpp.mustache
@@ -62,6 +62,39 @@ register_{{entity_singular}}_handlers(ores::nats::service::client& nats,
 
 } // namespace ores::{{component}}::messaging
 {{/domain_entity}}
+{{#junction}}
+#include "ores.{{component_core}}/messaging/{{name_singular}}_registrar.hpp"
+#include "ores.{{component_core}}/messaging/{{name_singular}}_handler.hpp"
+#include "ores.{{component_include}}/messaging/{{name_singular}}_protocol.hpp"
+#include <memory>
+
+namespace ores::{{component}}::messaging {
+
+namespace {
+static constexpr std::string_view queue_group = "ores.{{component}}.service";
+} // namespace
+
+std::vector<ores::nats::service::subscription>
+register_{{name_singular}}_handlers(ores::nats::service::client& nats,
+                                     ores::database::context ctx,
+                                     std::optional<ores::security::jwt::jwt_authenticator> verifier) {
+    std::vector<ores::nats::service::subscription> subs;
+    auto h = std::make_shared<{{name_singular}}_handler>(nats, std::move(ctx), std::move(verifier));
+{{#left.list_by}}
+    subs.push_back(nats.queue_subscribe(
+        get_{{name}}_by_{{left.column_short}}_request::nats_subject, queue_group,
+        [h](ores::nats::message msg) { h->list_by_{{left.column_short}}(std::move(msg)); }));
+{{/left.list_by}}
+{{#right.list_by}}
+    subs.push_back(nats.queue_subscribe(
+        get_{{name}}_by_{{right.column_short}}_request::nats_subject, queue_group,
+        [h](ores::nats::message msg) { h->list_by_{{right.column_short}}(std::move(msg)); }));
+{{/right.list_by}}
+    return subs;
+}
+
+} // namespace ores::{{component}}::messaging
+{{/junction}}
 {{#entity}}
 #include "ores.{{component_core}}/messaging/{{entity_singular}}_registrar.hpp"
 #include "ores.{{component_core}}/messaging/{{entity_singular}}_handler.hpp"

--- a/projects/ores.codegen/library/templates/cpp_nats_registrar.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_nats_registrar.hpp.mustache
@@ -22,6 +22,28 @@ register_{{entity_singular}}_handlers(ores::nats::service::client& nats,
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_REGISTRAR_HPP
+#define ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_REGISTRAR_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.nats/service/subscription.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include <optional>
+#include <vector>
+
+namespace ores::{{component}}::messaging {
+
+std::vector<ores::nats::service::subscription>
+register_{{name_singular}}_handlers(ores::nats::service::client& nats,
+                                     ores::database::context ctx,
+                                     std::optional<ores::security::jwt::jwt_authenticator> verifier);
+
+} // namespace ores::{{component}}::messaging
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_REGISTRAR_HPP
 #define ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_REGISTRAR_HPP

--- a/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
@@ -155,6 +155,57 @@ struct read_{{entity_plural}}_for_cache_response {
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_include_upper}}_MESSAGING_{{name_singular_upper}}_PROTOCOL_HPP
+#define ORES_{{component_include_upper}}_MESSAGING_{{name_singular_upper}}_PROTOCOL_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "ores.{{component_include}}/domain/{{name_singular}}.hpp"
+
+namespace ores::{{component}}::messaging {
+
+{{#left.list_by}}
+struct get_{{name}}_by_{{left.column_short}}_request {
+    using response_type = struct get_{{name}}_by_{{left.column_short}}_response;
+    static constexpr std::string_view nats_subject =
+        "{{component}}.v1.{{name}}.list_by_{{left.column}}";
+    std::string {{left.column}};
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
+};
+
+struct get_{{name}}_by_{{left.column_short}}_response {
+    std::vector<ores::{{component}}::domain::{{name_singular}}> {{name}};
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
+};
+
+{{/left.list_by}}
+{{#right.list_by}}
+struct get_{{name}}_by_{{right.column_short}}_request {
+    using response_type = struct get_{{name}}_by_{{right.column_short}}_response;
+    static constexpr std::string_view nats_subject =
+        "{{component}}.v1.{{name}}.list_by_{{right.column}}";
+    std::string {{right.column}};
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
+};
+
+struct get_{{name}}_by_{{right.column_short}}_response {
+    std::vector<ores::{{component}}::domain::{{name_singular}}> {{name}};
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
+};
+
+{{/right.list_by}}
+}
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
 #define ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP

--- a/projects/ores.codegen/library/templates/cpp_service.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_service.cpp.mustache
@@ -238,7 +238,12 @@ void {{name_singular}}_service::save_{{name_singular_short}}(const domain::{{nam
     if ({{name_singular_short}}.{{left.column}}.is_nil()) {
 {{/left.is_uuid}}
 {{^left.is_uuid}}
+{{#left.is_date}}
+    if (!{{name_singular_short}}.{{left.column}}.ok()) {
+{{/left.is_date}}
+{{^left.is_date}}
     if ({{name_singular_short}}.{{left.column}}.empty()) {
+{{/left.is_date}}
 {{/left.is_uuid}}
         throw std::invalid_argument("{{left.column_title}} cannot be empty.");
     }
@@ -246,7 +251,12 @@ void {{name_singular}}_service::save_{{name_singular_short}}(const domain::{{nam
     if ({{name_singular_short}}.{{right.column}}.is_nil()) {
 {{/right.is_uuid}}
 {{^right.is_uuid}}
+{{#right.is_date}}
+    if (!{{name_singular_short}}.{{right.column}}.ok()) {
+{{/right.is_date}}
+{{^right.is_date}}
     if ({{name_singular_short}}.{{right.column}}.empty()) {
+{{/right.is_date}}
 {{/right.is_uuid}}
         throw std::invalid_argument("{{right.column_title}} cannot be empty.");
     }

--- a/projects/ores.codegen/library/templates/ores.cpp.nats-handler.nats_handler_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.nats-handler.nats_handler_header.org
@@ -423,6 +423,130 @@ private:
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_HANDLER_HPP
+#define ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.{{component_include}}/messaging/{{name_singular}}_protocol.hpp"
+#include "ores.{{component_core}}/service/{{name_singular}}_service.hpp"
+
+namespace ores::{{component}}::messaging {
+
+namespace {
+inline auto& {{name_singular}}_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.{{component}}.messaging.{{name_singular}}_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for {{name_words}} operations.
+ */
+class {{name_singular}}_handler {
+public:
+    {{name_singular}}_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+{{#left.list_by}}
+    void list_by_{{left.column_short}}(ores::nats::message msg) {
+        BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::{{name_singular}}_service svc(req_ctx);
+        if (auto req = decode<get_{{name}}_by_{{left.column_short}}_request>(msg)) {
+            get_{{name}}_by_{{left.column_short}}_response resp;
+            try {
+                resp.{{name}} = svc.list_{{name_short}}_by_{{left.column_short}}(
+                    req->{{left.column}}, req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(
+                    svc.get_total_{{name_singular_short}}_count_by_{{left.column_short}}(req->{{left.column}}));
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV({{name_singular}}_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, resp);
+        } else {
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+{{/left.list_by}}
+{{#right.list_by}}
+    void list_by_{{right.column_short}}(ores::nats::message msg) {
+        BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::{{name_singular}}_service svc(req_ctx);
+        if (auto req = decode<get_{{name}}_by_{{right.column_short}}_request>(msg)) {
+            get_{{name}}_by_{{right.column_short}}_response resp;
+            try {
+                resp.{{name}} = svc.list_{{name_short}}_by_{{right.column_short}}(
+                    req->{{right.column}}, req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(
+                    svc.get_total_{{name_singular_short}}_count_by_{{right.column_short}}(req->{{right.column}}));
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV({{name_singular}}_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats_, msg, resp);
+        } else {
+            BOOST_LOG_SEV({{name_singular}}_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+{{/right.list_by}}
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::{{component}}::messaging
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_HANDLER_HPP
 #define ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_HANDLER_HPP

--- a/projects/ores.codegen/library/templates/ores.cpp.nats-handler.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.nats-handler.org
@@ -4,7 +4,7 @@
 #+title: ores.cpp.nats-handler
 #+description: NATS subscription handlers.
 #+type: facet
-#+model_types: domain_entity schema
+#+model_types: domain_entity schema junction
 #+level: cross
 #+facet_group: ores.cpp
 #+filetags: :codegen:physical-space:cpp:

--- a/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.nats_registrar_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.nats_registrar_header.org
@@ -48,6 +48,28 @@ register_{{entity_singular}}_handlers(ores::nats::service::client& nats,
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_REGISTRAR_HPP
+#define ORES_{{component_core_upper}}_MESSAGING_{{name_singular_upper}}_REGISTRAR_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.nats/service/subscription.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include <optional>
+#include <vector>
+
+namespace ores::{{component}}::messaging {
+
+std::vector<ores::nats::service::subscription>
+register_{{name_singular}}_handlers(ores::nats::service::client& nats,
+                                     ores::database::context ctx,
+                                     std::optional<ores::security::jwt::jwt_authenticator> verifier);
+
+} // namespace ores::{{component}}::messaging
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_REGISTRAR_HPP
 #define ORES_{{component_core_upper}}_MESSAGING_{{entity_singular_upper}}_REGISTRAR_HPP

--- a/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.nats_registrar_implementation.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.nats_registrar_implementation.org
@@ -121,6 +121,39 @@ register_{{entity_singular}}_handlers(ores::nats::service::client& nats,
 
 } // namespace ores::{{component}}::messaging
 {{/domain_entity}}
+{{#junction}}
+#include "ores.{{component_core}}/messaging/{{name_singular}}_registrar.hpp"
+#include "ores.{{component_core}}/messaging/{{name_singular}}_handler.hpp"
+#include "ores.{{component_include}}/messaging/{{name_singular}}_protocol.hpp"
+#include <memory>
+
+namespace ores::{{component}}::messaging {
+
+namespace {
+static constexpr std::string_view queue_group = "ores.{{component}}.service";
+} // namespace
+
+std::vector<ores::nats::service::subscription>
+register_{{name_singular}}_handlers(ores::nats::service::client& nats,
+                                     ores::database::context ctx,
+                                     std::optional<ores::security::jwt::jwt_authenticator> verifier) {
+    std::vector<ores::nats::service::subscription> subs;
+    auto h = std::make_shared<{{name_singular}}_handler>(nats, std::move(ctx), std::move(verifier));
+{{#left.list_by}}
+    subs.push_back(nats.queue_subscribe(
+        get_{{name}}_by_{{left.column_short}}_request::nats_subject, queue_group,
+        [h](ores::nats::message msg) { h->list_by_{{left.column_short}}(std::move(msg)); }));
+{{/left.list_by}}
+{{#right.list_by}}
+    subs.push_back(nats.queue_subscribe(
+        get_{{name}}_by_{{right.column_short}}_request::nats_subject, queue_group,
+        [h](ores::nats::message msg) { h->list_by_{{right.column_short}}(std::move(msg)); }));
+{{/right.list_by}}
+    return subs;
+}
+
+} // namespace ores::{{component}}::messaging
+{{/junction}}
 {{#entity}}
 #include "ores.{{component_core}}/messaging/{{entity_singular}}_registrar.hpp"
 #include "ores.{{component_core}}/messaging/{{entity_singular}}_handler.hpp"

--- a/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.nats-sub-registrar.org
@@ -4,7 +4,7 @@
 #+title: ores.cpp.nats-sub-registrar
 #+description: Per-entity NATS sub-registrar pair wiring an entity's subjects to its handler.
 #+type: facet
-#+model_types: domain_entity schema
+#+model_types: domain_entity schema junction
 #+level: cross
 #+facet_group: ores.cpp
 #+filetags: :codegen:physical-space:cpp:

--- a/projects/ores.codegen/library/templates/ores.cpp.protocol.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.protocol.org
@@ -4,7 +4,7 @@
 #+title: ores.cpp.protocol
 #+description: Protocol (de)serialisation.
 #+type: facet
-#+model_types: domain_entity schema
+#+model_types: domain_entity schema junction
 #+level: cross
 #+facet_group: ores.cpp
 #+filetags: :codegen:physical-space:cpp:

--- a/projects/ores.codegen/library/templates/ores.cpp.protocol.protocol_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.protocol.protocol_header.org
@@ -186,6 +186,57 @@ struct read_{{entity_plural}}_for_cache_response {
 
 #endif
 {{/domain_entity}}
+{{#junction}}
+#ifndef ORES_{{component_include_upper}}_MESSAGING_{{name_singular_upper}}_PROTOCOL_HPP
+#define ORES_{{component_include_upper}}_MESSAGING_{{name_singular_upper}}_PROTOCOL_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "ores.{{component_include}}/domain/{{name_singular}}.hpp"
+
+namespace ores::{{component}}::messaging {
+
+{{#left.list_by}}
+struct get_{{name}}_by_{{left.column_short}}_request {
+    using response_type = struct get_{{name}}_by_{{left.column_short}}_response;
+    static constexpr std::string_view nats_subject =
+        "{{component}}.v1.{{name}}.list_by_{{left.column}}";
+    std::string {{left.column}};
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
+};
+
+struct get_{{name}}_by_{{left.column_short}}_response {
+    std::vector<ores::{{component}}::domain::{{name_singular}}> {{name}};
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
+};
+
+{{/left.list_by}}
+{{#right.list_by}}
+struct get_{{name}}_by_{{right.column_short}}_request {
+    using response_type = struct get_{{name}}_by_{{right.column_short}}_response;
+    static constexpr std::string_view nats_subject =
+        "{{component}}.v1.{{name}}.list_by_{{right.column}}";
+    std::string {{right.column}};
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
+};
+
+struct get_{{name}}_by_{{right.column_short}}_response {
+    std::vector<ores::{{component}}::domain::{{name_singular}}> {{name}};
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
+};
+
+{{/right.list_by}}
+}
+
+#endif
+{{/junction}}
 {{#entity}}
 #ifndef ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
 #define ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP

--- a/projects/ores.codegen/library/templates/ores.cpp.service.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.service.org
@@ -4,7 +4,7 @@
 #+title: ores.cpp.service
 #+description: C++ service application classes.
 #+type: facet
-#+model_types: schema domain_entity
+#+model_types: schema domain_entity junction
 #+level: cross
 #+facet_group: ores.cpp
 #+filetags: :codegen:physical-space:cpp:

--- a/projects/ores.codegen/library/templates/ores.cpp.service.service_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.service.service_impl.org
@@ -263,7 +263,12 @@ void {{name_singular}}_service::save_{{name_singular_short}}(const domain::{{nam
     if ({{name_singular_short}}.{{left.column}}.is_nil()) {
 {{/left.is_uuid}}
 {{^left.is_uuid}}
+{{#left.is_date}}
+    if (!{{name_singular_short}}.{{left.column}}.ok()) {
+{{/left.is_date}}
+{{^left.is_date}}
     if ({{name_singular_short}}.{{left.column}}.empty()) {
+{{/left.is_date}}
 {{/left.is_uuid}}
         throw std::invalid_argument("{{left.column_title}} cannot be empty.");
     }
@@ -271,7 +276,12 @@ void {{name_singular}}_service::save_{{name_singular_short}}(const domain::{{nam
     if ({{name_singular_short}}.{{right.column}}.is_nil()) {
 {{/right.is_uuid}}
 {{^right.is_uuid}}
+{{#right.is_date}}
+    if (!{{name_singular_short}}.{{right.column}}.ok()) {
+{{/right.is_date}}
+{{^right.is_date}}
     if ({{name_singular_short}}.{{right.column}}.empty()) {
+{{/right.is_date}}
 {{/right.is_uuid}}
         throw std::invalid_argument("{{right.column_title}} cannot be empty.");
     }

--- a/projects/ores.refdata/api/include/ores.refdata.api/messaging/calendar_date_protocol.hpp
+++ b/projects/ores.refdata/api/include/ores.refdata.api/messaging/calendar_date_protocol.hpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_API_MESSAGING_CALENDAR_DATE_PROTOCOL_HPP
+#define ORES_REFDATA_API_MESSAGING_CALENDAR_DATE_PROTOCOL_HPP
+
+#include "ores.refdata.api/domain/calendar_date.hpp"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ores::refdata::messaging {
+
+struct get_calendar_dates_by_calendar_request {
+    using response_type = struct get_calendar_dates_by_calendar_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.calendar_dates.list_by_calendar_code";
+    std::string calendar_code;
+    std::uint32_t offset = 0;
+    std::uint32_t limit = 100;
+};
+
+struct get_calendar_dates_by_calendar_response {
+    std::vector<ores::refdata::domain::calendar_date> calendar_dates;
+    int total_available_count = 0;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/calendar_date_handler.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/calendar_date_handler.hpp
@@ -1,0 +1,100 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_CORE_MESSAGING_CALENDAR_DATE_HANDLER_HPP
+#define ORES_REFDATA_CORE_MESSAGING_CALENDAR_DATE_HANDLER_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.refdata.api/messaging/calendar_date_protocol.hpp"
+#include "ores.refdata.core/service/calendar_date_service.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include <optional>
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& calendar_date_handler_lg() {
+    static auto instance =
+        ores::logging::make_logger("ores.refdata.messaging.calendar_date_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for calendar dates operations.
+ */
+class calendar_date_handler {
+public:
+    calendar_date_handler(ores::nats::service::client& nats,
+                          ores::database::context ctx,
+                          std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats)
+        , ctx_(std::move(ctx))
+        , verifier_(std::move(verifier)) {}
+
+    void list_by_calendar(ores::nats::message msg) {
+        BOOST_LOG_SEV(calendar_date_handler_lg(), debug) << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::calendar_date_service svc(req_ctx);
+        if (auto req = decode<get_calendar_dates_by_calendar_request>(msg)) {
+            get_calendar_dates_by_calendar_response resp;
+            try {
+                resp.calendar_dates = svc.list_calendar_dates_by_calendar(
+                    req->calendar_code, req->offset, req->limit);
+                resp.total_available_count = static_cast<int>(
+                    svc.get_total_calendar_date_count_by_calendar(req->calendar_code));
+                resp.success = true;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(calendar_date_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.success = false;
+                resp.message = e.what();
+            }
+            BOOST_LOG_SEV(calendar_date_handler_lg(), debug) << "Completed " << msg.subject;
+            reply(nats_, msg, resp);
+        } else {
+            BOOST_LOG_SEV(calendar_date_handler_lg(), warn) << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/messaging/calendar_date_registrar.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/messaging/calendar_date_registrar.hpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_CORE_MESSAGING_CALENDAR_DATE_REGISTRAR_HPP
+#define ORES_REFDATA_CORE_MESSAGING_CALENDAR_DATE_REGISTRAR_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.nats/service/subscription.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include <optional>
+#include <vector>
+
+namespace ores::refdata::messaging {
+
+std::vector<ores::nats::service::subscription>
+register_calendar_date_handlers(ores::nats::service::client& nats,
+                                ores::database::context ctx,
+                                std::optional<ores::security::jwt::jwt_authenticator> verifier);
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata/core/include/ores.refdata.core/repository/calendar_date_repository.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/repository/calendar_date_repository.hpp
@@ -55,6 +55,17 @@ public:
 
     std::vector<domain::calendar_date> read_latest();
     std::vector<domain::calendar_date> read_latest_by_calendar(const std::string& calendar_code);
+    /**
+     * @brief Reads latest calendar dates filtered by calendar_code, with pagination.
+     */
+    std::vector<domain::calendar_date> read_latest_by_calendar(const std::string& calendar_code,
+                                                               std::uint32_t offset,
+                                                               std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active calendar dates filtered by calendar_code.
+     */
+    std::uint32_t get_total_calendar_date_count_by_calendar(const std::string& calendar_code);
     std::vector<domain::calendar_date> read_latest_by_date(const std::string& date);
 
     void remove(const std::string& calendar_code, const std::string& date);

--- a/projects/ores.refdata/core/include/ores.refdata.core/service/calendar_date_service.hpp
+++ b/projects/ores.refdata/core/include/ores.refdata.core/service/calendar_date_service.hpp
@@ -1,0 +1,103 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_CALENDAR_DATE_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_CALENDAR_DATE_SERVICE_HPP
+
+#include "ores.database/domain/context.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/calendar_date.hpp"
+#include "ores.refdata.core/repository/calendar_date_repository.hpp"
+#include <string>
+#include <vector>
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing calendar dates.
+ *
+ * This service provides functionality for:
+ * - Managing calendar dates (CRUD operations)
+ */
+class calendar_date_service {
+private:
+    inline static std::string_view logger_name = "ores.refdata.service.calendar_date_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Constructs a calendar_date_service with required repositories.
+     *
+     * @param ctx The database context.
+     */
+    explicit calendar_date_service(context ctx);
+
+    /**
+     * @brief Lists all calendar dates.
+     */
+    std::vector<domain::calendar_date> list_calendar_dates();
+
+    /**
+     * @brief Lists calendar dates for a specific calendar.
+     *
+     * @param calendar_code The calendar to filter by
+     */
+    std::vector<domain::calendar_date>
+    list_calendar_dates_by_calendar(const std::string& calendar_code);
+
+    /**
+     * @brief Lists calendar dates for a specific calendar, with pagination.
+     */
+    std::vector<domain::calendar_date> list_calendar_dates_by_calendar(
+        const std::string& calendar_code, std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Gets the total count of active calendar dates filtered by calendar_code.
+     */
+    std::uint32_t get_total_calendar_date_count_by_calendar(const std::string& calendar_code);
+
+    /**
+     * @brief Saves a calendar date (creates or updates).
+     *
+     * @param calendar_date The calendar date to save
+     */
+    void save_calendar_date(const domain::calendar_date& calendar_date);
+
+    /**
+     * @brief Removes a calendar date.
+     *
+     * @param calendar_code The calendar
+     * @param date The date
+     */
+    void remove_calendar_date(const std::string& calendar_code, const std::string& date);
+
+private:
+    repository::calendar_date_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/core/src/messaging/calendar_date_registrar.cpp
+++ b/projects/ores.refdata/core/src/messaging/calendar_date_registrar.cpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/messaging/calendar_date_registrar.hpp"
+#include "ores.refdata.api/messaging/calendar_date_protocol.hpp"
+#include "ores.refdata.core/messaging/calendar_date_handler.hpp"
+#include <memory>
+
+namespace ores::refdata::messaging {
+
+namespace {
+static constexpr std::string_view queue_group = "ores.refdata.service";
+} // namespace
+
+std::vector<ores::nats::service::subscription>
+register_calendar_date_handlers(ores::nats::service::client& nats,
+                                ores::database::context ctx,
+                                std::optional<ores::security::jwt::jwt_authenticator> verifier) {
+    std::vector<ores::nats::service::subscription> subs;
+    auto h = std::make_shared<calendar_date_handler>(nats, std::move(ctx), std::move(verifier));
+    subs.push_back(nats.queue_subscribe(
+        get_calendar_dates_by_calendar_request::nats_subject,
+        queue_group,
+        [h](ores::nats::message msg) { h->list_by_calendar(std::move(msg)); }));
+    return subs;
+}
+
+} // namespace ores::refdata::messaging

--- a/projects/ores.refdata/core/src/messaging/registrar.cpp
+++ b/projects/ores.refdata/core/src/messaging/registrar.cpp
@@ -29,6 +29,7 @@
 #include "ores.refdata.core/messaging/business_day_convention_type_registrar.hpp"
 #include "ores.refdata.core/messaging/business_unit_registrar.hpp"
 #include "ores.refdata.core/messaging/calendar_adjustment_registrar.hpp"
+#include "ores.refdata.core/messaging/calendar_date_registrar.hpp"
 #include "ores.refdata.core/messaging/calendar_materialisation_registrar.hpp"
 #include "ores.refdata.core/messaging/calendar_registrar.hpp"
 #include "ores.refdata.core/messaging/calendar_type_registrar.hpp"
@@ -284,6 +285,7 @@ registrar::register_handlers(ores::nats::service::client& nats,
     append(register_business_day_convention_type_handlers(nats, ctx, verifier));
     append(register_business_unit_handlers(nats, ctx, verifier));
     append(register_calendar_handlers(nats, ctx, verifier));
+    append(register_calendar_date_handlers(nats, ctx, verifier));
     append(register_calendar_materialisation_handlers(nats, ctx, verifier));
     append(register_calendar_adjustment_handlers(nats, ctx, verifier));
     append(register_calendar_type_handlers(nats, ctx, verifier));

--- a/projects/ores.refdata/core/src/repository/calendar_date_repository.cpp
+++ b/projects/ores.refdata/core/src/repository/calendar_date_repository.cpp
@@ -108,6 +108,50 @@ calendar_date_repository::read_latest_by_date(const std::string& date) {
         "Reading latest calendar dates by date.");
 }
 
+std::vector<domain::calendar_date> calendar_date_repository::read_latest_by_calendar(
+    const std::string& calendar_code, std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest calendar dates. Calendar: " << calendar_code
+                               << " offset: " << offset << " limit: " << limit;
+
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx_.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<calendar_date_entity>> |
+                       where("tenant_id"_c == tid && "calendar_code"_c == calendar_code &&
+                             "valid_to"_c == max.value()) |
+                       order_by("date"_c) | sqlgen::offset(offset) | sqlgen::limit(limit);
+
+    return execute_read_query<calendar_date_entity, domain::calendar_date>(
+        ctx_,
+        query,
+        [](const auto& entities) { return calendar_date_mapper::map(entities); },
+        lg(),
+        "Reading latest calendar dates by calendar (paginated).");
+}
+
+std::uint32_t calendar_date_repository::get_total_calendar_date_count_by_calendar(
+    const std::string& calendar_code) {
+    BOOST_LOG_SEV(lg(), debug) << "Retrieving total active calendar dates count. Calendar: "
+                               << calendar_code;
+    static const auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+
+    struct count_result {
+        long long count;
+    };
+
+    const auto tid = ctx_.tenant_id().to_string();
+    const auto query = sqlgen::select_from<calendar_date_entity>(sqlgen::count().as<"count">()) |
+                       where("tenant_id"_c == tid && "calendar_code"_c == calendar_code &&
+                             "valid_to"_c == max.value()) |
+                       sqlgen::to<count_result>;
+
+    const auto r = sqlgen::session(ctx_.connection_pool()).and_then(query);
+    ensure_success(r, lg());
+
+    const auto count = static_cast<std::uint32_t>(r->count);
+    BOOST_LOG_SEV(lg(), debug) << "Total active calendar dates count by calendar: " << count;
+    return count;
+}
+
 void calendar_date_repository::remove(const std::string& calendar_code, const std::string& date) {
     BOOST_LOG_SEV(lg(), debug) << "Removing calendar date from database: " << calendar_code << "/"
                                << date;

--- a/projects/ores.refdata/core/src/service/calendar_date_service.cpp
+++ b/projects/ores.refdata/core/src/service/calendar_date_service.cpp
@@ -1,0 +1,74 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/calendar_date_service.hpp"
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+calendar_date_service::calendar_date_service(context ctx)
+    : repo_(ctx) {}
+
+std::vector<domain::calendar_date> calendar_date_service::list_calendar_dates() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all calendar dates";
+    return repo_.read_latest();
+}
+
+std::vector<domain::calendar_date>
+calendar_date_service::list_calendar_dates_by_calendar(const std::string& calendar_code) {
+    BOOST_LOG_SEV(lg(), debug) << "Listing calendar dates for calendar: " << calendar_code;
+    return repo_.read_latest_by_calendar(calendar_code);
+}
+
+std::vector<domain::calendar_date> calendar_date_service::list_calendar_dates_by_calendar(
+    const std::string& calendar_code, std::uint32_t offset, std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Listing calendar dates for calendar: " << calendar_code
+                               << " offset: " << offset << " limit: " << limit;
+    return repo_.read_latest_by_calendar(calendar_code, offset, limit);
+}
+
+std::uint32_t
+calendar_date_service::get_total_calendar_date_count_by_calendar(const std::string& calendar_code) {
+    return repo_.get_total_calendar_date_count_by_calendar(calendar_code);
+}
+
+void calendar_date_service::save_calendar_date(const domain::calendar_date& calendar_date) {
+    if (calendar_date.calendar_code.empty()) {
+        throw std::invalid_argument("Calendar cannot be empty.");
+    }
+    if (!calendar_date.date.ok()) {
+        throw std::invalid_argument("Date cannot be empty.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving calendar date: " << calendar_date.calendar_code << "/"
+                               << calendar_date.date;
+    repo_.write(calendar_date);
+    BOOST_LOG_SEV(lg(), info) << "Saved calendar date: " << calendar_date.calendar_code << "/"
+                              << calendar_date.date;
+}
+
+void calendar_date_service::remove_calendar_date(const std::string& calendar_code,
+                                                 const std::string& date) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing calendar date: " << calendar_code << "/" << date;
+    repo_.remove(calendar_code, date);
+    BOOST_LOG_SEV(lg(), info) << "Removed calendar date: " << calendar_code << "/" << date;
+}
+
+}


### PR DESCRIPTION
## Summary

First real consumer of a paginated read-only list for a junction: generates calendar_date's service/protocol/nats-handler/nats-registrar layers, and fixes a latent codegen bug in primary-key/junction-key validation that this generation surfaced.

## Changes

- Added a junction section to the service/protocol/nats-handler/nats-registrar templates (extra_list_requests turned out to be domain_entity-only); generated calendar_date's messaging layer and wired calendar_date_registrar into registrar.cpp.
- Fixed cpp_service.cpp.mustache / ores.cpp.service.service_impl.org: primary-key/junction-key validation only branched is_uuid vs. a string-only .empty() fallback, breaking compilation for date-typed key columns (calendar_date.date is std::chrono::year_month_day). Added an is_date branch using .ok(), regenerated calendar_date_service.{hpp,cpp} from the corrected template.
- Verification: local build clean (linux-clang-debug-make); ctest 3/4 refdata suites fully passed, 1 pre-existing unrelated failure (party_generator_produces_valid_instance in ores.refdata.api.tests, untouched by this branch, present on main).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/story.html) | 16162B5B-1EDA-4CA7-9AB6-E5AD37D21426 |
| Task | [Codegen: generate calendar_date service/protocol/nats-handler layers using extra_list_requests](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/task_codegen-generate-calendar-date-messaging.html) | 3E688A38-757A-4DE6-A7D2-9CA9B1EC2255 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)