### PR TITLE
[ores.nats] Build wire_codec abstraction and startup config

### DIFF
--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
@@ -83,7 +83,7 @@ task.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:AC1B96D9-D86C-4BBB-94A4-E187469A0A8F][Write up the wire-format architecture analysis and design decision]] | DONE | 2026-07-28 | 2026-07-28 | Document the current blast-radius audit (every NATS-relevant rfl::json call site across ores.service, ores.qt, ores.shell, plus confirming ores.cli is out of scope), the chosen architecture (a single non-polymorphic wire_codec constructed once at startup from .env, threaded via dependency injection, no per-message negotiation), and the rationale versus the rejected per-message header-negotiation alternative. This becomes the spec the later implementation tasks execute against. |
-| [[id:D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA][Build wire_codec abstraction and startup config in ores.nats]] | BACKLOG | | | Add a wire_format enum (json, msgpack), a .env-driven config value read once at startup, and a wire_codec class holding the chosen format at construction with template encode/decode methods dispatching to rfl::json or rfl::msgpack. Non-polymorphic, no per-message branching on message content -- the format is fixed for the codec instance's lifetime. Round-trip unit tests for both formats. This is the shared foundation every other task in this story depends on. |
+| [[id:D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA][Build wire_codec abstraction and startup config in ores.nats]] | DONE | 2026-07-29 | 2026-07-29 | Add a wire_format enum (json, msgpack), a .env-driven config value read once at startup, and a wire_codec class holding the chosen format at construction with template encode/decode methods dispatching to rfl::json or rfl::msgpack. Non-polymorphic, no per-message branching on message content -- the format is fixed for the codec instance's lifetime. Round-trip unit tests for both formats. This is the shared foundation every other task in this story depends on. |
 | [[id:7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA][Migrate ores.service messaging handler_helpers to wire_codec]] | BACKLOG | | | Update reply() and decode() in ores.service/messaging/handler_helpers.hpp to route through an injected wire_codec instead of a hard-coded rfl::json call. This is the server-side choke point almost every service handler already goes through, so this single change flips every service's request/response handling in one pass. Audit for any service-to-service NATS calls that bypass these two helpers and migrate or document them separately. |
 | [[id:12674934-6F8E-40C9-A8D7-ED29B0ADF322][Consolidate and migrate ores.qt ClientManager to wire_codec]] | BACKLOG | | | ClientManager.hpp/.cpp plus ClientManagerExportPortfolio.cpp and ClientManagerTradeInstrument.cpp currently have around ten separate call sites hard-coding rfl::json (process_authenticated_request variants, send_authenticated_request variants, login, signup, event-cache decode, exportPortfolio, trade_instrument). Consolidate these into one or two shared private helpers first, reducing duplication as a side effect, then have those route through an injected wire_codec instead of rfl::json directly. |
 | [[id:926379AF-B17C-4700-AF89-6AD1EB006281][Consolidate and migrate ores.shell request helpers to wire_codec]] | BACKLOG | | | The do_request/do_auth_request template helper is copy-pasted independently into thirteen shell command .cpp files (18 definitions, 60 call sites), plus 7 more files using other direct rfl::json patterns (101 occurrences across 22 files total). De-duplicate into one shared helper in a shell-wide header first -- a real cleanup win independent of the format work -- then have that single helper route through an injected wire_codec instead of rfl::json directly. |
@@ -107,6 +107,20 @@ surface. Full blast-radius audit (6 call sites in =ores.service=, ~10
 plus stragglers in =ores.qt=, 101 across 22 files in =ores.shell=;
 =ores.cli= confirmed out of scope) and the =wire_codec= type's shape
 are recorded in that task's =* Plan=.
