### PR TITLE
[ores.shell] Consolidate and migrate request helpers to wire_codec

### DIFF
--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
@@ -86,7 +86,7 @@ task.
 | [[id:D7D9EF5E-0299-47C4-A4FD-E64B284DF8DA][Build wire_codec abstraction and startup config in ores.nats]] | DONE | 2026-07-29 | 2026-07-29 | Add a wire_format enum (json, msgpack), a .env-driven config value read once at startup, and a wire_codec class holding the chosen format at construction with template encode/decode methods dispatching to rfl::json or rfl::msgpack. Non-polymorphic, no per-message branching on message content -- the format is fixed for the codec instance's lifetime. Round-trip unit tests for both formats. This is the shared foundation every other task in this story depends on. |
 | [[id:7E1FE4CF-3FFD-4977-8ED8-2D7D51461BDA][Migrate ores.service messaging handler_helpers to wire_codec]] | DONE | 2026-07-29 | 2026-07-29 | Update reply() and decode() in ores.service/messaging/handler_helpers.hpp to route through an injected wire_codec instead of a hard-coded rfl::json call. This is the server-side choke point almost every service handler already goes through, so this single change flips every service's request/response handling in one pass. Audit for any service-to-service NATS calls that bypass these two helpers and migrate or document them separately. |
 | [[id:12674934-6F8E-40C9-A8D7-ED29B0ADF322][Consolidate and migrate ores.qt ClientManager to wire_codec]] | DONE | 2026-07-29 | 2026-07-30 | ClientManager.hpp/.cpp plus ClientManagerExportPortfolio.cpp and ClientManagerTradeInstrument.cpp currently have around ten separate call sites hard-coding rfl::json (process_authenticated_request variants, send_authenticated_request variants, login, signup, event-cache decode, exportPortfolio, trade_instrument). Consolidate these into one or two shared private helpers first, reducing duplication as a side effect, then have those route through an injected wire_codec instead of rfl::json directly. |
-| [[id:926379AF-B17C-4700-AF89-6AD1EB006281][Consolidate and migrate ores.shell request helpers to wire_codec]] | BACKLOG | | | The do_request/do_auth_request template helper is copy-pasted independently into thirteen shell command .cpp files (18 definitions, 60 call sites), plus 7 more files using other direct rfl::json patterns (101 occurrences across 22 files total). De-duplicate into one shared helper in a shell-wide header first -- a real cleanup win independent of the format work -- then have that single helper route through an injected wire_codec instead of rfl::json directly. |
+| [[id:926379AF-B17C-4700-AF89-6AD1EB006281][Consolidate and migrate ores.shell request helpers to wire_codec]] | DONE | 2026-07-30 | 2026-07-30 | The do_request/do_auth_request template helper is copy-pasted independently into thirteen shell command .cpp files (18 definitions, 60 call sites), plus 7 more files using other direct rfl::json patterns (101 occurrences across 22 files total). De-duplicate into one shared helper in a shell-wide header first -- a real cleanup win independent of the format work -- then have that single helper route through an injected wire_codec instead of rfl::json directly. |
 | [[id:493C5EF6-FE85-4623-8103-563EB5CA6EE3][End-to-end verify msgpack wire format and close out the story]] | BACKLOG | | | With every layer migrated, flip a test environment's .env to msgpack and verify round-trip correctness across Qt-to-service and shell-to-service, including the image-batch flows this whole investigation started from. Confirms the raw-bytes-not-base64-for-images task's goal is achieved for free. Abandon that task in favour of this story at close, and record the .env config knob in the relevant How do I recipe. |
 | [[id:581EDA54-D912-43C0-B68B-6CD33C8DFA0B][Migrate remaining service-to-service hard-coded rfl::json call sites to wire_codec]] | BACKLOG | | | A repo-wide sweep (grep for rfl::json combined with request_sync usage) found service-to-service NATS call sites still hard-coding rfl::json instead of routing through ores::nats::default_wire_codec(), discovered outside every completed task's audited file list: ores.iam.core/service/cache/party_cache.hpp, ores.iam.core/messaging/tenant_handler.hpp, ores.marketdata.client/crm_client.cpp, ores.refdata.client/service/cache/currency_pair_convention_cache.hpp, ores.reporting.core/messaging/report_definition_template_handler.hpp, ores.trading.core/messaging/trade_handler.hpp, plus ClientManagerTradeInstrument.cpp's decode side (parse_trade_instrument, a JSON-specific two-phase parser in ores.qt.headless). Migrate every one onto the common wire_codec encode/decode helpers, then re-run the sweep to confirm it is clean, so a full-environment msgpack switch is safe. |
 
@@ -165,6 +165,28 @@ repo-wide sweep at the same time found several more such call sites
 tracked as =* Notes= on the [[id:493C5EF6-FE85-4623-8103-563EB5CA6EE3][end-to-end-verify task]] rather than fixed
 here, to keep this task's diff scoped to =ores.qt=/its one universal
 blocker.
+
+** Shared primitive lives in ores.nats, not duplicated per client
+
+Decided in the [[id:926379AF-B17C-4700-AF89-6AD1EB006281][ores.shell migration task]], on explicit request mid-task:
+=ores.qt::ClientManager= and =ores.shell= each originally grew their
+own thin encode/transport/decode wrapper around =wire_codec=
+independently. Rather than leave two parallel copies, the actual
+primitive (=request_and_decode=/=authenticated_request_and_decode=,
+templated on =Response=/=Request=, returning =rfl::Result<Response>=)
+moved down into =ores.nats/service/request_helpers.hpp=, callable by
+any NATS consumer regardless of its error-reporting convention.
+=ores.shell='s =do_request=/=do_auth_request= (std::optional plus an
+=ostream= failure message) and =ClientManager='s unauthenticated
+=process_request()=/=testConnection()=/=signup()= (std::expected)
+both now call it directly; =ClientManager='s three header-scoped
+authenticated overloads keep their own thinner
+=encode_request=/=decode_response= wrappers, documented as
+deliberate rather than accidental duplication, since
+=send_authenticated_request*= must return raw bytes (not a decoded
+value) to preserve the MSVC-C1202-avoiding TU isolation
+=ClientManagerExportPortfolio.cpp=/=ClientManagerTradeInstrument.cpp=
+already relied on.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
@@ -8,7 +8,7 @@
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
 #+branch: feature/consolidate-migrate-shell-wire-codec
