### PR TITLE
[ores.service] Migrate handler_helpers to wire_codec

### DIFF
--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
@@ -84,7 +84,7 @@ task.
 |------+-------+-------+-----+-------------|
 | [[id:AC1B96D9-D86C-4BBB-94A4-E187469A0A8F][Write up the wire-format architecture analysis and design decision]] | DONE | 2026-07-28 | 2026-07-28 | Document the current blast-radius audit (every NATS-relevant rfl::json call site across ores.service, ores.qt, ores.shell, plus confirming ores.cli is out of scope), the chosen architecture (a single non-polymorphic wire_codec constructed once at startup from .env, threaded via dependency injection, no per-message negotiation), and the rationale versus the rejected per-message header-negotiation alternative. This becomes the spec the later implementation tasks execute against. |
 | [[id:D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA][Build wire_codec abstraction and startup config in ores.nats]] | DONE | 2026-07-29 | 2026-07-29 | Add a wire_format enum (json, msgpack), a .env-driven config value read once at startup, and a wire_codec class holding the chosen format at construction with template encode/decode methods dispatching to rfl::json or rfl::msgpack. Non-polymorphic, no per-message branching on message content -- the format is fixed for the codec instance's lifetime. Round-trip unit tests for both formats. This is the shared foundation every other task in this story depends on. |
-| [[id:7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA][Migrate ores.service messaging handler_helpers to wire_codec]] | BACKLOG | | | Update reply() and decode() in ores.service/messaging/handler_helpers.hpp to route through an injected wire_codec instead of a hard-coded rfl::json call. This is the server-side choke point almost every service handler already goes through, so this single change flips every service's request/response handling in one pass. Audit for any service-to-service NATS calls that bypass these two helpers and migrate or document them separately. |
+| [[id:7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA][Migrate ores.service messaging handler_helpers to wire_codec]] | DONE | 2026-07-29 | 2026-07-29 | Update reply() and decode() in ores.service/messaging/handler_helpers.hpp to route through an injected wire_codec instead of a hard-coded rfl::json call. This is the server-side choke point almost every service handler already goes through, so this single change flips every service's request/response handling in one pass. Audit for any service-to-service NATS calls that bypass these two helpers and migrate or document them separately. |
 | [[id:12674934-6F8E-40C9-A8D7-ED29B0ADF322][Consolidate and migrate ores.qt ClientManager to wire_codec]] | BACKLOG | | | ClientManager.hpp/.cpp plus ClientManagerExportPortfolio.cpp and ClientManagerTradeInstrument.cpp currently have around ten separate call sites hard-coding rfl::json (process_authenticated_request variants, send_authenticated_request variants, login, signup, event-cache decode, exportPortfolio, trade_instrument). Consolidate these into one or two shared private helpers first, reducing duplication as a side effect, then have those route through an injected wire_codec instead of rfl::json directly. |
 | [[id:926379AF-B17C-4700-AF89-6AD1EB006281][Consolidate and migrate ores.shell request helpers to wire_codec]] | BACKLOG | | | The do_request/do_auth_request template helper is copy-pasted independently into thirteen shell command .cpp files (18 definitions, 60 call sites), plus 7 more files using other direct rfl::json patterns (101 occurrences across 22 files total). De-duplicate into one shared helper in a shell-wide header first -- a real cleanup win independent of the format work -- then have that single helper route through an injected wire_codec instead of rfl::json directly. |
 | [[id:493C5EF6-FE85-4623-8103-563EB5CA6EE3][End-to-end verify msgpack wire format and close out the story]] | BACKLOG | | | With every layer migrated, flip a test environment's .env to msgpack and verify round-trip correctness across Qt-to-service and shell-to-service, including the image-batch flows this whole investigation started from. Confirms the raw-bytes-not-base64-for-images task's goal is achieved for free. Abandon that task in favour of this story at close, and record the .env config knob in the relevant How do I recipe. |
@@ -121,6 +121,25 @@ publicly (previously only transitively/privately via
 =ores.utility.lib=) since =wire_codec.hpp= is a public, header-only
 template type every consumer needs =rfl/json.hpp=/=rfl/msgpack.hpp=
 for.
