### PR TITLE
[claude_code] Add PreToolUse hook denying unscoped find invocations

### DIFF
--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:devx:sprint_24:v0:
 #+created: 2026-07-29
 #+updated: 2026-07-29
-#+environment: brave_hopper
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -45,6 +45,7 @@ developer-experience work.
 | [[id:BB046E80-655A-4D6F-950C-0A81C9040F05][Add compass command to prune merged git branches and report branch/environment usage]] | BACKLOG | | | Add a compass git subcommand (e.g. 'compass branches prune' or similar) that deletes all fully-merged local and remote git branches, and separately reports which branches are stale/unmerged, mapping each to the fleet worktree/environment currently using it if any. Formalises a manual git-branch cleanup workflow performed ad hoc in this session (fetch --prune, diff local/remote against origin/main, cross-reference against 'compass fleet' to avoid deleting a branch another environment has checked out, then git branch -d / git push origin --delete for the safe set). |
 | [[id:4E613004-5331-42C2-A654-56292F763095][Support multiple named .env files, e.g. per remote host]] | BACKLOG | | | Every compass command that needs environment or DB config (db recreate, services start, etc.) reads a single hardcoded .env at the repo root, with no way to point at a different target. Surfaced while deploying the containerized service runtime to Newton: compass db recreate had to be run against Newton's Postgres by temporarily editing the repo's own .env in place (ORES_DB_HOST, PGPORT), then restoring it afterward -- fragile and easy to forget to revert. Add support for named environment files, e.g. .env.newton alongside the default .env, and a way to select one per invocation (an --env-file flag or similar), so targeting a remote host's DB or services never requires mutating the working .env. |
 | [[id:C96740B8-89CA-44C1-98F1-38EF97886EDC][Show systemd slice/scope info in compass fleet and bearings]] | BACKLOG | | | Add systemd slice/scope information to compass fleet and compass bearings output |
