### PR TITLE
Restructure market data identifier documentation for clarity

### DIFF
--- a/doc/knowledge/domain/external_market_data_identifiers.org
+++ b/doc/knowledge/domain/external_market_data_identifiers.org
@@ -2,12 +2,12 @@
 :ID: F3010EA7-6A0E-405C-81FA-1EF051749B5E
 :END:
 #+title: External market data identifiers
-#+description: A comparative analysis of five market data identifier schemes — RIC, Bloomberg ticker, the ORE canonical key, MDDL, and FIX — their origin, ownership, formal specification status, and pros, cons, and limitations.
+#+description: A comparative analysis of six market data identifier schemes — RIC, Bloomberg ticker, the ORE canonical key, MDDL, FIX, and OpenGamma Strata — their origin, ownership, formal specification status, and pros, cons, and limitations.
 #+type: knowledge
 #+level: cross
 #+filetags: :marketdata:identifiers:
 #+created: 2026-06-25
-#+updated: 2026-07-25
+#+updated: 2026-07-28
 
 * Summary
 
@@ -27,10 +27,14 @@ notation. FIX (Financial Information eXchange — see
 explicit member schemes, but adds a dedicated wire-message family for
 market data itself (=MarketDataSnapshotFullRefresh=,
 =MarketDataIncrementalRefresh=, ...) that neither MDDL nor the other
-schemes have. This document is a comparative analysis of these five
-schemes on their own terms — what each is, who owns it, whether a formal
-specification exists, and each scheme's pros, cons, and limitations —
-independent of any particular consumer of the schemes.
+schemes have. OpenGamma Strata's =com.opengamma.strata.data.MarketDataId<T>=
+takes yet another approach: an open-source Java generic interface that names
+no concrete fields at the base level, leaving field structure entirely to
+each implementing class — the only scheme here that is a type abstraction
+rather than a string format or wire protocol. This document is a comparative
+analysis of these six schemes on their own terms — what each is, who owns
+it, whether a formal specification exists, and each scheme's pros, cons, and
+limitations — independent of any particular consumer of the schemes.
 
 * Format overviews
 
@@ -136,6 +140,42 @@ on GitHub]] (the =Examples/= directory contains the =marketdata.csv= files
 this key format is drawn from; =OREData/ored/marketdata/= contains the
 =CSVLoader=/=MarketDatum= parsing code).
 
+*** ORE's =CurveSpec= class hierarchy
+
+Alongside the canonical key format, ORE has a parallel internal
+addressing scheme used within its own engine: the =CurveSpec= class
+hierarchy, declared in =OREData/ored/marketdata/curvespec.hpp=. The base
+class carries a =curveConfigID= field common to every curve type, and
+each concrete subclass — =YieldCurveSpec=, =FXVolatilityCurveSpec=,
+=SwaptionVolatilityCurveSpec=, and so on — adds the type-specific fields
+that particular curve family needs to be uniquely addressed within ORE's
+own engine (a currency code for a yield curve; a currency pair for an FX
+volatility curve). =CurveSpec= additionally carries an explicit
+=CurveType= enumeration (=FX=, =Yield=, =CapFloorVolatility=, ...)
+discriminating which concrete subclass applies.
+
+=CurveSpec= is ORE's internal C++ representation, not the canonical key
+format: an external consumer's system produces a canonical key string
+(e.g. =DISCOUNT/RATE/EUR/EUR-DUMMY/2Y=) that ORE resolves to the
+corresponding =CurveSpec= object internally. From the point of view of
+a system projecting its own identifiers into ORE's notation, =CurveSpec=
+is the *target* that projection must produce — not a peer identifier
+scheme to be compared directly against the canonical key. The fields that
+$T_{\text{ORE}}$ would need to populate a =CurveSpec= (=curveConfigID=,
+ORE-specific curve-building hints) represent the physical-field gap that
+a purely logical identifier does not yet carry.
+
+One terminological trap is worth flagging explicitly: the file-level
+documentation comment at the top of =curvespec.hpp= reads /"Curve
+requirements specification."/ ORE's own prose calls =CurveSpec= — which
+sits on the *identifier* side of the requirement/identifier distinction
+and squarely on the *vendor* side of the identifier/vendor-key
+distinction — a "requirement." This is not a contradiction to resolve;
+it is a warning that "requirement" is not a safe, field-wide term with
+one settled meaning, and a reader moving between an external conceptual
+document and ORE's own source comments should not assume the word carries
+the same meaning in both places.
+
 ** MDDL (Market Data Definition Language)
 
 MDDL is an XML-based market data description language originally