+
+** Config: ORES_NATS_WIRE_FORMAT, default json, fail-fast on unrecognised value
+
+Decided in the [[id:D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA][wire_codec build task]]. The =--nats-wire-format=
+option (env =ORES_NATS_WIRE_FORMAT=, same per-service prefix
+convention as the existing =nats-tls-*= options) defaults to =json=,
+preserving today's behaviour for any process that doesn't set it. An
+unrecognised value throws =std::invalid_argument= at startup rather
+than silently falling back -- misconfiguration is a fail-fast error,
+not a silent default. =ores.nats.lib= links =reflectcpp::reflectcpp=
+publicly (previously only transitively/privately via
+=ores.utility.lib=) since =wire_codec.hpp= is a public, header-only
+template type every consumer needs =rfl/json.hpp=/=rfl/msgpack.hpp=
+for.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/wire-codec-and-startup-config
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
 #+updated: 2026-07-28
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -44,29 +44,68 @@ Build the shared foundation the rest of the story depends on:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                   |
 | Parent story | [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-28                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-29                               |
 
 * Acceptance
 
-- [ ] =wire_codec= compiles and round-trips a representative
+- [X] =wire_codec= compiles and round-trips a representative
   reflectable struct (including a byte-vector field) under both
   =json= and =msgpack=.
-- [ ] Config value is read once at startup from =.env=, with a
+- [X] Config value is read once at startup from =.env=, with a
   documented default that preserves today's behaviour if unset.
-- [ ] No per-call branching cost beyond the single format check
+- [X] No per-call branching cost beyond the single format check
   already implied by having two supported formats -- no header
   parsing, no per-message format inspection.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Built the shared foundation exactly as scoped in =* Goal=, mirroring
+=ores.nats::compression='s existing module layout:
+
+- =domain/wire_format.hpp=/=.cpp=: the =wire_format= enum (=json=,
+  =msgpack=) plus =parse_wire_format=/=to_string= free functions for
+  the =.env=/CLI string spelling, case-insensitive on parse.
+- =domain/wire_codec.hpp=: the non-polymorphic =wire_codec= value
+  type (header-only -- =encode=/=decode= are templates, so there is
+  no non-template code to put in a =.cpp=). =encode<T>= dispatches to
+  =rfl::json::write=/=rfl::msgpack::write=; =decode<T>= dispatches to
+  =rfl::json::read=/=rfl::msgpack::read=, both taking the fixed
+  =format_= as a single branch, not a per-message inspection.
+  =rfl::msgpack::read<T>= accepts a =std::span<const std::byte>=
+  directly (it satisfies reflect-cpp's =ContiguousByteContainer=
+  concept for =std::byte=); =rfl::json::read<T>= needs a
+  =std::string_view=, built via a =reinterpret_cast= over the same
+  span.
+- =config/nats_options.hpp=: added a =wire_format= field, defaulting
+  to =wire_format::json= (preserves pre-existing behaviour for any
+  process that doesn't set it).
+- =config/nats_configuration.cpp=: added the =--nats-wire-format=
+  option (default =\"json\"=, env =ORES_NATS_WIRE_FORMAT= via the
+  per-service =environment_mapper_factory= prefix, same convention as
+  the existing TLS options), parsed via =parse_wire_format= with a
+  thrown =std::invalid_argument= on an unrecognised value -- fails
+  fast at startup rather than silently falling back.
+- =src/CMakeLists.txt=: added =reflectcpp::reflectcpp= as a *public*
+  link dependency (previously =ores.nats.lib= only pulled it in
+  transitively and privately through =ores.utility.lib=), since
+  =wire_codec.hpp= is a public header that every consumer including
+  it needs =rfl/json.hpp=/=rfl/msgpack.hpp= for.
+
+Round-trip unit tests (new =tests/domain_wire_codec_tests.cpp=,
+=tests/domain_wire_format_tests.cpp=, plus additions to
+=tests/config_nats_configuration_tests.cpp=) cover: json round-trip,
+msgpack round-trip, a msgpack-vs-json size comparison confirming the
+byte-vector field is carried as native binary (smaller than its json/
+base64-equivalent, not larger), =format()= accessor, a malformed-input
+decode error case, =parse_wire_format=/=to_string= spelling and
+case-insensitivity, and the new CLI option's default/override/
+rejection paths. Full =ores.nats.tests= suite: 47 assertions, 24 test
+cases, all green -- no regressions.
 
 * Notes
 
@@ -94,3 +133,15 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Shared foundation complete: =ores::nats::wire_format= (=json=/
+=msgpack=, with =parse_wire_format=/=to_string=), =ores::nats::wire_codec=
+(non-polymorphic, template =encode=/=decode=), a new
+=--nats-wire-format=/=ORES_NATS_WIRE_FORMAT= config value (default
+=json=) on =nats_options=/=nats_configuration=, and round-trip unit
+tests for both formats including the byte-vector-as-native-binary
+property. =ores.nats.lib= now links =reflectcpp::reflectcpp= publicly
+so downstream consumers of =wire_codec.hpp= get the reflect-cpp
+headers transitively. This is the shared foundation the remaining
+implementation tasks (service handler_helpers, =ClientManager=,
+=ores.shell= request helpers, end-to-end verification) build on.

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
@@ -8,7 +8,7 @@
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
 #+branch: feature/wire-codec-and-startup-config
-#+pr:
+#+pr: 1745
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
@@ -124,7 +124,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1745][#1745]] | [ores.nats] Build wire_codec abstraction and startup config |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.org
@@ -130,7 +130,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Symmetric malformed-msgpack decode test missing (only json path covered) | domain_wire_codec_tests.cpp | Fixed | Added "wire_codec decode surfaces a parse error for malformed msgpack input" |
+| 2 | =nats_options::wire_format= member shadows the =ores::nats::wire_format= enum type name | nats_options.hpp | Fixed | Renamed field to =format= (call sites: =nats_configuration.cpp=, tests) |
+| 3 | Error message built via =+= concatenation instead of =std::format=, inconsistent with =ores.logging='s equivalent | nats_configuration.cpp | Fixed | Switched to =std::format= |
+|   | Only the CLI flag path is tested for wire format, not the =ORES_NATS_WIRE_FORMAT= env var directly | nats_configuration.cpp | Declined | Consistent with how the pre-existing TLS options are tested (CLI only); not a regression this task introduces |
 
 * Result
 

--- a/projects/ores.nats/include/ores.nats/config/nats_configuration.hpp
+++ b/projects/ores.nats/include/ores.nats/config/nats_configuration.hpp
@@ -34,7 +34,8 @@ namespace ores::nats::config {
  * logging_configuration and database_configuration.
  *
  * Standard options:
- *   --nats-url      NATS server URL (default: nats://localhost:4222)
+ *   --nats-url          NATS server URL (default: nats://localhost:4222)
+ *   --nats-wire-format  Message wire format: json or msgpack (default: json)
  */
 class ORES_NATS_EXPORT nats_configuration final {
 public:

--- a/projects/ores.nats/include/ores.nats/config/nats_options.hpp
+++ b/projects/ores.nats/include/ores.nats/config/nats_options.hpp
@@ -67,7 +67,7 @@ struct nats_options final {
      * startup (env: ORES_NATS_WIRE_FORMAT). Defaults to json, preserving
      * pre-existing behaviour for any process that doesn't set it.
      */
-    ores::nats::wire_format wire_format = ores::nats::wire_format::json;
+    ores::nats::wire_format format = ores::nats::wire_format::json;
 };
 
 }

--- a/projects/ores.nats/include/ores.nats/config/nats_options.hpp
+++ b/projects/ores.nats/include/ores.nats/config/nats_options.hpp
@@ -20,6 +20,7 @@
 #ifndef ORES_NATS_CONFIG_NATS_OPTIONS_HPP
 #define ORES_NATS_CONFIG_NATS_OPTIONS_HPP
 
+#include "ores.nats/domain/wire_format.hpp"
 #include <string>
 
 namespace ores::nats::config {
@@ -59,6 +60,14 @@ struct nats_options final {
     std::string tls_ca_cert;
     std::string tls_client_cert;
     std::string tls_client_key;
+
+    /**
+     * @brief Wire format used to serialize every NATS message body this
+     * process sends and decode every one it receives, decided once at
+     * startup (env: ORES_NATS_WIRE_FORMAT). Defaults to json, preserving
+     * pre-existing behaviour for any process that doesn't set it.
+     */
+    ores::nats::wire_format wire_format = ores::nats::wire_format::json;
 };
 
 }

--- a/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
+++ b/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_NATS_DOMAIN_WIRE_CODEC_HPP
+#define ORES_NATS_DOMAIN_WIRE_CODEC_HPP
+
+#include "ores.nats/domain/wire_format.hpp"
+#include <cstddef>
+#include <rfl/json.hpp>
+#include <rfl/msgpack.hpp>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace ores::nats {
+
+/**
+ * @brief Encodes/decodes NATS message bodies in a single wire_format
+ * fixed at construction.
+ *
+ * Deliberately non-polymorphic: the format is decided once, at process
+ * startup, from the resolved config value (see wire_format.hpp and
+ * config::nats_options::wire_format), and never changes for the
+ * instance's lifetime. There is no per-message format negotiation, no
+ * content-type header, no runtime auto-detection -- every encode()/
+ * decode() call branches on the same value for as long as the process
+ * runs. wire_codec is a 1-byte enum wrapped in a value type: trivially
+ * copyable, cheap to hold by value, reference, or as a member wherever
+ * a consumer needs it.
+ */
+class wire_codec final {
+public:
+    explicit wire_codec(wire_format format)
+        : format_(format) {}
+
+    [[nodiscard]] wire_format format() const {
+        return format_;
+    }
+
+    /**
+     * @brief Serializes @p obj to this codec's fixed wire_format.
+     */
+    template <typename T>
+    [[nodiscard]] std::vector<std::byte> encode(const T& obj) const {
+        switch (format_) {
+            case wire_format::json: {
+                const auto s = rfl::json::write(obj);
+                return to_bytes(s);
+            }
+            case wire_format::msgpack: {
+                const auto b = rfl::msgpack::write(obj);
+                return to_bytes(b);
+            }
+        }
+        std::unreachable();
+    }
+
+    /**
+     * @brief Deserializes @p data (assumed to be in this codec's fixed
+     * wire_format) into a T.
+     */
+    template <typename T>
+    [[nodiscard]] rfl::Result<T> decode(std::span<const std::byte> data) const {
+        switch (format_) {
+            case wire_format::json: {
+                const std::string_view sv(reinterpret_cast<const char*>(data.data()), data.size());
+                return rfl::json::read<T>(sv);
+            }
+            case wire_format::msgpack:
+                return rfl::msgpack::read<T>(data);
+        }
+        std::unreachable();
+    }
+
+private:
+    template <typename Container>
+    static std::vector<std::byte> to_bytes(const Container& c) {
+        const auto* p = reinterpret_cast<const std::byte*>(c.data());
+        return {p, p + c.size()};
+    }
+
+    wire_format format_;
+};
+
+}
+
+#endif

--- a/projects/ores.nats/include/ores.nats/domain/wire_format.hpp
+++ b/projects/ores.nats/include/ores.nats/domain/wire_format.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_NATS_DOMAIN_WIRE_FORMAT_HPP
+#define ORES_NATS_DOMAIN_WIRE_FORMAT_HPP
+
+#include "ores.nats/export.hpp"
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace ores::nats {
+
+/**
+ * @brief The serialization format used for every NATS message body a
+ * process sends and receives, decided once at startup and never
+ * renegotiated per-message.
+ */
+enum class wire_format {
+    json,
+    msgpack,
+};
+
+/**
+ * @brief Parses a wire_format from its .env/CLI string spelling
+ * ("json", "msgpack"), case-insensitively.
+ *
+ * @param name The configured value, e.g. from ORES_NATS_WIRE_FORMAT.
+ * @return The parsed wire_format, or std::nullopt if @p name is not
+ *         one of the recognised spellings.
+ */
+[[nodiscard]] ORES_NATS_EXPORT std::optional<wire_format> parse_wire_format(std::string_view name);
+
+/**
+ * @brief Renders a wire_format back to its .env/CLI string spelling.
+ */
+[[nodiscard]] ORES_NATS_EXPORT std::string to_string(wire_format format);
+
+}
+
+#endif

--- a/projects/ores.nats/src/CMakeLists.txt
+++ b/projects/ores.nats/src/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ${CNATS_LIB}
         Boost::program_options
+        reflectcpp::reflectcpp
     PRIVATE
         ores.logging.lib
         ores.utility.lib

--- a/projects/ores.nats/src/config/nats_configuration.cpp
+++ b/projects/ores.nats/src/config/nats_configuration.cpp
@@ -18,6 +18,9 @@
  *
  */
 #include "ores.nats/config/nats_configuration.hpp"
+#include "ores.nats/domain/wire_format.hpp"
+#include <boost/throw_exception.hpp>
+#include <stdexcept>
 
 namespace ores::nats::config {
 
@@ -28,6 +31,7 @@ const std::string nats_subject_prefix_arg("nats-subject-prefix");
 const std::string nats_tls_ca_arg("nats-tls-ca");
 const std::string nats_tls_cert_arg("nats-tls-cert");
 const std::string nats_tls_key_arg("nats-tls-key");
+const std::string nats_wire_format_arg("nats-wire-format");
 
 }
 
@@ -52,7 +56,11 @@ boost::program_options::options_description nats_configuration::make_options_des
         nats_tls_key_arg.c_str(),
         value<std::string>()->default_value(""),
         "Path to client private key for mTLS (<service>.key). "
-        "Env: ORES_NATS_TLS_KEY.");
+        "Env: ORES_NATS_TLS_KEY.")(nats_wire_format_arg.c_str(),
+                                   value<std::string>()->default_value("json"),
+                                   "Wire format for NATS message bodies: json or msgpack, "
+                                   "decided once at process startup. "
+                                   "Env: ORES_NATS_WIRE_FORMAT.");
 
     return r;
 }
@@ -64,6 +72,15 @@ nats_options nats_configuration::read_options(const boost::program_options::vari
     r.tls_ca_cert = vm[nats_tls_ca_arg].as<std::string>();
     r.tls_client_cert = vm[nats_tls_cert_arg].as<std::string>();
     r.tls_client_key = vm[nats_tls_key_arg].as<std::string>();
+
+    const auto wire_format_str = vm[nats_wire_format_arg].as<std::string>();
+    const auto parsed = parse_wire_format(wire_format_str);
+    if (!parsed)
+        BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid " + nats_wire_format_arg + ": '" +
+                                                    wire_format_str +
+                                                    "' (expected 'json' or 'msgpack')."));
+    r.wire_format = *parsed;
+
     return r;
 }
 

