### PR TITLE
[compass,agile] Narrow BASE_PORT_STEP to 200; close btrfs migration story

### DIFF
--- a/doc/agile/versions/v0/sprint_24/migrate-ccache-to-btrfs-reflink/story.org
+++ b/doc/agile/versions/v0/sprint_24/migrate-ccache-to-btrfs-reflink/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :devops:infrastructure:sprint_24:v0:
 #+created: 2026-07-28
-#+updated: 2026-07-28
+#+updated: 2026-07-29
 #+environment:
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
@@ -746,8 +746,27 @@ from Step 4 through =initdb= to live database files.
 Then, per worktree, the normal idempotent path:
 
 #+begin_src sh
-./projects/ores.compass/compass.sh db recreate -y -k
+./projects/ores.compass/compass.sh db recreate -y
 #+end_src
+
+*Gotcha (hit 2026-07-29):* after the ccache-default fix merged, =db
+recreate= failed on all seven remaining worktrees with =ERROR: .env is
+out of date=. Their =.env= files were written by the *pre-merge*
+=env_init.py= (version 12/14) while main now requires *15*. This is the
+migration note on PR #1727, and it applies to any checkout that predates
+a version bump:
+
+#+begin_src sh
+# Re-run configure FIRST; db recreate refuses to touch a stale .env.
+./projects/ores.compass/compass.sh env configure --preset linux-clang-debug-make -y
+#+end_src
+
+After that all seven wrote =ORES_ENV_VERSION=15=, preserved
+=ORES_COMPILER_CACHE=ccache= from their existing =.env= (no flag needed),
+and dropped the stale =SCCACHE_*= lines -- confirming the fix propagates
+correctly through merge and rebase. All nine databases then recreated in
+~1 minute each, 159 MB apiece, with
+=/mnt/development/postgres/18/main= still reporting =---------------C------=.
 
 Then build. Build *one* worktree to completion first to populate the
 ccache from cold, then the rest -- this maximises reflink sharing and
@@ -871,7 +890,35 @@ run as *root* -- unprivileged it prints nothing rather than failing.
 Exclude =/mnt/development/postgres= from any future dedup pass if one is
 scripted: deduplicating a NOCOW database file reintroduces shared
 extents, which silently converts writes back into copy-on-write and
-undoes Step 4.
+undoes Step 4. The run below was scoped to =OreStudio= and =Moimba=
+explicitly for this reason.
+
+**** Result (2026-07-29, all nine worktrees built)
+
+| | Used | Free |
+|-+------+------|
+| Before | 31G | 185G |
+| *After* | *14G* | *201G* |
+
+*17G reclaimed*, ~26 minutes over 237,250 files / 60.5GB.
+
+*The prediction in this story was wrong, and instructively so.* It named
+the nine near-identical =vcpkg_installed= trees as the prime target,
+estimating ~11G recoverable from pre-migration =du= figures. Measured on
+btrfs each vcpkg checkout costs *12M physical* (30M logical) -- ~108M for
+all nine. Compression had already absorbed that saving entirely.
+
+The 17G came from somewhere the plan never considered: *linked shared
+libraries*. Nine worktrees each link byte-identical =libores.*.so=
+binaries -- hundreds of MB apiece -- from identical object files, at nine
+separate paths. ccache cannot help there: *it caches compilation, not
+linking*. Reflinks cannot either, because nothing clones a linker's
+output. Dedup is the only mechanism that reaches it, which makes Step 7
+considerably more valuable than "mopping up" as originally framed.
+
+Integrity spot-checked afterwards: =ores.qt= intact at 38,111,376 bytes
+and executing (it reaches Qt platform-plugin init and fails only on
+=could not connect to display=, correct for a headless shell).
 
 *** 8. Verify
 
@@ -991,6 +1038,71 @@ genuinely uncompressed -- =file_clone= forces ccache's own compression
 off -- so on XFS they would occupy the full 6.6G. btrfs stores them in
 1.3G. That gap *is* the migration's justification.
 