@@ -189,26 +229,70 @@ Files retrieved from the QuickFIX open-source engine project (which
 redistributes the FIX Trading Community's own data dictionaries) are
 archived at [[proj:external/fix][=external/fix/=]].
 
+** OpenGamma Strata's =MarketDataId=
+
+OpenGamma Strata is an open-source Java library for OTC derivatives
+pricing and risk analytics, originally developed by OpenGamma Ltd and
+now maintained by the open-source community. Its identifier abstraction,
+=com.opengamma.strata.data.MarketDataId<T>=, differs fundamentally in
+kind from the other five schemes covered here: it is a Java generic
+interface, not a string format or wire protocol. The Javadoc describes it
+as "an identifier for a unique item of market data... Implementations can
+identify any piece of market data. This includes observable values, such
+as the quoted market value of a security, and derived values, such as a
+volatility surface or a discounting curve." The interface's only contract
+is uniqueness and a declared value type =T= (the type of the value the
+identifier resolves to — e.g. =double= for a spot rate, or a curve
+object for a full discount curve). All field structure is pushed down
+into each concrete implementing class; there is no single canonical field
+list at the interface level by design. Strata's rationale is
+extensibility across an open-ended set of data kinds a third-party
+library cannot anticipate in advance, in contrast to schemes that commit
+to a shared field shape across instrument types.
+
+Unlike every other scheme in this document, there is no canonical short
+string a consumer would use as a compact map key or pub/sub subject; the
+identifier is the Java object, not a serialisation of it. Strata does
+not mint a competing short-string notation and does not define a
+wire-message protocol. Like ORE's canonical key and unlike RIC,
+Bloomberg, MDDL, and FIX, Strata's =MarketDataId= is also silent on
+physical fields at the interface level — an implementing class is free to
+carry a source or convention, but nothing at the base contract requires
+or names one.
+
+The library is open source (Apache 2.0) and its source and Javadoc are
+freely readable without a licence of any kind. See
+[[https://github.com/OpenGamma/Strata][OpenGamma/Strata on GitHub]];
+the identifier interface lives in the =com.opengamma.strata.data=
+package, and concrete implementations such as =QuoteId=, =IborIndexId=,
+and =CurveId= illustrate the per-class field shape the interface
+deliberately omits at the base level.
+
 * Identifier scheme comparison
 
-Three of the five schemes address the same instruments with a short
+Three of the six schemes address the same instruments with a short
 string: RIC (Reuters/Refinitiv, now LSEG) is instrument-type-specific and
 not fully systematic; Bloomberg uses a space-separated =<ticker>
 <yellow-key>= composite; ORE uses a slash-delimited, per-type
 =TYPE/SUBTYPE/dim1/.../dimN= key consumed directly by the ORE pricing
 engine (=marketdata.csv=), documented type by type in the
 [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]].
-The other two, MDDL and FIX, do not — both wrap whichever short-string
+Two more, MDDL and FIX, do not — both wrap whichever short-string
 identifier a source system already publishes (MDDL's
 =instrumentIdentifier/codeType=, FIX's =SecurityIDSource=) rather than
 minting a competing one, so their comparison tables below carry a worked
-XML/message example instead of a short-string cell. RIC and Bloomberg
-cells below are compiled from publicly visible instrument examples, not a
-primary vendor spec — see [[*Sources][Sources]]. Every cell below is
-filled with either a concrete identifier or an explicit statement of why
-none exists (no standard public convention, no matching ORE quote type, or
-"not a single tradeable instrument") — see each subsection's notes for the
-reasoning behind any such cell.
+XML/message example instead of a short-string cell. OpenGamma Strata is
+similarly absent from the short-string columns — not because it wraps an
+existing scheme, but because it is a type abstraction with no canonical
+serialised form; it does not participate in an instrument-level comparison
+table and is covered separately in [[*OpenGamma Strata's =MarketDataId=][the
+format overview above]]. RIC and Bloomberg cells below are compiled from
+publicly visible instrument examples, not a primary vendor spec — see
+[[*Sources][Sources]]. Every cell below is filled with either a concrete
+identifier or an explicit statement of why none exists (no standard public
+convention, no matching ORE quote type, or "not a single tradeable
+instrument") — see each subsection's notes for the reasoning behind any
+such cell.
 
 ** FX
 
@@ -760,6 +844,7 @@ that every row in this document's comparison tables above draws from.
 | ORE canonical key | Open source and openly documented; the native format of every ORE pricing-engine input file; every type shares the same top-level =TYPE/SUBTYPE/dim1/.../dimN= shape, and the per-type dimension count and meaning is precisely documented for all 49 types; free of vendor licensing. | The per-type dimension count varies (2 to 8+), so — unlike RIC's or Bloomberg's flatter shapes — a consumer must know each type's specific dimension schema rather than applying one universal rule; several common real-world instruments (sovereign bond yields, listed equity/index futures) have no direct quote type at all; has no structured field for curve family or discount-vs-projection role. |
 | MDDL | Open, committee-governed specification (FISD/SIIA) rather than proprietary to one vendor; a full instrument-record XML schema, not just a key, so it carries far richer instrument/event data than a short identifier string; =instrumentIdentifier='s =codeType= controlled vocabulary can wrap ISIN, RIC, or any other existing scheme rather than forcing a migration. | Never adopted as any pricing engine's native input format (unlike ORE's key); last full release was 3.0-beta (2007) and the project was never finalised or continued — FISD instead contributed its vocabulary into ISO 20022/FIX; being a full XML record rather than a short string, it cannot serve as a compact pub/sub key or a natural map/dictionary key the way the other three schemes can. |
 | FIX | Open, committee-governed specification (FIX Trading Community), actively maintained (unlike MDDL) as "FIX Latest" since 2019; =SecurityIDSource= symbology explicitly names RIC and Bloomberg as member schemes rather than competing with them; the only scheme here with a dedicated market-data wire-message family (request/snapshot/incremental refresh/reject), not just an identifier or record shape; free of vendor licensing. | Not a compact string identifier any more than MDDL is — instrument identity plus market data both live inside multi-field messages, not a short key; correctly parsing tag=value framing (session header, checksum, repeating groups) generally requires a FIX engine rather than generic string/XML tooling; no native concept of curve family or discount-vs-projection role, same gap as the other four. |
+| OpenGamma Strata | Open source (Apache 2.0), freely readable without a licence; an interface-based design cleanly separates the identifier concept from any concrete field shape or string serialisation, giving implementations full freedom over field structure; actively maintained; like ORE's canonical key, silent on physical fields at the base level — a deliberate design choice, not an oversight. | Not a string identifier at all — no compact key usable as a pub/sub subject or map key without serialising the Java object; all field structure is per-implementation with no shared base-level shape, so two implementations covering the same logical instrument may be incompatible; Java-specific with no language-neutral wire form; no native concept of curve family, discount-vs-projection role, or physical source fields at the interface level, the same logical-only gap as ORE's canonical key. |
 
 * Sources
 
@@ -781,6 +866,13 @@ that every row in this document's comparison tables above draws from.
 - FIX — open, committee-governed specification published by the FIX Trading
   Community. See [[id:C7B36E6D-F30F-4E2C-BB5B-27B1D4516DF1][Financial
   Information eXchange (FIX) Protocol]] below.
+- OpenGamma Strata — open source (Apache 2.0), maintained by the
+  open-source community. See
+  [[https://github.com/OpenGamma/Strata][OpenGamma/Strata on GitHub]];
+  =com.opengamma.strata.data.MarketDataId= is the base identifier
+  interface, and the =com.opengamma.strata.data= package contains the
+  concrete implementations (=QuoteId=, =IborIndexId=, =CurveId=, ...) that
+  illustrate how field structure is expressed at the implementation level.
 
 * See also
 
@@ -788,4 +880,5 @@ that every row in this document's comparison tables above draws from.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — the authoritative, per-type quote-key dimension inventory (49 types) that every ORE quote key in this document's comparison tables is drawn from.
 - [[id:0FF6A2DC-EE01-4C3C-AF86-A0D08FD93925][Market Data Definition Language (MDDL)]] — the fourth scheme compared above: version history, content model, and where its retrieved specification files live.
 - [[id:C7B36E6D-F30F-4E2C-BB5B-27B1D4516DF1][Financial Information eXchange (FIX) Protocol]] — the fifth scheme compared above: version history, the Market Data message family, symbology, and where its retrieved data dictionaries live.
-- [[id:C3E053CA-0D4B-480B-9119-E11530160EC1][oresmd: ORE Studio Market Data URI]] — a proposed sixth scheme: ORE Studio's own canonical identifier, with deterministic projection rules into every scheme compared in this document.
+- [[id:3D56DB59-8075-42BB-8139-A7440C9786B2][Market Data Identifier]] — the conceptual document that uses ORE's and OpenGamma Strata's independent convergence on the same logical field shape as evidence for that shape's irreducibility.
+- [[id:C3E053CA-0D4B-480B-9119-E11530160EC1][oresmd: ORE Studio Market Data URI]] — a proposed extension of the ORE-derived logical identifier with an explicit physical field group, structured tenor/curve-role/instrument-type grammar, and deterministic projection rules into every scheme compared in this document.

--- a/doc/knowledge/domain/external_market_data_identifiers.org
+++ b/doc/knowledge/domain/external_market_data_identifiers.org
@@ -45,8 +45,8 @@ but still universally referred to as RIC, is a ticker-like code that
 Reuters — and, through successive acquisitions, Refinitiv and now LSEG
 (London Stock Exchange Group) — has used since the 1980s to identify
 tradeable instruments and indices across its market data terminals and
-feeds. It is the oldest of the three schemes covered in this document and
-carries that history in its design: rather than a single systematic
+feeds. It is the oldest of the schemes covered in this document and carries
+that history in its design: rather than a single systematic
 grammar, RIC is a loose family of per-asset-class conventions that grew
 organically as new instrument types were added to Reuters' systems over
 decades — an equity RIC appends an exchange suffix (=AAPL.OQ=), an index
@@ -117,7 +117,7 @@ and it is defined and owned entirely by
 the ORE open-source project, currently maintained by Acadia (formerly
 Quaternion Risk Management / AcadiaSoft). Because it exists to serve one
 program's input format rather than to label instruments for human traders
-across a whole industry, it is the most systematic of the three schemes:
+across a whole industry, it is the most systematic of the three short-string schemes:
 every key follows the same top-level slash-delimited shape,
 =TYPE/SUBTYPE/dim1/.../dimN=, regardless of asset class — though, unlike
 a flatter scheme, the number and meaning of the dimensions after
@@ -184,7 +184,7 @@ Software & Information Industry Association (SIIA), first published in
 the early 2000s; see
 [[id:0FF6A2DC-EE01-4C3C-AF86-A0D08FD93925][Market Data Definition
 Language (MDDL)]] for its full version history and current status.
-Structurally it is the odd one out among the four schemes covered here:
+Structurally it differs from the short-string schemes covered here:
 RIC, Bloomberg, and the ORE canonical key are each a short single
 string that *is* the identifier, whereas MDDL is a full XML instrument
 record, and instrument identity is carried by an =instrumentIdentifier=
@@ -211,7 +211,7 @@ eXchange (FIX) Protocol]] for its full version history and content
 model. Unlike MDDL, FIX was never wound down — it remains the dominant
 open standard for pre-trade, trade, and post-trade messaging and, since
 2019, is continuously extended as "FIX Latest" rather than released in
-numbered versions. It is the only one of the five schemes here with a
+numbered versions. It is the only one of the six schemes here with a
 dedicated *market data message family*: =MarketDataRequest=,
 =MarketDataSnapshotFullRefresh=, =MarketDataIncrementalRefresh=, and
 =MarketDataRequestReject= (plus =MarketDataStatisticsRequest/Report= and
@@ -235,7 +235,7 @@ OpenGamma Strata is an open-source Java library for OTC derivatives
 pricing and risk analytics, originally developed by OpenGamma Ltd and
 now maintained by the open-source community. Its identifier abstraction,
 =com.opengamma.strata.data.MarketDataId<T>=, differs fundamentally in
-kind from the other five schemes covered here: it is a Java generic
+kind from the other five schemes covered here — it is a Java generic
 interface, not a string format or wire protocol. The Javadoc describes it
 as "an identifier for a unique item of market data... Implementations can
 identify any piece of market data. This includes observable values, such
@@ -466,7 +466,7 @@ actual message bytes.)
   messages (multi-leg =Instrument=/=InstrmtLegGrp= structures) rather
   than streamed through =MarketDataSnapshotFullRefresh=. Shortcoming:
   this is the same broker-composite, not-retail-ticker gap RIC and
-  Bloomberg both have for this row — none of the five schemes here has
+  Bloomberg both have for this row — none of the schemes here has
   a clean, publicly documented tick-level convention for an IRS par
   rate, only ORE's =IR_SWAP/RATE= key (a pricing-engine input, not a
   market feed convention) comes close.
@@ -490,8 +490,8 @@ actual message bytes.)
   publishes.
 - *ORE quote key*: the key follows the catalogue's documented
   =SWAPTION/RATE_LNVOL/CCY/expiry/swap_tenor/strike= shape — a genuine
-  advantage here, since it is the only one of the three schemes with an
-  openly documented structure for this instrument at all. Shortcoming:
+  advantage here, since it is the only one of the short-string schemes
+  with an openly documented structure for this instrument at all. Shortcoming:
   the four-dimension surface coordinate (expiry, tenor, strike) is
   carried entirely inside the =point_id= segment, so — unlike the FX or
   rates rows — a consumer must already know this type's specific
@@ -507,7 +507,7 @@ actual message bytes.)
   Bloomberg — swaption vol is broker-composite, over-the-counter data
   that none of RIC, Bloomberg, MDDL, or FIX has a standardised public
   convention for; ORE's =SWAPTION/RATE_LNVOL= key remains the only
-  openly documented structure for this instrument among the five
+  openly documented structure for this instrument among all six
   schemes compared in this document.
 
 ** Equities and indices
@@ -629,7 +629,7 @@ code's scheme URI is unchanged.)
   record, FIX pairs a comparably rich instrument description with a
   dedicated wire-level delivery mechanism — the =MarketDataRequest=/
   =MarketDataSnapshotFullRefresh=/=MarketDataIncrementalRefresh= message
-  family — that none of the other four schemes define. Shortcoming: FIX
+  family — that none of the other five schemes define. Shortcoming: FIX
   messages are typically consumed and generated through a FIX engine
   rather than read as a standalone document the way an MDDL or ORE
   =marketdata.csv= file can be; correctly parsing tag=value framing

--- a/doc/knowledge/domain/market_data_identifier.org
+++ b/doc/knowledge/domain/market_data_identifier.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :knowledge:domain:marketdata:identifiers:
 #+created: 2026-07-23
-#+updated: 2026-07-23
+#+updated: 2026-07-28
 
 * Summary
 
@@ -95,6 +95,31 @@ one identifier from among however many project onto a given requirement,
 which is a genuine decision, not a computation performable on the
 requirement's fields alone.
 
+#+begin_note
+*Aspirational: tenor-pinned requirements*
+
+The projection model above treats the specific tenor or surface
+coordinate as the field that most sharply distinguishes an identifier
+from a requirement for term-structure data: a requirement says "the
+EUR discount curve" and resolution adds "...at the 5Y point." In
+practice, however, some valuation models know the exact tenor they
+need at requirement-generation time — a 1Y put option requires the 1Y
+volatility-surface point, not the surface as a whole, and no
+resolution choice is needed for that dimension. Allowing a requirement
+to carry an optional explicit tenor or tenor range would enable
+resolution to produce a more precisely scoped identifier directly for
+those cases, skipping the point-selection step where the call-site
+already knows the answer.
+
+Extending the requirement model in this direction is recognised as a
+desirable refinement but is not yet fully specified, because it
+introduces significant complexity: a requirement may need a range or
+a set of tenors rather than a single point, resolution may need to
+interpolate rather than look up, and the clean binary between "coarser
+requirement" and "fully specified identifier" becomes a spectrum. This
+document notes the aspiration without committing to a shape.
+#+end_note
+
 ** Identifier identity: what makes two identifiers the same?
 
 Two market data identifiers are the same identifier exactly when every
@@ -108,67 +133,52 @@ source, or convention); it is, however, sufficient for them to share the
 same requirement, since requirement equality is defined purely over the
 logical fields.
 
-*** This repository's own scheme
+*** The ORE-derived logical identifier scheme
 
-[[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][Market data identifiers]]
-documents this system's own identifier format in detail; the essential
-structure is a slash-delimited tuple
+The ORE canonical key — documented in
+[[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data
+identifiers]] — provides a concrete realisation of the logical field
+group as a slash-delimited tuple and was adopted wholesale as the
+starting-point canonical form:
 
 : <series_type>/<metric>/<qualifier>[/<point_id>]
 
 where =series_type= names the asset class and curve family (=FX=,
 =DISCOUNT=, =SWAPTION=), =metric= names what is being quoted (=RATE=,
-=RATE_LNVOL=), =qualifier= names the specific instance within that family
-(a currency, a currency pair, a credit name), and the optional
+=RATE_LNVOL=), =qualifier= names the specific instance within that
+family (a currency, a currency pair, a credit name), and the optional
 =point_id= — present only for term-structure series — names a specific
 tenor or surface coordinate. =FX/RATE/EUR/USD= identifies EUR/USD spot;