--- a/projects/ores.nats/src/config/nats_configuration.cpp
+++ b/projects/ores.nats/src/config/nats_configuration.cpp
@@ -20,6 +20,7 @@
 #include "ores.nats/config/nats_configuration.hpp"
 #include "ores.nats/domain/wire_format.hpp"
 #include <boost/throw_exception.hpp>
+#include <format>
 #include <stdexcept>
 
 namespace ores::nats::config {
@@ -76,10 +77,11 @@ nats_options nats_configuration::read_options(const boost::program_options::vari
     const auto wire_format_str = vm[nats_wire_format_arg].as<std::string>();
     const auto parsed = parse_wire_format(wire_format_str);
     if (!parsed)
-        BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid " + nats_wire_format_arg + ": '" +
-                                                    wire_format_str +
-                                                    "' (expected 'json' or 'msgpack')."));
-    r.wire_format = *parsed;
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument(std::format("Invalid {}: '{}' (expected 'json' or 'msgpack').",
+                                              nats_wire_format_arg,
+                                              wire_format_str)));
+    r.format = *parsed;
 
     return r;
 }

--- a/projects/ores.nats/src/domain/wire_format.cpp
+++ b/projects/ores.nats/src/domain/wire_format.cpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.nats/domain/wire_format.hpp"
+#include <algorithm>
+#include <cctype>
+#include <utility>
+
+namespace ores::nats {
+
+namespace {
+
+std::string to_lower(std::string_view s) {
+    std::string r(s);
+    std::ranges::transform(r, r.begin(), [](unsigned char c) { return std::tolower(c); });
+    return r;
+}
+
+}
+
+std::optional<wire_format> parse_wire_format(std::string_view name) {
+    const auto lowered = to_lower(name);
+    if (lowered == "json")
+        return wire_format::json;
+    if (lowered == "msgpack")
+        return wire_format::msgpack;
+    return std::nullopt;
+}
+
+std::string to_string(wire_format format) {
+    switch (format) {
+        case wire_format::json:
+            return "json";
+        case wire_format::msgpack:
+            return "msgpack";
+    }
+    std::unreachable();
+}
+
+}