+
+** Server: process-wide default wire_codec, not per-call-site DI
+
+Decided in the [[id:7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA][handler_helpers migration task]]. =decode<Req>(msg)= is
+called from ~250+ handler call sites across every service, none of
+which have a =wire_codec= or =client= reference in scope -- threading
+one through would mean editing every call site, defeating this
+task's "single change, no per-handler edits" goal. Resolved with
+=ores::nats::default_wire_codec()=/=set_default_wire_codec()=: a
+process-wide default set automatically by
+=nats::service::client='s constructor (every server process
+constructs exactly one client, from its resolved =nats_options=), so
+=handler_helpers.hpp='s =reply()=/=decode()= (and the
+=heartbeat_publisher=/=workflow_helpers= stragglers) read it with zero
+edits anywhere else. This is a deliberate, narrow exception to
+per-instance dependency injection -- justified because wire format is
+a single process-wide, decided-once-at-startup value, not a
+per-instance or per-message choice, matching this story's core
+architectural decision above.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/migrate-handler-helpers-to-wire-codec
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
 #+updated: 2026-07-28
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -38,30 +38,81 @@ scope.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                   |
 | Parent story | [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-28                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-29                               |
 
 * Acceptance
 
-- [ ] =reply()=/=decode()= use the injected =wire_codec=; no direct
+- [X] =reply()=/=decode()= use the injected =wire_codec=; no direct
   =rfl::json= call remains in =handler_helpers.hpp=.
-- [ ] Every existing service test suite still passes unmodified
+- [X] Every existing service test suite still passes unmodified
   (proves the migration is behaviour-preserving when the codec is
   configured for =json=, today's default).
-- [ ] Audit result for bypassing call sites recorded in Notes, with
+- [X] Audit result for bypassing call sites recorded in Notes, with
   each one either migrated or explicitly deferred with a reason.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+=reply()=/=decode()= in =handler_helpers.hpp= now call
+=ores::nats::default_wire_codec().encode(resp)=/=.decode<Req>(msg.data)=
+instead of hard-coded =rfl::json::write=/=read=.
+
+The blocker: =decode<Req>(msg)= is called from ~250+ handler call
+sites across every service (=ores.dq=, =ores.iam=, =ores.compute=,
+=ores.trading=, ...), none of which have a =wire_codec= or a
+=nats::service::client= reference in scope at the call site --
+threading one through would mean editing every one of those call
+sites, which is exactly what this task's "single change, no
+per-handler edits" framing rules out. Solution: a process-wide
+default =wire_codec= (=ores::nats::default_wire_codec()=/
+=set_default_wire_codec()=, added to =wire_codec.hpp=/=.cpp= in
+=ores.nats=), set automatically by =nats::service::client='s
+constructor -- every server process constructs exactly one =client=
+at startup from its resolved =nats_options=, so this requires zero
+edits at any of the ~250 call sites or any service's =host.cpp=. This
+is a deliberate, narrow exception to per-instance DI, justified
+because wire format is a single process-wide decided-once-at-startup
+value (per the write-up task's rejected-alternatives rationale), not
+a per-instance or per-message choice; documented as such directly on
+=default_wire_codec()='s doc comment.
+
+Stragglers migrated onto the same default codec:
+- =heartbeat_publisher.hpp='s =publish_once()=: replaced the manual
+  =rfl::json::write= + byte-copy with =default_wire_codec().encode(hb)=.
+- =workflow_helpers.hpp=: both the =step_completed_event= publish
+  (=workflow_step_context::publish()=) and the
+  =get_step_result_request=/=response= round-trip
+  (=check_step_idempotency()=) now go through the default codec. Left
+  untouched: the doc-comment example's =rfl::json::write(result)= and
+  the =result_json=/=error_message= string fields on
+  =step_completed_event= -- these are an embedded JSON domain field
+  (the step's own result payload, itself carried inside the wire
+  message), not the NATS wire-format serialization, matching the
+  write-up task's =OreImportWizard.cpp= false-positive precedent.
+
+Verification: full-repo =compass build --preset linux-clang-debug-make=
+clean (100%, no errors, including all ~40 service handler headers
+that transitively include =handler_helpers.hpp=); full
+=ctest --preset linux-clang-debug-make= 74/74 suites passed,
+confirming the migration is behaviour-preserving with the =json=
+default.
 
 * Notes
+
+Audit for call sites bypassing =handler_helpers.hpp='s =reply()=/
+=decode()= (per the write-up task's blast-radius audit,
+=doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_write-up-wire-format-architecture.org=):
+
+- =heartbeat_publisher.hpp= and =workflow_helpers.hpp= -- migrated,
+  see =* Plan= above.
+- No further bypassing =rfl::json::write=/=read= call sites found in
+  =ores.service= beyond those two files and the doc-comment mention
+  in =workflow_helpers.hpp= (an embedded-JSON-field example, not a
+  wire-format call site).
 
 * Test Scenarios
 
@@ -87,3 +138,17 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+=handler_helpers.hpp='s =reply()=/=decode()= choke point, plus the two
+straggler call sites identified by the write-up task
+(=heartbeat_publisher.hpp=, =workflow_helpers.hpp=), all now route
+through =ores::nats::default_wire_codec()= instead of hard-coded
+=rfl::json=. Because =decode<Req>(msg)= is called from ~250+ handler
+sites across every service with no client/codec reference in scope,
+the codec is a process-wide default set automatically by
+=nats::service::client='s constructor (one client per process,
+constructed from the resolved =nats_options.format=) rather than
+threaded through every call site -- zero edits needed at any handler
+call site or any service's =host.cpp=. Full-repo build and the
+complete 74-suite =ctest= run both pass, confirming the migration is
+behaviour-preserving under today's =json= default.

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
@@ -8,7 +8,7 @@
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
 #+branch: feature/migrate-handler-helpers-to-wire-codec
-#+pr:
+#+pr: 1748
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
@@ -129,7 +129,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1748][#1748]] | [ores.service] Migrate handler_helpers to wire_codec |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.org
@@ -135,7 +135,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | No direct unit test for default_wire_codec()/set_default_wire_codec() | domain_wire_codec_tests.cpp | Fixed | Added a test covering the pre-client json default and set_default_wire_codec() changing it, resetting to json afterwards |
+| 2 | Global mutable state relies on startup-ordering (client ctor before worker threads) without a lock/atomic | wire_codec.hpp | Fixed | Strengthened the doc comment to spell out the happens-before reliance explicitly; kept the plain (non-atomic) field, consistent with the design's single-client-per-process assumption noted by all three review passes as non-blocking |
 
 * Result
 

--- a/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
+++ b/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
@@ -99,6 +99,38 @@ private:
     wire_format format_;
 };
 
+/**
+ * @brief Sets the process-wide default wire_codec.
+ *
+ * Every server process constructs exactly one ores::nats::service::client
+ * at startup from its resolved config, and that constructor calls this to
+ * publish the codec matching its ORES_NATS_WIRE_FORMAT setting. Generic
+ * message-handling code that has no client reference in scope --
+ * ores.service::messaging's reply()/decode() choke point, called from
+ * hundreds of handler call sites that were never threaded a client or a
+ * codec -- reads it back via default_wire_codec() instead of requiring a
+ * signature change at every one of those call sites.
+ *
+ * This is a deliberate, narrow exception to per-instance dependency
+ * injection, not a general-purpose global: it is safe precisely because
+ * the wire format is a single, process-wide, decided-once-at-startup
+ * value (see the write-up task's rejected-alternatives rationale), not a
+ * per-instance or per-message choice. Not thread-safe against concurrent
+ * set_default_wire_codec() calls from multiple clients disagreeing on
+ * format -- no service constructs more than one client with conflicting
+ * config, so this does not arise in practice.
+ */
+ORES_NATS_EXPORT void set_default_wire_codec(wire_codec codec);
+
+/**
+ * @brief Returns the process-wide default wire_codec (see
+ * set_default_wire_codec()). Defaults to wire_format::json before any
+ * client is constructed, matching the pre-existing behaviour for any
+ * caller that runs before startup config is applied (e.g. free-standing
+ * unit tests).
+ */
+[[nodiscard]] ORES_NATS_EXPORT const wire_codec& default_wire_codec();
+
 }
 
 #endif

