### PR TITLE
[agile] Close hotfix story, file clang-format retrospective task

### DIFF
--- a/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/story.org
+++ b/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/story.org
@@ -22,14 +22,14 @@ everywhere, every time.
 
 * Status
 
-| Field         | Value                                  |
-|---------------+----------------------------------------|
-| State         | DONE                              |
-| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Nothing.                               |
-| Waiting on    | Nothing.                               |
-| Next          | Nothing.                               |
-| Last touched  | 2026-08-04                               |
+| Field         | Value      |
+|---------------+------------|
+| State         | DONE       |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]  |
+| Now           | Nothing.   |
+| Waiting on    | Nothing.   |
+| Next          | Nothing.   |
+| Last touched  | 2026-08-04 |
 
 * Acceptance
 
@@ -39,10 +39,10 @@ everywhere, every time.
 
 * Tasks
 
-| Task | State | Start | End | Description |
-|------+-------+-------+-----+-------------|
-| [[id:E9D1441B-211A-424A-B8FF-0B4B75682624][Scaffold story: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:0D055056-3497-43C1-8024-4C1B1A532DD7][Implement Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Initial task for: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL) |
+| Task                                                                                        | State |      Start |        End | Description                                                                                                        |
+|---------------------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------------------------------------|
+| [[id:E9D1441B-211A-424A-B8FF-0B4B75682624][Scaffold story: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE  | 2026-08-04 | 2026-08-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:0D055056-3497-43C1-8024-4C1B1A532DD7][Implement Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]]       | DONE  | 2026-08-04 | 2026-08-04 | Initial task for: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)                      |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/story.org
+++ b/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/story.org
@@ -24,11 +24,11 @@ everywhere, every time.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Root cause confirmed, fix applied and verified. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | PR.                                    |
+| Next          | Nothing.                               |
 | Last touched  | 2026-08-04                               |
 
 * Acceptance
