### PR TITLE
[marketdata,qt] Fix fx_spot_subscription hardcoded rfl::json, ignoring wire codec

### DIFF
--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_24:v0:
 #+created: 2026-07-28
 #+updated: 2026-07-28
-#+environment: solid_dirac
+#+environment: swift_curie
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -48,7 +48,7 @@ task.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | DONE                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:D269862E-2035-4857-A0D0-A6E93B0E24C9][Sprint 24]] |
 | Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
@@ -89,6 +89,7 @@ task.
 | [[id:926379AF-B17C-4700-AF89-6AD1EB006281][Consolidate and migrate ores.shell request helpers to wire_codec]] | DONE | 2026-07-30 | 2026-07-30 | The do_request/do_auth_request template helper is copy-pasted independently into thirteen shell command .cpp files (18 definitions, 60 call sites), plus 7 more files using other direct rfl::json patterns (101 occurrences across 22 files total). De-duplicate into one shared helper in a shell-wide header first -- a real cleanup win independent of the format work -- then have that single helper route through an injected wire_codec instead of rfl::json directly. |
 | [[id:493C5EF6-FE85-4623-8103-563EB5CA6EE3][End-to-end verify msgpack wire format and close out the story]] | DONE | 2026-07-31 | 2026-07-31 | With every layer migrated, flip a test environment's .env to msgpack and verify round-trip correctness across Qt-to-service and shell-to-service, including the image-batch flows this whole investigation started from. Confirms the raw-bytes-not-base64-for-images task's goal is achieved for free. Abandon that task in favour of this story at close, and record the .env config knob in the relevant How do I recipe. |
 | [[id:581EDA54-D912-43C0-B68B-6CD33C8DFA0B][Migrate remaining service-to-service hard-coded rfl::json call sites to wire_codec]] | DONE | 2026-07-30 | 2026-07-30 | A repo-wide sweep (grep for rfl::json combined with request_sync usage) found service-to-service NATS call sites still hard-coding rfl::json instead of routing through ores::nats::default_wire_codec(), discovered outside every completed task's audited file list: ores.iam.core/service/cache/party_cache.hpp, ores.iam.core/messaging/tenant_handler.hpp, ores.marketdata.client/crm_client.cpp, ores.refdata.client/service/cache/currency_pair_convention_cache.hpp, ores.reporting.core/messaging/report_definition_template_handler.hpp, ores.trading.core/messaging/trade_handler.hpp, plus ClientManagerTradeInstrument.cpp's decode side (parse_trade_instrument, a JSON-specific two-phase parser in ores.qt.headless). Migrate every one onto the common wire_codec encode/decode helpers, then re-run the sweep to confirm it is clean, so a full-environment msgpack switch is safe. |
