### PR TITLE
[qt,codegen] Badge sources should badge their own list too

### DIFF
--- a/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/story.org
+++ b/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/story.org
@@ -39,10 +39,10 @@ distinct from the coverage-audit-and-rollout work split into
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | Palette-swatch task done; PR pending.   |
-| Waiting on    | Nothing.                               |
-| Next          | Pick up "Badge sources should badge their own list too". |
-| Last touched  | 2026-07-26                               |
+| Now           | Both tasks implemented, built, and tested; PR for the self-badging task pending. |
+| Waiting on    | Manual QA of the self-badging task (live client, not performed this session). |
+| Next          | Manual QA, then close the story.       |
+| Last touched  | 2026-07-28                               |
 
 * Acceptance
 
@@ -62,7 +62,7 @@ distinct from the coverage-audit-and-rollout work split into
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:FFD9EFC2-AB60-4008-BC2A-FED99C7B09AD][Badge palette swatch rendering + data-driven fallback badge]] | DONE | 2026-07-22 | 2026-07-26 | Colour-swatch delegate and picker for Badge Definitions/Severities admin UI; replace the hardcoded Qt fallback constant with a real, reserved badge_definition row. |
-| [[id:5BAE2E27-7C8A-4C3E-B65C-5D6F631528C7][Badge sources should badge their own list too]] | BACKLOG | | | Codegen mechanism so a badge-source entity's own code/name column also gets badge_key wired to its own code_domain. |
+| [[id:5BAE2E27-7C8A-4C3E-B65C-5D6F631528C7][Badge sources should badge their own list too]] | DONE | 2026-07-28 | 2026-07-28 | Codegen mechanism so a badge-source entity's own code/name column also gets badge_key wired to its own code_domain. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
+++ b/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
@@ -8,7 +8,7 @@
 #+filetags: :badge_colour_scheme_snags:sprint_24:v0:
 #+owner: marco
 #+branch: feature/badge-source-self-annotation
-#+pr:
+#+pr: 1723
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
@@ -94,7 +94,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1723][#1723]] | [qt,codegen] Badge sources should badge their own list too |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
+++ b/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
@@ -100,7 +100,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | ModifiedBy/RecordedAt rows missing trailing empty is_badge/badge_key cells, inconsistent with book.org/portfolio.org | =ores.refdata.book_status.org= | Accepted | Added the trailing empty cells; cosmetic only, confirmed zero regen diff |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
+++ b/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.org
@@ -12,8 +12,8 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-15
-#+updated: 2026-07-21
-#+environment:
+#+updated: 2026-07-28
+#+environment: eager_maxwell
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8D2F638E-B4DA-4E36-8258-3D30DAAFC2B6][Badge colour scheme: visual polish and self-badging fixes]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,27 +26,58 @@ Opening a badge-source entity's own list window (e.g. Book Status) shows its own
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:8D2F638E-B4DA-4E36-8258-3D30DAAFC2B6][Badge colour scheme: visual polish and self-badging fixes]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-15                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-28                               |
 
 * Acceptance
 
