### PR TITLE
[agile] IR curve bootstrapping: lineage + bootstrap-config design

### DIFF
--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/story.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/story.org
@@ -40,6 +40,54 @@ not the bootstrapped curve a desk would price off of. Promoted from
 an inbox capture into a real Sprint 24 story now that Sprint 24's
 mission includes improving IR generation.
 
+** Design: derivation lineage, bootstrap config, build order
+
+Working through what a persisted, bootstrapped curve object actually
+is (see [[id:A26CFA71-21C0-4E98-ABC4-25F0EAD517E3][Multicurve Management]]'s "curve template" requirement)
+surfaced a gap this story must close rather than inherit: reusing the
+existing =market_series=/=market_observations= tables for bootstrapped
+output (the same pattern the CRM's computed crosses would eventually
+use, and the same shape =ores.synthetic='s raw-tick storage already
+uses) is architecturally correct — it is the established pattern here,
+applied a third time, not a new one — but doing so *without* a
+lineage mechanism would leave "was this point observed or computed,
+and by what" unanswerable except by guessing from the =source= string,
+which is exactly CRM's current soft spot (CRM's derived crosses are
+pull-only today — see =crm_handler='s "never broadcast the full
+derived set as ticks" — so this gap is latent there, not yet realised
+in storage; this story should not add a second, curve-specific version
+of the same weakness).
+
+Three design decisions this story now commits to, detailed in the
+tasks below:
+
+- *Shared, generic lineage* — a =derivation_kind= marker on
+  =market_series= (sentinel ='OBSERVED'=, matching the existing
+  =curve_role='NONE'= convention on =instrument_codes= rather than a
+  nullable column) plus a per-observation =observation_lineage= side
+  table, deliberately generic so CRM can reuse it unchanged whenever
+  it starts persisting derived crosses — not this story's job to
+  change CRM itself, but its job not to build something CRM would
+  later have to duplicate.
+- *Bootstrap config as refdata*, not marketdata — recipe/config
+  entities consistently live in =ores.refdata= in this codebase
+  (=crm_topology_config=, =curve_role=, =tenor=); the bootstrap
+  config follows that placement, reusing =tenor= and =curve_role=
+  directly rather than inventing parallel concepts.
+- *Build order as data* — the Funding-before-Projection dependency
+  ([[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]]) is encoded via a self-referencing
+  =discount_curve_config_id= on the bootstrap config (nil-uuid sentinel
+  for Funding, required for Projection), so a Projection curve's
+  bootstrap run has an explicit, queryable dependency rather than an
+  implicit ordering assumption.
+
+Every nullable field considered during design was replaced with either
+a sentinel paired to a discriminator column (=curve_family_role=
+FUNDING -> nil =discount_curve_config_id=; ='OBSERVED'= -> nil
+=derivation_config_id=) or, where the null represented a genuinely
+avoidable gap (=output_series_id= before first publish), removed by
+minting the output series row at config-creation time instead.
+
 * Status
 
 | Field         | Value                                  |
@@ -60,12 +108,30 @@ mission includes improving IR generation.
   ores.marketdata's existing raw-producer-tick remap onto the
   official tenant-scoped stream, so downstream consumers read a real
   usable curve rather than raw ticks.
