### PR TITLE
[compass] Name compass claude's systemd scope after the environment identity

### DIFF
--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:devx:sprint_24:v0:
 #+created: 2026-07-29
 #+updated: 2026-07-29
-#+environment:
+#+environment: brave_hopper
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -41,6 +41,7 @@ developer-experience work.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:8780F2D4-E135-448B-995C-8C36302B74E4][Add compass claude, a systemd-scoped Claude Code launcher]] | DONE | 2026-07-29 | 2026-07-29 | New compass claude subcommand launches Claude Code as a transient systemd --user scope under a checked-in app-claude.slice, so systemd-oomd can kill a runaway session without taking its parent (e.g. Emacs) down with it. Deploys the slice unit on first use, no separate machine bootstrap needed. |
+| [[id:9D32A18D-C05C-4189-867B-A26A0CDEF719][Name compass claude's systemd scope after the environment identity]] | STARTED | 2026-07-29 | | compass claude currently names its transient systemd scope/unit claude-<pid>, so systemd-cgtop/systemctl --user status can't tell which worktree a Claude session belongs to. Include ORES_ENV_NAME (falling back to the checkout dir name) in the unit name, e.g. claude-<env>-<pid>. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
@@ -26,7 +26,7 @@ developer-experience work.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | First task done; PR pending.           |
+| Now           | Both current tasks DONE; second PR pending. |
 | Waiting on    | Nothing.                               |
 | Next          | Raise the PR; add further tasks as they come up. |
 | Last touched  | 2026-07-29                               |
@@ -41,7 +41,7 @@ developer-experience work.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:8780F2D4-E135-448B-995C-8C36302B74E4][Add compass claude, a systemd-scoped Claude Code launcher]] | DONE | 2026-07-29 | 2026-07-29 | New compass claude subcommand launches Claude Code as a transient systemd --user scope under a checked-in app-claude.slice, so systemd-oomd can kill a runaway session without taking its parent (e.g. Emacs) down with it. Deploys the slice unit on first use, no separate machine bootstrap needed. |
-| [[id:9D32A18D-C05C-4189-867B-A26A0CDEF719][Name compass claude's systemd scope after the environment identity]] | STARTED | 2026-07-29 | | compass claude currently names its transient systemd scope/unit claude-<pid>, so systemd-cgtop/systemctl --user status can't tell which worktree a Claude session belongs to. Include ORES_ENV_NAME (falling back to the checkout dir name) in the unit name, e.g. claude-<env>-<pid>. |
+| [[id:9D32A18D-C05C-4189-867B-A26A0CDEF719][Name compass claude's systemd scope after the environment identity]] | DONE | 2026-07-29 | 2026-07-29 | compass claude currently names its transient systemd scope/unit claude-<pid>, so systemd-cgtop/systemctl --user status can't tell which worktree a Claude session belongs to. Include ORES_ENV_NAME (falling back to the checkout dir name) in the unit name, e.g. claude-<env>-<pid>. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
@@ -35,11 +35,11 @@ e.g. =claude-brave_hopper-<pid>=, and in the scope's =--description=.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F64924CE-8D35-437A-B275-617558DC5FBE][Compass quality-of-life improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-29                               |
 
 * Acceptance
@@ -55,9 +55,11 @@ e.g. =claude-brave_hopper-<pid>=, and in the scope's =--description=.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Added =_env_name(project_root)= to =compass_claude.py=: reads
+=ORES_ENV_NAME= from the checkout's =.env=, falls back to the checkout
+directory's own name, then sanitises to =[A-Za-z0-9_.-]= (systemd unit
+name charset). Threaded the result into both =--unit= and
+=--description= of the =systemd-run= invocation in =run()=.
 
 * Notes
 
@@ -85,3 +87,13 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+`compass claude`'s systemd scope/unit is now named
+=claude-<env>-<pid>= (e.g. =claude-brave_hopper-<pid>=) instead of
+=claude-<pid>=, with the environment identity also carried in the
+=--description=. Environment identity resolves from =ORES_ENV_NAME=
+in =.env=, falling back to the checkout directory name, sanitised to
+the characters systemd unit names allow. Verified with unit tests
+against =_env_name()= (real =.env=, missing =project_root=, missing
+=.env= file) and =python3 -m py_compile= for a clean compile. All
+acceptance criteria met; no change to the plain =claude= binary path.

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
@@ -8,7 +8,7 @@
 #+filetags: :compass-quality-of-life-improvements:sprint_24:v0:
 #+owner: marco
 #+branch: feature/scope-name-by-environment
-#+pr:
+#+pr: 1731
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-29
@@ -78,7 +78,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1731][#1731]] | [compass] Name compass claude's systemd scope after the environment identity |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.org
@@ -1,0 +1,87 @@
+:PROPERTIES:
+:ID: 9D32A18D-C05C-4189-867B-A26A0CDEF719
+:END:
+#+title: Task: Name compass claude's systemd scope after the environment identity
+#+description: compass claude currently names its transient systemd scope/unit claude-<pid>, so systemd-cgtop/systemctl --user status can't tell which worktree a Claude session belongs to. Include ORES_ENV_NAME (falling back to the checkout dir name) in the unit name, e.g. claude-<env>-<pid>.
+#+type: task
+#+level: s1
+#+filetags: :compass-quality-of-life-improvements:sprint_24:v0:
+#+owner: marco
+#+branch: feature/scope-name-by-environment
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-29
+#+updated: 2026-07-29
+#+environment: brave_hopper
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F64924CE-8D35-437A-B275-617558DC5FBE][Compass quality-of-life improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+`compass claude` launches Claude Code in a transient systemd --user scope
+named =claude-<pid>=, under =app-claude.slice=. This isolates it from
+=emacs.service= for oomd purposes, but every scope looks identical in
+=systemd-cgtop --user= / =systemctl --user status= — there is no way to
+tell which worktree/environment a given Claude session belongs to short
+of cross-referencing PIDs.
+
+Include the environment identity (=ORES_ENV_NAME= from the checkout's
+=.env=, falling back to the checkout directory name) in the unit name,
+e.g. =claude-brave_hopper-<pid>=, and in the scope's =--description=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:F64924CE-8D35-437A-B275-617558DC5FBE][Compass quality-of-life improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-07-29                               |
+
+* Acceptance
+
+- The scope/unit name includes the environment identity (=ORES_ENV_NAME=,
+  falling back to the checkout directory name), sanitised to the
+  characters systemd unit names allow.
+- The =--description= passed to =systemd-run= also carries the
+  environment identity alongside the pid.
+- Falls back sanely when =project_root= or =.env= is unavailable.
+- No change in behaviour for anyone invoking the plain =claude= binary
+  directly (this only affects the =compass claude= launcher).
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.compass/src/compass_claude.py
+++ b/projects/ores.compass/src/compass_claude.py
@@ -28,6 +28,7 @@ Inspect live accounting with: systemd-cgtop --user
 
 import filecmp
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -45,11 +46,12 @@ def run(argv, project_root=None) -> int:
 
     if _has_user_systemd():
         _ensure_slice_deployed()
+        env_name = _env_name(project_root)
         cmd = [
             "systemd-run", "--user", "--scope", "-q", "--collect",
-            f"--unit=claude-{os.getpid()}",
+            f"--unit=claude-{env_name}-{os.getpid()}",
             f"--slice={_SLICE_NAME}",
-            f"--description=Claude Code session (pid {os.getpid()})",
+            f"--description=Claude Code session ({env_name}, pid {os.getpid()})",
             real, *argv,
         ]
         os.execvp(cmd[0], cmd)
@@ -57,6 +59,29 @@ def run(argv, project_root=None) -> int:
     print("compass claude: no user systemd manager; running unscoped",
           flush=True)
     os.execvp(real, [real, *argv])
+
+
+def _env_name(project_root) -> str:
+    """Resolve the environment's identity for use in a systemd unit name.
+
+    Reads ORES_ENV_NAME from the checkout's .env, falling back to the
+    checkout directory's own name, then sanitises it to the characters
+    systemd unit names allow.
+    """
+    name = None
+    if project_root is not None:
+        env_file = Path(project_root) / ".env"
+        if env_file.is_file():
+            for line in env_file.read_text(encoding="utf-8").splitlines():
+                if line.lstrip().startswith("ORES_ENV_NAME="):
+                    name = line.partition("=")[2].strip().strip("'\"")
+                    break
+        if not name:
+            name = Path(project_root).name
+
+    name = name or "unknown"
+    name = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+    return name or "unknown"
 
 
 def _has_user_systemd() -> bool:


### PR DESCRIPTION
## Summary

compass claude named its transient systemd scope claude-PID, so systemd-cgtop --user / systemctl --user status couldn't tell which worktree a Claude session belonged to without cross-referencing PIDs.

## Changes

- Resolve environment identity from ORES_ENV_NAME in .env, falling back to the checkout directory name, sanitised to the characters systemd unit names allow
- Thread the resolved name into both --unit and --description of the systemd-run invocation, e.g. claude-brave_hopper-PID
- No change in behaviour for anyone invoking the plain claude binary directly
- Verification: unit tests against _env_name() (real .env, missing project_root, missing .env file); python3 -m py_compile clean

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality-of-life improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.html) | F64924CE-8D35-437A-B275-617558DC5FBE |
| Task | [Name compass claude's systemd scope after the environment identity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_scope-name-by-environment.html) | 9D32A18D-C05C-4189-867B-A26A0CDEF719 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)