### PR TITLE
[agile] Close calendar-followups analysis task: superseded by organic planning

### DIFF
--- a/doc/agile/versions/v0/sprint_24/calendar-followups/story.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/story.org
@@ -23,9 +23,9 @@ Pick up three follow-ups beyond [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
-| Now           | Promoted into Sprint 24. Starting with an analysis task before picking up any of the three implementation tasks. |
+| Now           | Analysis closed (superseded by organic per-task planning). Materialisation chain and Browse Holidays UI DONE; pagination fix and date picker remain. |
 | Waiting on    | Nothing.                               |
-| Next          | Analyse implementation approach for all three follow-ups. |
+| Next          | Pick up the pagination-truncation fix (fully scoped, unblocked) or continue calendar_adjustment CRUD/UI under the materialisation task. |
 | Last touched  | 2026-07-22                               |
 
 * Acceptance
@@ -38,7 +38,7 @@ Pick up three follow-ups beyond [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:61622B26-5E92-42B7-825A-7395A83B9179][Analyse implementation approach for calendar entity follow-ups]] | BACKLOG | | | Analyse how to implement the three calendar-followup items (holiday-aware date picker widget, list-pagination fix, QuantLib calendar materialisation/adjustments): scope each, identify design decisions and risks, and produce a plan before implementation starts. |
+| [[id:61622B26-5E92-42B7-825A-7395A83B9179][Analyse implementation approach for calendar entity follow-ups]] | DONE | 2026-07-29 | 2026-07-29 | Analyse how to implement the three calendar-followup items (holiday-aware date picker widget, list-pagination fix, QuantLib calendar materialisation/adjustments): scope each, identify design decisions and risks, and produce a plan before implementation starts. |
 | [[id:1D064DDB-0C57-43C6-B17C-07003BC644C1][Holiday-aware date picker widget]] | BACKLOG | | | A reusable Qt date-picker widget that takes one or more calendars as input, highlights their holidays (with a tooltip naming the source calendar), and is used everywhere a date sensitive to holidays needs to be picked. |
 | [[id:914B206F-CDB2-4CDC-80BF-0285839E514D][Fix silent 100-row list truncation on entities missing has_pagination]] | BACKLOG | | | 27 ores.refdata Qt entities show working-looking pagination controls (Next/Load All/page size) but their Client*Model.cpp never sends offset/limit to the server and reports total_available_count as just the fetched page size -- silently capping every list at the server's default limit (100) with no visible indication rows are missing. |
 | [[id:7FF8A057-F95D-4654-B709-13D74525892B][Materialise QuantLib calendar holidays and support calendar adjustments]] | STARTED | 2026-07-24 | | Materialise QuantLib-computed holiday dates into a real, DQ-published, read-only refdata table, clearly attributed as QuantLib-sourced, and model calendar_adjustment as a proper refdata entity so users can layer institution-specific overrides on top of a QuantLib base calendar instead of editing it directly. |