-=SWAPTION/RATE_LNVOL/EUR/5Y/2Y/ATM= identifies one specific point on the
-EUR swaption volatility surface. This tuple maps directly onto the
-=market_series= table's own =(series_type, metric, qualifier)= columns
-and converts deterministically to a NATS subject by lowercasing and
-replacing =/= with =.= — see that document for the full mapping and its
-worked examples.
+=SWAPTION/RATE_LNVOL/EUR/5Y/2Y/ATM= identifies one specific point on
+the EUR swaption volatility surface.
 
-This tuple is, honestly, only the *logical* field group formalised so
-far — it says nothing about source or convention, because nothing in
-this repository's own storage or messaging layer has needed those fields
-yet. Whether and how to extend this scheme with an explicit physical
-field group (so that a stored identifier alone is sufficient to drive a
-vendor projection, rather than relying on configuration held elsewhere)
-is an open design question this document flags rather than settles.
+This tuple covers only the *logical* field group — it says nothing
+about source, convention, or any other physical field. The idealised
+target extends this logical scheme with an explicit physical field
+group, making a canonical identifier self-sufficient for projection
+into any external vendor's notation without relying on out-of-band
+configuration. How exactly to extend the logical tuple with physical
+fields is an open design question this document flags rather than
+settles; see [[id:C3E053CA-0D4B-480B-9119-E11530160EC1][oresmd:
+ORE Studio Market Data URI]] for one concrete proposal in that
+direction.
 