--- a/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
+++ b/projects/ores.nats/include/ores.nats/domain/wire_codec.hpp
@@ -118,7 +118,13 @@ private:
  * per-instance or per-message choice. Not thread-safe against concurrent
  * set_default_wire_codec() calls from multiple clients disagreeing on
  * format -- no service constructs more than one client with conflicting
- * config, so this does not arise in practice.
+ * config, so this does not arise in practice. This also relies on
+ * set_default_wire_codec() completing (from the client constructor, on
+ * the main thread) before any NATS worker thread that calls decode()/
+ * default_wire_codec() is spawned -- true today because client
+ * construction always precedes connect()/subscribe(), but not enforced
+ * by any lock; revisit with a std::atomic<wire_format> if that startup
+ * ordering ever changes.
  */
 ORES_NATS_EXPORT void set_default_wire_codec(wire_codec codec);
 

--- a/projects/ores.nats/src/domain/wire_codec.cpp
+++ b/projects/ores.nats/src/domain/wire_codec.cpp
@@ -1,0 +1,41 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.nats/domain/wire_codec.hpp"
+
+namespace ores::nats {
+
+namespace {
+
+wire_codec& mutable_default_wire_codec() {
+    static wire_codec instance(wire_format::json);
+    return instance;
+}
+
+}
+
+void set_default_wire_codec(wire_codec codec) {
+    mutable_default_wire_codec() = codec;
+}
+
+const wire_codec& default_wire_codec() {
+    return mutable_default_wire_codec();
+}
+
+}