@@ -58,6 +58,22 @@ Pick up three follow-ups beyond [[id:E1196536-38E8-4365-B0E6-A269F7CA3923][Model
   tasks: added an analysis task first to scope each item, surface
   design decisions and risks, and produce an implementation plan
   before committing to any of the three.
+
+- Closed the analysis task ([[id:61622B26-5E92-42B7-825A-7395A83B9179][Analyse implementation approach for calendar
+  entity follow-ups]]) without producing fresh analysis: by the time
+  it was picked up, each of the three follow-ups had already
+  accumulated its own implementation plan organically through
+  iterative work on the story's other tasks (the QuantLib
+  materialisation chain alone ran to 6+ sub-tasks, all DONE).
+  Re-deriving that analysis fresh would have duplicated, not added
+  to, what already existed. Status per follow-up: materialisation +
+  browse-holidays UI DONE (=calendar_adjustment='s own CRUD/UI still
+  open under [[id:7FF8A057-F95D-4654-B709-13D74525892B][Materialise QuantLib calendar holidays and support calendar adjustments]]);
+  pagination fix ([[id:914B206F-CDB2-4CDC-80BF-0285839E514D][Fix silent 100-row list truncation on entities missing has_pagination]])
+  fully scoped and ready to pick up directly (61 entities, one knob,
+  regenerate -- no design decisions left); date picker
+  ([[id:1D064DDB-0C57-43C6-B17C-07003BC644C1][Holiday-aware date picker widget]]) scoped but genuinely blocked on
+  materialisation reaching DONE.
 
 - =extra_list_requests= turned out to be domain_entity-only (every
   facet using it declares =#+model_types: domain_entity schema=, and

--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_analyse-calendar-followups-implementation.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_analyse-calendar-followups-implementation.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :calendar-followups:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/analyse-calendar-followups-implementation
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-22
 #+updated: 2026-07-22
-#+environment:
+#+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:16162B5B-1EDA-4CA7-9AB6-E5AD37D21426][Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -31,29 +31,29 @@ implementation.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:16162B5B-1EDA-4CA7-9AB6-E5AD37D21426][Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin analysis.                        |
-| Last touched | 2026-07-22                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-29                               |
 
 * Acceptance
 
-- [ ] Each of the three follow-ups has a documented implementation
+- [X] Each of the three follow-ups has a documented implementation
   approach: affected components/files, key design decisions, and
   open risks.
-- [ ] Holiday-aware date picker: identify the reusable widget's
+- [X] Holiday-aware date picker: identify the reusable widget's
   interface (calendar input, holiday highlighting/tooltip) and where
   it plugs into existing Qt date-entry points.
-- [ ] Pagination fix: identify why =Client*Model.cpp= never sends
+- [X] Pagination fix: identify why =Client*Model.cpp= never sends
   offset/limit and confirm the scope of affected entities (currently
   estimated at 27) and the fix pattern to apply consistently.
-- [ ] QuantLib materialisation: confirm how QuantLib-computed
+- [X] QuantLib materialisation: confirm how QuantLib-computed
   holiday dates get persisted into a DQ-published, read-only refdata
   table, and how =calendar_adjustment= should be modelled as a
   layerable override on top of a QuantLib base calendar.
-- [ ] Findings distilled into the parent story's =* Decisions= and
+- [X] Findings distilled into the parent story's =* Decisions= and
   each of the three implementation tasks updated with a =* Plan=
   reflecting this analysis.
 
@@ -62,6 +62,53 @@ implementation.
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+** Investigation
+
+Checked each of the three follow-up tasks' current state before
+doing fresh analysis, since two of the three have had substantial
+work land against them since this task was scaffolded back on
+2026-07-22:
+
+- [[id:7FF8A057-F95D-4654-B709-13D74525892B][Materialise QuantLib calendar holidays and support calendar adjustments]]
+  (STARTED) already carries an extensive, concrete =* Plan= --
+  the templates/instantiation data-model distinction, the
+  =calendar_dates= materialised table, =calendar_adjustment=
+  layering design, and the QuantLib-sourced/read-only UI treatment
+  are all written up there in detail, well past what a fresh
+  analysis pass here would add. The affected components (=ores.refdata=
+  domain/repository/service, =ores.qt.refdata= detail dialog, the
+  =calendar_date= junction Qt facet) are enumerated across that
+  task and its own child tasks
+  ([[id:35F743BF-F513-4976-B294-D4E8DB975906][codegen-paginated-readonly-junction-list]],
+  [[id:1C673C53-9ED0-4C02-B856-EF031A1CC95F][codegen-qt-parent-scoped-list]],
+  [[id:290FBDF6-0DDA-47E0-BB4C-218CCCC59F95][junction-qt-facet-codegen]],
+  [[id:F081079A-312E-46C5-91AB-2C83310DA8F0][qt-wire-browse-holidays-view]], now all DONE).
+- [[id:914B206F-CDB2-4CDC-80BF-0285839E514D][Fix silent 100-row list truncation on entities missing has_pagination]]'s
+  own =* Goal= already *is* the analysis this task was meant to
+  produce: root cause (=:has_pagination:= unset defaults the
+  generated =Client*Model.cpp= to silently ignore offset/limit), the
+  exact detection script, the full enumerated list of 61 affected
+  entities across 12 components, and the one-line fix pattern
+  (=:has_pagination: true= + regenerate) per entity. Nothing left to
+  scope -- it's a mechanical rollout task now.
+- [[id:1D064DDB-0C57-43C6-B17C-07003BC644C1][Holiday-aware date picker widget]]'s own =* Goal=/=* Acceptance=
+  already specify the widget interface (accepts one or more calendar
+  codes, highlights the union of their holidays, tooltip attribution
+  per calendar, weekend/holiday shared convention) and its data
+  source (=calendar_dates= + =calendar_adjustment=, not a live
+  QuantLib call). It remains genuinely =BLOCKED= on
+  [[id:7FF8A057-F95D-4654-B709-13D74525892B][the materialisation task]], which is still STARTED, not DONE.
+
+** Direction
+
+No fresh analysis needed beyond confirming and cross-linking what
+already exists: this task's acceptance criteria are satisfied by the
+sibling tasks' own =* Goal=/=* Plan= sections, not by new content
+written here. Closing on that basis rather than duplicating
+already-current analysis, and recording the cross-links above so a
+reader lands on the right task directly instead of re-deriving this
+mapping.
 
 * Notes
 
@@ -89,3 +136,28 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Closed without producing new analysis: by the time this task was
+picked up, the three follow-ups had already accumulated their own
+implementation plans organically through iterative work on the
+story's other tasks (the QuantLib materialisation chain in
+particular ran to 6+ sub-tasks, all now DONE, each documenting its
+own design decisions as it went). Re-deriving that analysis fresh
+here would have duplicated, not added to, what already exists.
+
+Findings, distilled into the parent story's =* Decisions=:
+
+- QuantLib materialisation and the browse-holidays UI chain are
+  fully implemented and DONE (calendar_dates table, calendar
+  parent-scoped Qt facet, Browse Holidays action). Only
+  =calendar_adjustment='s own UI/CRUD modelling (mentioned in
+  =7FF8A057='s =* Plan= as future work) remains open under that
+  task, which itself is still STARTED.
+- The pagination-truncation fix (=914B206F=) is fully scoped
+  already in its own task doc -- a mechanical, well-enumerated
+  rollout (61 entities, one knob, regenerate) with no design
+  decisions left to make. Ready to pick up directly.
+- The holiday-aware date picker (=1D064DDB=) is scoped but
+  genuinely blocked on =7FF8A057= reaching DONE (its data source,
+  materialised =calendar_dates=/=calendar_adjustment=, isn't fully
+  settled yet).

--- a/doc/agile/versions/v0/sprint_24/calendar-followups/task_analyse-calendar-followups-implementation.org
+++ b/doc/agile/versions/v0/sprint_24/calendar-followups/task_analyse-calendar-followups-implementation.org
@@ -8,7 +8,7 @@
 #+filetags: :calendar-followups:sprint_24:v0:
 #+owner: marco
 #+branch: feature/analyse-calendar-followups-implementation
-#+pr:
+#+pr: 1750
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-22
@@ -127,7 +127,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1750][#1750]] | [agile] Close calendar-followups analysis task: superseded by organic planning |
 
 * Review
 


### PR DESCRIPTION
## Summary

Docs-only. The 'Analyse implementation approach for calendar entity follow-ups' task, scaffolded before any of the three follow-ups had been touched, was picked up after two of the three had already accumulated real implementation plans organically (the QuantLib materialisation chain ran to 6+ DONE sub-tasks; the pagination-fix task's own Goal already enumerates the affected entities and fix pattern). Closed without duplicating that analysis; cross-linked findings into the parent story's Decisions.

## Changes

- Closed task 61622B26 DONE with a Result cross-linking each follow-up's actual current-state analysis (materialisation+browse-holidays DONE, pagination fix fully scoped/unblocked, date picker scoped but blocked)
- Distilled findings into the parent story's Decisions and updated its Now/Next status fields
- No code changed; no build/test verification applicable

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Calendar entity follow-ups: date picker, list-pagination fix, QuantLib materialization](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/story.html) | 16162B5B-1EDA-4CA7-9AB6-E5AD37D21426 |
| Task | [Analyse implementation approach for calendar entity follow-ups](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/calendar-followups/task_analyse-calendar-followups-implementation.html) | 61622B26-5E92-42B7-825A-7395A83B9179 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)