-- New model annotation (e.g. #+badge_source_domain: <code_domain>, or reuse badge_key on the entity's own key column) drives codegen to badge_key-wire the entity's own list column to its own code_domain.
-- Piloted on at least book_status (or another entity already referenced via badge_key elsewhere) -- regenerated, its own list now shows badges matching the same colours consumers already show.
-- No change to consumer entities' existing badge rendering (zero diff on their generated files).
-- Manual QA: open the pilot entity's own list window, confirm badges render and match the colours seen when the same values are badged elsewhere (e.g. Book's Status column).
+- [X] New model annotation (e.g. #+badge_source_domain: <code_domain>, or reuse badge_key on the entity's own key column) drives codegen to badge_key-wire the entity's own list column to its own code_domain.
+- [X] Piloted on at least book_status (or another entity already referenced via badge_key elsewhere) -- regenerated, its own list now shows badges matching the same colours consumers already show.
+- [X] No change to consumer entities' existing badge rendering (zero diff on their generated files).
+- [ ] Manual QA: open the pilot entity's own list window, confirm badges render and match the colours seen when the same values are badged elsewhere (e.g. Book's Status column). Not performed this session -- no live client/environment run; only build+ctest verified. Should be exercised by the user or a follow-up session before closing the parent story.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Reused =badge_key= on the entity's own list column rather than
+inventing a new =#+badge_source_domain:= annotation: investigation
+showed codegen's =is_badge=/=badge_key= mechanism is already
+column-agnostic about whether the value comes from a foreign
+entity's code or the domain's own code -- the same
+=BadgeCache::resolve(domain, code)= call works either way. Piloted
+on =book_status=: added =is_badge: true=/=badge_key: book_status= to
+its own =Code= column in the "Columns (Qt model)" table, regenerated.
+
+Blocked mid-implementation by an unrelated, pre-existing bug: codegen's
+primary-key model shape migration (task D230B754/story 36A25C95) had
+landed on =org_loader.py= without any =.org= model migrated yet, so
+=book_status.org= (old =* Primary key=/=* Natural keys= heading
+format) failed to load at all. Migrated =book_status.org= (and,
+to verify zero-diff on consumers, =book.org=/=portfolio.org=) to the
+new =* Columns=/=:primary_key:= shape as a prerequisite -- landed
+separately as PR #1716's sibling investigation surfaced a second,
+larger side quest (see Notes) split into its own PR (#1720) before
+returning to finish this task here.
 
 * Notes
+
+Regenerating =book= (a =book_status= consumer, to verify the
+zero-diff acceptance criterion) surfaced that the As-of lookup
+resolution codegen facet (story 753E984D) had extended the backend
+(repository/service/protocol/NATS-handler) codegen layers properly,
+but its Qt-side wiring was hand-patched directly onto
+=BookDetailDialog.cpp=/=BookController.cpp= instead of becoming a
+template facet -- invisible to codegen, so this task's own regen
+would have silently deleted it. Fixed as a proper
+=combo_as_of_fetch_fn= detail-field facet and merged separately as
+PR #1720, since it's unrelated to badge self-annotation. Also
+surfaced (and fixed in a separate hotfix, PR #1716) a pre-existing,
+unrelated test-drift bug in =party_generator_produces_valid_instance=
+and an unsafe =business_center_code= generator default in
+=party.org=.
 
 * Test Scenarios
 
@@ -72,3 +103,14 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+=book_status='s own =code= column is now =is_badge: true=/
+=badge_key: book_status= in its "Columns (Qt model)" table --
+the same mechanism every consumer already uses, with no new codegen
+facet needed (the =BadgeCache::resolve(domain, code)= call is
+column-agnostic about who owns the domain). Regenerated
+=BookStatusMdiWindow=/=BookStatusController= (+ hand-wired
+=RefdataPlugin.cpp= constructor call updated for the new
+=BadgeCache*= parameter). Verified =book=/=portfolio= (consumers)
+regenerate with zero diff. Local build clean; ctest 74/74 passed.
+Manual QA (live client) not performed this session -- flagged above.

--- a/projects/ores.qt/refdata/include/ores.qt/BookStatusController.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookStatusController.hpp
@@ -36,6 +36,7 @@ namespace ores::qt {
 
 class BookStatusMdiWindow;
 class DetachableMdiSubWindow;
+class BadgeCache;
 class ChangeReasonCache;
 
 /**
@@ -62,6 +63,7 @@ public:
                          ClientManager* clientManager,
                          ChangeReasonCache* changeReasonCache,
                          const QString& username,
+                         BadgeCache* badgeCache,
                          QObject* parent = nullptr);
 
     void showListWindow() override;
@@ -106,6 +108,7 @@ private:
             callback);
 
     ChangeReasonCache* changeReasonCache_;
+    BadgeCache* badgeCache_;
     BookStatusMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt/refdata/include/ores.qt/BookStatusMdiWindow.hpp
+++ b/projects/ores.qt/refdata/include/ores.qt/BookStatusMdiWindow.hpp
@@ -32,6 +32,7 @@
 
 namespace ores::qt {
 
+class BadgeCache;
 
 /**
  * @brief MDI window for displaying and managing book statuses.
@@ -54,6 +55,7 @@ private:
 public:
     explicit BookStatusMdiWindow(ClientManager* clientManager,
                                  const QString& username,
+                                 BadgeCache* badgeCache,
                                  QWidget* parent = nullptr);
     ~BookStatusMdiWindow() override = default;
 
@@ -100,6 +102,7 @@ private:
 
     ClientManager* clientManager_;
     QString username_;
+    BadgeCache* badgeCache_;
 
     QToolBar* toolbar_;
     QTableView* tableView_;

--- a/projects/ores.qt/refdata/src/BookStatusController.cpp
+++ b/projects/ores.qt/refdata/src/BookStatusController.cpp
@@ -49,9 +49,11 @@ BookStatusController::BookStatusController(QMainWindow* mainWindow,
                                            ClientManager* clientManager,
                                            ChangeReasonCache* changeReasonCache,
                                            const QString& username,
+                                           BadgeCache* badgeCache,
                                            QObject* parent)
     : EntityController(mainWindow, mdiArea, clientManager, username, status_event_name, parent)
     , changeReasonCache_(changeReasonCache)
+    , badgeCache_(badgeCache)
     , listWindow_(nullptr)
     , listMdiSubWindow_(nullptr) {
 
@@ -68,7 +70,7 @@ void BookStatusController::showListWindow() {
     }
 
     // Create new window
-    listWindow_ = new BookStatusMdiWindow(clientManager_, username_);
+    listWindow_ = new BookStatusMdiWindow(clientManager_, username_, badgeCache_);
 
     // Connect signals
     connect(listWindow_,

--- a/projects/ores.qt/refdata/src/BookStatusMdiWindow.cpp
+++ b/projects/ores.qt/refdata/src/BookStatusMdiWindow.cpp
@@ -18,7 +18,9 @@
  *
  */
 #include "ores.qt/BookStatusMdiWindow.hpp"
+#include "ores.qt/BadgeCache.hpp"
 #include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/EntityItemDelegate.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.refdata.api/messaging/book_status_protocol.hpp"
@@ -34,10 +36,12 @@ using namespace ores::logging;
 
 BookStatusMdiWindow::BookStatusMdiWindow(ClientManager* clientManager,
                                          const QString& username,
+                                         BadgeCache* badgeCache,
                                          QWidget* parent)
     : EntityListMdiWindow(parent)
     , clientManager_(clientManager)
     , username_(username)
+    , badgeCache_(badgeCache)
     , toolbar_(nullptr)
     , tableView_(nullptr)
     , model_(nullptr)
@@ -121,6 +125,44 @@ void BookStatusMdiWindow::setupTable() {
     tableView_->setAlternatingRowColors(true);
     tableView_->verticalHeader()->setVisible(false);
 
+    using cs = column_style;
+    auto* delegate = new EntityItemDelegate(
+        {
+            cs::badge_centered,
+            cs::text_left,
+            cs::text_left,
+            cs::mono_center,
+            cs::mono_center,
+            cs::text_left,
+            cs::text_left,
+        },
+        tableView_);
+    delegate->set_badge_color_resolver(
+        0, [cache = badgeCache_](const QString& value) -> badge_color_pair {
+            static const badge_color_pair hardcoded_fallback{
+                color_constants::badge_fallback, color_constants::badge_fallback_text, true};
+            if (!cache)
+                return hardcoded_fallback;
+            auto* def = cache->resolve("book_status", value.toStdString());
+            if (!def) {
+                auto* reserved = cache->fallback();
+                if (!reserved)
+                    return hardcoded_fallback;
+                return {QColor(QString::fromStdString(reserved->background_colour)),
+                        QColor(QString::fromStdString(reserved->text_colour)),
+                        true};
+            }
+            return {QColor(QString::fromStdString(def->background_colour)),
+                    QColor(QString::fromStdString(def->text_colour))};
+        });
+    tableView_->setItemDelegate(delegate);
+    if (badgeCache_) {
+        if (badgeCache_->isLoaded())
+            tableView_->viewport()->update();
+        connect(badgeCache_, &BadgeCache::loaded, tableView_->viewport(), [this]() {
+            tableView_->viewport()->update();
+        });
+    }
 
     initializeTableSettings(tableView_,
                             model_,

--- a/projects/ores.qt/refdata/src/RefdataPlugin.cpp
+++ b/projects/ores.qt/refdata/src/RefdataPlugin.cpp
@@ -256,6 +256,7 @@ void RefdataPlugin::on_login(const plugin_context& ctx) {
                                                                    ctx_.client_manager,
                                                                    ctx_.change_reason_cache,
                                                                    ctx_.username,
+                                                                   ctx_.badge_cache,
                                                                    this);
     connectControllerSignals(bookStatusController_.get());
 

--- a/projects/ores.refdata/modeling/ores.refdata.book_status.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book_status.org
@@ -197,8 +197,8 @@ drop function if exists ores_refdata_validate_book_status_fn;
 | Description  | description   | Description   | string    | auto  |          |             |
 | DisplayOrder | display_order | Display Order | int       | 70    |          |             |
 | Version      | version       | Version       | int       | 70    |          |             |
-| ModifiedBy   | modified_by   | Modified By   | string    | auto  |
-| RecordedAt   | recorded_at   | Recorded At   | timestamp | auto  |
+| ModifiedBy   | modified_by   | Modified By   | string    | auto  |          |             |
+| RecordedAt   | recorded_at   | Recorded At   | timestamp | auto  |          |             |
 
 ** Custom repository methods
 

--- a/projects/ores.refdata/modeling/ores.refdata.book_status.org
+++ b/projects/ores.refdata/modeling/ores.refdata.book_status.org
@@ -190,13 +190,13 @@ drop function if exists ores_refdata_validate_book_status_fn;
 
 *** Columns (Qt model)
 
-| enum_name    | field         | header        | type      | width |
-|--------------+---------------+---------------+-----------+-------|
-| Code         | code          | Code          | string    | auto  |
-| Name         | name          | Name          | string    | auto  |
-| Description  | description   | Description   | string    | auto  |
-| DisplayOrder | display_order | Display Order | int       | 70    |
-| Version      | version       | Version       | int       | 70    |
+| enum_name    | field         | header        | type      | width | is_badge | badge_key   |
+|--------------+---------------+---------------+-----------+-------+----------+-------------|
+| Code         | code          | Code          | string    | auto  | true     | book_status |
+| Name         | name          | Name          | string    | auto  |          |             |
+| Description  | description   | Description   | string    | auto  |          |             |
+| DisplayOrder | display_order | Display Order | int       | 70    |          |             |
+| Version      | version       | Version       | int       | 70    |          |             |
 | ModifiedBy   | modified_by   | Modified By   | string    | auto  |
 | RecordedAt   | recorded_at   | Recorded At   | timestamp | auto  |
 


### PR DESCRIPTION
## Summary

An entity that IS a code_domain (e.g. book_status) didn't badge itself on its own list -- only consumers did. Reuses the existing badge_key mechanism (no new annotation needed): BadgeCache::resolve(domain, code) is column-agnostic about who owns the domain.

## Changes

- book_status.org: mark its own code column is_badge/badge_key: book_status
- Regenerate BookStatusController/MdiWindow; update RefdataPlugin.cpp's hand-wired constructor call for the new BadgeCache* parameter
- Verified book/portfolio (consumers) regenerate with zero diff
- Verification: local build clean (linux-clang-debug-make); ctest 74/74 passed. Manual QA (live client) not performed this session -- flagged in the task doc.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Badge colour scheme: visual polish and self-badging fixes](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/story.html) | 8D2F638E-B4DA-4E36-8258-3D30DAAFC2B6 |
| Task | [Badge sources should badge their own list too](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/badge_colour_scheme_snags/task_badge-source-self-annotation.html) | 5BAE2E27-7C8A-4C3E-B65C-5D6F631528C7 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)