+*** 8c. Final state (2026-07-29)
+
+Fleet rebuilt after merging the ccache-default fix and rebasing every
+worktree onto main. All nine: *exit 0, zero errors*.
+
+| Worktree | Time | ccache hit rate |
+|----------+------+-----------------|
+| =merry_newton= | incremental | 5 objects |
+| =solid_dirac= | 4m | 99.87% |
+| =eager_maxwell= | 4m | 99.87% |
+| =bright_faraday= | 4m | 99.71% |
+| =prime_origin= | 2m | 99.85% (incremental, 661 objects) |
+| =swift_curie= | 4m | 99.71% |
+| =brave_hopper= | 4m | 99.62% |
+| =jolly_knuth= | 4m | 99.83% |
+| =clever_dijkstra= | 4m | 99.83% |
+
+*Eight full rebuilds at 99.6-99.9% in ~4 minutes each, against ~40
+minutes cold.* The whole fleet rebuilt in about the time one cold build
+takes. Note the contrast with the 72.5% measured earlier across
+*divergent* branches: once every worktree shares a common main base,
+reuse is essentially total.
+
+Builds were run strictly *one at a time*. Concurrent builds contend on
+the vcpkg lock -- the failure mode that stalled Step 6 -- and serial runs
+keep per-worktree hit rates interpretable.
+
+**** Space, end to end
+
+| Measure | Value |
+|---------+-------|
+| Referenced (what nine worktrees see) | *146G* |
+| Unique uncompressed | 34G |
+| *Actually on disk* | *13G* |
+| Marginal cost of one more built worktree | ~4G physical (14G logical) |
+
+Nine *fully built* worktrees, a 9.6G ccache, Corimba and PostgreSQL
+occupy *16G of 216G* (14G before the databases). The old partition held
+nine *partially* built worktrees plus the cache at *173G, 83% full*.
+
+Three mechanisms stack, in this order of contribution: reflinks reduce
+146G of references to 34G unique; zstd takes that to 13G; dedup collapses
+the linker output neither can reach.
+
+**** How many worktrees can this now support?
+
+Disk has stopped being the constraint -- 201G free at ~4G marginal cost
+is ~40 more. *The binding limit is port allocation: 13.*
+
+: BASE_PORT_START = 20000, BASE_PORT_STEP = 1000, top offset +6
+: EPHEMERAL_PORT_FLOOR = 32768   (kernel range here: 32768-60999)
+
+Bases must stay below the ephemeral floor, giving 20000..32000 = *13
+slots*. Nine are held (20000-28000); *four remain* (29000-32000).
+
+Raising it is not a one-constant change -- version 11 moved
+=BASE_PORT_START= off 50000 precisely to stop fixed listeners colliding
+with kernel-assigned ephemeral source ports. The clean lever is
+=BASE_PORT_STEP=: only 7 offsets are used, so 1000 is generous and 100
+would give ~127 slots.
+
+Secondary limits arrive only if services *run* in many worktrees at once,
+not from building: 31G RAM against ~17 services per worktree, and
+PostgreSQL =max_connections= (800, restored in Step 6).
+
 *** 9. Ongoing maintenance
 
 Not required for acceptance, but this is what btrfs costs versus XFS
@@ -1008,11 +1120,11 @@ and it should be written down rather than rediscovered:
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | DONE                                   |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | Steps 0-6 and 8 DONE. btrfs live; fleet re-cloned; PostgreSQL recreated; two worktrees built clean; caching fully validated (see 8b). |
-| Waiting on    | PR review for the ccache-default fix.   |
-| Next          | Merge the PR, rebase the other worktrees, build the remaining seven, then 6b (Corimba) and 7 (duperemove). |
+| Now           | *All steps DONE.* btrfs live; fleet re-cloned and rebuilt (9/9 clean); Corimba recreated; PostgreSQL and all nine databases recreated; caching validated; dedup run. PR #1727 merged. |
+| Waiting on    | Nothing.                                |
+| Next          | Close the story. Follow-ups: header-comment drift from PR #1727 review finding 3; rotate the postgres superuser password. |
 | Last touched  | 2026-07-28                               |
 
 * Acceptance