--- a/projects/ores.nats/src/service/client.cpp
+++ b/projects/ores.nats/src/service/client.cpp
@@ -20,6 +20,7 @@
 #include "ores.nats/service/client.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/compression.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/buffered_subscription.hpp"
 #include "ores.nats/service/jetstream_admin.hpp"
 #include "ores.nats/service/nats_connect_error.hpp"
@@ -341,6 +342,7 @@ std::size_t buffered_subscription::size() const {
 client::client(config::nats_options opts)
     : impl_(std::make_unique<impl>()) {
     impl_->opts = std::move(opts);
+    set_default_wire_codec(wire_codec(impl_->opts.format));
 }
 
 client::~client() {

--- a/projects/ores.nats/tests/domain_wire_codec_tests.cpp
+++ b/projects/ores.nats/tests/domain_wire_codec_tests.cpp
@@ -112,3 +112,18 @@ TEST_CASE("wire_codec decode surfaces a parse error for malformed msgpack input"
 
     CHECK_FALSE(decoded.has_value());
 }
+
+TEST_CASE("default_wire_codec defaults to json and reflects set_default_wire_codec", tags) {
+    // No ores::nats::service::client has been constructed in this test
+    // binary, so the process-wide default is still whatever it was left
+    // at by construction (json) -- verify that, then verify
+    // set_default_wire_codec() actually changes it, restoring json
+    // afterwards so this test doesn't leak state into others.
+    CHECK(ores::nats::default_wire_codec().format() == ores::nats::wire_format::json);
+
+    ores::nats::set_default_wire_codec(ores::nats::wire_codec(ores::nats::wire_format::msgpack));
+    CHECK(ores::nats::default_wire_codec().format() == ores::nats::wire_format::msgpack);
+
+    ores::nats::set_default_wire_codec(ores::nats::wire_codec(ores::nats::wire_format::json));
+    CHECK(ores::nats::default_wire_codec().format() == ores::nats::wire_format::json);
+}

--- a/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
@@ -25,12 +25,12 @@
 #include "ores.nats/domain/correlation.hpp"
 #include "ores.nats/domain/headers.hpp"
 #include "ores.nats/domain/message.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.service/error_code.hpp"
 #include "ores.utility/rfl/reflectors.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <optional>
-#include <rfl/json.hpp>
 #include <span>
 #include <string_view>
 
@@ -172,9 +172,8 @@ template <typename Resp>
 void reply(ores::nats::service::client& nats, const ores::nats::message& msg, const Resp& resp) {
     if (msg.reply_subject.empty())
         return;
-    const auto json = rfl::json::write(resp);
-    const auto* p = reinterpret_cast<const std::byte*>(json.data());
-    nats.publish(msg.reply_subject, std::span<const std::byte>(p, json.size()));
+    const auto bytes = ores::nats::default_wire_codec().encode(resp);
+    nats.publish(msg.reply_subject, std::span<const std::byte>(bytes));
 }
 
 /**
@@ -243,12 +242,11 @@ inline void error_reply(ores::nats::service::client& nats,
                  {{std::string(ores::nats::headers::x_error), std::string(error_str)}});
 }
 
-// Deserialise the message payload from JSON into Req.
-// Returns nullopt on parse failure.
+// Deserialise the message payload into Req using the process-wide default
+// wire_codec. Returns nullopt on parse failure.
 template <typename Req>
 std::optional<Req> decode(const ores::nats::message& msg) {
-    const std::string_view sv(reinterpret_cast<const char*>(msg.data.data()), msg.data.size());
-    auto r = rfl::json::read<Req>(sv);
+    auto r = ores::nats::default_wire_codec().decode<Req>(msg.data);
     if (!r)
         return std::nullopt;
     return *r;

--- a/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
@@ -21,12 +21,12 @@
 #define ORES_SERVICE_MESSAGING_WORKFLOW_HELPERS_HPP
 
 #include "ores.nats/domain/message.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.workflow.api/messaging/steps_query_protocol.hpp"
 #include "ores.workflow.api/messaging/workflow_events.hpp"
 #include <chrono>
 #include <optional>
-#include <rfl/json.hpp>
 #include <span>
 #include <string>
 #include <string_view>
@@ -175,8 +175,7 @@ private:
                                                               .error_message = error_msg,
                                                               .log = log};
 
-        const auto json = rfl::json::write(event);
-        const auto data = std::as_bytes(std::span{json.data(), json.size()});
+        const auto data = ores::nats::default_wire_codec().encode(event);
         nats->js_publish(ores::workflow::messaging::step_completed_event::nats_subject, data);
     }
 };
@@ -248,16 +247,14 @@ inline std::optional<cached_step_result> check_step_idempotency(ores::nats::serv
     using namespace ores::workflow::messaging;
 
     const get_step_result_request req{.step_id = step_id};
-    const auto json = rfl::json::write(req);
-    const auto data = std::as_bytes(std::span{json.data(), json.size()});
+    const auto data = ores::nats::default_wire_codec().encode(req);
 
     try {
         const auto reply_msg = nats.request_sync(
             get_step_result_request::nats_subject, data, {}, std::chrono::seconds(5));
 
-        const std::string_view sv(reinterpret_cast<const char*>(reply_msg.data.data()),
-                                  reply_msg.data.size());
-        const auto resp = rfl::json::read<get_step_result_response>(sv);
+        const auto resp =
+            ores::nats::default_wire_codec().decode<get_step_result_response>(reply_msg.data);
         if (!resp || !resp->found)
             return std::nullopt;
 

--- a/projects/ores.service/include/ores.service/service/heartbeat_publisher.hpp
+++ b/projects/ores.service/include/ores.service/service/heartbeat_publisher.hpp
@@ -21,6 +21,7 @@
 #define ORES_SERVICE_SERVICE_HEARTBEAT_PUBLISHER_HPP
 
 #include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.telemetry.core/messaging/service_samples_protocol.hpp"
 #include "ores.utility/uuid/uuid_v7_generator.hpp"
@@ -31,7 +32,6 @@
 #include <boost/system/system_error.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <cstdint>
-#include <rfl/json.hpp>
 #include <string>
 
 namespace ores::service::service {
@@ -110,10 +110,7 @@ private:
             hb.instance_id = instance_id_;
             hb.version = version_;
 
-            const auto json = rfl::json::write(hb);
-            std::vector<std::byte> data(
-                reinterpret_cast<const std::byte*>(json.data()),
-                reinterpret_cast<const std::byte*>(json.data() + json.size()));
+            auto data = ores::nats::default_wire_codec().encode(hb);
             nats_.publish(telemetry::messaging::service_heartbeat_message::nats_subject,
                           std::move(data));
             BOOST_LOG_SEV(lg(), ores::logging::trace) << "Heartbeat published: " << service_name_;


### PR DESCRIPTION
## Summary

reply()/decode() in ores.service::messaging::handler_helpers, plus the heartbeat_publisher and workflow_helpers stragglers, now route through a wire_codec instead of hard-coded rfl::json, flipping the NATS wire format for almost every service handler in one pass.

## Changes

- reply()/decode() use ores::nats::default_wire_codec() instead of rfl::json::write/read directly
- Migrated heartbeat_publisher::publish_once() and workflow_helpers.hpp (step_completed_event publish, get_step_result_request/response round-trip) onto the same default codec
- Added ores::nats::default_wire_codec()/set_default_wire_codec(): a process-wide default set automatically by nats::service::client's constructor, avoiding a signature change at the roughly 250 decode(msg) call sites across every service that have no client or codec reference in scope
- Left untouched: workflow_helpers.hpp's embedded result_json/error_message domain fields and its doc-comment example, matching the write-up task's embedded-JSON-field precedent
- Verification: full-repo compass build --preset linux-clang-debug-make clean (100%, no errors); full ctest --preset linux-clang-debug-make 74/74 suites passed, confirming behaviour-preserving migration under today's json default

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Make NATS wire format configurable: JSON/MessagePack, decided once at startup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.html) | 1A815B1E-904E-460C-A2FB-31D9E3B392E2 |
| Task | [Migrate ores.service messaging handler_helpers to wire_codec](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_migrate-handler-helpers-to-wire-codec.html) | 7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)