+- A shared, generic derivation-lineage mechanism exists on
+  =market_series=/a new =observation_lineage= table, such that any
+  published series or observation can be queried for "was this
+  observed or derived, and by what config/version/source" without
+  guessing from the =source= string — usable unchanged by CRM's own
+  derived-cross publishing whenever that lands (not this story's
+  scope to change CRM itself).
+- The bootstrap recipe (source series, pillar list, interpolation
+  method, day-count convention, curve family role, discount-curve
+  dependency) is a first-class, inspectable =ores.refdata= entity, not
+  implicit in code or ad hoc per bootstrap run.
+- The Funding-before-Projection build order is enforced/encoded as
+  data (a config's discount-curve dependency), not left as an
+  implicit ordering assumption in the engine.
 
 * Tasks
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:4F78BAA7-71A0-4433-AF1E-54180DB0669A][FOMC-dated OIS short end with flat-forward interpolation]] | BACKLOG | | | Bootstrap the SOFR OIS short end off FOMC-meeting-dated pillars with a flat-forward (step) interpolation method, transitioning to a continuous method (log-linear/spline) at the long-end swap pillars. |
+| [[id:18B74DD5-0A67-4873-A700-B006D4A99FDD][Shared derivation lineage: market_series marker + observation lineage table]] | BACKLOG | | | A derivation_kind/derivation_config_id/derivation_config_version marker on market_series (sentinel 'OBSERVED', not nullable) plus a new observation_lineage side table for per-observation provenance -- foundational for both the curve bootstrap output and, later, CRM's own derived-cross publishing. |
+| [[id:5255E8A6-9EE6-44FA-A5CB-41ABD508ED37][IR curve bootstrap config: refdata entities for the bootstrap recipe]] | BACKLOG | | | New ores.refdata entities (bootstrap config + pillar children, mirroring ir_curve_template_entries' shape but source-independent) recording how a curve is bootstrapped: source series, curve family role (Funding/Projection), the discount_curve_config_id build-order link, interpolation method, day-count convention, and split tenor. |
+| [[id:D1C9368C-4B32-4074-9A17-3A895DB12F83][IR curve bootstrapping engine: inverse solve over the raw instrument grid]] | BACKLOG | | | Given a bootstrap config and the raw pillar rates already published by the IR curve family feed, solve tenor-by-tenor for discount factors that reprice each pillar -- the inverse of curve_instrument_pricer's forward rate functions -- applying the configured interpolation method, day-count convention, and Funding-before-Projection build order. |
+| [[id:202295CC-B715-431F-BFCF-DD960CA7D1FE][Official curve republish: write bootstrapped output as a lineage-stamped market_series]] | BACKLOG | | | Publish the bootstrapper's output curve into its pre-minted output_series_id via market_observations, stamping the observation_lineage table per observation -- the republish/remap half of the story's goal, a transform rather than a passthrough. |
 
 * Decisions
 
@@ -74,6 +140,14 @@ mission includes improving IR generation.
 - Modelling the raw instrument grid itself and its publishing
   pipeline — already delivered by [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]]
   (Sprint 23, DONE).