+| [[id:1FC899C9-48A9-416C-87D0-FF4BB54F0DB7][Fix fx_spot_subscription hardcoded rfl::json, ignoring wire codec]] | DONE | 2026-08-02 | 2026-08-02 | fx_spot_subscription.cpp still hardcodes rfl::json::read regardless of ORES_NATS_WIRE_FORMAT, so FX Spot Monitor and Cross-Rates Matrix silently receive zero ticks under msgpack -- missed by the story's migration sweep. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
@@ -97,7 +97,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | FxSpotChartWindow uses the same fx_spot_subscription class but only reports subscribe failures, not per-tick decode failures | FxSpotChartWindow.cpp | Accepted | Wired the on_error callback the same way as FxSpotGridWindow, mirroring the pattern rather than deferring to a follow-up. |
+| 2 | No dedicated unit test for the decode-failure -> on_error path | fx_spot_subscription_tests.cpp | Declined | Matches existing convention for this NATS-facing class (crm_client.cpp's equivalent decode path is also untested at this granularity); client isn't easily mockable. |
+| 3 | default_wire_codec() called inline per-message instead of bound once, unlike crm_client.cpp | fx_spot_subscription.cpp | Declined | Cheap const& to a process-wide singleton; not a performance concern, purely stylistic. |
 
 * Result
 
@@ -110,3 +112,8 @@ Verified manually against a running msgpack environment (FX Spot
 Monitor and Cross-Rates Matrix receiving live ticks, zero
 deserialisation-failure log lines after the fix) and locally: build
 clean (linux-clang-debug-make), ctest 71/71 passed (100%).
+
+Review round 1: also wired the =on_error= callback into
+=FxSpotChartWindow= (same class of gap the reviewer flagged, mirrors
+=FxSpotGridWindow='s wiring). Two minor style/test-coverage points
+declined as consistent with existing project convention.

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
@@ -8,7 +8,7 @@
 #+filetags: :nats-configurable-wire-format:sprint_24:v0:
 #+owner: marco
 #+branch: feature/fix-fx-spot-subscription-hardcoded-json
-#+pr:
+#+pr: 1809
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-02
@@ -91,7 +91,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1809][#1809]] | [marketdata,qt] Fix fx_spot_subscription hardcoded rfl::json, ignoring wire codec |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
+++ b/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.org
@@ -1,0 +1,112 @@
+:PROPERTIES:
+:ID: 1FC899C9-48A9-416C-87D0-FF4BB54F0DB7
+:END:
+#+title: Task: Fix fx_spot_subscription hardcoded rfl::json, ignoring wire codec
+#+description: fx_spot_subscription.cpp still hardcodes rfl::json::read regardless of ORES_NATS_WIRE_FORMAT, so FX Spot Monitor and Cross-Rates Matrix silently receive zero ticks under msgpack -- missed by the story's migration sweep.
+#+type: task
+#+level: s1
+#+filetags: :nats-configurable-wire-format:sprint_24:v0:
+#+owner: marco
+#+branch: feature/fix-fx-spot-subscription-hardcoded-json
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-02
+#+updated: 2026-08-02
+#+environment: swift_curie
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Switch =fx_spot_subscription.cpp= from a hardcoded =rfl::json::read= to
+=ores::nats::default_wire_codec().decode<T>()=, matching the pattern
+already used by =crm_client.cpp=, so FX spot ticks deserialise
+correctly regardless of =ORES_NATS_WIRE_FORMAT=. Also surface
+deserialisation failures to the UI instead of only logging a WARN
+(add an =error_handler= callback wired to the existing
+=errorOccurred=/status-bar mechanism), since a silently-failing stream
+is otherwise invisible to the user.
+
+Discovered during manual QA of an unrelated task (controller
+decommission, sprint 24): under msgpack, FX Spot Monitor and
+Cross-Rates Matrix showed no data at all, with the only signal a WARN
+in =ores.marketdata.client.fx_spot_subscription='s log
+(=Failed to deserialise fx_spot_tick: ...=).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:1A815B1E-904E-460C-A2FB-31D9E3B392E2][Make NATS wire format configurable: JSON/MessagePack, decided once at startup]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-08-02                              |
+
+* Acceptance
+
+- =fx_spot_subscription.cpp= decodes via
+  =ores::nats::default_wire_codec()= instead of hardcoded
+  =rfl::json::read=.
+- =fx_spot_subscription='s constructor gains an optional
+  =error_handler= invoked on deserialisation failure, in addition to
+  the existing WARN log.
+- =FxSpotGridWindow::subscribe= wires that callback to
+  =errorOccurred= (status-bar message), so a wire-format mismatch or
+  corrupt stream is visible to the user, not just the log.
+- Manually verified against a running msgpack environment: FX Spot
+  Monitor and Cross-Rates Matrix receive live ticks with zero
+  deserialisation-failure log lines.
+
+* Plan
+
+Root cause: =fx_spot_subscription.cpp= was the one NATS-tick call site
+missed by the wire-format migration story's sweep (it isn't a
+service-to-service =request_sync= call, which is what that sweep
+grepped for — it's a fire-and-forget subscription handler). Fixed by
+switching to =default_wire_codec().decode<T>()=, following the
+already-correct pattern in =crm_client.cpp=. Also added an
+=error_handler= callback since the existing code only
+logged a WARN on failure — invisible to a user with no server-log
+access, and the actual symptom that made this bug hard to diagnose
+during manual QA (grids just silently stayed empty).
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Fixed =fx_spot_subscription.cpp= to decode via
+=ores::nats::default_wire_codec()= instead of hardcoded
+=rfl::json::read=, and added an =error_handler= callback wired to
+=FxSpotGridWindow='s =errorOccurred= status-bar signal so
+deserialisation failures are visible to the user, not just logged.
+Verified manually against a running msgpack environment (FX Spot
+Monitor and Cross-Rates Matrix receiving live ticks, zero
+deserialisation-failure log lines after the fix) and locally: build
+clean (linux-clang-debug-make), ctest 71/71 passed (100%).

--- a/projects/ores.marketdata/client/include/ores.marketdata.client/fx_spot_subscription.hpp
+++ b/projects/ores.marketdata/client/include/ores.marketdata.client/fx_spot_subscription.hpp
@@ -34,9 +34,13 @@ namespace ores::marketdata::client {
  *
  * Translates an ORE key (e.g. "FX/RATE/EUR/USD") into the canonical NATS
  * fan-out subject ("marketdata.v1.tick.fx.rate.eur.usd") and subscribes to
- * it. Each arriving message is deserialised with rfl::json and delivered to
- * the caller-supplied handler. Malformed messages are logged and silently
- * dropped.
+ * it. Each arriving message is deserialised with the process-wide
+ * default_wire_codec() (matches whatever ORES_NATS_WIRE_FORMAT the
+ * publisher used) and delivered to the caller-supplied handler. Malformed
+ * messages are logged and reported via @p on_error, if supplied — a
+ * consistently-failing stream (e.g. a wire-format mismatch) is otherwise
+ * invisible in the UI: ticks silently never arrive, with nothing to tell
+ * the user why.
  *
  * The subscription is torn down automatically when this object is destroyed.
  * Move-only — the underlying NATS subscription cannot be shared.
@@ -55,6 +59,17 @@ public:
     using handler = std::function<void(const domain::fx_spot_tick&)>;
 
     /**
+     * @brief Callback invoked (on the NATS delivery thread, same as @ref
+     * handler) when a tick fails to deserialise. Not rate-limited: under
+     * normal operation this path should never fire, since the codec
+     * matches the publisher's own wire format -- if it does fire
+     * repeatedly, that is itself the signal worth surfacing (e.g. a wire
+     * format mismatch, or a genuinely corrupt stream), not something to
+     * suppress.
+     */
+    using error_handler = std::function<void(const std::string&)>;
+
+    /**
      * @brief Subscribe to tick updates for an ORE key.
      *
      * @param nats       Connected NATS client to subscribe on.
@@ -63,11 +78,15 @@ public:
      *                   subscription matches the tenant-scoped publish path used
      *                   by the ingest loop.
      * @param on_tick    Invoked on the NATS delivery thread for each valid tick.
+     * @param on_error   Optional; invoked on the NATS delivery thread for each
+     *                   tick that fails to deserialise. Failures are always
+     *                   logged regardless of whether this is supplied.
      */
     fx_spot_subscription(ores::nats::service::client& nats,
                          std::string ore_key,
                          std::string tenant_id,
-                         handler on_tick);
+                         handler on_tick,
+                         error_handler on_error = {});
 
     ~fx_spot_subscription() = default;
 

--- a/projects/ores.marketdata/client/src/fx_spot_subscription.cpp
+++ b/projects/ores.marketdata/client/src/fx_spot_subscription.cpp
@@ -21,7 +21,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.marketdata.client/detail/subject_helpers.hpp"
 #include "ores.nats/domain/message.hpp"
-#include <rfl/json.hpp>
+#include "ores.nats/domain/wire_codec.hpp"
 
 namespace ores::marketdata::client {
 
@@ -41,19 +41,22 @@ inline static std::string_view logger_name = "ores.marketdata.client.fx_spot_sub
 fx_spot_subscription::fx_spot_subscription(ores::nats::service::client& nats,
                                            std::string ore_key,
                                            std::string tenant_id,
-                                           handler on_tick)
-    : sub_(nats.subscribe(detail::ore_key_to_subject(ore_key, tenant_id),
-                          [on_tick = std::move(on_tick)](ores::nats::message msg) {
-                              auto tick = rfl::json::read<ores::marketdata::domain::fx_spot_tick>(
-                                  ores::nats::as_string_view(msg.data));
-                              if (tick) {
-                                  on_tick(*tick);
-                              } else {
-                                  using namespace ores::logging;
-                                  BOOST_LOG_SEV(lg(), warn)
-                                      << "Failed to deserialise fx_spot_tick: "
-                                      << tick.error().what();
-                              }
-                          })) {}
+                                           handler on_tick,
+                                           error_handler on_error)
+    : sub_(nats.subscribe(
+          detail::ore_key_to_subject(ore_key, tenant_id),
+          [on_tick = std::move(on_tick), on_error = std::move(on_error)](ores::nats::message msg) {
+              auto tick = ores::nats::default_wire_codec()
+                              .decode<ores::marketdata::domain::fx_spot_tick>(msg.data);
+              if (tick) {
+                  on_tick(*tick);
+              } else {
+                  using namespace ores::logging;
+                  const std::string reason = tick.error().what();
+                  BOOST_LOG_SEV(lg(), warn) << "Failed to deserialise fx_spot_tick: " << reason;
+                  if (on_error)
+                      on_error(reason);
+              }
+          })) {}
 
 } // namespace ores::marketdata::client