-*** OpenGamma Strata's scheme
+*** Convergence across independently-designed schemes
 
-OpenGamma Strata's identifier abstraction,
-=com.opengamma.strata.data.MarketDataId<T>=, is deliberately more
-minimal than the tuple above — an interface, not a concrete tuple of
-fields, whose Javadoc describes it as "an identifier for a unique item
-of market data... Implementations can identify any piece of market data.
-This includes observable values, such as the quoted market value of a
-security, and derived values, such as a volatility surface or a
-discounting curve." Strata pushes the actual field structure down into
-each concrete implementing class (there is no single canonical field
-list at the interface level, by design — the interface's only contract
-is uniqueness and a declared value type =T=), whereas this repository's
-scheme commits to a shared field shape at the base level. Both are
-defensible engineering positions, not a case of one being more correct
-than the other — Strata optimises for extensibility across an
-open-ended set of data kinds a third-party library cannot anticipate in
-advance; this repository optimises for a smaller, closed, well-understood
-set of curve/surface families where a shared field shape (currency,
-curve family, tenor) genuinely does hold across almost every case. Like
-this repository's own scheme, Strata's =MarketDataId= is also silent on
-physical fields — an implementing class is free to carry a source or a
-convention, but nothing at the interface level requires or names one.
-
-These two schemes — independently engineered, and agreeing on the same
-underlying logical shape (an asset-class/type discriminator, a
-qualifying instance within it, and optionally a further coordinate for a
-single point) — are the strongest evidence available that this shape is
-close to the irreducible shape of the *logical* side of the concept, not
-an accident of either system's design history. Neither, on its own,
-says anything about how the physical field group ought to be shaped;
-that question is addressed separately, below.
+That the ORE canonical key and OpenGamma Strata's
+=com.opengamma.strata.data.MarketDataId<T>= — two independently
+engineered systems — arrive at the same underlying logical shape (an
+asset-class/type discriminator, a qualifying instance within it, and
+optionally a further single-point coordinate) is the strongest
+available evidence that this shape reflects the concept's irreducible
+form rather than either system's design history. Both are also silent
+on physical fields at their respective base levels — a convergence in
+what they deliberately omit, not just in what they include. The
+[[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][comparative analysis of
+external market data identifier schemes]] covers OpenGamma Strata
+alongside RIC, Bloomberg, ORE, MDDL, and FIX in full detail. Neither
+scheme, on its own, says anything about how the physical field group
+ought to be shaped; that question is addressed separately, below.
 
 ** Vendor projection: from identifier to external notation
 