+- Changing CRM itself to persist derived crosses — CRM's derived rates
+  are pull-only today (=crm_handler='s explicit "never broadcast the
+  full derived set as ticks" architecture decision), so there is
+  nothing to retrofit yet. This story's shared derivation-lineage
+  table is deliberately generic so that whenever CRM persistence does
+  land, it becomes a schema-only follow-on (stamp =derivation_kind =
+  'CRM_DERIVATION'=, reuse =derived_rate::as_of= as =source_as_of=) —
+  not a task this story needs to do.
 
 * References
 

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrap-config.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrap-config.org
@@ -1,0 +1,119 @@
+:PROPERTIES:
+:ID: 5255E8A6-9EE6-44FA-A5CB-41ABD508ED37
+:END:
+#+title: Task: IR curve bootstrap config: refdata entities for the bootstrap recipe
+#+description: New ores.refdata entities (bootstrap config + pillar children, mirroring ir_curve_template_entries' shape but source-independent) recording how a curve is bootstrapped: source series, curve family role (Funding/Projection), the discount_curve_config_id build-order link, interpolation method, day-count convention, and split tenor.
+#+type: task
+#+level: s1
+#+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Record *how* a curve is bootstrapped as a named, inspectable artefact —
+the "curve template" concept [[id:A26CFA71-21C0-4E98-ABC4-25F0EAD517E3][Multicurve Management]] calls for — owned by
+=ores.refdata= (matching where every other recipe/config entity lives
+in this codebase: =crm_topology_config=, =curve_role=, =tenor=,
+=overnight_index_convention=; not =ores.marketdata=, which owns only
+the generic value store).
+
+- =ores_refdata_ir_curve_bootstrap_configs_tbl=: =source_series_id=
+  (the raw =RATES/YIELD= =market_series= this bootstraps),
+  =output_series_id= (not null — *minted at config-creation time*,
+  never deferred, so there is no "not yet published" null state to
+  sentinel around), =curve_family_role= (='FUNDING'= | ='PROJECTION'=
+  — a new axis, distinct from the existing instrument-pricing
+  =curve_role=), =discount_curve_config_id= (self-referencing;
+  =ores_utility_nil_uuid_fn()= sentinel when =curve_family_role =
+  'FUNDING'=, a required FK when ='PROJECTION'= — this is what encodes
+  [[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]]'s Funding-before-Projection build-order
+  dependency as data), =interpolation_method=, =day_count_convention=,
+  =split_tenor_code= (a genuine tenor value, not a sentinel — for a
+  single-segment method it equals the curve's own last pillar's
+  =end_tenor_code=, matching the spirit of =ir_curve_template_entries='s
+  existing ='SPOT'= tenor, which its own doc comment is explicit isn't
+  a sentinel hack).
+- =ores_refdata_ir_curve_bootstrap_pillars_tbl=: =bootstrap_config_id=,
+  =sequence_index=, =start_tenor_code=/=end_tenor_code= (FK to
+  =ores_refdata_tenors_tbl.code=), =curve_role_code= (FK to
+  =ores_refdata_curve_roles_tbl.code= — DEPOSIT/FRA/SWAP). Same
+  one-parent-many-children shape as =ir_curve_template_entries=, but
+  source-independent: it names a raw series + pillar list to bootstrap
+  from, not a synthetic generation recipe.
+
+Depends on the shared derivation-lineage task for the
+=ores_refdata_derivation_kinds_tbl= values this config's output series
+will be stamped with.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- Both tables exist in =ores.refdata=, tenant/party-scoped, versioned,
+  following the standard temporal-entity convention (=valid_from=/
+  =valid_to=, GIST exclusion, soft-update/delete triggers) already used
+  by =ir_curve_template_entries= and =crm_topology_configs=.
+- Creating a bootstrap config mints its =output_series_id= =market_series=
+  row atomically — no code path can observe a config with a null/absent
+  output series.
+- =discount_curve_config_id= is enforced (check constraint) to be
+  nil-uuid iff =curve_family_role = 'FUNDING'=, and a valid FK to
+  another config's id iff ='PROJECTION'=.
+- Pillar rows validate =start_tenor_code=/=end_tenor_code= against
+  =ores_refdata_tenors_tbl= and =curve_role_code= against
+  =ores_refdata_curve_roles_tbl=, exactly as =ir_curve_template_entries=
+  already does for its own tenor/instrument_code references.
+- No new tenor or curve-role concepts invented — both are read-only
+  references into the existing reference data.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrap-config.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrap-config.org
@@ -37,7 +37,15 @@ the generic value store).
   =ores_utility_nil_uuid_fn()= sentinel when =curve_family_role =
   'FUNDING'=, a required FK when ='PROJECTION'= — this is what encodes
   [[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]]'s Funding-before-Projection build-order
-  dependency as data), =interpolation_method=, =day_count_convention=,
+  dependency as data. *Strict two-tier only*: the referenced config
+  must itself have =curve_family_role = 'FUNDING'=, enforced by check
+  constraint/trigger — Multi-Curve Construction is explicit that a
+  Projection Curve depends on the Funding Curve only, never on another
+  Projection Curve, and names basis-linked/cyclic Projection
+  dependencies as an out-of-scope modelling gap, not something this
+  design should silently permit by leaving the FK's target
+  unconstrained; also guarded against self-reference,
+  =discount_curve_config_id <> id=), =interpolation_method=, =day_count_convention=,
   =split_tenor_code= (a genuine tenor value, not a sentinel — for a
   single-segment method it equals the curve's own last pillar's
   =end_tenor_code=, matching the spirit of =ir_curve_template_entries='s
@@ -47,7 +55,9 @@ the generic value store).
   =sequence_index=, =start_tenor_code=/=end_tenor_code= (FK to
   =ores_refdata_tenors_tbl.code=), =curve_role_code= (FK to
   =ores_refdata_curve_roles_tbl.code= — DEPOSIT/FRA/SWAP). Same
