### PR TITLE
[refdata] Fix stale party generator test/business_center_code

### DIFF
--- a/doc/agile/versions/v0/sprint_24/party_generator_test_drift/story.org
+++ b/doc/agile/versions/v0/sprint_24/party_generator_test_drift/story.org
@@ -1,0 +1,49 @@
+:PROPERTIES:
+:ID: 9B26660C-8680-4771-8067-280E87B83E56
+:END:
+#+title: Story: Party generator test expectations and business_center_code drift
+#+description: party_generator_produces_valid_instance asserted stale pre-standardization values (version==1, change_reason_code=='system.new'); party.org's business_center_code generator block specifies GBLO, an FpML code not guaranteed seeded, a landmine for the next clean regen.
+#+type: story
+#+level: s2
+#+filetags: :refdata:codegen:tech-debt:sprint_24:v0:
+#+created: 2026-07-28
+#+updated: 2026-07-28
+#+environment: eager_maxwell
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore ores.refdata.api.tests to green on main, and remove the
+business_center_code landmine from party.org before it reaches
+another regen.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                              |
+| Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
+| Now           | Nothing. |
+| Waiting on    | Nothing.                               |
+| Next          | Nothing. |
+| Last touched  | 2026-07-28                               |
+
+* Acceptance
+
+- ores.refdata.api.tests passes.
+- party.org's business_center_code generator uses a guaranteed-seeded value.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:2769150C-C885-43A1-86E5-4F06F2382854][Scaffold story: Party generator test expectations and business_center_code drift]] | DONE | 2026-07-28 | 2026-07-28 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:AD3D9B64-8A21-412C-8EEA-1A5E3A080DB4][Implement Party generator test expectations and business_center_code drift]] | DONE | 2026-07-28 | 2026-07-28 | Initial task for: Party generator test expectations and business_center_code drift |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_implement_party_generator_test_drift.org
+++ b/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_implement_party_generator_test_drift.org
@@ -8,7 +8,7 @@
 #+filetags: :party_generator_test_drift:sprint_24:v0:
 #+owner: marco
 #+branch: hotfix/party-generator-test-drift
-#+pr:
+#+pr: 1716
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
@@ -64,7 +64,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1716][#1716]] | [refdata] Fix stale party generator test/business_center_code |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_implement_party_generator_test_drift.org
+++ b/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_implement_party_generator_test_drift.org
@@ -1,0 +1,83 @@
+:PROPERTIES:
+:ID: AD3D9B64-8A21-412C-8EEA-1A5E3A080DB4
+:END:
+#+title: Task: Implement Party generator test expectations and business_center_code drift
+#+description: Initial task for: Party generator test expectations and business_center_code drift
+#+type: task
+#+level: s1
+#+filetags: :party_generator_test_drift:sprint_24:v0:
+#+owner: marco
+#+branch: hotfix/party-generator-test-drift
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-28
+#+updated: 2026-07-28
+#+environment: eager_maxwell
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9B26660C-8680-4771-8067-280E87B83E56][Party generator test expectations and business_center_code drift]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix ores.refdata.api.tests, currently broken on main: the
+party_generator_produces_valid_instance test asserts stale
+pre-standardization values, and party.org's business_center_code
+generator block is a landmine for the next clean regen.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:9B26660C-8680-4771-8067-280E87B83E56][Party generator test expectations and business_center_code drift]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-28                               |
+
+* Acceptance
+
+- ores.refdata.api.tests passes locally.
+- party.org's business_center_code generator matches a value guaranteed seeded by a default db recreate.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Fixed party_generator_produces_valid_instance's two stale assertions
+(version==0, change_reason_code=="system.test", matching every other
+entity's codegen-standard generator boilerplate -- the committed
+generator was already correct). Reverted party.org's
+business_center_code generator block from GBLO to WRLD, the
+guaranteed-seeded sentinel already used by book/portfolio for the
+same reason. Verified: ores.refdata.api.tests 1/1 passed locally.

--- a/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_scaffold_party_generator_test_drift.org
+++ b/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_scaffold_party_generator_test_drift.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 2769150C-C885-43A1-86E5-4F06F2382854
+:END:
+#+title: Task: Scaffold story: Party generator test expectations and business_center_code drift
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :party_generator_test_drift:sprint_24:v0:
+#+owner: marco
+#+branch: hotfix/party-generator-test-drift
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-28
+#+updated: 2026-07-28
+#+environment: eager_maxwell
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:9B26660C-8680-4771-8067-280E87B83E56][Party generator test expectations and business_center_code drift]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:9B26660C-8680-4771-8067-280E87B83E56][Party generator test expectations and business_center_code drift]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-28                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Scaffolding created and wired into sprint_24. Actual fix committed in
+the same PR as this scaffold task (see the sibling implement task).