+| [[id:6A77C68E-EB6C-432F-801A-5825AE44E16C][Deny unscoped find invocations via PreToolUse hook]] | DONE | 2026-07-30 | 2026-07-30 | Block find invocations rooted at a filesystem-wide directory, surfaced when an unscoped find scan touched the whole machine while researching ORE index conventions. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_deny-unscoped-find-hook.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_deny-unscoped-find-hook.org
@@ -1,0 +1,89 @@
+:PROPERTIES:
+:ID: 6A77C68E-EB6C-432F-801A-5825AE44E16C
+:END:
+#+title: Task: Deny unscoped find invocations via PreToolUse hook
+#+description: Block find invocations rooted at a filesystem-wide directory, surfaced when an unscoped find scan touched the whole machine while researching ORE index conventions.
+#+type: task
+#+level: s1
+#+filetags: :compass-quality-of-life-improvements:sprint_24:v0:
+#+owner: marco
+#+branch: chore/deny-unscoped-find-hook
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-07-30
+#+updated: 2026-07-30
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F64924CE-8D35-437A-B275-617558DC5FBE][Compass quality-of-life improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Extend the existing PreToolUse hook mechanism to also deny find commands rooted at a filesystem-wide directory, so a targeted search stays targeted.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:F64924CE-8D35-437A-B275-617558DC5FBE][Compass quality-of-life improvements]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-07-30                               |
+
+* Acceptance
+
+- A new deny_unscoped_find_hook.py denies filesystem-root-rooted finds (no subpath) while allowing relative and narrower absolute paths; wired into .claude/settings.json's PreToolUse hooks alongside the existing piped-compass hook; unit tests cover both deny and allow cases, including find-as-prose-word false positives.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Added =projects/ores.compass/src/deny_unscoped_find_hook.py=, a
+second =PreToolUse= hook alongside the existing piped-compass hook
+(same fail-open-if-missing guard). Denies a =find= invocation whose
+first non-flag path argument is exactly one of =/=, =/home=, =/usr=,
+=/etc=, =/var=, =/proc=, =/sys=, =/root=, =/opt=, =/boot=, =/dev=,
+=/mnt=, =/tmp= (no subpath); relative paths and any narrower absolute
+path pass through untouched. =find= is only recognised as a command
+word at the very start of the command string or directly after a
+shell operator (=;=, =&=, =|=, =(=) -- not bare whitespace -- since
+matching on bare whitespace would also catch "find" used as an
+ordinary English word inside an unrelated argument (caught live: a
+=compass add task --description= string mentioning "...an unscoped
+find / scanned the whole machine..." tripped an earlier draft of the
+regex). 13 unit tests cover both deny/allow cases and that false-
+positive class specifically. Wired into =.claude/settings.json= via
+=doc/llm/claude_code_settings.org='s =hooks-pretooluse= noweb block,
+alongside the existing hook entry.

--- a/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_deny-unscoped-find-hook.org
+++ b/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_deny-unscoped-find-hook.org
@@ -8,7 +8,7 @@
 #+filetags: :compass-quality-of-life-improvements:sprint_24:v0:
 #+owner: marco
 #+branch: chore/deny-unscoped-find-hook
-#+pr:
+#+pr: 1775
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-30
@@ -60,7 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1775][#1775]] | [claude_code] Add PreToolUse hook denying unscoped find invocations |
 
 * Review
 

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -767,6 +767,204 @@ def test_malformed_json_does_not_crash(monkeypatch):
     assert hook.main() == 0
 #+end_src
 
+** Deny unscoped `find` invocations
+
+A `find` rooted at `/` or another filesystem-wide root (`/home`,
+`/usr`, `/etc`, `/var`, `/proc`, `/sys`, `/root`, `/opt`, `/boot`,
+`/dev`, `/mnt` with no subpath) scans far more of the machine than any
+task in this repo needs, is slow, and risks surfacing content from
+unrelated projects/worktrees. Permission allow/deny rules cannot tell
+`find . -iname foo.hpp` apart from `find / -iname foo.hpp` — both are
+just `find` with arguments — so this is enforced the same way as the
+piped-compass rule above: a =PreToolUse= hook that inspects the full
+command string.
+
+The hook denies only when `find`'s first non-flag argument is exactly
+one of those unscoped roots; a relative path (`.`, `projects/`,
+`../Engine`), a path under the project root, or any other explicitly
+narrower absolute path (e.g. `/home/marco/Development/ORE/Engine`) is
+untouched. When a genuinely broad search is needed, ask the user
+first rather than routing around this with a narrower-looking but
+still-unscoped path.
+
+`find` is only recognised as a command word at the very start of the
+command string or directly after a shell operator (`;`, `&`, `|`,
+`(`) -- not after bare whitespace. This is deliberately stricter than
+the piped-compass hook's own boundary check: matching on bare
+whitespace too would also catch `find` used as an ordinary English
+word inside an unrelated argument (e.g. a `compass add task
+--description` string that happens to say "...surfaced when an
+unscoped find / scanned the whole machine..."), denying a command
+that contains no `find` invocation at all.
+
+Same fail-open guard as the piped-compass hook: exits 0 (allow) if
+the script itself is missing rather than hard-blocking the =Bash=
+tool.
+
+#+begin_src python :tangle ../../projects/ores.compass/src/deny_unscoped_find_hook.py :mkdirp yes :shebang "#!/usr/bin/env python3"
+"""PreToolUse hook: deny `find` invocations rooted at `/` or another
+filesystem-wide root. See doc/llm/claude_code_settings.org's Hooks
+section.
+
+Targeted finds (relative paths, or absolute paths narrower than a
+top-level root) are unaffected -- only a bare filesystem-root scan is
+denied.
+"""
+import json
+import re
+import sys
+
+# Matches "find" as a command word: start of the whole command, or
+# immediately after a shell operator (;, &, |, () skipping any
+# whitespace -- deliberately NOT bare whitespace alone, which would
+# also match "find" appearing as an ordinary English word inside an
+# unrelated argument (e.g. a --description string mentioning "you'll
+# find / at the root"). Followed by its first non-flag argument; flags
+# (anything starting with "-") are skipped since find's path
+# argument(s) may follow options like -H/-L/-P. Captures that first
+# path argument.
+FIND_RE = re.compile(
+    r"(?:^|[&;|(]\s*)find\s+(?:-\w+\s+)*(\S+)"
+)
+
+# Filesystem-wide roots with no further subpath -- a scan starting here
+# walks far more of the machine than any task in this repo needs.
+UNSCOPED_ROOTS = {
+    "/", "/home", "/usr", "/etc", "/var", "/proc", "/sys",
+    "/root", "/opt", "/boot", "/dev", "/mnt", "/tmp",
+}
+
+DENIAL_MESSAGE = (
+    "Unscoped `find` rooted at a filesystem-wide directory is denied -- "
+    "scope it to the project directory (or another specific, narrower "
+    "path) instead, or ask the user explicitly if a broader search is "
+    "genuinely needed. See doc/llm/claude_code_settings.org.\n"
+)
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+        return 0
+    command = data.get("tool_input", {}).get("command", "")
+    for match in FIND_RE.finditer(command):
+        if match.group(1) in UNSCOPED_ROOTS:
+            sys.stderr.write(DENIAL_MESSAGE)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+#+end_src
+
+#+begin_src python :tangle ../../projects/ores.compass/tests/test_deny_unscoped_find_hook.py :mkdirp yes
+"""
+Tests for the unscoped-find PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_unscoped_find_hook.py -v
+No live database or file system access required.
+"""
+
+import io
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_unscoped_find_hook as hook
+
+
+def run(command, tool_name="Bash", monkeypatch=None):
+    """Drive hook.main() with a synthetic PreToolUse payload on stdin,
+    returning (exit_code, stderr_text)."""
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    import json
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr)
+    return hook.main(), stderr.getvalue()
+
+
+def test_find_root_denied(monkeypatch):
+    code, msg = run('find / -iname "aonia.hpp"', monkeypatch=monkeypatch)
+    assert code == 2
+    assert "Unscoped `find`" in msg
+
+
+def test_find_home_denied(monkeypatch):
+    code, _ = run("find /home -iname '*.hpp'", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_relative_path_allowed(monkeypatch):
+    code, _ = run("find . -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_project_relative_allowed(monkeypatch):
+    code, _ = run("find projects/ores.sql -iname '*.sql'",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_narrower_absolute_path_allowed(monkeypatch):
+    code, _ = run("find /home/marco/Development/ORE/Engine -iname '*.hpp'",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_with_flags_before_path_denied(monkeypatch):
+    code, _ = run("find -L / -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_after_chain_operator_denied(monkeypatch):
+    code, _ = run("cd /tmp && find / -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_as_prose_word_in_unrelated_command_allowed(monkeypatch):
+    """"find" as an ordinary English word inside an unrelated command's
+    argument (e.g. a --description string) must not be mistaken for a
+    find invocation just because it's preceded by whitespace."""
+    code, _ = run(
+        'compass add task --description "surfaced when an unscoped '
+        'find / scanned the whole machine"',
+        monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_unrelated_command_allowed(monkeypatch):
+    code, _ = run("git log --oneline -5", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_bash_tool_allowed(monkeypatch):
+    code, _ = run("find / -iname foo.hpp", tool_name="Read",
+                  monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_dict_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[1, 2, 3]"))
+    assert hook.main() == 0
+
+
+def test_null_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("null"))
+    assert hook.main() == 0
+
+
+def test_malformed_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
+#+end_src
+
 #+begin_src json :tangle no :noweb-ref hooks-pretooluse
     "PreToolUse": [
       {
@@ -775,6 +973,10 @@ def test_malformed_json_does_not_crash(monkeypatch):
           {
             "type": "command",
             "command": "sh -c 'f=projects/ores.compass/src/deny_piped_compass_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'f=projects/ores.compass/src/deny_unscoped_find_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
           }
         ]
       }

--- a/projects/ores.compass/src/deny_unscoped_find_hook.py
+++ b/projects/ores.compass/src/deny_unscoped_find_hook.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: deny `find` invocations rooted at `/` or another
+filesystem-wide root. See doc/llm/claude_code_settings.org's Hooks
+section.
+
+Targeted finds (relative paths, or absolute paths narrower than a
+top-level root) are unaffected -- only a bare filesystem-root scan is
+denied.
+"""
+import json
+import re
+import sys
+
+# Matches "find" as a command word: start of the whole command, or
+# immediately after a shell operator (;, &, |, () skipping any
+# whitespace -- deliberately NOT bare whitespace alone, which would
+# also match "find" appearing as an ordinary English word inside an
+# unrelated argument (e.g. a --description string mentioning "you'll
+# find / at the root"). Followed by its first non-flag argument; flags
+# (anything starting with "-") are skipped since find's path
+# argument(s) may follow options like -H/-L/-P. Captures that first
+# path argument.
+FIND_RE = re.compile(
+    r"(?:^|[&;|(]\s*)find\s+(?:-\w+\s+)*(\S+)"
+)
+
+# Filesystem-wide roots with no further subpath -- a scan starting here
+# walks far more of the machine than any task in this repo needs.
+UNSCOPED_ROOTS = {
+    "/", "/home", "/usr", "/etc", "/var", "/proc", "/sys",
+    "/root", "/opt", "/boot", "/dev", "/mnt", "/tmp",
+}
+
+DENIAL_MESSAGE = (
+    "Unscoped `find` rooted at a filesystem-wide directory is denied -- "
+    "scope it to the project directory (or another specific, narrower "
+    "path) instead, or ask the user explicitly if a broader search is "
+    "genuinely needed. See doc/llm/claude_code_settings.org.\n"
+)
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+        return 0
+    command = data.get("tool_input", {}).get("command", "")
+    for match in FIND_RE.finditer(command):
+        if match.group(1) in UNSCOPED_ROOTS:
+            sys.stderr.write(DENIAL_MESSAGE)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/ores.compass/tests/test_deny_unscoped_find_hook.py
+++ b/projects/ores.compass/tests/test_deny_unscoped_find_hook.py
@@ -1,0 +1,101 @@
+"""
+Tests for the unscoped-find PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_unscoped_find_hook.py -v
+No live database or file system access required.
+"""
+
+import io
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_unscoped_find_hook as hook
+
+
+def run(command, tool_name="Bash", monkeypatch=None):
+    """Drive hook.main() with a synthetic PreToolUse payload on stdin,
+    returning (exit_code, stderr_text)."""
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    import json
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr)
+    return hook.main(), stderr.getvalue()
+
+
+def test_find_root_denied(monkeypatch):
+    code, msg = run('find / -iname "aonia.hpp"', monkeypatch=monkeypatch)
+    assert code == 2
+    assert "Unscoped `find`" in msg
+
+
+def test_find_home_denied(monkeypatch):
+    code, _ = run("find /home -iname '*.hpp'", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_relative_path_allowed(monkeypatch):
+    code, _ = run("find . -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_project_relative_allowed(monkeypatch):
+    code, _ = run("find projects/ores.sql -iname '*.sql'",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_narrower_absolute_path_allowed(monkeypatch):
+    code, _ = run("find /home/marco/Development/ORE/Engine -iname '*.hpp'",
+                   monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_find_with_flags_before_path_denied(monkeypatch):
+    code, _ = run("find -L / -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_after_chain_operator_denied(monkeypatch):
+    code, _ = run("cd /tmp && find / -iname foo.hpp", monkeypatch=monkeypatch)
+    assert code == 2
+
+
+def test_find_as_prose_word_in_unrelated_command_allowed(monkeypatch):
+    """"find" as an ordinary English word inside an unrelated command's
+    argument (e.g. a --description string) must not be mistaken for a
+    find invocation just because it's preceded by whitespace."""
+    code, _ = run(
+        'compass add task --description "surfaced when an unscoped '
+        'find / scanned the whole machine"',
+        monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_unrelated_command_allowed(monkeypatch):
+    code, _ = run("git log --oneline -5", monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_bash_tool_allowed(monkeypatch):
+    code, _ = run("find / -iname foo.hpp", tool_name="Read",
+                  monkeypatch=monkeypatch)
+    assert code == 0
+
+
+def test_non_dict_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[1, 2, 3]"))
+    assert hook.main() == 0
+
+
+def test_null_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("null"))
+    assert hook.main() == 0
+
+
+def test_malformed_json_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0


### PR DESCRIPTION
## Summary

Adds a second PreToolUse hook (deny_unscoped_find_hook.py) alongside the existing piped-compass hook, denying find invocations rooted at a filesystem-wide directory with no subpath (/, /home, /usr, /etc, /var, /proc, /sys, /root, /opt, /boot, /dev, /mnt, /tmp).

## Changes

- Deny only when find's first path argument is exactly one of the unscoped roots; relative paths and narrower absolute paths pass through untouched.
- find is only recognised as a command word at the start of the command or after a shell operator, not bare whitespace -- avoids a false positive against find as an ordinary English word inside an unrelated argument (caught live during dev).
- Same fail-open guard as the existing piped-compass hook: allows the Bash tool if the hook script itself is missing.
- Verification: 13/13 unit tests pass (test_deny_unscoped_find_hook.py); python/org-only change, no C++ sources touched.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass quality-of-life improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/story.html) | F64924CE-8D35-437A-B275-617558DC5FBE |
| Task | [Deny unscoped find invocations via PreToolUse hook](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/compass-quality-of-life-improvements/task_deny-unscoped-find-hook.html) | 6A77C68E-EB6C-432F-801A-5825AE44E16C |
| Environment | bright_faraday | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)