### PR TITLE
[database] Lower default per-service DB connection pool size

### DIFF
--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
@@ -50,7 +50,7 @@ first start attempt.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | BACKLOG | | | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
-| [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | STARTED | 2026-08-04 | | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
+| [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | DONE | 2026-08-04 | 2026-08-04 | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
 | [[id:A54DB993-A61C-44D3-AEE0-964EBD457D0E][Make DB connection pool size runtime-configurable]] | DONE | 2026-08-04 | 2026-08-04 | Move pool_size out of the codegen template literal into database_options/database_configuration, sourced from a CLI flag and ORES_<APP>_DB_POOL_SIZE env var. |
 | [[id:4544572F-7C42-4A37-8440-C11B58511C94][Unify application.cpp and service initialisation across services]] | BACKLOG | | | Clean up application.cpp and service initialisation across all services (including the divergent ores.cli, ores.shell, ores.compute/wrapper shapes), finding commonalities: extract common code to a shared utility, codegen boilerplate that is identical across services, and reduce remaining variation to a minimum handled via variability switches. |
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
@@ -50,7 +50,7 @@ first start attempt.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | BACKLOG | | | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
-| [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | BACKLOG | | | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
+| [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | STARTED | 2026-08-04 | | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
 | [[id:A54DB993-A61C-44D3-AEE0-964EBD457D0E][Make DB connection pool size runtime-configurable]] | DONE | 2026-08-04 | 2026-08-04 | Move pool_size out of the codegen template literal into database_options/database_configuration, sourced from a CLI flag and ORES_<APP>_DB_POOL_SIZE env var. |
 | [[id:4544572F-7C42-4A37-8440-C11B58511C94][Unify application.cpp and service initialisation across services]] | BACKLOG | | | Clean up application.cpp and service initialisation across all services (including the divergent ores.cli, ores.shell, ores.compute/wrapper shapes), finding commonalities: extract common code to a shared utility, codegen boilerplate that is identical across services, and reduce remaining variation to a minimum handled via variability switches. |
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
@@ -91,7 +91,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | test_database_manager.cpp still hardcodes pool_size=4 | test_database_manager.cpp | Declined | Separate literal on context_factory::configuration, not database_options; intentional test-context headroom, out of scope |
+| 2 | pool_size=2 is an aggressive floor, watch for contention under load | (n/a) | Acknowledged | Deliberate product call per parent story, verified live; noted as a follow-up watch item, no code change |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
@@ -8,7 +8,7 @@
 #+filetags: :reduce_db_connection_pool_load:sprint_25:v0:
 #+owner: marco
 #+branch: feature/lower-default-db-pool-size
-#+pr:
+#+pr: 1828
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -85,7 +85,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1828][#1828]] | [database] Lower default per-service DB connection pool size |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :reduce_db_connection_pool_load:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/lower-default-db-pool-size
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
 #+updated: 2026-08-04
-#+environment:
+#+environment: eager_maxwell
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -37,7 +37,7 @@ projects/ores.<component>/service/modeling/component_overview.org
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.org
@@ -37,11 +37,11 @@ projects/ores.<component>/service/modeling/component_overview.org
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-04                               |
 
 * Acceptance
@@ -50,9 +50,23 @@ projects/ores.<component>/service/modeling/component_overview.org
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Superseded by the sibling task landing first: =pool_size= is no
+longer a per-service codegen literal (PR #1821 collapsed it into a
+single =database_options::pool_size= field). So this task no longer
+needs template edits, re-tangling, or 17-service regeneration — just
+change the two remaining =4= defaults:
+
+1. =projects/ores.database/include/ores.database/domain/database_options.hpp=
+   — =int pool_size = 4;= -> =2=.
+2. =projects/ores.database/src/config/database_configuration.cpp= —
+   the =--db-pool-size= =default_value(4)= -> =default_value(2)=.
+3. Update =database_options_tests.cpp='s default-value assertion
+   (currently checks =4=) to match.
+4. Rebuild, run =ores.database.tests=; no codegen regen needed since
+   all 18 =application.cpp= files already read from =db_opts.pool_size=
+   rather than a literal.
+5. Live verify: start a service via systemd with no override, confirm
+   via =pg_stat_activity= it opens 2 connections instead of 4.
 
 * Notes
 
@@ -80,6 +94,29 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Shipped per the revised =* Plan= — the sibling task (PR #1821,
+merged) already collapsed =pool_size= into a single
+=database_options= field, so this was two literal changes rather
+than a codegen edit + 17-service regeneration:
+
+- =database_options::pool_size= default =4= -> =2=.
+- =database_configuration='s =--db-pool-size= =default_value(4)= ->
+  =default_value(2)=.
+- Updated the two tests asserting the old default
+  (=database_options_tests.cpp=, =ores.iam.service=
+  =config_parser_tests.cpp=).
+
+Verified: local build clean; =ores.database.tests= 7/7 and
+=ores.iam.service.tests= [config] 12/12 passed; live systemd smoke
+test — restarted =ores.iam.service= with no override, confirmed via
+=pg_stat_activity= it now opens 2 connections (was 4). No codegen
+regeneration was needed since every =application.cpp= already reads
+=pool_size= from options rather than a literal.
+
+Story not closed — "Audit compass services start systemd
+integration" and "Unify application.cpp and service initialisation
+across services" both remain BACKLOG.
 
 * Promoted from capture
 

--- a/projects/ores.database/include/ores.database/domain/database_options.hpp
+++ b/projects/ores.database/include/ores.database/domain/database_options.hpp
@@ -62,7 +62,7 @@ struct database_options final {
     /**
      * @brief Number of connections in this service's connection pool.
      */
-    int pool_size = 4;
+    int pool_size = 2;
 };
 
 ORES_DATABASE_EXPORT std::ostream& operator<<(std::ostream& s, const database_options& v);

--- a/projects/ores.database/src/config/database_configuration.cpp
+++ b/projects/ores.database/src/config/database_configuration.cpp
@@ -59,7 +59,7 @@ boost::program_options::options_description database_configuration::make_options
         "Required for multi-tenant database operations. "
         "Also reads from ORES_TENANT env var.")(
         "db-pool-size",
-        value<int>()->default_value(4),
+        value<int>()->default_value(2),
         "Number of connections in this service's connection pool. "
         "Reads from ORES_<APP>_DB_POOL_SIZE env var.");
 

--- a/projects/ores.database/tests/database_options_tests.cpp
+++ b/projects/ores.database/tests/database_options_tests.cpp
@@ -63,7 +63,7 @@ TEST_CASE("database_options_default_values", tags) {
     CHECK(sut.port == 5432);
     CHECK(sut.user.empty());
     CHECK(sut.database.empty());
-    CHECK(sut.pool_size == 4);
+    CHECK(sut.pool_size == 2);
 }
 
 TEST_CASE("database_options_custom_values", tags) {

--- a/projects/ores.iam/service/tests/config_parser_tests.cpp
+++ b/projects/ores.iam/service/tests/config_parser_tests.cpp
@@ -47,7 +47,7 @@ TEST_CASE("parse_defaults_returns_expected_values", tags) {
     CHECK(result->nats.subject_prefix.empty());
     CHECK(result->database.host == "localhost");
     CHECK(result->database.port == 5432);
-    CHECK(result->database.pool_size == 4);
+    CHECK(result->database.pool_size == 2);
     CHECK_FALSE(result->logging.has_value());
 }
 


### PR DESCRIPTION
## Summary

Lowers the default database connection pool size from 4 to 2. Now that pool_size lives in a single database_options field (PR #1821), this is just two literal changes rather than a codegen template edit and 17-service regeneration.

## Changes

- Change database_options::pool_size default from 4 to 2
- Change database_configuration's --db-pool-size default_value from 4 to 2
- Update the two tests asserting the old default (database_options_tests.cpp, ores.iam.service config_parser_tests.cpp)
- Verification: local build clean (linux-clang-debug-make); ctest 71/71 passed; live systemd smoke test (restarted ores.iam.service with no override, confirmed via pg_stat_activity it now opens 2 connections vs the previous default of 4)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Reduce and configure per-service DB connection pool size](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.html) | 1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3 |
| Task | [Lower default per-service DB connection pool size](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_lower_default_db_pool_size.html) | E3E201CD-6A62-4772-8307-730D763BBEE9 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)