--- a/projects/ores.nats/tests/config_nats_configuration_tests.cpp
+++ b/projects/ores.nats/tests/config_nats_configuration_tests.cpp
@@ -80,7 +80,7 @@ TEST_CASE("nats_configuration_wire_format_defaults_to_json", tags) {
 
     const auto result = parse({});
 
-    CHECK(result.wire_format == ores::nats::wire_format::json);
+    CHECK(result.format == ores::nats::wire_format::json);
 }
 
 TEST_CASE("nats_configuration_wire_format_msgpack", tags) {
@@ -88,7 +88,7 @@ TEST_CASE("nats_configuration_wire_format_msgpack", tags) {
 
     const auto result = parse({"--nats-wire-format", "msgpack"});
 
-    CHECK(result.wire_format == ores::nats::wire_format::msgpack);
+    CHECK(result.format == ores::nats::wire_format::msgpack);
 }
 
 TEST_CASE("nats_configuration_wire_format_rejects_unknown_value", tags) {

--- a/projects/ores.nats/tests/config_nats_configuration_tests.cpp
+++ b/projects/ores.nats/tests/config_nats_configuration_tests.cpp
@@ -74,3 +74,25 @@ TEST_CASE("nats_configuration_url_and_prefix_together", tags) {
     CHECK(result.url == "nats://cluster:4222");
     CHECK(result.subject_prefix == "ores.staging.node2");
 }
+
+TEST_CASE("nats_configuration_wire_format_defaults_to_json", tags) {
+    auto lg(ores::logging::make_logger(test_suite));
+
+    const auto result = parse({});
+
+    CHECK(result.wire_format == ores::nats::wire_format::json);
+}
+
+TEST_CASE("nats_configuration_wire_format_msgpack", tags) {
+    auto lg(ores::logging::make_logger(test_suite));
+
+    const auto result = parse({"--nats-wire-format", "msgpack"});
+
+    CHECK(result.wire_format == ores::nats::wire_format::msgpack);
+}
+
+TEST_CASE("nats_configuration_wire_format_rejects_unknown_value", tags) {
+    auto lg(ores::logging::make_logger(test_suite));
+
+    CHECK_THROWS_AS(parse({"--nats-wire-format", "bson"}), std::invalid_argument);
+}

--- a/projects/ores.nats/tests/domain_wire_codec_tests.cpp
+++ b/projects/ores.nats/tests/domain_wire_codec_tests.cpp
@@ -1,0 +1,103 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.nats/domain/wire_codec.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+const std::string tags("[domain][wire_codec]");
+
+struct sample {
+    std::string name;
+    int value = 0;
+    std::vector<std::uint8_t> payload;
+};
+
+}
+
+TEST_CASE("wire_codec round-trips a reflectable struct under json", tags) {
+    const ores::nats::wire_codec codec(ores::nats::wire_format::json);
+
+    const sample original{"alpha", 42, {std::uint8_t{1}, std::uint8_t{2}, std::uint8_t{3}}};
+    const auto bytes = codec.encode(original);
+    const auto decoded = codec.decode<sample>(bytes);
+
+    REQUIRE(decoded.has_value());
+    CHECK(decoded->name == original.name);
+    CHECK(decoded->value == original.value);
+    CHECK(decoded->payload == original.payload);
+}
+
+TEST_CASE("wire_codec round-trips a reflectable struct under msgpack", tags) {
+    const ores::nats::wire_codec codec(ores::nats::wire_format::msgpack);
+
+    const sample original{"beta", -7, {std::uint8_t{9}, std::uint8_t{8}, std::uint8_t{7}}};
+    const auto bytes = codec.encode(original);
+    const auto decoded = codec.decode<sample>(bytes);
+
+    REQUIRE(decoded.has_value());
+    CHECK(decoded->name == original.name);
+    CHECK(decoded->value == original.value);
+    CHECK(decoded->payload == original.payload);
+}
+
+TEST_CASE("wire_codec msgpack round-trips a byte-vector field natively, not as base64", tags) {
+    // This is the property the whole story exists to exploit: msgpack's
+    // native binary type carries std::vector<uint8_t> as raw bytes, not
+    // a base64-inflated string -- so the msgpack encoding of a
+    // byte-heavy payload should not be larger than its json equivalent.
+    const ores::nats::wire_codec json_codec(ores::nats::wire_format::json);
+    const ores::nats::wire_codec msgpack_codec(ores::nats::wire_format::msgpack);
+
+    sample original;
+    original.name = "gamma";
+    original.value = 1;
+    original.payload.assign(1000, std::uint8_t{0xAB});
+
+    const auto json_bytes = json_codec.encode(original);
+    const auto msgpack_bytes = msgpack_codec.encode(original);
+
+    CHECK(msgpack_bytes.size() < json_bytes.size());
+
+    const auto decoded = msgpack_codec.decode<sample>(msgpack_bytes);
+    REQUIRE(decoded.has_value());
+    CHECK(decoded->payload == original.payload);
+}
+
+TEST_CASE("wire_codec::format returns the format fixed at construction", tags) {
+    CHECK(ores::nats::wire_codec(ores::nats::wire_format::json).format() ==
+          ores::nats::wire_format::json);
+    CHECK(ores::nats::wire_codec(ores::nats::wire_format::msgpack).format() ==
+          ores::nats::wire_format::msgpack);
+}
+
+TEST_CASE("wire_codec decode surfaces a parse error for malformed input", tags) {
+    const ores::nats::wire_codec codec(ores::nats::wire_format::json);
+    const std::string garbage = "not json";
+    const std::span<const std::byte> bytes(reinterpret_cast<const std::byte*>(garbage.data()),
+                                           garbage.size());
+
+    const auto decoded = codec.decode<sample>(bytes);
+
+    CHECK_FALSE(decoded.has_value());
+}

--- a/projects/ores.nats/tests/domain_wire_codec_tests.cpp
+++ b/projects/ores.nats/tests/domain_wire_codec_tests.cpp
@@ -91,9 +91,20 @@ TEST_CASE("wire_codec::format returns the format fixed at construction", tags) {
           ores::nats::wire_format::msgpack);
 }
 
