### PR TITLE
[agile] Abandon Qt client systemd migration: X display unreachable

### DIFF
--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :compass:systemd:infrastructure:sprint_25:v0:
 #+created: 2026-07-31
-#+updated: 2026-07-31
+#+updated: 2026-08-04
 #+environment: brave_hopper
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
@@ -38,12 +38,12 @@ implementation.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | BACKLOG                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Not yet started.                       |
+| Now           | Not yet started -- the one task picked up so far (migrate the Qt client to systemd) was abandoned; see its Result. |
 | Waiting on    | Nothing.                               |
 | Next          | Start with WS-7 change 1 (drop build lock slot c) and WS-1 (per-environment Claude slices). |
-| Last touched  | 2026-07-31                               |
+| Last touched  | 2026-08-04                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
@@ -8,7 +8,7 @@
 #+filetags: :compass:systemd:infrastructure:sprint_25:v0:
 #+created: 2026-07-31
 #+updated: 2026-07-31
-#+environment:
+#+environment: brave_hopper
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -38,7 +38,7 @@ implementation.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -67,7 +67,7 @@ implementation.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:9913E08D-977A-4C36-8376-62BCEA9A41CB][Per-environment systemd resource limits (Claude slices, services, builds)]] | BACKLOG | | | Implement WS-1 through WS-5 and WS-7 of the resource-management plan: per-environment Claude slices with MemoryHigh/MemoryMax/MemorySwapMax/CPUWeight limits (WS-1); converge compass services onto systemctl --user against the generated ores@ENV.target units, staged behind --legacy (WS-2); compass deploys the generated units instead of printing instructions (WS-3); per-environment status/tree/top views (WS-4); protect Emacs and the interactive session via slice drop-ins (WS-5, unprivileged half); reduce build lock to two slots and run builds inside a memory-capped app-build-ENV.slice (WS-7). See systemd-resource-management-plan.org for full analysis, design decisions, and sequencing. WS-6 (PID 1 ownership) is explicitly deferred and out of scope for this task. |
-| [[id:8D87830E-2DD3-4C3E-B743-3410BB0C1B61][Migrate Qt client to a proper systemd unit]] | BACKLOG | | | compass client start/stop currently uses its own PID-file launch/stop path, unlike the rest of the fleet (systemd_generate.py-driven, systemctl --user). Once compass site serve moves to an idiomatic (concrete, non-templated) systemd --user unit, apply the same approach to the client -- one concrete unit per colour instance. |
+| [[id:8D87830E-2DD3-4C3E-B743-3410BB0C1B61][Migrate Qt client to a proper systemd unit]] | ABANDONED | 2026-08-04 | 2026-08-04 | Abandoned: systemd --user sessions on this WSLg/XWayland setup cannot reach the X display (confirmed empirically), a real blocker beyond mere architectural inconsistency. See the task's Result. |
 | [[id:EC737E65-FD0E-46E8-A5A2-807D6BE17E84][Investigate decommissioning ores.controller.service and its DB tables]] | BACKLOG | | | ores.controller.service/process_supervisor's process-launching role was replaced by systemd cascading (split-services-into-per-service-containers story). ores_controller_service_definitions_tbl/ores_controller_service_dependencies_tbl are still in active use as the source of truth systemd_generate.py reads from, but the old controller binary/process_supervisor code and any now-dead controller-specific tables/columns may still be present. Audit what's actually dead vs. still load-bearing (the generator's own data source) before removing anything. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
@@ -8,7 +8,7 @@
 #+filetags: :systemd-resource-management-and-isolation:sprint_25:v0:
 #+owner: marco
 #+branch: feature/migrate-client-to-systemd
-#+pr:
+#+pr: 1833
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -76,7 +76,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1833][#1833]] | [agile] Abandon Qt client systemd migration: X display unreachable |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
@@ -82,7 +82,8 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | story.org State=STARTED but Now/Next/Last touched stale (4 review passes flagged this) | story.org | Accepted | No task in this story is actually in flight (the one started task was abandoned) -- reverted State to BACKLOG rather than inventing a fake Now/Next. |
+| 2 | Comma splice / missing connector in Result prose | task_migrate_client_to_systemd.org | Accepted | Reworded "...or a broken binary, specifically..." to "...or a broken binary; specifically, ...". |
 
 * Result
 
@@ -101,7 +102,7 @@ blocker, not just an architectural-consistency nice-to-have:
   subprocess (i.e. exactly what =compass client start='s current
   PID-file =_launch= does, and what this whole session's screenshot
   work relied on) -- so this isn't a broken X server or a broken
-  binary, specifically the =systemd --user= session boundary on this
+  binary; specifically, the =systemd --user= session boundary on this
   WSLg/XWayland setup isn't inheriting (or isn't authorized for) the
   interactive login session's X access the same way a normal child
   process is.

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :systemd-resource-management-and-isolation:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/migrate-client-to-systemd
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
 #+updated: 2026-08-04
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE][Systemd resource management and per-environment isolation]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -34,11 +34,11 @@ must preserve that), following the same "site-serve" precedent
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | ABANDONED                              |
 | Parent story | [[id:344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE][Systemd resource management and per-environment isolation]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-08-04                               |
 
 * Acceptance
@@ -54,9 +54,10 @@ must preserve that), following the same "site-serve" precedent
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Before implementing, verified empirically whether a GUI Qt process
+can even run under =systemctl --user= on this environment
+(WSLg/XWayland remote X). It cannot -- see =* Result=. Abandoned once
+that was confirmed reproducible; no unit-generation code was written.
 
 * Notes
 