-  one-parent-many-children shape as =ir_curve_template_entries=, but
+  one-parent-many-children shape as =ir_curve_template_entries=,
+  including its unique-active-row index on
+  =(tenant_id, party_id, bootstrap_config_id, sequence_index)= — but
   source-independent: it names a raw series + pillar list to bootstrap
   from, not a synthetic generation recipe.
 
@@ -77,11 +87,18 @@ will be stamped with.
   output series.
 - =discount_curve_config_id= is enforced (check constraint) to be
   nil-uuid iff =curve_family_role = 'FUNDING'=, and a valid FK to
-  another config's id iff ='PROJECTION'=.
+  another config's id iff ='PROJECTION'= — and, when set, that
+  referenced config's own =curve_family_role= must be ='FUNDING'=
+  (strict two-tier, no chaining) and must not equal the referencing
+  config's own id (no self-reference). Proven by a test attempting a
+  PROJECTION-to-PROJECTION chain and a self-referencing row, both
+  rejected.
 - Pillar rows validate =start_tenor_code=/=end_tenor_code= against
   =ores_refdata_tenors_tbl= and =curve_role_code= against
   =ores_refdata_curve_roles_tbl=, exactly as =ir_curve_template_entries=
-  already does for its own tenor/instrument_code references.
+  already does for its own tenor/instrument_code references, and carry
+  the same =(tenant_id, party_id, bootstrap_config_id, sequence_index)=
+  unique-active-row index =ir_curve_template_entries= has.
 - No new tenor or curve-role concepts invented — both are read-only
   references into the existing reference data.
 

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrapping-engine.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrapping-engine.org
@@ -41,6 +41,18 @@ bootstrap run reads its =discount_curve_config_id='s *already-published*
 output series to discount its own pillars, rather than bootstrapping in
 isolation (see [[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]]).
 