--- a/projects/ores.compass/src/env_init.py
+++ b/projects/ores.compass/src/env_init.py
@@ -101,7 +101,20 @@ def _read_env(env_file: Path) -> dict:
 # that range; existing environments keep their old ports via ORES_BASE_PORT
 # in .env until migrated by hand.
 BASE_PORT_START = 20000
-BASE_PORT_STEP = 1000
+# 200, not 1000. Only 7 offsets are actually used (0..6, see below), so a
+# 1000-wide slot spent 993 ports per environment on nothing and capped the
+# machine at 13 environments between BASE_PORT_START and
+# EPHEMERAL_PORT_FLOOR -- a real ceiling once the btrfs migration (story
+# 03831B51) dropped the disk cost of a built worktree to ~4G and made disk
+# stop being the limiting factor. 200 still leaves ~28x headroom over the 7
+# ports an environment claims, so a new offset can be added without
+# revisiting this, and yields 64 slots.
+#
+# Existing environments are unaffected: they keep their allocated base via
+# ORES_BASE_PORT in .env, and _scan_ports only picks a step-aligned base for
+# *new* ones. Bases already handed out on the old 1000 spacing (20000, 21000,
+# ...) simply remain claimed; the next allocation fills 20200.
+BASE_PORT_STEP = 200
 # Conservative floor for the kernel's ephemeral port range: the default is
 # usually 32768 (see /proc/sys/net/ipv4/ip_local_port_range), but some
 # systems start lower, so _scan_ports refuses to hand out a base_port whose


### PR DESCRIPTION
Follow-on to #1727, which migrated `/mnt/development` to btrfs.

## `BASE_PORT_STEP` 1000 → 200

An environment claims **7 ports** (offsets 0..6), so a 1000-wide slot spent 993
per environment on nothing and capped the machine at **13 environments** between
`BASE_PORT_START` (20000) and `EPHEMERAL_PORT_FLOOR` (32768).

That ceiling only started to bind now. Before the migration a built worktree cost
~17G and **disk** was the constraint; it now costs ~4G physical, so nine fully
built worktrees plus ccache, Corimba and PostgreSQL occupy **16G of 216G**. Disk
stopped being the limit and port allocation became it.

| | Before | After |
|---|---|---|
| Slots (20000 → 32768) | 13 | **64** |
| Free | 4 | **55** |
| Spare ports per environment | 993 | 193 |

`BASE_PORT_START` and `EPHEMERAL_PORT_FLOOR` are deliberately untouched: version 11
moved the range off 50000 precisely so fixed listeners could not collide with
kernel-assigned ephemeral source ports, and that reasoning still holds. 200 still
leaves 193 spare ports per environment, so a new offset can be added later without
revisiting this.

**No `.env` format change, so no version bump.** Existing environments keep their
allocated base via `ORES_BASE_PORT`, and `_scan_ports` only picks a step-aligned
base for *new* ones. Verified by re-running `env configure` across the fleet — all
nine kept their bases (20000..28000); the next allocation is 20200.

## Story closure

Records the migration's outcome. Two findings worth carrying forward:

**The dedup prediction was wrong.** The plan named nine near-identical `vcpkg`
trees as the prime target, estimating ~11G from pre-migration `du` figures. On
btrfs each costs **12M physical** — compression had already taken that saving. The
**17G** `duperemove` actually reclaimed came from **linked shared libraries**: nine
byte-identical `libores.*.so` binaries at nine paths. ccache caches compilation,
not linking, and nothing clones a linker's output, so dedup is the only mechanism
that reaches them.

**The version-15 bump bit us.** `db recreate` failed on all seven remaining
worktrees with `.env is out of date` — they predated the bump #1727 introduced.
Re-running `env configure` first fixed it, and confirmed the ccache default
propagates correctly through merge and rebase.

## Final state

| Measure | Value |
|---|---|
| Worktrees built | 9/9, exit 0, zero errors |
| ccache hit rate on rebuild | 99.6–99.9%, ~4 min each (vs ~40 cold) |
| Referenced → unique → on disk | 146G → 34G → **13G** |
| Total footprint | **16G of 216G** (was 173G at 83%) |

> [!NOTE]
> No re-run of `compass env configure` is required for this change. Existing
> environments are unaffected; only newly created ones use the tighter spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)