-#+pr:
+#+pr: 1774
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
@@ -183,7 +183,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1774][#1774]] | [ores.shell] Consolidate and migrate request helpers to wire_codec |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
@@ -189,7 +189,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Dead =#include <rfl/json.hpp>= left after migration | change_reason_categories_commands.cpp, change_reasons_commands.cpp, variability_commands.cpp | Accepted | No remaining =rfl::= usage in these 3 files; removed. |
+| 2 | =repl.cpp= logout call silently switched from the =string_view= =authenticated_request= overload (30s default) to the =span<byte>= overload (10s default) | repl.cpp | Accepted | Passed explicit =std::chrono::seconds(30)= to preserve the prior timeout. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/consolidate-migrate-shell-wire-codec
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-28
 #+updated: 2026-07-28
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -44,27 +44,127 @@ call. Full breakdown recorded in the write-up task's =* Plan=.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                    |
 | Parent story | [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-28                               |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                                |
+| Next         | Nothing. |
+| Last touched | 2026-07-30                              |
 
 * Acceptance
 
-- [ ] =do_request=/=do_auth_request= exist in exactly one place, used
+- [X] =do_request=/=do_auth_request= exist in exactly one place, used
   by every command file that previously had its own copy.
-- [ ] That shared helper (and the other direct call sites identified
+- [X] That shared helper (and the other direct call sites identified
   above) route through the injected =wire_codec=.
-- [ ] Existing shell command behaviour is unchanged when the codec is
+- [X] Existing shell command behaviour is unchanged when the codec is
   configured for =json= (today's default).
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Consolidated =ores.shell='s ~101 =rfl::json= occurrences across 22
+files onto a single shared helper, and -- prompted mid-task by an
+explicit request to avoid parallel copies -- moved the actual
+encode/decode/transport primitive one layer further down into
+=ores.nats=, so =ores.qt::ClientManager= and =ores.shell= now build
+on literally the same code rather than each having their own thin
+wrapper.
+
+** Two-layer design: ores.nats primitive, ores.shell convention wrapper
+
+- =ores.nats/service/request_helpers.hpp= (new, header-only):
+  =request_and_decode<Response>(session, subject, req)=,
+  =authenticated_request_and_decode<Response>(session, subject, req,
+  timeout)=, and a =Request::nats_subject=/=Request::response_type=-deriving
+  overload (matching the shape =provision_commands.cpp= already
+  used). Each encodes via =default_wire_codec()=, calls
+  =session.request()=/=authenticated_request()=, and decodes via the
+  same codec, returning =rfl::Result<Response>=. Exceptions from the
+  transport propagate uncaught -- this is a pure primitive, agnostic
+  of any particular error-reporting convention.
+- =ores.shell/app/request_helpers.hpp=: =do_request=/=do_auth_request=
+  are now thin wrappers translating that =rfl::Result= into
+  =std::optional= plus a =fail(out)= message -- the convention every
+  shell command already used.
+- =ores.qt::ClientManager=: =process_request()= (the fully
+  unauthenticated overload) now calls
+  =ores::nats::service::request_and_decode()= directly, as do
+  =testConnection()=/=signup()= (their throwaway =nats_client=
+  sessions fit the primitive's shape exactly). The three
+  header-scoped authenticated overloads (=process_authenticated_request=
+  and its workspace variants) keep their own
+  =encode_request=/=decode_response= private helpers, because
+  =send_authenticated_request*= must return raw bytes rather than
+  decode them itself -- decoding has to happen in
+  =ClientManagerExportPortfolio.cpp=/=ClientManagerTradeInstrument.cpp='s
+  own translation units to preserve the MSVC C1202 avoidance those
+  files' doc comments already explain. Both helpers' doc comments now
+  point at =request_and_decode()= as the thing they wrap, so the
+  duplication that remains is documented as deliberate, not
+  overlooked.
+
+** ores.shell migration, file by file
+
+- Nine files had the identical =do_request=/=do_auth_request= template
+  pair copy-pasted verbatim (=account_parties_commands.cpp=,
+  =countries_commands.cpp=, =currencies_commands.cpp=,
+  =rbac_commands.cpp=, =change_reasons_commands.cpp=,
+  =change_reason_categories_commands.cpp=, =accounts_commands.cpp=,
+  =tenants_commands.cpp=, =variability_commands.cpp=): local copies
+  deleted, =#include "ores.shell/app/request_helpers.hpp"= added,
+  call sites' =rfl::json::write(req)= arguments simplified to =req=
+  (the helper now does the encoding).
+- Three more (=bundles_commands.cpp=, =crm_commands.cpp=,
+  =marketdata_commands.cpp=) had only =do_auth_request= (with an
+  extra =timeout= parameter) copy-pasted; migrated the same way.
+- =provision_commands.cpp='s differently-shaped =do_request=
+  (=Request=-derives-subject-and-response-type, plus
+  =timeout=/=authenticated= params) matches the shared header's third
+  overload exactly -- deleted with zero call-site changes needed.
+- Seven files using other direct =rfl::json= patterns, not through
+  any =do_request= variant (=reports_commands.cpp=,
+  =lei_commands.cpp=, =parties_commands.cpp=,
+  =connection_commands.cpp=, =history_diff_renderer.cpp=,
+  =synthetic_commands.cpp=, =workflow_commands.cpp=): each migrated
+  individually onto either the shell's =do_request=/=do_auth_request=
+  (where the existing =out=/=fail()= convention fit) or
+  =ores::nats::service::request_and_decode=/
+  =authenticated_request_and_decode= directly (where the call site
+  used a different return convention -- =std::expected= in
+  =workflow_commands.cpp='s =fetch_steps()=, or silently discarded a
+  malformed response in =connection_commands.cpp='s bootstrap-status
+  check).
+- =application.cpp='s auto-connect bootstrap-status check and
+  auto-login, and =repl.cpp='s logout-on-exit: migrated the same way
+  as the seven direct-pattern files above (=repl.cpp='s logout
+  discards the response entirely, so only needed =encode()=, no
+  decode).
+- Also caught and fixed one manual, non-=do_request= call site inside
+  an otherwise-migrated file: =accounts_commands.cpp='s
+  =process_logout()= hand-rolled =rfl::json::write=/=read= directly
+  against =session.authenticated_request()=, missed by the
+  file-level migration since it didn't go through the local
+  =do_auth_request= copy; now calls =do_auth_request= like every
+  other command in that file.
+- Left deliberately untouched: =synthetic_commands.cpp='s debug-log
+  line (=rfl::json::write(req)= for a human-readable log message, not
+  a wire call), and =ores.shell/src/config/options.cpp=/
+  =login_options.cpp= (config-file I/O, confirmed out of scope by the
+  write-up task's original audit).
+
+Verification: full-repo =compass build --preset linux-clang-debug-make=
+clean; full =compass build rat --preset linux-clang-debug-make= (every
+component's test target) passed with zero failures. Live smoke test:
+brought the environment up (=json=, today's default), logged in as
+=tenant_admin@barclays_plc=, and exercised a representative spread of
+the migrated commands end to end --
+=currencies get=, =countries get=, =lei countries=, =parties list=,
+=roles list=, =reports templates=, =tenants get=, =account-parties
+list= -- all returned correct data. (=permissions list= failed with
+"no service is handling subject" -- a pre-existing, unrelated gap:
+that handler was never registered server-side, confirmed by grepping
+=ores.iam= for the subject; not something this migration introduced
+or could have caused.)
 
 * Notes
 
@@ -92,3 +192,24 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+=ores.shell='s ~101 =rfl::json= occurrences across 22 files are
+consolidated onto a single shared helper
+(=ores.shell/app/request_helpers.hpp='s =do_request=/=do_auth_request=),
+itself a thin convention wrapper over a new shared primitive in
+=ores.nats/service/request_helpers.hpp=
+(=request_and_decode=/=authenticated_request_and_decode=) that
+=ores::qt::ClientManager= now also calls directly for its
+unauthenticated paths, per an explicit mid-task request to avoid two
+parallel copies of the encode/transport/decode logic. All 13
+=do_request=/=do_auth_request= definitions (18 copies) are gone,
+along with the 7 other direct-pattern files and the =application.cpp=/
+=repl.cpp= stragglers the write-up task's audit named -- plus one
+manual call site the file-level migration would have missed
+(=accounts_commands.cpp='s =process_logout()=). Full-repo build and
+the complete =rat= test run both pass; a live smoke test against a
+running environment (=json=, today's default) exercised eight
+representative migrated commands across both consolidation shapes,
+all returning correct data, with one unrelated pre-existing gap noted
+(=permissions list= -- no server-side handler registered for that
+subject, unconnected to this migration).

--- a/projects/ores.nats/include/ores.nats/service/request_helpers.hpp
+++ b/projects/ores.nats/include/ores.nats/service/request_helpers.hpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_NATS_SERVICE_REQUEST_HELPERS_HPP
+#define ORES_NATS_SERVICE_REQUEST_HELPERS_HPP
+
+#include "ores.nats/domain/wire_codec.hpp"
+#include "ores.nats/service/nats_client.hpp"
+#include <chrono>
+#include <string>
+#include <string_view>
+
+namespace ores::nats::service {
+
+/**
+ * @brief Encode @p req, send it as an unauthenticated request on
+ * @p subject, and decode the reply as @p Response -- all via the
+ * process-wide default_wire_codec().
+ *
+ * The shared primitive behind both ores::qt::ClientManager's and
+ * ores.shell's request helpers: previously each had its own
+ * hard-coded rfl::json::write/read pair (ClientManager's inline, and
+ * copy-pasted independently into ~13 ores.shell command files).
+ * Exceptions from the transport (nats_connect_error,
+ * session_expired_error, etc.) propagate uncaught -- callers with
+ * different error-reporting conventions (std::expected for
+ * ClientManager, std::optional plus an ostream message for
+ * ores.shell) wrap this in their own try/catch.
+ */
+template <typename Response, typename Request>
+rfl::Result<Response>
+request_and_decode(nats_client& session, std::string_view subject, const Request& req) {
+    const auto& codec = default_wire_codec();
+    const auto bytes = codec.encode(req);
+    const std::string body(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    const auto reply = session.request(subject, body);
+    return codec.decode<Response>(reply.data);
+}
+
+/**
+ * @brief Like request_and_decode(), but sends an authenticated
+ * request (Bearer token from @p session) with an optional @p timeout.
+ */
+template <typename Response, typename Request>
+rfl::Result<Response>
+authenticated_request_and_decode(nats_client& session,
+                                 std::string_view subject,
+                                 const Request& req,
+                                 std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
+    const auto& codec = default_wire_codec();
+    const auto reply = session.authenticated_request(subject, codec.encode(req), timeout);
+    return codec.decode<Response>(reply.data);
+}
+
+/**
+ * @brief Like request_and_decode()/authenticated_request_and_decode(),
+ * but derives the subject and response type from @p req itself
+ * (@c Request::nats_subject / @c Request::response_type) rather than
+ * taking them explicitly, and picks authenticated vs. unauthenticated
+ * via @p authenticated. Matches the shape ores.shell's
+ * provision_commands.cpp wizard call sites already used.
+ */
+template <typename Request>
+rfl::Result<typename Request::response_type>
+request_and_decode(nats_client& session,
+                   const Request& req,
+                   std::chrono::milliseconds timeout = std::chrono::seconds(30),
+                   bool authenticated = false) {
+    using Response = typename Request::response_type;
+    const auto& codec = default_wire_codec();
+    const auto bytes = codec.encode(req);
+    const auto subject = std::string(req.nats_subject);
+    const auto reply =
+        authenticated ?
+            session.authenticated_request(subject, bytes, timeout) :
+            session.request(subject,
+                            std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+    return codec.decode<Response>(reply.data);
+}
+
+}
+
+#endif

--- a/projects/ores.nats/src/component_files.cmake
+++ b/projects/ores.nats/src/component_files.cmake
@@ -49,6 +49,7 @@ set(HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/jwks.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/nats_client.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/nats_connect_error.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/request_helpers.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/retry.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/session_expired_error.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.nats/service/subscription.hpp"

--- a/projects/ores.qt/api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt/api/include/ores.qt/ClientManager.hpp
@@ -28,6 +28,7 @@
 #include "ores.nats/service/jetstream_admin.hpp"
 #include "ores.nats/service/nats_client.hpp"
 #include "ores.nats/service/nats_connect_error.hpp"
+#include "ores.nats/service/request_helpers.hpp"
 #include "ores.nats/service/session_expired_error.hpp"
 #include "ores.nats/service/subscription.hpp"
 #include "ores.qt/WorkspaceContext.hpp"
@@ -430,7 +431,9 @@ public:
      * @brief Process a request that does not require authentication.
      *
      * Serializes the request via the process-wide default wire_codec, sends
-     * it via NATS, and deserializes the response the same way.
+     * it via NATS, and deserializes the response the same way -- via
+     * ores::nats::service::request_and_decode(), the primitive shared with
+     * ores.shell's do_request() helper.
      *
      * @tparam RequestType Request type (must satisfy nats_request concept)
      * @param request The request to send
@@ -441,10 +444,12 @@ public:
         -> std::expected<typename RequestType::response_type, std::string> {
         using ResponseType = typename RequestType::response_type;
         try {
-            auto msg = session_.request(RequestType::nats_subject, encode_request(request));
-            const std::string_view data(reinterpret_cast<const char*>(msg.data.data()),
-                                        msg.data.size());
-            return decode_response<ResponseType>(data);
+            auto result = ores::nats::service::request_and_decode<ResponseType>(
+                session_, RequestType::nats_subject, request);
+            if (!result)
+                return std::unexpected(std::string("Failed to deserialize response: ") +
+                                       result.error().what());
+            return std::move(*result);
         } catch (const ores::nats::service::nats_connect_error&) {
             throw; // Propagate so connect() can map to a user-visible message
         } catch (const std::exception& e) {
@@ -743,9 +748,20 @@ private:
     /**
      * @brief Serializes @p request using the process-wide default wire_codec
      * (see ores::nats::default_wire_codec()), returned as a std::string for
-     * interop with session_.request()/send_authenticated_request*'s existing
+     * interop with send_authenticated_request*'s existing
      * std::string_view-based signatures -- std::string preserves embedded
      * nulls, so this is safe for msgpack's binary output too, not just JSON.
+     *
+     * Only still needed for the header-scoped authenticated path
+     * (send_authenticated_request*, which must return raw bytes rather than
+     * decode them itself -- see exportPortfolio()'s doc comment for why that
+     * TU-isolation matters) and for exportPortfolio()/getTradeInstrument(),
+     * which decode in their own translation unit for the same reason.
+     * process_request(), testConnection(), and signup() call
+     * ores::nats::service::request_and_decode() directly instead -- the
+     * primitive this and decode_response() are themselves thin wrappers
+     * around, and the same one ores.shell's do_request()/do_auth_request()
+     * build on.
      */
     template <typename T>
     static std::string encode_request(const T& request) {
@@ -756,7 +772,8 @@ private:
     /**
      * @brief Deserializes @p raw (a raw NATS response payload) into T using
      * the process-wide default wire_codec, returning std::unexpected with a
-     * formatted message on parse failure.
+     * formatted message on parse failure. See encode_request()'s doc comment
+     * for why this still exists alongside request_and_decode().
      */
     template <typename T>
     static std::expected<T, std::string> decode_response(std::string_view raw) {

--- a/projects/ores.qt/api/src/ClientManager.cpp
+++ b/projects/ores.qt/api/src/ClientManager.cpp
@@ -611,13 +611,10 @@ LoginResult ClientManager::testConnection(const std::string& host,
 
         // Attempt login
         iam::messaging::login_request request{.principal = username, .password = password};
-        auto msg = temp_session.request(iam::messaging::login_request::nats_subject,
-                                        encode_request(request));
+        auto resp = ores::nats::service::request_and_decode<iam::messaging::login_response>(
+            temp_session, iam::messaging::login_request::nats_subject, request);
         temp_session.disconnect();
 
-        const std::string_view data(reinterpret_cast<const char*>(msg.data.data()),
-                                    msg.data.size());
-        auto resp = decode_response<iam::messaging::login_response>(data);
         if (!resp || !resp->success) {
             const std::string err = resp ? resp->error_message : "Invalid response";
             return {.success = false, .error_message = QString::fromStdString(err)};
@@ -650,13 +647,10 @@ SignupResult ClientManager::signup(const std::string& host,
 
         iam::messaging::signup_request request{
             .principal = username, .password = password, .email = email};
-        auto msg = temp_session.request(iam::messaging::signup_request::nats_subject,
-                                        encode_request(request));
+        auto resp = ores::nats::service::request_and_decode<iam::messaging::signup_response>(
+            temp_session, iam::messaging::signup_request::nats_subject, request);
         temp_session.disconnect();
 
-        const std::string_view data(reinterpret_cast<const char*>(msg.data.data()),
-                                    msg.data.size());
-        auto resp = decode_response<iam::messaging::signup_response>(data);
         if (!resp || !resp->success) {
             const std::string err = resp ? resp->message : "Invalid response";
             return {.success = false, .error_message = QString::fromStdString(err)};

--- a/projects/ores.shell/include/ores.shell/app/request_helpers.hpp
+++ b/projects/ores.shell/include/ores.shell/app/request_helpers.hpp
@@ -1,0 +1,120 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_APP_REQUEST_HELPERS_HPP
+#define ORES_SHELL_APP_REQUEST_HELPERS_HPP
+
+#include "ores.nats/service/request_helpers.hpp"
+#include "ores.shell/app/command_feedback.hpp"
+#include <chrono>
+#include <optional>
+#include <ostream>
+#include <string_view>
+
+namespace ores::shell::app::commands {
+
+/**
+ * @brief Send an unauthenticated NATS request and decode its response,
+ * reporting failure through the shell's ostream/command_feedback
+ * convention.
+ *
+ * Thin wrapper over ores::nats::service::request_and_decode() -- the
+ * primitive shared with ores::qt::ClientManager -- adapting its
+ * rfl::Result return into the std::optional-plus-fail(out)-message
+ * convention every shell command already expects. Replaces the
+ * copy-pasted per-command-file @c do_request template that used to
+ * hard-code @c rfl::json::write/read directly in ~13 files.
+ */
+template <typename Response, typename Request>
+std::optional<Response> do_request(std::ostream& out,
+                                   ores::nats::service::nats_client& session,
+                                   std::string_view subject,
+                                   const Request& req) {
+    try {
+        auto result = ores::nats::service::request_and_decode<Response>(session, subject, req);
+        if (!result) {
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+/**
+ * @brief Send an authenticated NATS request and decode its response.
+ *
+ * See do_request() -- same shape, plus a Bearer token from @p session and
+ * an optional @p timeout (default 30s, matching the pre-existing
+ * per-command-file copies' default).
+ */
+template <typename Response, typename Request>
+std::optional<Response>
+do_auth_request(std::ostream& out,
+                ores::nats::service::nats_client& session,
+                std::string_view subject,
+                const Request& req,
+                std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
+    try {
+        auto result = ores::nats::service::authenticated_request_and_decode<Response>(
+            session, subject, req, timeout);
+        if (!result) {
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+/**
+ * @brief Like do_request(), but derives the subject and response type from
+ * @p req itself (@c Request::nats_subject / @c Request::response_type),
+ * and can optionally send authenticated. Matches the shape
+ * =provision_commands.cpp='s wizard call sites already used, kept as a
+ * distinct overload rather than folded into do_request()/do_auth_request()
+ * above since those two take an explicit subject and response type instead.
+ */
+template <typename Request>
+std::optional<typename Request::response_type>
+do_request(std::ostream& out,
+           ores::nats::service::nats_client& session,
+           const Request& req,
+           std::chrono::milliseconds timeout = std::chrono::seconds(30),
+           bool authenticated = false) {
+    try {
+        auto result = ores::nats::service::request_and_decode(session, req, timeout, authenticated);
+        if (!result) {
+            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+            return std::nullopt;
+        }
+        return *result;
+    } catch (const std::exception& e) {
+        fail(out) << "Request failed: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}
+
+}
+
+#endif

--- a/projects/ores.shell/src/app/application.cpp
+++ b/projects/ores.shell/src/app/application.cpp
@@ -21,10 +21,10 @@
 #include "ores.iam.api/messaging/bootstrap_protocol.hpp"
 #include "ores.iam.api/messaging/login_protocol.hpp"
 #include "ores.nats/service/nats_client.hpp"
+#include "ores.nats/service/request_helpers.hpp"
 #include "ores.shell/app/repl.hpp"
 #include "ores.utility/version/version.hpp"
 #include <iostream>
-#include <rfl/json.hpp>
 #include <sstream>
 
 namespace ores::shell::app {
@@ -66,11 +66,11 @@ bool auto_connect(ores::nats::service::nats_client& session,
 
 void check_bootstrap_status(ores::nats::service::nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request(iam::messaging::bootstrap_status_request::nats_subject,
-                                     rfl::json::write(iam::messaging::bootstrap_status_request{}));
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<iam::messaging::bootstrap_status_response>(data_str);
+        auto result =
+            ores::nats::service::request_and_decode<iam::messaging::bootstrap_status_response>(
+                session,
+                iam::messaging::bootstrap_status_request::nats_subject,
+                iam::messaging::bootstrap_status_request{});
         if (!result)
             return;
         if (result->is_in_bootstrap_mode) {
@@ -90,10 +90,8 @@ bool auto_login(ores::nats::service::nats_client& session,
         iam::messaging::login_request req;
         req.principal = login_config.username;
         req.password = login_config.password;
-        auto reply = session.request("iam.v1.auth.login", rfl::json::write(req));
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<iam::messaging::login_response>(data_str);
+        auto result = ores::nats::service::request_and_decode<iam::messaging::login_response>(
+            session, "iam.v1.auth.login", req);
         if (!result || !result->success) {
             out << "✗ Auto-login failed: " << (result ? result->message : "parse error")
                 << std::endl;

--- a/projects/ores.shell/src/app/commands/account_parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/account_parties_commands.cpp
@@ -24,13 +24,13 @@
 #include "ores.nats/domain/message.hpp"
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -38,25 +38,6 @@ using namespace logging;
 using ores::nats::service::nats_client;
 
 namespace {
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
 
 std::optional<boost::uuids::uuid>
 parse_uuid(std::ostream& out, const std::string& value, std::string_view what) {
@@ -98,7 +79,7 @@ void account_parties_commands::process_list(std::ostream& out, nats_client& sess
 
     iam::messaging::get_account_parties_request req;
     auto result = do_auth_request<iam::messaging::get_account_parties_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
+        out, session, std::string(req.nats_subject), req);
     if (!result)
         return;
 
@@ -131,7 +112,7 @@ void account_parties_commands::process_add(std::ostream& out,
     refdata::messaging::get_parties_request parties_req;
     parties_req.limit = 1000;
     auto parties = do_auth_request<refdata::messaging::get_parties_response>(
-        out, session, std::string(parties_req.nats_subject), rfl::json::write(parties_req));
+        out, session, std::string(parties_req.nats_subject), parties_req);
     if (!parties)
         return;
 
@@ -157,7 +138,7 @@ void account_parties_commands::process_add(std::ostream& out,
     req.account_parties.push_back(std::move(association));
 
     auto result = do_auth_request<iam::messaging::save_account_party_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
+        out, session, std::string(req.nats_subject), req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -31,6 +31,7 @@
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/rbac_commands.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -40,7 +41,6 @@
 #include <iomanip>
 #include <map>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <sstream>
 
 namespace ores::shell::app::commands {
@@ -74,48 +74,6 @@ std::string format_duration(std::chrono::seconds dur) {
         return std::to_string(hours.count()) + "h " + std::to_string(mins.count()) + "m";
     }
     return std::to_string(mins.count()) + "m";
-}
-
-template <typename Response>
-std::optional<Response> do_request(std::ostream& out,
-                                   nats_client& session,
-                                   std::string_view subject,
-                                   const std::string& body) {
-    try {
-        auto reply = session.request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        std::string_view subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
 }
 
 } // anonymous namespace
@@ -321,7 +279,7 @@ void accounts_commands::process_list_accounts(std::ostream& out,
     req.limit = pagination.page_size();
 
     auto result = do_auth_request<iam::messaging::get_accounts_response>(
-        out, session, "iam.v1.accounts.list", rfl::json::write(req));
+        out, session, "iam.v1.accounts.list", req);
     if (!result)
         return;
 
@@ -350,8 +308,8 @@ void accounts_commands::process_login(std::ostream& out,
     req.principal = std::move(principal);
     req.password = std::move(password);
 
-    auto result = do_request<iam::messaging::login_response>(
-        out, session, "iam.v1.auth.login", rfl::json::write(req));
+    auto result =
+        do_request<iam::messaging::login_response>(out, session, "iam.v1.auth.login", req);
     if (!result)
         return;
 
@@ -392,7 +350,7 @@ void accounts_commands::process_lock_account(std::ostream& out,
     req.account_ids = {account_id};
 
     auto result = do_auth_request<iam::messaging::lock_account_response>(
-        out, session, "iam.v1.accounts.lock", rfl::json::write(req));
+        out, session, "iam.v1.accounts.lock", req);
     if (!result)
         return;
 
@@ -430,7 +388,7 @@ void accounts_commands::process_unlock_account(std::ostream& out,
     req.account_ids = {account_id};
 
     auto result = do_auth_request<iam::messaging::unlock_account_response>(
-        out, session, "iam.v1.accounts.unlock", rfl::json::write(req));
+        out, session, "iam.v1.accounts.unlock", req);
     if (!result)
         return;
 
@@ -465,7 +423,7 @@ void accounts_commands::process_create_account(std::ostream& out,
     req.email = std::move(email);
 
     auto result = do_auth_request<iam::messaging::save_account_response>(
-        out, session, "iam.v1.accounts.save", rfl::json::write(req));
+        out, session, "iam.v1.accounts.save", req);
     if (!result)
         return;
 
@@ -483,10 +441,7 @@ void accounts_commands::process_list_login_info(std::ostream& out, nats_client& 
     BOOST_LOG_SEV(lg(), debug) << "Initiating list login info request.";
 
     auto result = do_auth_request<iam::messaging::list_login_info_response>(
-        out,
-        session,
-        "iam.v1.accounts.list-logins",
-        rfl::json::write(iam::messaging::list_login_info_request{}));
+        out, session, "iam.v1.accounts.list-logins", iam::messaging::list_login_info_request{});
     if (!result)
         return;
 
@@ -502,11 +457,8 @@ void accounts_commands::process_logout(std::ostream& out, nats_client& session) 
     }
 
     try {
-        auto reply = session.authenticated_request(
-            "iam.v1.auth.logout", rfl::json::write(iam::messaging::logout_request{}));
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<iam::messaging::logout_response>(data_str);
+        auto result = do_auth_request<iam::messaging::logout_response>(
+            out, session, "iam.v1.auth.logout", iam::messaging::logout_request{});
         if (result && result->success) {
             out << "✓ Logged out successfully." << std::endl;
         } else {
@@ -531,10 +483,7 @@ void accounts_commands::process_bootstrap(std::ostream& out,
     req.email = std::move(email);
 
     auto result = do_request<iam::messaging::create_initial_admin_response>(
-        out,
-        session,
-        iam::messaging::create_initial_admin_request::nats_subject,
-        rfl::json::write(req));
+        out, session, iam::messaging::create_initial_admin_request::nats_subject, req);
     if (!result)
         return;
 
@@ -571,7 +520,7 @@ void accounts_commands::process_list_sessions(std::ostream& out,
     }
 
     auto result = do_auth_request<iam::messaging::list_sessions_response>(
-        out, session, "iam.v1.sessions.list", rfl::json::write(req));
+        out, session, "iam.v1.sessions.list", req);
     if (!result)
         return;
 
@@ -620,10 +569,7 @@ void accounts_commands::process_active_sessions(std::ostream& out, nats_client& 
     BOOST_LOG_SEV(lg(), debug) << "Initiating active sessions request.";
 
     auto result = do_auth_request<iam::messaging::get_active_sessions_response>(
-        out,
-        session,
-        "iam.v1.sessions.active",
-        rfl::json::write(iam::messaging::get_active_sessions_request{}));
+        out, session, "iam.v1.sessions.active", iam::messaging::get_active_sessions_request{});
     if (!result)
         return;
 
@@ -669,7 +615,7 @@ void accounts_commands::process_session_stats(std::ostream& out, nats_client& se
     req.end_time = end_date;
 
     auto result = do_auth_request<iam::messaging::get_session_statistics_response>(
-        out, session, "iam.v1.sessions.statistics", rfl::json::write(req));
+        out, session, "iam.v1.sessions.statistics", req);
     if (!result)
         return;
 
@@ -737,7 +683,7 @@ void accounts_commands::process_get_account_history(std::ostream& out,
     req.username = std::move(username);
 
     auto result = do_auth_request<iam::messaging::get_account_history_response>(
-        out, session, "iam.v1.accounts.history", rfl::json::write(req));
+        out, session, "iam.v1.accounts.history", req);
     if (!result)
         return;
 
@@ -768,10 +714,7 @@ void accounts_commands::process_set_default_party(std::ostream& out,
     refdata::messaging::get_parties_request parties_req;
     parties_req.limit = 1000;
     auto parties = do_auth_request<refdata::messaging::get_parties_response>(
-        out,
-        session,
-        refdata::messaging::get_parties_request::nats_subject,
-        rfl::json::write(parties_req));
+        out, session, refdata::messaging::get_parties_request::nats_subject, parties_req);
     if (!parties)
         return;
 
@@ -797,10 +740,7 @@ void accounts_commands::process_set_default_party(std::ostream& out,
     req.party_id = boost::uuids::to_string(party->id);
 
     auto result = do_auth_request<iam::messaging::set_my_default_party_response>(
-        out,
-        session,
-        iam::messaging::set_my_default_party_request::nats_subject,
-        rfl::json::write(req));
+        out, session, iam::messaging::set_my_default_party_request::nats_subject, req);
     if (!result)
         return;
 
@@ -828,7 +768,7 @@ void accounts_commands::process_account_info(std::ostream& out,
     hist_req.username = username;
 
     auto history_result = do_auth_request<iam::messaging::get_account_history_response>(
-        out, session, "iam.v1.accounts.history", rfl::json::write(hist_req));
+        out, session, "iam.v1.accounts.history", hist_req);
     if (!history_result)
         return;
 
@@ -873,7 +813,7 @@ void accounts_commands::process_account_info(std::ostream& out,
     out << "-----" << std::endl;
 
     auto roles_result = do_auth_request<iam::messaging::get_account_roles_response>(
-        out, session, "iam.v1.roles.for-account", rfl::json::write(roles_req));
+        out, session, "iam.v1.roles.for-account", roles_req);
     if (!roles_result) {
         out << "  (failed to retrieve roles)" << std::endl;
     } else if (roles_result->roles.empty()) {
@@ -897,7 +837,7 @@ void accounts_commands::process_account_info(std::ostream& out,
     out << "---------------------" << std::endl;
 
     auto perms_result = do_auth_request<iam::messaging::get_account_permissions_response>(
-        out, session, "iam.v1.permissions.for-account", rfl::json::write(perms_req));
+        out, session, "iam.v1.permissions.for-account", perms_req);
     if (!perms_result) {
         out << "  (failed to retrieve permissions)" << std::endl;
     } else if (perms_result->permission_codes.empty()) {

--- a/projects/ores.shell/src/app/commands/bundles_commands.cpp
+++ b/projects/ores.shell/src/app/commands/bundles_commands.cpp
@@ -25,12 +25,12 @@
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/workflow_commands.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <chrono>
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -43,27 +43,6 @@ namespace {
 // wizards' generous request timeout.
 constexpr std::chrono::minutes publish_timeout(5);
 constexpr std::chrono::seconds default_wait_timeout(300);
-
-template <typename Response>
-std::optional<Response>
-do_auth_request(std::ostream& out,
-                nats_client& session,
-                const std::string& subject,
-                const std::string& body,
-                std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
-    try {
-        auto reply = session.authenticated_request(subject, body, timeout);
-        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
 
 }
 
@@ -91,7 +70,7 @@ void bundles_commands::process_list(std::ostream& out, nats_client& session) {
 
     dq::messaging::get_dataset_bundles_request req;
     auto result = do_auth_request<dq::messaging::get_dataset_bundles_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
+        out, session, std::string(req.nats_subject), req);
     if (!result)
         return;
 
@@ -163,7 +142,7 @@ void bundles_commands::process_publish(std::ostream& out,
     out << "Publishing bundle '" << code << "'..." << std::endl;
 
     auto result = do_auth_request<dq::messaging::publish_bundle_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req), publish_timeout);
+        out, session, std::string(req.nats_subject), req, publish_timeout);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
@@ -26,7 +26,6 @@
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 

--- a/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reason_categories_commands.cpp
@@ -21,6 +21,7 @@
 #include "ores.dq.api/domain/change_reason_category_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_reason_category_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>
@@ -32,51 +33,6 @@ namespace ores::shell::app::commands {
 using namespace logging;
 using ores::nats::service::nats_client;
 
-namespace {
-
-template <typename Response>
-std::optional<Response> do_request(std::ostream& out,
-                                   nats_client& session,
-                                   const std::string& subject,
-                                   const std::string& body) {
-    try {
-        auto reply = session.request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-} // anonymous namespace
 
 void change_reason_categories_commands::register_commands(cli::Menu& root_menu,
                                                           nats_client& session) {
@@ -126,7 +82,7 @@ void change_reason_categories_commands::process_get_categories(std::ostream& out
         out,
         session,
         "dq.v1.change_reason_categories.list",
-        rfl::json::write(dq::messaging::get_change_reason_categories_request{}));
+        dq::messaging::get_change_reason_categories_request{});
     if (!result)
         return;
 
@@ -158,7 +114,7 @@ void change_reason_categories_commands::process_add_category(std::ostream& out,
                                            .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<dq::messaging::save_change_reason_category_response>(
-        out, session, "dq.v1.change_reason_categories.save", rfl::json::write(req));
+        out, session, "dq.v1.change_reason_categories.save", req);
     if (!result)
         return;
 
@@ -187,7 +143,7 @@ void change_reason_categories_commands::process_delete_category(std::ostream& ou
     req.codes = {code};
 
     auto result = do_auth_request<dq::messaging::delete_change_reason_category_response>(
-        out, session, "dq.v1.change_reason_categories.delete", rfl::json::write(req));
+        out, session, "dq.v1.change_reason_categories.delete", req);
     if (!result)
         return;
 
@@ -215,7 +171,7 @@ void change_reason_categories_commands::process_get_category_history(std::ostrea
     req.code = std::move(code);
 
     auto result = do_auth_request<dq::messaging::get_change_reason_category_history_response>(
-        out, session, "dq.v1.change_reason_categories.history", rfl::json::write(req));
+        out, session, "dq.v1.change_reason_categories.history", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
@@ -26,7 +26,6 @@
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 

--- a/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
+++ b/projects/ores.shell/src/app/commands/change_reasons_commands.cpp
@@ -21,6 +21,7 @@
 #include "ores.dq.api/domain/change_reason_table_io.hpp" // IWYU pragma: keep.
 #include "ores.dq.api/messaging/change_reason_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>
@@ -32,51 +33,6 @@ namespace ores::shell::app::commands {
 using namespace logging;
 using ores::nats::service::nats_client;
 
-namespace {
-
-template <typename Response>
-std::optional<Response> do_request(std::ostream& out,
-                                   nats_client& session,
-                                   const std::string& subject,
-                                   const std::string& body) {
-    try {
-        auto reply = session.request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-} // anonymous namespace
 
 void change_reasons_commands::register_commands(cli::Menu& root_menu,
                                                 nats_client& session,
@@ -127,10 +83,7 @@ void change_reasons_commands::process_get_change_reasons(std::ostream& out, nats
     BOOST_LOG_SEV(lg(), debug) << "Initiating get change reasons request.";
 
     auto result = do_request<dq::messaging::get_change_reasons_response>(
-        out,
-        session,
-        "dq.v1.change_reasons.list",
-        rfl::json::write(dq::messaging::get_change_reasons_request{}));
+        out, session, "dq.v1.change_reasons.list", dq::messaging::get_change_reasons_request{});
     if (!result)
         return;
 
@@ -168,7 +121,7 @@ void change_reasons_commands::process_add_change_reason(std::ostream& out,
                                   .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<dq::messaging::save_change_reason_response>(
-        out, session, "dq.v1.change_reasons.save", rfl::json::write(req));
+        out, session, "dq.v1.change_reasons.save", req);
     if (!result)
         return;
 
@@ -197,7 +150,7 @@ void change_reasons_commands::process_delete_change_reason(std::ostream& out,
     req.codes = {code};
 
     auto result = do_auth_request<dq::messaging::delete_change_reason_response>(
-        out, session, "dq.v1.change_reasons.delete", rfl::json::write(req));
+        out, session, "dq.v1.change_reasons.delete", req);
     if (!result)
         return;
 
@@ -225,7 +178,7 @@ void change_reasons_commands::process_get_change_reason_history(std::ostream& ou
     req.code = std::move(code);
 
     auto result = do_auth_request<dq::messaging::get_change_reason_history_response>(
-        out, session, "dq.v1.change_reasons.history", rfl::json::write(req));
+        out, session, "dq.v1.change_reasons.history", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -21,12 +21,12 @@
 #include "ores.iam.api/messaging/bootstrap_protocol.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/config/nats_options.hpp"
+#include "ores.nats/service/request_helpers.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <stdexcept>
 
 namespace ores::shell::app::commands {
@@ -45,11 +45,11 @@ auto& anon_lg() {
 
 void check_bootstrap_status(nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request(iam::messaging::bootstrap_status_request::nats_subject,
-                                     rfl::json::write(iam::messaging::bootstrap_status_request{}));
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<iam::messaging::bootstrap_status_response>(data_str);
+        auto result =
+            ores::nats::service::request_and_decode<iam::messaging::bootstrap_status_response>(
+                session,
+                iam::messaging::bootstrap_status_request::nats_subject,
+                iam::messaging::bootstrap_status_request{});
         if (!result)
             return;
         if (result->is_in_bootstrap_mode) {

--- a/projects/ores.shell/src/app/commands/countries_commands.cpp
+++ b/projects/ores.shell/src/app/commands/countries_commands.cpp
@@ -23,41 +23,17 @@
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/history_diff_renderer.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
 using namespace logging;
 using ores::nats::service::nats_client;
 
-namespace {
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-} // anonymous namespace
 
 void countries_commands::register_commands(cli::Menu& root_menu,
                                            nats_client& session,
@@ -134,7 +110,7 @@ void countries_commands::process_get_countries(std::ostream& out,
     req.limit = pagination.page_size();
 
     auto result = do_auth_request<refdata::messaging::get_countries_response>(
-        out, session, "refdata.v1.countries.list", rfl::json::write(req));
+        out, session, "refdata.v1.countries.list", req);
     if (!result)
         return;
 
@@ -187,7 +163,7 @@ void countries_commands::process_add_country(std::ostream& out,
                                  .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<refdata::messaging::save_country_response>(
-        out, session, "refdata.v1.countries.save", rfl::json::write(req));
+        out, session, "refdata.v1.countries.save", req);
     if (!result)
         return;
 
@@ -216,7 +192,7 @@ void countries_commands::process_delete_country(std::ostream& out,
     req.alpha2_codes = {alpha2_code};
 
     auto result = do_auth_request<refdata::messaging::delete_country_response>(
-        out, session, "refdata.v1.countries.delete", rfl::json::write(req));
+        out, session, "refdata.v1.countries.delete", req);
     if (!result)
         return;
 
@@ -277,7 +253,7 @@ void countries_commands::process_get_country_history(std::ostream& out,
     req.alpha2_code = alpha2_code;
 
     auto result = do_auth_request<refdata::messaging::get_country_history_response>(
-        out, session, "refdata.v1.countries.history", rfl::json::write(req));
+        out, session, "refdata.v1.countries.history", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/crm_commands.cpp
+++ b/projects/ores.shell/src/app/commands/crm_commands.cpp
@@ -28,13 +28,13 @@
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <cli/cli.h>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <unordered_map>
 
 namespace ores::shell::app::commands {
@@ -45,30 +45,6 @@ namespace marketdata_client = ores::marketdata::client;
 namespace marketdata_msg = ores::marketdata::messaging;
 namespace refdata_msg = ores::refdata::messaging;
 
-namespace {
-
-template <typename Response>
-std::optional<Response>
-do_auth_request(std::ostream& out,
-                nats_client& session,
-                const std::string& subject,
-                const std::string& body,
-                std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
-    try {
-        auto reply = session.authenticated_request(subject, body, timeout);
-        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-}
 
 void crm_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto menu = std::make_unique<cli::Menu>("crm");
@@ -93,7 +69,7 @@ resolve_party_id(std::ostream& out, nats_client& session, const std::string& par
     refdata_msg::get_parties_request req;
     req.limit = 1000;
     auto parties = do_auth_request<refdata_msg::get_parties_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
+        out, session, std::string(req.nats_subject), req);
     if (!parties)
         return std::nullopt;
 
@@ -166,7 +142,7 @@ void crm_commands::process_rates(std::ostream& out,
     rates_req.crm_name = crm_name;
     rates_req.reciprocal = reciprocal;
     auto rates_result = do_auth_request<marketdata_msg::get_crm_rates_response>(
-        out, session, std::string(rates_req.nats_subject), rfl::json::write(rates_req));
+        out, session, std::string(rates_req.nats_subject), rates_req);
     if (!rates_result)
         return;
     if (!rates_result->success) {
@@ -182,7 +158,7 @@ void crm_commands::process_rates(std::ostream& out,
     refdata_msg::get_currency_pair_conventions_request conventions_req;
     conventions_req.limit = 10000;
     auto conventions_result = do_auth_request<refdata_msg::get_currency_pair_conventions_response>(
-        out, session, std::string(conventions_req.nats_subject), rfl::json::write(conventions_req));
+        out, session, std::string(conventions_req.nats_subject), conventions_req);
     if (!conventions_result)
         return;
 

--- a/projects/ores.shell/src/app/commands/currencies_commands.cpp
+++ b/projects/ores.shell/src/app/commands/currencies_commands.cpp
@@ -23,63 +23,17 @@
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/history_diff_renderer.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <algorithm>
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
 using namespace logging;
 using ores::nats::service::nats_client;
-
-namespace {
-
-template <typename Response>
-std::optional<Response> do_request(std::ostream& out,
-                                   nats_client& session,
-                                   std::string_view subject,
-                                   const std::string& body) {
-    try {
-        auto reply = session.request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        std::string_view subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-} // anonymous namespace
 
 void currencies_commands::register_commands(cli::Menu& root_menu,
                                             nats_client& session,
@@ -151,7 +105,7 @@ void currencies_commands::process_get_currencies(std::ostream& out,
     req.limit = pagination.page_size();
 
     auto result = do_auth_request<refdata::messaging::get_currencies_response>(
-        out, session, "refdata.v1.currencies.list", rfl::json::write(req));
+        out, session, "refdata.v1.currencies.list", req);
     if (!result)
         return;
 
@@ -220,7 +174,7 @@ void currencies_commands::process_add_currency(std::ostream& out,
                                   .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<refdata::messaging::save_currency_response>(
-        out, session, "refdata.v1.currencies.save", rfl::json::write(req));
+        out, session, "refdata.v1.currencies.save", req);
     if (!result)
         return;
 
@@ -249,7 +203,7 @@ void currencies_commands::process_delete_currency(std::ostream& out,
     req.iso_codes = {iso_code};
 
     auto result = do_auth_request<refdata::messaging::delete_currency_response>(
-        out, session, "refdata.v1.currencies.delete", rfl::json::write(req));
+        out, session, "refdata.v1.currencies.delete", req);
     if (!result)
         return;
 
@@ -309,7 +263,7 @@ void currencies_commands::process_get_currency_history(std::ostream& out,
     req.iso_code = iso_code;
 
     auto result = do_auth_request<refdata::messaging::get_currency_history_response>(
-        out, session, "refdata.v1.currencies.history", rfl::json::write(req));
+        out, session, "refdata.v1.currencies.history", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/history_diff_renderer.cpp
+++ b/projects/ores.shell/src/app/commands/history_diff_renderer.cpp
@@ -21,8 +21,8 @@
 #include "ores.history.api/messaging/history_protocol.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include <algorithm>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -61,14 +61,9 @@ void render_history_diff(std::ostream& out,
     req.entity_id = std::move(entity_id);
 
     const auto subject = ores::history::messaging::history_subject_for(req.entity_type);
-    auto reply = session.authenticated_request(subject, rfl::json::write(req));
-    auto data_str =
-        std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-    auto result = rfl::json::read<get_entity_history_response>(data_str);
-    if (!result) {
-        fail(out) << "Failed to parse response" << std::endl;
+    auto result = do_auth_request<get_entity_history_response>(out, session, subject, req);
+    if (!result)
         return;
-    }
 
     if (!result->success) {
         BOOST_LOG_SEV(lg(), warn) << "Failed to get history: " << result->message;

--- a/projects/ores.shell/src/app/commands/lei_commands.cpp
+++ b/projects/ores.shell/src/app/commands/lei_commands.cpp
@@ -22,12 +22,12 @@
 #include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include <algorithm>
 #include <cli/cli.h>
 #include <functional>
 #include <iomanip>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <set>
 
 namespace ores::shell::app::commands {
@@ -43,14 +43,10 @@ fetch_entities(std::ostream& out, nats_client& session, const std::string& count
     req.country_filter = country_filter;
 
     try {
-        auto reply =
-            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
-        auto result = rfl::json::read<dq::messaging::get_lei_entities_summary_response>(
-            ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+        auto result = do_auth_request<dq::messaging::get_lei_entities_summary_response>(
+            out, session, std::string(req.nats_subject), req);
+        if (!result)
             return std::nullopt;
-        }
         if (!result->success) {
             fail(out) << "Failed to fetch LEI entities: " << result->error_message << std::endl;
             return std::nullopt;

--- a/projects/ores.shell/src/app/commands/marketdata_commands.cpp
+++ b/projects/ores.shell/src/app/commands/marketdata_commands.cpp
@@ -22,6 +22,7 @@
 #include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <chrono>
 #include <cli/cli.h>
@@ -29,7 +30,6 @@
 #include <functional>
 #include <optional>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <sstream>
 
 namespace ores::shell::app::commands {
@@ -42,27 +42,6 @@ namespace {
 // Imports can be large market.txt/fixings.txt files; mirror the
 // bundles publish command's generous request timeout.
 constexpr std::chrono::minutes import_timeout(5);
-
-template <typename Response>
-std::optional<Response>
-do_auth_request(std::ostream& out,
-                nats_client& session,
-                const std::string& subject,
-                const std::string& body,
-                std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
-    try {
-        auto reply = session.authenticated_request(subject, body, timeout);
-        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
 
 std::optional<std::string> read_file(const std::string& path) {
     std::ifstream file(path);
@@ -140,7 +119,7 @@ void marketdata_commands::process_import(std::ostream& out,
     out << "Importing market data..." << std::endl;
 
     auto result = do_auth_request<marketdata::messaging::import_market_data_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req), import_timeout);
+        out, session, std::string(req.nats_subject), req, import_timeout);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/parties_commands.cpp
+++ b/projects/ores.shell/src/app/commands/parties_commands.cpp
@@ -23,12 +23,12 @@
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <algorithm>
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -94,14 +94,10 @@ void parties_commands::process_list(std::ostream& out,
     req.limit = list_limit;
 
     try {
-        auto reply =
-            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
-        auto result = rfl::json::read<refdata::messaging::get_parties_response>(
-            ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+        auto result = do_auth_request<refdata::messaging::get_parties_response>(
+            out, session, std::string(req.nats_subject), req);
+        if (!result)
             return;
-        }
 
         std::vector<refdata::domain::party> filtered;
         for (const auto& party : result->parties) {

--- a/projects/ores.shell/src/app/commands/provision_commands.cpp
+++ b/projects/ores.shell/src/app/commands/provision_commands.cpp
@@ -33,6 +33,7 @@
 #include "ores.shell/app/commands/accounts_commands.hpp"
 #include "ores.shell/app/commands/synthetic_commands.hpp"
 #include "ores.shell/app/commands/workflow_commands.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
 #include <boost/lexical_cast.hpp>
@@ -43,7 +44,6 @@
 #include <functional>
 #include <ostream>
 #include <regex>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -64,33 +64,6 @@ const std::regex username_regex("^[a-zA-Z][a-zA-Z0-9_]{2,49}$");
 const std::regex email_regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._-]+\\.[a-zA-Z]{2,}$");
 const std::regex tenant_code_regex("^[a-z][a-z0-9_]{0,49}$");
 constexpr std::size_t min_password_length = 8;
-
-template <typename Request>
-std::optional<typename Request::response_type>
-do_request(std::ostream& out,
-           nats_client& session,
-           const Request& req,
-           std::chrono::milliseconds timeout = std::chrono::seconds(30),
-           bool authenticated = false) {
-    using Response = typename Request::response_type;
-    try {
-        const auto body = rfl::json::write(req);
-        // The unauthenticated request overload has no timeout knob.
-        auto reply =
-            authenticated ?
-                session.authenticated_request(std::string(req.nats_subject), body, timeout) :
-                session.request(std::string(req.nats_subject), body);
-        auto result = rfl::json::read<Response>(ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
 
 bool validate_account(std::ostream& out,
                       std::string_view what,

--- a/projects/ores.shell/src/app/commands/rbac_commands.cpp
+++ b/projects/ores.shell/src/app/commands/rbac_commands.cpp
@@ -22,6 +22,7 @@
 #include "ores.iam.api/domain/role_table_io.hpp"       // IWYU pragma: keep.
 #include "ores.iam.api/messaging/authorization_protocol.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -29,7 +30,6 @@
 #include <functional>
 #include <optional>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <string_view>
 
 namespace ores::shell::app::commands {
@@ -83,27 +83,6 @@ void format_string_list(std::ostream& out,
     out << "Total: " << items.size() << " item(s)" << std::endl;
 }
 
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
 } // anonymous namespace
 
 void rbac_commands::register_commands(cli::Menu& root_menu,
@@ -155,10 +134,7 @@ void rbac_commands::process_list_permissions(std::ostream& out, nats_client& ses
     BOOST_LOG_SEV(lg(), debug) << "Initiating list permissions request.";
 
     auto result = do_auth_request<iam::messaging::list_permissions_response>(
-        out,
-        session,
-        "iam.v1.permissions.list",
-        rfl::json::write(iam::messaging::list_permissions_request{}));
+        out, session, "iam.v1.permissions.list", iam::messaging::list_permissions_request{});
     if (!result)
         return;
 
@@ -171,7 +147,7 @@ void rbac_commands::process_list_roles(std::ostream& out, nats_client& session) 
     BOOST_LOG_SEV(lg(), debug) << "Initiating list roles request.";
 
     auto result = do_auth_request<iam::messaging::list_roles_response>(
-        out, session, "iam.v1.roles.list", rfl::json::write(iam::messaging::list_roles_request{}));
+        out, session, "iam.v1.roles.list", iam::messaging::list_roles_request{});
     if (!result)
         return;
 
@@ -187,8 +163,8 @@ void rbac_commands::process_get_role(std::ostream& out,
     iam::messaging::get_role_request req;
     req.identifier = role_identifier;
 
-    auto result = do_auth_request<iam::messaging::get_role_response>(
-        out, session, "iam.v1.roles.get", rfl::json::write(req));
+    auto result =
+        do_auth_request<iam::messaging::get_role_response>(out, session, "iam.v1.roles.get", req);
     if (!result)
         return;
 
@@ -237,7 +213,7 @@ void rbac_commands::process_assign_role(std::ostream& out,
         req.role_id = role_id_or_name;
 
         auto result = do_auth_request<iam::messaging::assign_role_response>(
-            out, session, "iam.v1.roles.assign", rfl::json::write(req));
+            out, session, "iam.v1.roles.assign", req);
         if (!result)
             return;
 
@@ -257,7 +233,7 @@ void rbac_commands::process_assign_role(std::ostream& out,
         req.role_name = role_id_or_name;
 
         auto result = do_auth_request<iam::messaging::assign_role_response>(
-            out, session, "iam.v1.roles.assign-by-name", rfl::json::write(req));
+            out, session, "iam.v1.roles.assign-by-name", req);
         if (!result)
             return;
 
@@ -287,7 +263,7 @@ void rbac_commands::process_revoke_role(std::ostream& out,
         req.role_id = role_id_or_name;
 
         auto result = do_auth_request<iam::messaging::revoke_role_response>(
-            out, session, "iam.v1.roles.revoke", rfl::json::write(req));
+            out, session, "iam.v1.roles.revoke", req);
         if (!result)
             return;
 
@@ -307,7 +283,7 @@ void rbac_commands::process_revoke_role(std::ostream& out,
         req.role_name = role_id_or_name;
 
         auto result = do_auth_request<iam::messaging::revoke_role_response>(
-            out, session, "iam.v1.roles.revoke-by-name", rfl::json::write(req));
+            out, session, "iam.v1.roles.revoke-by-name", req);
         if (!result)
             return;
 
@@ -335,7 +311,7 @@ void rbac_commands::process_get_account_roles(std::ostream& out,
     req.account_id = account_id;
 
     auto result = do_auth_request<iam::messaging::get_account_roles_response>(
-        out, session, "iam.v1.roles.for-account", rfl::json::write(req));
+        out, session, "iam.v1.roles.for-account", req);
     if (!result)
         return;
 
@@ -361,7 +337,7 @@ void rbac_commands::process_get_account_permissions(std::ostream& out,
     req.account_id = account_id;
 
     auto result = do_auth_request<iam::messaging::get_account_permissions_response>(
-        out, session, "iam.v1.permissions.for-account", rfl::json::write(req));
+        out, session, "iam.v1.permissions.for-account", req);
     if (!result)
         return;
 
@@ -392,7 +368,7 @@ void rbac_commands::process_suggest_role_commands(std::ostream& out,
     }
 
     auto result = do_auth_request<iam::messaging::suggest_role_commands_response>(
-        out, session, "iam.v1.roles.suggest-commands", rfl::json::write(req));
+        out, session, "iam.v1.roles.suggest-commands", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/reports_commands.cpp
+++ b/projects/ores.shell/src/app/commands/reports_commands.cpp
@@ -22,11 +22,11 @@
 #include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include <cli/cli.h>
 #include <functional>
 #include <iomanip>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -70,14 +70,10 @@ void reports_commands::process_templates(std::ostream& out,
     BOOST_LOG_SEV(lg(), debug) << "Listing report templates for bundle: " << req.bundle_code;
 
     try {
-        auto reply =
-            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
-        auto result = rfl::json::read<dq::messaging::list_dq_report_definition_templates_response>(
-            ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+        auto result = do_auth_request<dq::messaging::list_dq_report_definition_templates_response>(
+            out, session, std::string(req.nats_subject), req);
+        if (!result)
             return;
-        }
         if (!result->success) {
             fail(out) << "Failed to list report templates: " << result->message << std::endl;
             return;

--- a/projects/ores.shell/src/app/commands/synthetic_commands.cpp
+++ b/projects/ores.shell/src/app/commands/synthetic_commands.cpp
@@ -21,6 +21,7 @@
 #include "ores.nats/domain/message.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.synthetic.api/messaging/generate_organisation_protocol.hpp"
 #include <chrono>
 #include <cli/cli.h>
@@ -156,14 +157,10 @@ bool synthetic_commands::generate(std::ostream& out,
         << " parties)..." << std::endl;
 
     try {
-        auto reply = session.authenticated_request(
-            std::string(req.nats_subject), rfl::json::write(req), generate_timeout);
-        auto result = rfl::json::read<synthetic::messaging::generate_organisation_response>(
-            ores::nats::as_string_view(reply.data));
-        if (!result) {
-            fail(out) << "Failed to parse response: " << result.error().what() << std::endl;
+        auto result = do_auth_request<synthetic::messaging::generate_organisation_response>(
+            out, session, std::string(req.nats_subject), req, generate_timeout);
+        if (!result)
             return false;
-        }
         if (!result->success) {
             fail(out) << "Generation failed: " << result->error_message << std::endl;
             return false;

--- a/projects/ores.shell/src/app/commands/tenants_commands.cpp
+++ b/projects/ores.shell/src/app/commands/tenants_commands.cpp
@@ -22,6 +22,7 @@
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
 #include "ores.platform/time/datetime.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -29,7 +30,6 @@
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 
@@ -40,27 +40,6 @@ namespace {
 
 std::string format_time(std::chrono::system_clock::time_point tp) {
     return ores::platform::time::datetime::to_local_display_string(tp);
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
 }
 
 } // anonymous namespace
@@ -136,7 +115,7 @@ void tenants_commands::process_get_tenants(std::ostream& out,
     req.include_deleted = include_deleted;
 
     auto result = do_auth_request<iam::messaging::get_tenants_response>(
-        out, session, "iam.v1.tenants.list", rfl::json::write(req));
+        out, session, "iam.v1.tenants.list", req);
     if (!result)
         return;
 
@@ -179,7 +158,7 @@ void tenants_commands::process_add_tenant(std::ostream& out,
                             .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<iam::messaging::save_tenant_response>(
-        out, session, "iam.v1.tenants.save", rfl::json::write(req));
+        out, session, "iam.v1.tenants.save", req);
     if (!result)
         return;
 
@@ -212,7 +191,7 @@ void tenants_commands::process_tenant_history(std::ostream& out,
     req.id = tenant_id;
 
     auto result = do_auth_request<iam::messaging::get_tenant_history_response>(
-        out, session, "iam.v1.tenants.history", rfl::json::write(req));
+        out, session, "iam.v1.tenants.history", req);
     if (!result)
         return;
 
@@ -278,7 +257,7 @@ void tenants_commands::process_delete_tenant(std::ostream& out,
     req.ids = {tenant_id};
 
     auto result = do_auth_request<iam::messaging::delete_tenant_response>(
-        out, session, "iam.v1.tenants.delete", rfl::json::write(req));
+        out, session, "iam.v1.tenants.delete", req);
     if (!result)
         return;
 
@@ -301,7 +280,7 @@ void tenants_commands::process_complete_provisioning(std::ostream& out, nats_cli
 
     iam::messaging::complete_tenant_provisioning_command req;
     auto result = do_auth_request<iam::messaging::complete_tenant_provisioning_response>(
-        out, session, std::string(req.nats_subject), rfl::json::write(req));
+        out, session, std::string(req.nats_subject), req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/variability_commands.cpp
+++ b/projects/ores.shell/src/app/commands/variability_commands.cpp
@@ -26,7 +26,6 @@
 #include <cli/cli.h>
 #include <functional>
 #include <ostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app::commands {
 

--- a/projects/ores.shell/src/app/commands/variability_commands.cpp
+++ b/projects/ores.shell/src/app/commands/variability_commands.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/commands/variability_commands.hpp"
 #include "ores.shell/app/command_feedback.hpp"
+#include "ores.shell/app/request_helpers.hpp"
 #include "ores.utility/rfl/reflectors.hpp"                         // IWYU pragma: keep.
 #include "ores.variability.api/domain/system_setting_table_io.hpp" // IWYU pragma: keep.
 #include "ores.variability.api/messaging/system_settings_protocol.hpp"
@@ -32,51 +33,6 @@ namespace ores::shell::app::commands {
 using namespace ores::logging;
 using ores::nats::service::nats_client;
 
-namespace {
-
-template <typename Response>
-std::optional<Response> do_request(std::ostream& out,
-                                   nats_client& session,
-                                   const std::string& subject,
-                                   const std::string& body) {
-    try {
-        auto reply = session.request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-template <typename Response>
-std::optional<Response> do_auth_request(std::ostream& out,
-                                        nats_client& session,
-                                        const std::string& subject,
-                                        const std::string& body) {
-    try {
-        auto reply = session.authenticated_request(subject, body);
-        auto data_str =
-            std::string(reinterpret_cast<const char*>(reply.data.data()), reply.data.size());
-        auto result = rfl::json::read<Response>(data_str);
-        if (!result) {
-            fail(out) << "Failed to parse response" << std::endl;
-            return std::nullopt;
-        }
-        return *result;
-    } catch (const std::exception& e) {
-        fail(out) << "Request failed: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-}
-
-} // anonymous namespace
 
 void variability_commands::register_commands(cli::Menu& root_menu, nats_client& session) {
     auto variability_menu = std::make_unique<cli::Menu>("variability");
@@ -130,7 +86,7 @@ void variability_commands::process_list_settings(std::ostream& out, nats_client&
         out,
         session,
         "variability.v1.settings.list",
-        rfl::json::write(variability::messaging::list_settings_request{}));
+        variability::messaging::list_settings_request{});
     if (!result)
         return;
 
@@ -168,7 +124,7 @@ void variability_commands::process_save_setting(std::ostream& out,
                                             .recorded_at = std::chrono::system_clock::now()});
 
     auto result = do_auth_request<variability::messaging::save_setting_response>(
-        out, session, "variability.v1.settings.save", rfl::json::write(req));
+        out, session, "variability.v1.settings.save", req);
     if (!result)
         return;
 
@@ -197,7 +153,7 @@ void variability_commands::process_delete_setting(std::ostream& out,
     req.name = std::move(name);
 
     auto result = do_auth_request<variability::messaging::delete_setting_response>(
-        out, session, "variability.v1.settings.delete", rfl::json::write(req));
+        out, session, "variability.v1.settings.delete", req);
     if (!result)
         return;
 
@@ -225,7 +181,7 @@ void variability_commands::process_get_setting_history(std::ostream& out,
     req.name = std::move(name);
 
     auto result = do_auth_request<variability::messaging::get_setting_history_response>(
-        out, session, "variability.v1.settings.history", rfl::json::write(req));
+        out, session, "variability.v1.settings.history", req);
     if (!result)
         return;
 

--- a/projects/ores.shell/src/app/commands/workflow_commands.cpp
+++ b/projects/ores.shell/src/app/commands/workflow_commands.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/commands/workflow_commands.hpp"
 #include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/request_helpers.hpp"
 #include "ores.shell/app/command_args.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.workflow.api/messaging/workflow_query_protocol.hpp"
@@ -26,7 +27,6 @@
 #include <expected>
 #include <map>
 #include <ostream>
-#include <rfl/json.hpp>
 #include <thread>
 
 namespace ores::shell::app::commands {
@@ -55,10 +55,9 @@ fetch_steps(nats_client& session, const std::string& instance_id) {
     req.workflow_instance_id = instance_id;
 
     try {
-        auto reply =
-            session.authenticated_request(std::string(req.nats_subject), rfl::json::write(req));
-        auto result = rfl::json::read<workflow::messaging::get_workflow_steps_response>(
-            ores::nats::as_string_view(reply.data));
+        auto result = ores::nats::service::authenticated_request_and_decode<
+            workflow::messaging::get_workflow_steps_response>(
+            session, std::string(req.nats_subject), req);
         if (!result)
             return std::unexpected("Failed to parse response: " + result.error().what());
         return *result;

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -47,6 +47,7 @@
 #include "ores.utility/rfl/reflectors.hpp"       // IWYU pragma: keep.
 #include "ores.utility/streaming/std_vector.hpp" // IWYU pragma: keep.
 #include "ores.utility/version/version.hpp"
+#include <chrono>
 #include <cli/cli.h>
 #include <cli/clifilesession.h>
 #include <iostream>
@@ -137,7 +138,8 @@ void repl::cleanup() {
         try {
             std::ignore = session_.authenticated_request(
                 "iam.v1.auth.logout",
-                ores::nats::default_wire_codec().encode(iam::messaging::logout_request{}));
+                ores::nats::default_wire_codec().encode(iam::messaging::logout_request{}),
+                std::chrono::seconds(30));
             BOOST_LOG_SEV(lg(), info) << "Logged out successfully.";
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(lg(), warn) << "Logout request failed during cleanup: " << e.what();

--- a/projects/ores.shell/src/app/repl.cpp
+++ b/projects/ores.shell/src/app/repl.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.shell/app/repl.hpp"
 #include "ores.iam.api/messaging/login_protocol.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.shell/app/command_feedback.hpp"
 #include "ores.shell/app/commands/account_parties_commands.hpp"
 #include "ores.shell/app/commands/accounts_commands.hpp"
@@ -49,7 +50,6 @@
 #include <cli/cli.h>
 #include <cli/clifilesession.h>
 #include <iostream>
-#include <rfl/json.hpp>
 
 namespace ores::shell::app {
 
@@ -136,7 +136,8 @@ void repl::cleanup() {
         BOOST_LOG_SEV(lg(), debug) << "Sending logout request before exit.";
         try {
             std::ignore = session_.authenticated_request(
-                "iam.v1.auth.logout", rfl::json::write(iam::messaging::logout_request{}));
+                "iam.v1.auth.logout",
+                ores::nats::default_wire_codec().encode(iam::messaging::logout_request{}));
             BOOST_LOG_SEV(lg(), info) << "Logged out successfully.";
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(lg(), warn) << "Logout request failed during cleanup: " << e.what();

--- a/projects/ores.shell/src/component_files.cmake
+++ b/projects/ores.shell/src/component_files.cmake
@@ -87,6 +87,7 @@ set(HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/app/ores.shell.app.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/app/pagination_context.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/app/repl.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/app/request_helpers.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/app/script_runner.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/config/login_options.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../include/ores.shell/config/options.hpp"


### PR DESCRIPTION
## Summary

De-duplicates ores.shell's do_request/do_auth_request (18 copies across 13 files) plus 7 more direct rfl::json call sites and the application.cpp/repl.cpp stragglers -- 101 occurrences across 22 files -- onto a single shared helper routing through wire_codec. Also moves the shared encode/transport/decode primitive down into ores.nats so ores.qt::ClientManager and ores.shell build on the same code instead of parallel copies.

## Changes

- Added ores.nats/service/request_helpers.hpp: request_and_decode/authenticated_request_and_decode, the shared primitive both ClientManager and ores.shell now build on
- Added ores.shell/app/request_helpers.hpp: do_request/do_auth_request, thin wrappers translating the primitive's rfl Result into the shell's std::optional plus fail(out) convention
- Deleted 18 copy-pasted do_request/do_auth_request definitions across 13 command files, migrated 7 more direct-pattern files (reports, lei, parties, connection, history_diff_renderer, synthetic, workflow commands) plus application.cpp/repl.cpp stragglers, and fixed one manual call site accounts_commands.cpp's process_logout had missed
- ClientManager's unauthenticated process_request/testConnection/signup now call the shared ores.nats primitive directly; the three header-scoped authenticated overloads keep their own thinner wrappers, documented why, to preserve the existing MSVC C1202 TU-isolation property
- Verification: full-repo compass build clean; full compass build rat (every component's test target) passed with zero failures; live smoke test against a running environment (json default) exercised 8 representative migrated commands end to end, all correct

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Make NATS wire format configurable: JSON/MessagePack, decided once at startup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.html) | 1A815B1E-904E-460C-A2FB-31D9E3B392E2 |
| Task | [Consolidate and migrate ores.shell request helpers to wire_codec](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_consolidate-migrate-shell-wire-codec.html) | 926379AF-B17C-4700-AF89-6AD1EB006281 |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)