-TEST_CASE("wire_codec decode surfaces a parse error for malformed input", tags) {
+TEST_CASE("wire_codec decode surfaces a parse error for malformed json input", tags) {
     const ores::nats::wire_codec codec(ores::nats::wire_format::json);
     const std::string garbage = "not json";
+    const std::span<const std::byte> bytes(reinterpret_cast<const std::byte*>(garbage.data()),
+                                           garbage.size());
+
+    const auto decoded = codec.decode<sample>(bytes);
+
+    CHECK_FALSE(decoded.has_value());
+}
+
+TEST_CASE("wire_codec decode surfaces a parse error for malformed msgpack input", tags) {
+    const ores::nats::wire_codec codec(ores::nats::wire_format::msgpack);
+    const std::string garbage = "not msgpack";
     const std::span<const std::byte> bytes(reinterpret_cast<const std::byte*>(garbage.data()),
                                            garbage.size());
 

--- a/projects/ores.nats/tests/domain_wire_format_tests.cpp
+++ b/projects/ores.nats/tests/domain_wire_format_tests.cpp
@@ -1,0 +1,50 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.nats/domain/wire_format.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+
+const std::string tags("[domain][wire_format]");
+
+}
+
+TEST_CASE("parse_wire_format accepts the documented spellings", tags) {
+    CHECK(ores::nats::parse_wire_format("json") == ores::nats::wire_format::json);
+    CHECK(ores::nats::parse_wire_format("msgpack") == ores::nats::wire_format::msgpack);
+}
+
+TEST_CASE("parse_wire_format is case-insensitive", tags) {
+    CHECK(ores::nats::parse_wire_format("JSON") == ores::nats::wire_format::json);
+    CHECK(ores::nats::parse_wire_format("MsgPack") == ores::nats::wire_format::msgpack);
+}
+
+TEST_CASE("parse_wire_format rejects unrecognised spellings", tags) {
+    CHECK_FALSE(ores::nats::parse_wire_format("").has_value());
+    CHECK_FALSE(ores::nats::parse_wire_format("bson").has_value());
+    CHECK_FALSE(ores::nats::parse_wire_format("json ").has_value());
+}
+
+TEST_CASE("to_string round-trips through parse_wire_format", tags) {
+    CHECK(ores::nats::parse_wire_format(ores::nats::to_string(ores::nats::wire_format::json)) ==
+          ores::nats::wire_format::json);
+    CHECK(ores::nats::parse_wire_format(ores::nats::to_string(ores::nats::wire_format::msgpack)) ==
+          ores::nats::wire_format::msgpack);
+}


### PR DESCRIPTION
## Summary

Add a non-polymorphic wire_codec value type (json/msgpack, decided once at process startup from ORES_NATS_WIRE_FORMAT, default json) and round-trip unit tests, giving the rest of the NATS-wire-format story a shared codec to migrate ores.service, ores.qt, and ores.shell onto.

## Changes

- Add ores::nats::wire_format enum plus parse_wire_format/to_string
- Add ores::nats::wire_codec: non-polymorphic, templated encode/decode methods dispatching to rfl::json or rfl::msgpack based on the format fixed at construction
- Add --nats-wire-format/ORES_NATS_WIRE_FORMAT config option (default json), fail-fast std::invalid_argument on an unrecognised value
- Link reflectcpp::reflectcpp publicly from ores.nats.lib since wire_codec.hpp is a public header needing rfl/json.hpp and rfl/msgpack.hpp
- Round-trip unit tests: json, msgpack, byte-vector-as-native-binary size comparison, malformed-input decode error, parse/to_string spelling, new CLI option paths
- Verification: local build clean (preset linux-clang-debug-make); ores.nats.tests 47/47 assertions passed, 24/24 test cases, no regressions

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Make NATS wire format configurable: JSON/MessagePack, decided once at startup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.html) | 1A815B1E-904E-460C-A2FB-31D9E3B392E2 |
| Task | [Build wire_codec abstraction and startup config in ores.nats](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_wire-codec-and-startup-config.html) | D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)