@@ -194,57 +204,16 @@ deciding, case by case and possibly vendor by vendor, what a given
 external key actually means in our own logical and physical terms. That
 problem is out of scope for this document.
 
-*** ORE's =CurveSpec=: a worked vendor-projection target
-
-ORE — the Open Source Risk Engine this system's own pricing model is
-built to interoperate with — has its own =CurveSpec= class hierarchy,
-documented in
-[[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]].
-The base class, in =OREData/ored/marketdata/curvespec.hpp=, carries a
-=curveConfigID= field common to every curve type, and each concrete
-subclass — =YieldCurveSpec=, =FXVolatilityCurveSpec=,
-=SwaptionVolatilityCurveSpec=, and so on — adds the type-specific fields
-that particular curve family needs to be uniquely addressed within ORE's
-own engine (a currency code for a yield curve; a currency pair for an FX
-volatility curve). =CurveSpec= additionally carries an explicit
-=CurveType= enumeration (=FX=, =Yield=, =CapFloorVolatility=, ...)
-discriminating which concrete subclass applies.
-
-=CurveSpec= is *ORE's* internal addressing scheme, built for ORE's own
-purposes — from this repository's point of view it is exactly the kind
-of target $T_{\text{ORE}}$ must produce, not a peer scheme our own
-identifier should be judged against. (An earlier version of this
-document treated =CurveSpec= as a third independently-converging
-logical scheme alongside this repository's own and Strata's; on
-reflection that conflated "a well-designed engine-internal addressing
-scheme" with "a vendor's own foreign notation" — =CurveSpec= is the
-latter, from our vantage point, however cleanly it is designed from
-ORE's own.) Whatever fields $T_{\text{ORE}}$ needs that this
-repository's own identifier doesn't yet carry as a physical field —
-=curveConfigID=-equivalent bookkeeping, ORE-specific curve-building
-hints — are exactly the gap the previous section flags as unresolved.
-
-One genuine terminological trap surfaces here, worth flagging explicitly
-rather than silently working around: the file-level documentation
-comment at the top of =curvespec.hpp= reads /"Curve requirements
-specification."/ ORE's own prose calls =CurveSpec= — which, on this
-document's reading, sits on the *identifier* side of the requirement/
-identifier distinction, and squarely on the *vendor* side of the
-identifier/vendor-key distinction — a "requirement." This is not a
-contradiction to resolve; it is a warning that "requirement" is not a
-safe, field-wide term with one settled meaning, and a reader moving
-between this document cluster and ORE's own source comments should not
-assume the word carries the same meaning in both places.
-
-Bloomberg tickers and Reuters RICs are further instances of the same
-kind of target — a vendor's own grammar, independently designed, that
-$T_{\text{vendor}}$ must be able to produce from a fully-specified
-identifier. Working out the concrete field-by-field mapping for those
-(and for ORE's =CurveSpec=) is the subject of this repository's separate
-[[id:DE8A3312-90B2-486C-B3EB-0B19C089CD93][survey of ORE, Bloomberg, and
-Reuters notations]]; this document only fixes the *shape* of the
-relationship — a one-directional projection into a foreign namespace —
-not any one vendor's specific grammar.
+Bloomberg tickers, Reuters RICs, and ORE's =CurveSpec= class hierarchy
+are all instances of the same kind of target — vendor's own grammars,
+independently designed, that $T_{\text{vendor}}$ must be able to produce
+from a fully-specified identifier. The
+[[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][comparative analysis of
+external market data identifier schemes]] covers ORE's =CurveSpec= in
+detail alongside RIC, Bloomberg, MDDL, FIX, and OpenGamma Strata; this
+document only fixes the *shape* of the relationship — a one-directional
+projection into a foreign namespace — not any one vendor's specific
+grammar.
 
 ** Why a requirement is permitted to be coarser than the identifier it's satisfied by
 
@@ -268,6 +237,6 @@ identifier" actually happens.
 - [[id:41200F4A-BAC1-4C7A-8998-2EDCC8C8787F][Market Data Requirement]] — the logical-only projection of an identifier.
 - [[id:842487B3-BEA2-4E74-8EA4-E1007FD559F3][Market Data Universe]] — the space of every valid identifier.
 - [[id:3F7F814B-E96F-4A62-99E2-76A3074AC832][Market Data Configuration]] — the resolution mechanism picking exactly one identifier for a requirement.
-- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data identifiers]] — RIC/Bloomberg/ORE/MDDL/FIX comparison, worked through above.
-- [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — a worked vendor-projection target, worked through above.
-- [[id:C3E053CA-0D4B-480B-9119-E11530160EC1][oresmd: ORE Studio Market Data URI]] — a proposed replacement for this document's own canonical key, generalising it with a structured tenor/curve-role/instrument-type grammar.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data identifiers]] — comparative analysis of RIC, Bloomberg, ORE canonical key, ORE CurveSpec, MDDL, FIX, and OpenGamma Strata; convergence evidence and vendor-projection targets covered in full.
+- [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — the authoritative per-type dimension inventory for ORE quote keys.
+- [[id:C3E053CA-0D4B-480B-9119-E11530160EC1][oresmd: ORE Studio Market Data URI]] — a proposed extension of the ORE-derived logical identifier with an explicit physical field group, structured tenor/curve-role/instrument-type grammar, and deterministic projection rules into every external vendor scheme.

--- a/doc/knowledge/domain/market_data_identifier.org
+++ b/doc/knowledge/domain/market_data_identifier.org
@@ -25,8 +25,8 @@ down. This document defines the identifier's two field groups, what
 makes two identifiers the same identifier, and — since an identifier is
 expected to carry enough information to be re-expressed in any external
 vendor's own notation (Bloomberg, Reuters, ORE, ...) — what "physical"
-actually has to include for that to be possible, worked through this
-repository's own concrete scheme.
+actually has to include for that to be possible, worked through the
+ORE-derived canonical form adopted as the logical starting point.
 
 * Layperson's mental model
 
@@ -185,7 +185,7 @@ ought to be shaped; that question is addressed separately, below.
 An identifier's physical fields exist for one purpose: so that a
 one-directional transform can render the identifier into a specific
 external vendor's own notation — a Bloomberg ticker, a Reuters RIC, an
-ORE quote key — without needing to invent information the identifier
+ORE =CurveSpec= — without needing to invent information the identifier
 itself doesn't carry. Call this transform, per vendor, $T_{\text{vendor}}$:
 
 $$T_{\text{vendor}}: \mathrm{Identifier} \to \mathrm{VendorKey}$$

--- a/doc/knowledge/domain/market_data_identifier.org
+++ b/doc/knowledge/domain/market_data_identifier.org
@@ -30,6 +30,19 @@ ORE-derived canonical form adopted as the logical starting point.
 
 * Layperson's mental model
 
+In the DNS analogy this cluster uses throughout, an identifier plays the
+role of the IP address — the physical, fully-specified reference that a
+network (or a database query, or a NATS subject) can actually act on,
+as opposed to the domain name (the requirement) that describes what is
+wanted without naming any particular physical answer. The one place the
+DNS analogy stops rather than being stretched is the vendor projection
+step: there is no DNS counterpart to "re-express this IP address in a
+second registrar's own notation," the way $T_{\text{vendor}}$ must
+re-express an identifier in Bloomberg's or Reuters' own grammar. The
+CIDR aside below covers that coarseness relationship — why a requirement
+is necessarily less specific than the identifier that satisfies it —
+more precisely than DNS can.
+
 Think of an identifier as a form with two sections. The top section —
 asset class, qualifier, curve role, and (where relevant) a specific
 tenor or surface point — is exactly what a requirement already

--- a/doc/knowledge/domain/market_data_requirements_resolution_hub.org
+++ b/doc/knowledge/domain/market_data_requirements_resolution_hub.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :knowledge:domain:marketdata:requirements:resolution:
 #+created: 2026-07-23
-#+updated: 2026-07-23
+#+updated: 2026-07-28
 
 This is the hub note for how a logical need for market data — a
 requirement — becomes a concrete, usable piece of data at valuation
@@ -45,6 +45,7 @@ a notation, for precision.
 
 ** Lens 1: analogy — the DNS mapping
 
+#+begin_note
 Every document below returns to the same worked analogy: the Domain
 Name System. A market data *requirement* plays the role of a *domain
 name* — a stable, human-legible description of what is wanted,
@@ -68,18 +69,19 @@ vendor projection, covered in
 DNS has no real analogue for it (an IP address doesn't need to be
 re-expressed in a second registrar's own addressing scheme the way a
 market data identifier needs to be re-expressed in Bloomberg's or
-Reuters' notation). *Dependency resolution* plays the role of a browser recursively
-fetching a page's stylesheets, fonts, and images before it can finish
-rendering. A *snapshot* plays the role of a cached DNS record with its
-own retention policy, kept around after the fact for a different purpose
-than the cache it superficially resembles. The analogy is chosen because
-DNS is a system almost every reader already understands intuitively, and
-because — as it happens — DNS has already had to solve, in a completely
-unrelated domain, nearly every structural problem this cluster is
-concerned with. Where the analogy breaks down (most notably for
-snapshotting, whose *purpose* differs meaningfully from DNS caching's),
-each document says so explicitly rather than stretching the comparison
-past where it still illuminates.
+Reuters' notation). *Dependency resolution* plays the role of a browser
+recursively fetching a page's stylesheets, fonts, and images before it
+can finish rendering. A *snapshot* plays the role of a cached DNS record
+with its own retention policy, kept around after the fact for a different
+purpose than the cache it superficially resembles. The analogy is chosen
+because DNS is a system almost every reader already understands
+intuitively, and because — as it happens — DNS has already had to solve,
+in a completely unrelated domain, nearly every structural problem this
+cluster is concerned with. Where the analogy breaks down (most notably
+for snapshotting, whose *purpose* differs meaningfully from DNS
+caching's), each document says so explicitly rather than stretching the
+comparison past where it still illuminates.
+#+end_note
 
 ** Lens 2: notation — sets, not containers
 

--- a/doc/knowledge/domain/market_data_requirements_resolution_hub.org
+++ b/doc/knowledge/domain/market_data_requirements_resolution_hub.org
@@ -37,18 +37,12 @@ assume without re-deriving.
 Each linked note is a single focused concept; start here and follow
 the links in whatever order matches the question you have.
 
-* Two lenses on this cluster
-
-Every document below can be read through either of two lenses, used
-together rather than as alternatives: an analogy, for intuition, and
-a notation, for precision.
-
-** Lens 1: analogy — the DNS mapping
+** Aside, for readers who know DNS
 
 #+begin_note
-Every document below returns to the same worked analogy: the Domain
-Name System. A market data *requirement* plays the role of a *domain
-name* — a stable, human-legible description of what is wanted,
+Every document in this cluster returns to the same worked analogy: the
+Domain Name System. A market data *requirement* plays the role of a
+*domain name* — a stable, human-legible description of what is wanted,
 independent of any specific physical answer. A market data *identifier*
 plays the role of the *IP address* a domain name resolves to — the only
 kind of reference a network (or a database query, or a NATS subject) can
@@ -80,37 +74,38 @@ in a completely unrelated domain, nearly every structural problem this
 cluster is concerned with. Where the analogy breaks down (most notably
 for snapshotting, whose *purpose* differs meaningfully from DNS
 caching's), each document says so explicitly rather than stretching the
-comparison past where it still illuminates.
+comparison past where it still illuminates. Skip this aside entirely if
+DNS isn't already familiar; nothing in the individual documents depends
+on it.
 #+end_note
 
-** Lens 2: notation — sets, not containers
+* Set notation
 
-This cluster deliberately describes its concepts using ordinary
-mathematical set notation and set operations — union, intersection,
-subset, closure — rather than container-like, configuration-like prose.
-Several candidate terms were weighed for the collection of quotes a
-valuation actually resolves against. "Environment" was rejected: it
-connotes something ambient and configured once per run (closer to a
-deployment's env vars than to a value that varies per trade, per
-valuation date, and per pricing engine), and it invites confusion with
-unrelated senses of "environment" already in use elsewhere (runtime,
-test, deployment). "ORE's today's market" and similar ORE-flavoured
-names were also considered and rejected: they tie the concept to one
-engine's terminology and don't generalise to Bloomberg- or
-Reuters-sourced data, nor to the static/dynamic split this cluster
-relies on. "Set" was chosen because the concept genuinely is a set —
-closed under union, intersection, and closure, with subset and
-membership tests that matter operationally (does this valuation's
-requirement set fall inside the market data universe?) — so the
-mathematical vocabulary is not a metaphor layered on top but a precise
-description of how these objects behave; see
-[[id:842487B3-BEA2-4E74-8EA4-E1007FD559F3][Market Data Universe]] for
-the fuller comparison. The payoff of this framing is that most of the relationships
-between these concepts collapse from paragraphs of prose into a single
-line of notation, checkable the way an algebraic identity is checkable,
-rather than merely plausible the way a prose description is merely
-plausible. The central relationship every other document in this
-cluster either builds toward or assumes is:
+This cluster describes its concepts using ordinary mathematical set
+notation and set operations — union, intersection, subset, closure —
+rather than container-like, configuration-like prose. Several candidate
+terms were weighed for the collection of quotes a valuation actually
+resolves against. "Environment" was rejected: it connotes something
+ambient and configured once per run (closer to a deployment's env vars
+than to a value that varies per trade, per valuation date, and per
+pricing engine), and it invites confusion with unrelated senses of
+"environment" already in use elsewhere (runtime, test, deployment).
+"ORE's today's market" and similar ORE-flavoured names were also
+considered and rejected: they tie the concept to one engine's
+terminology and don't generalise to Bloomberg- or Reuters-sourced data,
+nor to the static/dynamic split this cluster relies on. "Set" was chosen
+because the concept genuinely is a set — closed under union,
+intersection, and closure, with subset and membership tests that matter
+operationally (does this valuation's requirement set fall inside the
+market data universe?) — so the mathematical vocabulary is not a
+metaphor layered on top but a precise description of how these objects
+behave; see [[id:842487B3-BEA2-4E74-8EA4-E1007FD559F3][Market Data
+Universe]] for the fuller comparison. The payoff of this framing is that
+most of the relationships between these concepts collapse from paragraphs
+of prose into a single line of notation, checkable the way an algebraic
+identity is checkable, rather than merely plausible the way a prose
+description is merely plausible. The central relationship every other
+document in this cluster either builds toward or assumes is:
 
 $$\mathrm{MDS}(T) \;=\; \mathrm{closure}\bigl(\rho(\,\mathrm{static}(\tau(T)) \,\cup\, \mathrm{dynamic}(T, d)\,)\bigr) \,\cap\, U$$
 
@@ -126,10 +121,10 @@ steps into one symbol for the population-level formula, since the
 formula only needs the final, most-refined set. The union of
 $\mathrm{static}(\tau(T))$ and $\mathrm{dynamic}(T, d)$ is *resolved*
 ($\rho$) into physical identifiers, one per requirement; the result is
-expanded to its full *dependency closure*;
-and intersecting that closure with the *market data universe* $U$
-produces $\mathrm{MDS}(T)$ — the concrete market data set the valuation
-of $T$ actually needs, and the only part of $U$ it ever touches.
+expanded to its full *dependency closure*; and intersecting that closure
+with the *market data universe* $U$ produces $\mathrm{MDS}(T)$ — the
+concrete market data set the valuation of $T$ actually needs, and the
+only part of $U$ it ever touches.
 [[id:842487B3-BEA2-4E74-8EA4-E1007FD559F3][Market Data Universe]] walks
 through this formula in full, with a worked FX Forward example; every
 symbol in it is defined, in depth, by exactly one of the linked

--- a/doc/knowledge/domain/market_data_requirements_resolution_hub.org
+++ b/doc/knowledge/domain/market_data_requirements_resolution_hub.org
@@ -192,7 +192,7 @@ guess as settled prior art.
 * See also
 
 - [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][Open Source Risk Engine (ORE)]] — one of this cluster's two reference systems.
-- [[id:3D56DB59-8075-42BB-8139-A7440C9786B2][Market Data Identifier]] — this repository's own concrete (logical-field) identifier scheme.
-- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data identifiers]] — RIC, Bloomberg, and ORE quote key compared as external vendor schemes.
+- [[id:3D56DB59-8075-42BB-8139-A7440C9786B2][Market Data Identifier]] — the ORE-derived logical/physical two-field-group identifier and its one-directional vendor projection.
+- [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data identifiers]] — comparative analysis of six vendor schemes: RIC, Bloomberg ticker, ORE canonical key (with CurveSpec), MDDL, FIX, and OpenGamma Strata.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — ORE's own concrete quote-key scheme, worked through in the same document as a vendor-projection target, not a peer identifier scheme.
 - [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]] — an adjacent, distinct concept (how a resolved value is priced, not how it is resolved), explicitly disambiguated in [[id:3F7F814B-E96F-4A62-99E2-76A3074AC832][Market Data Configuration]].


### PR DESCRIPTION
## Summary

Reorganized and expanded the market data identifier documentation cluster to improve clarity, add missing content, and correct conceptual framing. The changes consolidate related material, introduce OpenGamma Strata as a sixth comparative scheme, and refactor the hub document's introductory structure.

## Key Changes

- **market_data_identifier.org**: 
  - Expanded "Layperson's mental model" section with detailed DNS analogy explaining the requirement/identifier/vendor-projection relationship
  - Added aspirational note on tenor-pinned requirements as a future refinement
  - Renamed "This repository's own scheme" to "The ORE-derived logical identifier scheme" to clarify that the canonical form is ORE-derived, not original
  - Consolidated vendor-projection discussion, removing the lengthy ORE CurveSpec subsection and replacing it with a brief cross-reference
  - Restructured the convergence section to emphasize that ORE canonical key and OpenGamma Strata independently arrived at the same logical shape
  - Updated reference descriptions to be more precise about what each linked document covers

- **external_market_data_identifiers.org**:
  - Added OpenGamma Strata's `MarketDataId<T>` as a sixth scheme (previously only five were covered)
  - Expanded ORE section with new subsection on `CurveSpec` class hierarchy, clarifying it as an internal representation and vendor-projection target rather than a peer identifier scheme
  - Updated all comparative language to reference "six schemes" instead of "five"
  - Clarified that Strata is a type abstraction with no canonical serialized form, not a short-string scheme
  - Added explicit note about the "requirement" terminology trap in ORE's source comments

- **market_data_requirements_resolution_hub.org**:
  - Restructured introductory sections: moved DNS analogy into an optional "Aside, for readers who know DNS" note block
  - Renamed "Lens 2" section to "Set notation" and reorganized for clarity
  - Simplified language to make the hub more accessible as an entry point
  - Clarified that DNS analogy is optional background, not required reading

## Notable Implementation Details

- The ORE canonical key is now explicitly positioned as the "logical starting point" adopted from ORE, not an original contribution
- `CurveSpec` is now clearly distinguished as a vendor-projection *target* (what `T_ORE` must produce) rather than a peer identifier scheme
- The DNS analogy is now presented as optional context for readers already familiar with DNS, reducing cognitive load for those who aren't
- All cross-references updated to reflect the new document organization and expanded scheme coverage

https://claude.ai/code/session_01Cy4rrFn53NwPGzjYmDDdvT