@@ -84,3 +85,37 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Abandoned after empirical testing showed a real, reproducible
+blocker, not just an architectural-consistency nice-to-have:
+
+- Launched =ores.qt= via a transient =systemd-run --user= unit with
+  =DISPLAY= explicitly set (=--setenv=DISPLAY=neumann:11.0=): failed
+  immediately with =qt.qpa.xcb: could not connect to display
+  neumann:11.0=, process aborted (SIGABRT).
+- Retried with =XAUTHORITY= also explicitly set to the working
+  =~/.Xauthority= cookie file (confirmed via =xauth list= to contain
+  a valid =MIT-MAGIC-COOKIE-1= entry for that exact display): same
+  failure, same crash.
+- The identical binary launches and renders correctly via a plain
+  subprocess (i.e. exactly what =compass client start='s current
+  PID-file =_launch= does, and what this whole session's screenshot
+  work relied on) -- so this isn't a broken X server or a broken
+  binary, specifically the =systemd --user= session boundary on this
+  WSLg/XWayland setup isn't inheriting (or isn't authorized for) the
+  interactive login session's X access the same way a normal child
+  process is.
+
+Every other ORE Studio process is headless, so the fleet's migration
+to systemd never had to cross this boundary. Root-causing *why*
+systemd user sessions can't reach the X display here (session
+scoping? cgroup/namespace isolation specific to WSLg? something else
+entirely?) is a real, separate investigation with no guaranteed
+payoff -- and even if solved, the client's per-invocation dynamic args
+(colour, =--open-scenario= path, =--master-password=) are a
+structurally worse fit for systemd's generate-once-at-config-time
+unit model than the fleet's static, DB-driven service definitions
+ever were. The PID-file lifecycle it has today already satisfies the
+actual goal (no orphans, clean start/stop) -- it was inconsistent
+with the rest of the fleet, but not actually broken. Not worth
+pursuing further without a concrete reason beyond consistency.


### PR DESCRIPTION
## Summary

Empirically tested before implementing: systemd --user sessions on this WSLg/XWayland setup cannot reach the X display, a real blocker beyond mere architectural inconsistency with the rest of the (headless) fleet. Recorded as ABANDONED with the finding written up.

## Changes

- Tested via transient systemd-run --user unit with DISPLAY and XAUTHORITY explicitly set: reproducible connection failure (SIGABRT), same binary works fine via plain subprocess
- No code changes -- task abandoned before any unit-generation code was written
- Verification: doc-only change, no build/test impact

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Systemd resource management and per-environment isolation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.html) | 344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE |
| Task | [Migrate Qt client to a proper systemd unit](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_migrate_client_to_systemd.html) | 8D87830E-2DD3-4C3E-B743-3410BB0C1B61 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)