### PR TITLE
Export ir_curve_feed factory functions from synthetic service

### DIFF
--- a/projects/ores.synthetic/service/src/ir_curve_feed.hpp
+++ b/projects/ores.synthetic/service/src/ir_curve_feed.hpp
@@ -136,7 +136,7 @@ private:
  * @throws vintage_data_missing_error if cfg.price_source is "vintage" and no matching observation
  * is found (or the config has no DEPOSIT entry to anchor on).
  */
-std::shared_ptr<ir_curve_feed>
+ORES_SYNTHETIC_SERVICE_EXPORT std::shared_ptr<ir_curve_feed>
 make_ir_curve_feed(ores::nats::service::client& nats,
                    ores::nats::service::nats_client& auth_nats,
                    const ores::synthetic::domain::ir_curve_generation_config& cfg,
@@ -151,7 +151,7 @@ make_ir_curve_feed(ores::nats::service::client& nats,
  * resolved has no DEPOSIT entry. Exposed separately from make_ir_curve_feed's vintage resolution
  * so the pure selection logic is unit-testable without a live market_data_client.
  */
-const ir_curve_resolved_entry*
+ORES_SYNTHETIC_SERVICE_EXPORT const ir_curve_resolved_entry*
 select_vintage_anchor_entry(const std::vector<ir_curve_resolved_entry>& resolved);
 
 }


### PR DESCRIPTION
## Summary
Add `ORES_SYNTHETIC_SERVICE_EXPORT` macro to the declarations of `make_ir_curve_feed()` and `select_vintage_anchor_entry()` to properly export these functions from the synthetic service library.

## Changes
- Mark `make_ir_curve_feed()` factory function with export macro
- Mark `select_vintage_anchor_entry()` helper function with export macro

## Details
These functions are part of the public API of the synthetic service library and need to be explicitly exported to be accessible to consumers of the library. The `ORES_SYNTHETIC_SERVICE_EXPORT` macro ensures proper symbol visibility on platforms that require explicit export declarations (e.g., Windows DLLs).

https://claude.ai/code/session_01D6MVWBeE4ct9kRNwbGBJpN