@@ -41,16 +41,27 @@ everywhere, every time.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:E9D1441B-211A-424A-B8FF-0B4B75682624][Scaffold story: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | STARTED | 2026-08-04 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:E9D1441B-211A-424A-B8FF-0B4B75682624][Scaffold story: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
 | [[id:0D055056-3497-43C1-8024-4C1B1A532DD7][Implement Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Initial task for: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL) |
 
 * Decisions
 
-- Fixed by widening the test's requested JWT TTL from 1 second to 60
+- Fixed by widening the test's requested JWT TTL from 1 second to 120
   seconds (per user direction: never mint JWTs with sub-minute
-  validity), rather than adding verifier leeway to production
-  `jwt_authenticator::validate` — this keeps the fix test-only and
-  does not loosen expiry checking for real tokens.
+  validity; 120s rather than `mint_token`'s own 60s default, per
+  review round 1, so the test still catches a regression where the
+  ttl argument stops being forwarded), rather than adding verifier
+  leeway to production `jwt_authenticator::validate` — this keeps the
+  fix test-only and does not loosen expiry checking for real tokens.
+- While unblocking this PR's CI, found and fixed an unrelated,
+  pre-existing bug: clang-format is not idempotent in one pass for a
+  multi-line comment trailing an assignment before a lambda, causing
+  `ores.refdata` codegen drift to oscillate depending on which of
+  `ores.codegen`'s `clang_format_files()`, the CMake `format` target,
+  or `nightly-format.yml` last touched a file. Fixed by running
+  clang-format twice in all three. Filed a retrospective task under
+  the "Refactor ores.codegen C++ generation" story to write this up
+  properly for the team.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
+++ b/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
@@ -8,7 +8,7 @@
 #+filetags: :jwt_test_ttl_too_short:sprint_25:v0:
 #+owner: marco
 #+branch: hotfix/jwt-test-ttl-too-short
-#+pr:
+#+pr: 1823
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -60,6 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1823][#1823]] | [agile] Close hotfix story, file clang-format retrospective task |
 | [[https://github.com/OreStudio/OreStudio/pull/1820][#1820]] | [iam] Fix flaky mint_token_respects_the_requested_ttl (1s JWT TTL) |
 
 * Review

--- a/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
+++ b/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
@@ -26,11 +26,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-04                               |
 
 * Acceptance
@@ -60,7 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1820][#1820]] | [iam] Fix flaky mint_token_respects_the_requested_ttl (1s JWT TTL) |
 
 * Review
 
@@ -69,3 +69,7 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Story scaffolding (story.org, task files, sprint wiring) rode PR #1820
+alongside the implementation task rather than a separate scaffold-only
+PR — the whole story was small enough to land in one PR. Merged.

--- a/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
+++ b/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.org
@@ -24,14 +24,14 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | DONE                              |
+| Field        | Value                                                                       |
+|--------------+-----------------------------------------------------------------------------|
+| State        | DONE                                                                        |
 | Parent story | [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] |
-| Now          | Nothing. |
-| Waiting on   | Nothing.                               |
-| Next         | Nothing. |
-| Last touched | 2026-08-04                               |
+| Now          | Nothing.                                                                    |
+| Waiting on   | Nothing.                                                                    |
+| Next         | Nothing.                                                                    |
+| Last touched | 2026-08-04                                                                  |
 
 * Acceptance
 
@@ -58,16 +58,17 @@ via its "Verifies task" field.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-| [[https://github.com/OreStudio/OreStudio/pull/1823][#1823]] | [agile] Close hotfix story, file clang-format retrospective task |
+| PR    | Title                                                              |
+|-------+--------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/1823][#1823]] | [agile] Close hotfix story, file clang-format retrospective task   |
 | [[https://github.com/OreStudio/OreStudio/pull/1820][#1820]] | [iam] Fix flaky mint_token_respects_the_requested_ttl (1s JWT TTL) |
 
 * Review
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Org-table column alignment broken after editing values without re-aligning. | story.org, task_scaffold_jwt_test_ttl_too_short.org | Accepted | Re-aligned both tables with org-table-align. |
+| 2 | sprint.org and refactor_codegen_cpp/story.org weren't given a bumped #+updated even though edited today. | sprint.org, refactor_codegen_cpp/story.org | Accepted | Bumped both to 2026-08-04. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
@@ -8,7 +8,7 @@
 #+filetags: :tooling:codegen:sprint_25:v0:
 #+branch: feature/refactor-codegen-cpp
 #+created: 2026-05-30
-#+updated: 2026-06-12
+#+updated: 2026-08-04
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
@@ -159,6 +159,7 @@ trading, iam, dq, and all remaining components.
 | [[id:950FB9D4-48E0-45A4-BC71-F9668D42BE9A][Apply safe drift to workspace-cpp]] | BACKLOG | | | Add has_party_id template flag; restore workspace_service, workspace_repository, workspace_protocol. |
 | [[id:51E65D05-7F22-4DE1-9509-D50A9D98A503][Apply safe drift to compute-cpp]] | BACKLOG | | | Heaviest exclusion catalogue: restore all 6 services + 6 other files. |
 | [[id:A0A1834D-F274-4066-A38D-D597A8827C8D][Apply safe drift to marketdata-cpp]] | BACKLOG | | | The 75-model drift catalog never audited ores.marketdata; market_fixing regenerates with new untracked files (messaging/presentation registrars) on clean origin/main. Audit and apply safe drift following the refdata-cpp pilot pattern. |
+| [[id:E5EEFA91-BE41-4E0B-A69E-DDF965A7F39F][Retrospective: clang-format non-idempotency causing refdata codegen drift]] | BACKLOG | | | Write up the clang-format single-pass non-idempotency bug found and fixed while unblocking PR #1820's CI, and audit for other affected patterns/components beyond ores.refdata. |
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_retro_clang_format_nonidempotency.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_retro_clang_format_nonidempotency.org
@@ -1,0 +1,96 @@
+:PROPERTIES:
+:ID: E5EEFA91-BE41-4E0B-A69E-DDF965A7F39F
+:END:
+#+title: Task: Retrospective: clang-format non-idempotency causing refdata codegen drift
+#+description: Write up the clang-format single-pass non-idempotency bug found and fixed while unblocking PR #1820's CI, and audit for other affected patterns/components beyond ores.refdata.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+While unblocking PR #1820's `refdata-codegen-drift` CI failure, found
+and fixed a genuine clang-format bug: `clang-format` is not idempotent
+in a single pass for a multi-line comment trailing an assignment
+before a lambda (`field = // line1\n// line2\n[idx]{...}`) -- pass 1
+on raw codegen output lands on a "flat" continuation indent, pass 2
+re-indents it to "aligned" (matching the first `//`'s column) and is
+the true fixed point from pass 2 onward. Fixed by running
+clang-format twice in `ores.codegen`'s `clang_format_files()`, the
+CMake `format` target, and `nightly-format.yml`.
+
+This task is the retrospective/audit follow-up, not the fix itself
+(already merged in #1820): write up the investigation properly (root
+cause, how it was proven, why a single pass can leave codegen output
+and the nightly-format bot disagreeing) for the team/future readers,
+and check whether the same non-idempotent comment pattern exists in
+other components beyond `ores.refdata` (whose drift check is the only
+one currently exercised in CI) where it could cause the same
+oscillation once/if their drift checks are turned on.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- A knowledge doc (or an addition to an existing one) captures the
+  root cause, the proof (multi-pass reformatting experiment), and the
+  fix, so a future occurrence of this class of drift is fast to
+  diagnose instead of requiring a from-scratch investigation.
+- Every other component's generator templates are checked for the
+  same multi-line trailing-comment-before-lambda pattern; any hits
+  are either fixed at the model/template source (avoid the pattern)
+  or noted as latent risk once that component's own codegen-drift
+  check is enabled.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -56,7 +56,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | BACKLOG | | | Test mints a JWT with a 1-second TTL and validates it immediately with zero verifier leeway; on slower/loaded nightly runners the token expires before validation, causing a spurious failure. |
+| [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Test mints a JWT with a 1-second TTL and validates it immediately with zero verifier leeway; on slower/loaded nightly runners the token expires before validation, causing a spurious failure. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -9,7 +9,7 @@
 #+created: 2026-08-03
 #+start_date: 2026-08-03
 #+end_date: 2026-08-10
-#+updated: 2026-08-03
+#+updated: 2026-08-04
 #+todo: STARTED | DONE
 
 This page documents a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] (*Sprint 25*) of ORE Studio. It captures the sprint's mission, current status, and the stories that compose it. For the surrounding context — version goals, sprint order, and product identity — see [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]].


### PR DESCRIPTION
## Summary

Docs-only bookkeeping: close scaffold/story for the mint_token_respects_the_requested_ttl hotfix (PR #1820, merged) and file a retrospective task under the Refactor ores.codegen C++ generation story to write up and audit the clang-format non-idempotency bug found while unblocking that PR's CI.

## Changes

- Scaffold task and story both set DONE; sprint.org Hotfixes row updated.
- New task filed: retrospective + cross-component audit for the clang-format single-pass non-idempotency pattern.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/story.html) | 536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C |
| Task | [Scaffold story: Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/jwt_test_ttl_too_short/task_scaffold_jwt_test_ttl_too_short.html) | E9D1441B-211A-424A-B8FF-0B4B75682624 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)