+*This task owns enforcing that order at run time* — the config schema
+(bootstrap-config task) only records the dependency; nothing else in
+this story's task breakdown schedules or checks it. Concretely: before
+running a =PROJECTION= config's bootstrap, this engine must confirm its
+=discount_curve_config_id='s output series already has a discount-factor
+generation covering the required as-of, and fail/defer cleanly (not
+silently bootstrap against stale or absent discount factors) if it
+doesn't. Whether that's a same-process dependency check, a small queue,
+or a DAG walk over =discount_curve_config_id= across all of a tenant's
+configs is an implementation decision for this task's =* Plan=, not
+decided up front here.
+
 The existing [[id:4F78BAA7-71A0-4433-AF1E-54180DB0669A][FOMC-dated OIS short end with flat-forward interpolation]]
 task is the concrete first interpolation-method instance this engine
 must support (flat-forward step short end, continuous long end, split
@@ -80,6 +92,10 @@ this engine reads.
   =discount_curve_config_id='s already-published discount factors
   rather than re-deriving them; a =FUNDING= config's bootstrap has no
   such dependency.
+- A =PROJECTION= bootstrap attempted before its discount curve's
+  required generation exists fails/defers cleanly rather than running
+  against stale or absent discount factors — this engine, not any
+  other task, owns that check.
 - Unit tests cover at least: a single-segment curve, a two-segment
   (FOMC-style) curve, and a Projection curve discounted off a
   previously-bootstrapped Funding curve.

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrapping-engine.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_ir-curve-bootstrapping-engine.org
@@ -1,0 +1,118 @@
+:PROPERTIES:
+:ID: D1C9368C-4B32-4074-9A17-3A895DB12F83
+:END:
+#+title: Task: IR curve bootstrapping engine: inverse solve over the raw instrument grid
+#+description: Given a bootstrap config and the raw pillar rates already published by the IR curve family feed, solve tenor-by-tenor for discount factors that reprice each pillar -- the inverse of curve_instrument_pricer's forward rate functions -- applying the configured interpolation method, day-count convention, and Funding-before-Projection build order.
+#+type: task
+#+level: s1
+#+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Build the actual bootstrapper: given an
+=ir_curve_bootstrap_config= + its pillar list, and the raw pillar rates
+already sitting in =market_observations= (published by the IR curve
+family feed — [[id:3ECC4BA8-6ACA-4028-9E42-AE7F25FC3B98][IR Rates synthetic data generation]], DONE), solve
+tenor-by-tenor for the discount factors that reprice every pillar at
+its observed rate. This is the *inverse* of
+=ores.analytics.quant::service::curve_instrument_pricer= — that class
+derives a par rate from a discount factor (=deposit_rate=, =fra_rate=,
+=swap_par_rate=, all forward calculations used by the synthetic
+generator); this engine goes the other way, solving for the discount
+factor a published rate implies, tenor by tenor from the short end,
+taking all shorter-maturity discount factors as already known (see
+[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]'s bootstrapping section).
+
+Applies the bootstrap config's =interpolation_method= and
+=day_count_convention= within each segment, and honours the
+Funding-before-Projection build order: a =PROJECTION= config's
+bootstrap run reads its =discount_curve_config_id='s *already-published*
+output series to discount its own pillars, rather than bootstrapping in
+isolation (see [[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]]).
+
+The existing [[id:4F78BAA7-71A0-4433-AF1E-54180DB0669A][FOMC-dated OIS short end with flat-forward interpolation]]
+task is the concrete first interpolation-method instance this engine
+must support (flat-forward step short end, continuous long end, split
+at =split_tenor_code=) — sequenced after this task, not duplicated by
+it.
+
+Depends on the bootstrap-config task for the config/pillar entities
+this engine reads.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- A pure engine function/class exists (mirroring
+  =curve_instrument_pricer='s pure, discount-factor-in/rate-out shape,
+  inverted) that takes a bootstrap config's pillar list + the raw
+  observed rate per pillar and returns one discount factor per tenor,
+  reproducing each pillar instrument's observed market rate to within a
+  documented numerical tolerance.
+- Day-count conventions are applied per pillar per
+  =day_count_convention=, not a single hardcoded convention across all
+  instrument types.
+- The configured =interpolation_method= governs discount factors
+  between pillars; the FOMC-dated task's flat-forward/continuous split
+  is provable as one configuration of this engine, not special-cased
+  in the engine's code.
+- A =PROJECTION= config's bootstrap consumes its
+  =discount_curve_config_id='s already-published discount factors
+  rather than re-deriving them; a =FUNDING= config's bootstrap has no
+  such dependency.
+- Unit tests cover at least: a single-segment curve, a two-segment
+  (FOMC-style) curve, and a Projection curve discounted off a
+  previously-bootstrapped Funding curve.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_official-curve-republish.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_official-curve-republish.org
@@ -1,0 +1,107 @@
+:PROPERTIES:
+:ID: 202295CC-B715-431F-BFCF-DD960CA7D1FE
+:END:
+#+title: Task: Official curve republish: write bootstrapped output as a lineage-stamped market_series
+#+description: Publish the bootstrapper's output curve into its pre-minted output_series_id via market_observations, stamping the observation_lineage table per observation -- the republish/remap half of the story's goal, a transform rather than a passthrough.
+#+type: task
+#+level: s1
+#+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Take the bootstrapping engine's output (one discount factor per tenor
+for a given config) and publish it as a real, consumable curve:
+persist each point into =market_observations= under the bootstrap
+config's pre-minted =output_series_id=, and stamp
+=ores_marketdata_observation_lineage_tbl= per observation with
+=derivation_config_id=/=derivation_config_version= (the bootstrap
+config that produced it), =source_as_of= (the raw grid's as-of
+timestamp the bootstrap read), and =source_series_ids= (the
+=source_series_id=, plus the discount curve's series id when this is a
+=PROJECTION= config).
+
+This is the "republish/remap" half of the story's goal: analogous to
+=ores.marketdata='s existing raw-producer-tick remap onto the official
+tenant-scoped stream ([[id:DF2B616F-E112-4C57-A73B-69F85BE96EF4][Market Data Architecture]]), except the transform
+is a bootstrap rather than a passthrough — downstream consumers read
+=output_series_id= exactly like any other official series, with no
+knowledge that it was derived rather than observed.
+
+Depends on the shared derivation-lineage task (the table being written
+to) and the bootstrapping engine task (the values being written).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- A bootstrap run's output is readable from =output_series_id= via the
+  exact same as-of query (=market_observations_repository::read_as_of()=)
+  the raw-grid viewer already uses — no bespoke read path for
+  bootstrapped curves.
+- Every published discount-factor observation has a corresponding
+  =observation_lineage= row; querying "who produced this point and from
+  what source as-of" is a single join, never a guess from a =source=
+  string.
+- =market_series.derivation_kind = 'IR_CURVE_BOOTSTRAP'= on the output
+  series, matching the shared lineage task's marker convention.
+- Re-running a bootstrap (new raw ticks arrived) produces a new
+  observation generation without corrupting or requiring deletion of
+  the prior one — the existing bitemporal/soft-update convention on
+  =market_observations= already provides this; this task must not
+  special-case it.
+- A =PROJECTION= config's republish is provably sequenced after its
+  =discount_curve_config_id='s own republish has completed for the same
+  bootstrap cycle.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
@@ -35,16 +35,33 @@ its own ad hoc provenance. Two parts:
   ='IR_CURVE_BOOTSTRAP'=, ='CRM_DERIVATION'= — extensible for future
   kinds without a schema migration.
 - A *per-observation* lineage side table,
-  =ores_marketdata_observation_lineage_tbl= (tenant_id, series_id,
-  observation_datetime, point_id [not null, ='''= sentinel for scalar
-  series, matching =market_observations='s own
-  =coalesce(point_id, '')= convention], derivation_config_id,
-  derivation_config_version, source_as_of, source_series_ids uuid[]),
-  written only alongside a derived observation — never a column on
-  =market_observations_tbl= itself, which is a TimescaleDB hypertable
-  explicitly documented as carrying no audit columns because tick-level
-  volumes make that impractical. A row's existence *is* the "derived"
-  marker; no nullable columns.
+  =ores_marketdata_observation_lineage_tbl= (tenant_id, party_id,
+  series_id, observation_datetime, point_id [not null, ='''= sentinel
+  for scalar series — a *stricter* rule than =market_observations=,
+  whose own =point_id= column is genuinely nullable and only reaches
+  ='''= via =coalesce(point_id, '')= inside index/trigger predicates,
+  not as a column-level convention; this new table chooses not to
+  carry that nullability forward], derivation_config_id,
+  derivation_config_version, source_as_of, source_series_ids uuid[],
+  valid_from, valid_to), written only alongside a derived observation
+  — never a column on =market_observations_tbl= itself, which is a
+  TimescaleDB hypertable explicitly documented as carrying no audit
+  columns because tick-level volumes make that impractical. A row's
+  existence *is* the "derived" marker; no nullable columns.
+  =party_id= is included in the key because =market_observations_tbl=
+  itself carries =party_id= as part of its own current-row uniqueness
+  index — omitting it here would leave the lineage table unable to
+  uniquely identify the observation it describes whenever a series
+  isn't 1:1 with a single party. =valid_from=/=valid_to= mirror
+  =market_observations='s own bitemporal treatment: a bootstrap or CRM
+  derivation can rerun and produce a new generation at the same
+  =(series_id, observation_datetime, point_id)= natural key (the
+  soft-update trigger closes the prior generation's =market_observations=
+  row rather than overwriting it), so the lineage row for each
+  generation must be equally versioned — otherwise a rerun would
+  either collide or silently overwrite the prior generation's
+  provenance, defeating "which config produced this" for any
+  generation but the latest.
 
 Deliberately generic, not curve-specific: this is what lets a future
 CRM change (persisting derived crosses — currently pull-only, out of
@@ -74,9 +91,12 @@ today, currently discarded once the pull-reply is sent) as
   ='IR_CURVE_BOOTSTRAP'=, ='CRM_DERIVATION'=, validated the same way
   =curve_roles= is (soft FK + validate function).
 - =ores_marketdata_observation_lineage_tbl= exists, is never written on
-  the raw-tick ingest hot path, and supports a query "for this series +
-  observation_datetime (+ point_id), which config/version/source
-  produced it" in one lookup.
+  the raw-tick ingest hot path, and supports a query "for this
+  tenant/party/series + observation_datetime (+ point_id), which
+  config/version/source produced it" in one lookup — including when
+  more than one generation exists at the same natural key (proven by a
+  test that reruns a derivation over the same tenor/point and asserts
+  both generations' lineage remain independently queryable).
 - No column added to =market_observations_tbl= itself.
 
 * Plan
@@ -108,6 +128,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | discount_curve_config_id self-reference has no cycle/chain protection (raised independently by all 4 review passes) | task_ir-curve-bootstrap-config.org | Accepted | Added strict two-tier check constraint (referenced config must itself be FUNDING) plus explicit self-reference guard, per Multi-Curve Construction's own stated no-chaining model |
+| 2 | observation_lineage key omits party_id and has no tie to a specific market_observations generation | task_shared-derivation-lineage.org | Accepted | Added party_id to the key and valid_from/valid_to bitemporal columns mirroring market_observations' own soft-update convention, so reruns don't collide or overwrite prior generations' lineage |
+| 3 | No task explicitly owns enforcing Funding-before-Projection ordering at run time | task_ir-curve-bootstrapping-engine.org | Accepted | Added an explicit ownership note and acceptance criterion; mechanism (dependency check/queue/DAG walk) left as an implementation decision for that task's Plan |
+| 4 | Pillar table's unique-active-row index not called out explicitly | task_ir-curve-bootstrap-config.org | Accepted | Added explicit acceptance criterion mirroring ir_curve_template_entries' (tenant_id, party_id, config_id, sequence_index) index |
+| 5 | point_id sentinel described as "matching" market_observations' convention, but that column is nullable there | task_shared-derivation-lineage.org | Accepted | Reworded to describe it as a stricter rule than market_observations, not a literal match |
 
 * Result

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/ir-curve-bootstrap-design
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
@@ -1,0 +1,113 @@
+:PROPERTIES:
+:ID: 18B74DD5-0A67-4873-A700-B006D4A99FDD
+:END:
+#+title: Task: Shared derivation lineage: market_series marker + observation lineage table
+#+description: A derivation_kind/derivation_config_id/derivation_config_version marker on market_series (sentinel 'OBSERVED', not nullable) plus a new observation_lineage side table for per-observation provenance -- foundational for both the curve bootstrap output and, later, CRM's own derived-cross publishing.
+#+type: task
+#+level: s1
+#+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Give the system one shared way to answer, for any published series or
+observation, "was this observed or computed, and by what" — instead of
+each derivation mechanism (curve bootstrap, and eventually CRM) inventing
+its own ad hoc provenance. Two parts:
+
+- A *catalog-level* marker on =market_series=: =derivation_kind=
+  (not null, sentinel ='OBSERVED'=, matching the =curve_role='NONE'=
+  precedent on =instrument_codes=), =derivation_config_id= (not null,
+  =ores_utility_nil_uuid_fn()= sentinel when =derivation_kind =
+  'OBSERVED'=), =derivation_config_version= (not null, default 0). A new
+  small =ores_refdata_derivation_kinds_tbl= reference table (same shape
+  as =curve_roles=) seeds at least ='OBSERVED'=,
+  ='IR_CURVE_BOOTSTRAP'=, ='CRM_DERIVATION'= — extensible for future
+  kinds without a schema migration.
+- A *per-observation* lineage side table,
+  =ores_marketdata_observation_lineage_tbl= (tenant_id, series_id,
+  observation_datetime, point_id [not null, ='''= sentinel for scalar
+  series, matching =market_observations='s own
+  =coalesce(point_id, '')= convention], derivation_config_id,
+  derivation_config_version, source_as_of, source_series_ids uuid[]),
+  written only alongside a derived observation — never a column on
+  =market_observations_tbl= itself, which is a TimescaleDB hypertable
+  explicitly documented as carrying no audit columns because tick-level
+  volumes make that impractical. A row's existence *is* the "derived"
+  marker; no nullable columns.
+
+Deliberately generic, not curve-specific: this is what lets a future
+CRM change (persisting derived crosses — currently pull-only, out of
+scope here) stamp the exact same table with =derivation_kind =
+'CRM_DERIVATION'= and reuse =derived_rate::as_of= (already computed
+today, currently discarded once the pull-reply is sent) as
+=source_as_of=, rather than inventing a second lineage mechanism.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:0BB7EC81-B2A1-4160-AA8D-A21E011F562D][IR curve bootstrapping + official curve republish]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- =market_series= carries =derivation_kind=/=derivation_config_id=/
+  =derivation_config_version=, all =not null=; every existing series
+  defaults to ='OBSERVED'= + nil-uuid + 0 with no behaviour change to
+  today's raw-tick/FX-spot publishing.
+- =ores_refdata_derivation_kinds_tbl= exists, seeded with ='OBSERVED'=,
+  ='IR_CURVE_BOOTSTRAP'=, ='CRM_DERIVATION'=, validated the same way
+  =curve_roles= is (soft FK + validate function).
+- =ores_marketdata_observation_lineage_tbl= exists, is never written on
+  the raw-tick ingest hot path, and supports a query "for this series +
+  observation_datetime (+ point_id), which config/version/source
+  produced it" in one lookup.
+- No column added to =market_observations_tbl= itself.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
+++ b/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.org
@@ -8,7 +8,7 @@
 #+filetags: :ir-curve-bootstrapping-and-republish:sprint_25:v0:
 #+owner: marco
 #+branch: feature/ir-curve-bootstrap-design