--- a/doc/agile/versions/v0/sprint_24/sprint.org
+++ b/doc/agile/versions/v0/sprint_24/sprint.org
@@ -93,6 +93,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 |-------+-------+-------+-----+-------------|
 | [[id:474B7173-EB04-485A-BEB5-87FC0B34CE32][Hotfix: CMake 4.4 uninitialized-variable warnings on Linux CI]] | DONE | 2026-07-22 | 2026-07-22 | Linux CI started emitting a batch of new CMake Warning (uninitialized) messages on 2026-07-20, all from the project() call at CMakeLists.txt:51 under CMake 4.4.0. |
 | [[id:36ABA3D4-FEC5-4D65-9FBC-A3819C46284A][Hotfix: remaining CMake 4.4 uninitialized-variable warnings]] | DONE | 2026-07-22 | 2026-07-22 | Fix the remaining CMake 4.4.0 uninitialized-variable warnings discovered while fixing the vcpkg-toolchain batch in PR #1664: two genuine use-before-define bugs (SPRINT, flags), one dead-variable reference (DOGEN_VERSION), and CPack/InstallRequiredSystemLibraries vendored-module noise. |
+| [[id:9B26660C-8680-4771-8067-280E87B83E56][Party generator test expectations and business_center_code drift]] | DONE | 2026-07-28 | 2026-07-28 | party_generator_produces_valid_instance asserted stale pre-standardization values (version==1, change_reason_code=='system.new'); party.org's business_center_code generator block specifies GBLO, an FpML code not guaranteed seeded, a landmine for the next clean regen. |
 
 * Achievements
 

--- a/projects/ores.refdata/api/tests/generators_tests.cpp
+++ b/projects/ores.refdata/api/tests/generators_tests.cpp
@@ -52,7 +52,7 @@ TEST_CASE("party_generator_produces_valid_instance", tags) {
 
     BOOST_LOG_SEV(lg, info) << "Generated party: " << sut.full_name;
 
-    CHECK(sut.version == 1);
+    CHECK(sut.version == 0);
     CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.full_name.empty());
@@ -62,7 +62,7 @@ TEST_CASE("party_generator_produces_valid_instance", tags) {
     CHECK(sut.status == "Active");
     CHECK(!sut.modified_by.empty());
     CHECK(!sut.performed_by.empty());
-    CHECK(sut.change_reason_code == "system.new");
+    CHECK(sut.change_reason_code == "system.test");
 }
 
 TEST_CASE("party_generator_produces_multiple_instances", tags) {

--- a/projects/ores.refdata/modeling/ores.refdata.party.org
+++ b/projects/ores.refdata/modeling/ores.refdata.party.org
@@ -177,10 +177,17 @@ std::nullopt
 
 Business center location code.
 
-FpML business center code indicating primary location.
+FpML business center code indicating primary location. Synthetic
+parties default to =WRLD= (the global sentinel business centre,
+guaranteed seeded for every tenant by the system-tenant bootstrap --
+see the same reasoning in =ores.refdata.book.org=), not a real FpML
+city code like =GBLO=: real city codes only exist once the large,
+optional FpML business-centre reference dataset has been loaded, so
+using one here would make a freshly-generated party fail its
+FK-validation trigger in any environment that hasn't loaded it.
 
 #+begin_src cpp :name generator
-std::string("GBLO")
+std::string("WRLD")
 #+end_src
 
 ** status


### PR DESCRIPTION
## Summary

party_generator_produces_valid_instance asserted pre-standardization version/change_reason_code values; the committed generator was already correct, only the test lagged. Separately, party.org's business_center_code generator block specifies GBLO, which isn't guaranteed seeded (only WRLD is) -- a landmine for the next clean regen.

## Changes

- Fix party_generator_produces_valid_instance to expect version==0/change_reason_code=='system.test', matching every other entity's codegen-standard generator boilerplate
- Revert party.org's business_center_code generator block from GBLO to WRLD, the guaranteed-seeded sentinel already used by book/portfolio for the same reason
- Verification: local build clean (linux-clang-debug-make); ctest ores.refdata.api.tests 1/1 passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Party generator test expectations and business_center_code drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/party_generator_test_drift/story.html) | 9B26660C-8680-4771-8067-280E87B83E56 |
| Task | [Implement Party generator test expectations and business_center_code drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/party_generator_test_drift/task_implement_party_generator_test_drift.html) | AD3D9B64-8A21-412C-8EEA-1A5E3A080DB4 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)