--- a/projects/ores.qt/mktdata/src/FxSpotChartWindow.cpp
+++ b/projects/ores.qt/mktdata/src/FxSpotChartWindow.cpp
@@ -453,6 +453,16 @@ void FxSpotChartWindow::startLiveSubscription() {
                             self->addSample(ms, mid);
                     },
                     Qt::QueuedConnection);
+            },
+            [self](const std::string& reason) {
+                QMetaObject::invokeMethod(
+                    self,
+                    [self, reason]() {
+                        if (self)
+                            emit self->errorOccurred(
+                                tr("Failed to parse FX tick: %1").arg(QString::fromStdString(reason)));
+                    },
+                    Qt::QueuedConnection);
             });
         BOOST_LOG_SEV(lg(), debug) << "Live subscription started for " << oreKey_.toStdString();
     } catch (const std::exception& e) {

--- a/projects/ores.qt/mktdata/src/FxSpotGridWindow.cpp
+++ b/projects/ores.qt/mktdata/src/FxSpotGridWindow.cpp
@@ -460,6 +460,22 @@ void FxSpotGridWindow::subscribe(RowState& rs) {
                             self->applyTick(ore_key, mid, when);
                     },
                     Qt::QueuedConnection);
+            },
+            [self, ore_key](const std::string& reason) {
+                // Not rate-limited here either: a consistently-failing
+                // stream (e.g. the wire-format mismatch this callback was
+                // added to catch) is a real, actionable problem, not
+                // per-tick noise to suppress -- see fx_spot_subscription's
+                // own error_handler docstring.
+                QMetaObject::invokeMethod(
+                    self,
+                    [self, ore_key, reason]() {
+                        if (self)
+                            emit self->errorOccurred(
+                                tr("Failed to parse FX tick for %1: %2")
+                                    .arg(QString::fromStdString(ore_key), QString::fromStdString(reason)));
+                    },
+                    Qt::QueuedConnection);
             });
         BOOST_LOG_SEV(lg(), debug) << "Subscribed to " << ore_key;
     } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary

fx_spot_subscription.cpp was the one NATS-tick call site missed by the wire-format migration story's sweep, so FX Spot Monitor and Cross-Rates Matrix silently received zero ticks under msgpack.

## Changes

- Switch fx_spot_subscription.cpp to default_wire_codec decode, matching crm_client.cpp's already-correct pattern
- Add an error_handler callback to fx_spot_subscription, wired to FxSpotGridWindow's errorOccurred status-bar signal, so deserialisation failures are visible to the user instead of only logged
- Verification: local build clean (linux-clang-debug-make); ctest 71/71 passed; manually verified against a running msgpack environment

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Make NATS wire format configurable: JSON/MessagePack, decided once at startup](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/story.html) | 1A815B1E-904E-460C-A2FB-31D9E3B392E2 |
| Task | [Fix fx_spot_subscription hardcoded rfl::json, ignoring wire codec](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_24/nats-configurable-wire-format/task_fix-fx-spot-subscription-hardcoded-json.html) | 1FC899C9-48A9-416C-87D0-FF4BB54F0DB7 |
| Environment | swift_curie | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)