-#+pr:
+#+pr: 1822
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -102,7 +102,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1822][#1822]] | [agile] IR curve bootstrapping: lineage + bootstrap-config design |
 
 * Review
 


### PR DESCRIPTION
## Summary

Docs-only PR to get review on the design approach for the IR curve bootstrapping + official curve republish story before implementation starts.

## Changes

- Break the story into four tasks: shared derivation lineage, refdata bootstrap config, bootstrapping engine, official curve republish
- Introduce a shared derivation_kind/observation_lineage mechanism on market_series so any published point can be traced to observed-vs-derived and by what config, generalized to cover CRM's future derived-cross publishing (currently pull-only) without duplicating the mechanism
- Bootstrap recipe (source series, pillars, interpolation, day-count, curve family role) modelled as a new ores.refdata entity, matching where recipe/config entities already live in this codebase (crm_topology_config, curve_role, tenor)
- Funding-before-Projection build order encoded as data via a self-referencing discount_curve_config_id, per Multi-Curve Construction
- Every nullable field considered was replaced with a sentinel paired to a discriminator column, or removed entirely (output_series_id minted at config-creation time instead of left null until first publish)
- Verification: N/A -- docs-only change (story/task org files), no code touched, nothing to build or test

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [IR curve bootstrapping + official curve republish](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/story.html) | 0BB7EC81-B2A1-4160-AA8D-A21E011F562D |
| Task | [Shared derivation lineage: market_series marker + observation lineage table](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/ir-curve-bootstrapping-and-republish/task_shared-derivation-lineage.html) | 18B74DD5-0A67-4873-A700-B006D4A99FDD |
| Environment | swift_curie | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)