### PR TITLE
[testing] Fix parse_defaults tests leaking real .env NATS values

### DIFF
--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/story.org
@@ -21,11 +21,11 @@ Restore the coded defaults (nats://localhost:4222, empty subject prefix) for par
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing.                       |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing.            |
 | Last touched  | 2026-08-04                               |
 
 * Acceptance
@@ -39,9 +39,20 @@ Restore the coded defaults (nats://localhost:4222, empty subject prefix) for par
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:A979A858-424F-487A-9D3E-EE8D1B79BD35][Scaffold story: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | DONE | 2026-08-04 | 2026-08-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:EEBC6A1A-8DC3-43D9-879A-02A75FB8313F][Implement Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | BACKLOG | | | Initial task for: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests |
+| [[id:EEBC6A1A-8DC3-43D9-879A-02A75FB8313F][Implement Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | DONE | | 2026-08-04 | Initial task for: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests |
 
 * Decisions
+
+- Fixed at the test layer, not the registry: PR #1819's shared-domain
+  fallback tier was working exactly as designed
+  (=nats_configuration::register_shared_domain()= explicitly allows
+  =URL=/=SUBJECT_PREFIX=/=WIRE_FORMAT=), and the leak only surfaced
+  because the affected tests were never actually
+  environment-isolated — they relied on no service parser recognizing
+  a bare =ORES_NATS_URL=, an assumption #1819 correctly invalidated.
+  Restoring hermeticity in the 11 affected tests (=unsetenv= before
+  each "no overrides given" assertion) preserves #1819's intended
+  production behaviour rather than papering over it.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/story.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: BC40520B-4CCF-49B9-B1D2-1908C4915F28
+:END:
+#+title: Story: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests
+#+description: PR #1819's generic ORES_NATS_* shared-domain fallback tier makes 11 service config_parser test suites fail their parse_defaults_returns_expected_values case, because the checkout's real .env NATS URL/subject-prefix now leaks in as a fallback where the test expects the coded default with no overrides.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:testing:nats:environment_mapper:sprint_25:v0:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment: eager_maxwell
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore the coded defaults (nats://localhost:4222, empty subject prefix) for parse_defaults tests when no CLI args or per-app env vars are set, without breaking PR #1819's intended generic ORES_NATS_* fallback for real deployments.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-08-04                               |
+
+* Acceptance
+
+- All 11 previously-failing service config_parser test suites pass parse_defaults_returns_expected_values again
+- PR #1819's actual goal (services pick up bare ORES_NATS_* env vars with zero argv threading) is preserved for real deployment use, not just papered over in tests
+- Root cause documented: why the shared-domain fallback tier applies even when the test harness's own environment (not a real per-service override) happens to set ORES_NATS_URL
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:A979A858-424F-487A-9D3E-EE8D1B79BD35][Scaffold story: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | DONE | 2026-08-04 | 2026-08-04 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:EEBC6A1A-8DC3-43D9-879A-02A75FB8313F][Implement Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | BACKLOG | | | Initial task for: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :fix_shared_nats_fallback_leaks_env_into_test_defaults:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: hotfix/fix-shared-nats-fallback-leaks-env-into-test-defaults
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
 #+updated: 2026-08-04
-#+environment:
+#+environment: eager_maxwell
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,11 +26,11 @@ Restore the coded defaults (nats://localhost:4222, empty subject prefix) for par
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-04                               |
 
 * Acceptance
@@ -41,9 +41,27 @@ Restore the coded defaults (nats://localhost:4222, empty subject prefix) for par
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Root cause: PR #1819's generic =ORES_NATS_*= shared-domain fallback
+tier is working exactly as designed —
+=nats_configuration::register_shared_domain()= explicitly allows the
+=URL=/=SUBJECT_PREFIX=/=WIRE_FORMAT= suffixes, and all 11 affected
+domain services correctly call it. The bug is in the tests, not the
+registry: their =parse_defaults_returns_expected_values= case asserts
+the coded default (=nats://localhost:4222=, empty subject prefix)
+with zero CLI args, but was never actually environment-isolated — it
+only passed before #1819 because no service parser recognized a bare
+=ORES_NATS_URL=. Once the fallback tier made that generic var visible
+fleet-wide (the PR's actual, intended goal), this checkout's real
+=.env= value leaked into every one of these "no overrides given"
+tests.
+
+Fix: =unsetenv("ORES_NATS_URL")=/=unsetenv("ORES_NATS_SUBJECT_PREFIX")=/
+=unsetenv("ORES_NATS_WIRE_FORMAT")= right before the =parse()= call in
+all 11 affected test files' =parse_defaults_returns_expected_values=
+case, matching the existing =setenv=/=unsetenv= idiom already used in
+=ores.nats/tests/config_nats_configuration_tests.cpp=. No production
+code changed — PR #1819's fallback behaviour for real deployments is
+untouched.
 
 * Notes
 
@@ -71,3 +89,17 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+11 =config_parser_tests.cpp= files patched
+(=ores.assets/service=, =ores.compute/service=, =ores.dq/service=,
+=ores.iam/service=, =ores.refdata/service=, =ores.reporting/service=,
+=ores.scheduler/service=, =ores.synthetic/service=,
+=ores.telemetry/service=, =ores.trading/service=,
+=ores.variability/service=) — each gains a 3-line =unsetenv= block
+before their =parse_defaults_returns_expected_values= case's
+=parse()= call, plus =#include <cstdlib>= where missing.
+
+Verified: rebuilt clean; all 11 previously-failing test binaries
+individually confirmed passing (=parse_defaults_returns_expected_values=
+filter); full =ctest --preset linux-clang-debug-make= afterward:
+71/71 passed, 0 failed.

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: EEBC6A1A-8DC3-43D9-879A-02A75FB8313F
+:END:
+#+title: Task: Implement Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests
+#+description: Initial task for: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests
+#+type: task
+#+level: s1
+#+filetags: :fix_shared_nats_fallback_leaks_env_into_test_defaults:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Restore the coded defaults (nats://localhost:4222, empty subject prefix) for parse_defaults tests when no CLI args or per-app env vars are set, without breaking PR #1819's intended generic ORES_NATS_* fallback for real deployments.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+- All 11 previously-failing service config_parser test suites pass parse_defaults_returns_expected_values again
+- PR #1819's actual goal (services pick up bare ORES_NATS_* env vars with zero argv threading) is preserved for real deployment use, not just papered over in tests
+- Root cause documented: why the shared-domain fallback tier applies even when the test harness's own environment (not a real per-service override) happens to set ORES_NATS_URL
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -86,7 +86,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | 3-line unsetenv block duplicated across all 11 files; consider a shared test fixture | (all 11 config_parser_tests.cpp) | Acknowledged | Correct call for a scoped hotfix per all 4 review passes; a shared Catch2 listener/fixture in ores.testing is a reasonable follow-up if a 12th service parser test needs the same isolation, not done here to keep the diff minimal |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_implement_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_shared_nats_fallback_leaks_env_into_test_defaults:sprint_25:v0:
 #+owner: marco
 #+branch: hotfix/fix-shared-nats-fallback-leaks-env-into-test-defaults
-#+pr:
+#+pr: 1836
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -80,7 +80,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1836][#1836]] | [testing] Fix parse_defaults tests leaking real .env NATS values |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_scaffold_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_scaffold_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_shared_nats_fallback_leaks_env_into_test_defaults:sprint_25:v0:
 #+owner: marco
 #+branch: hotfix/fix-shared-nats-fallback-leaks-env-into-test-defaults
-#+pr:
+#+pr: 1836
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -60,7 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1836][#1836]] | [testing] Fix parse_defaults tests leaking real .env NATS values |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_scaffold_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
+++ b/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_scaffold_fix_shared_nats_fallback_leaks_env_into_test_defaults.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: A979A858-424F-487A-9D3E-EE8D1B79BD35
+:END:
+#+title: Task: Scaffold story: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :fix_shared_nats_fallback_leaks_env_into_test_defaults:sprint_25:v0:
+#+owner: marco
+#+branch: hotfix/fix-shared-nats-fallback-leaks-env-into-test-defaults
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-04
+#+updated: 2026-08-04
+#+environment: eager_maxwell
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-08-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Story and task docs scaffolded and wired into Sprint 25's Hotfixes
+table. No code — see the "Implement" task for the actual fix.

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -59,6 +59,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Test mints a JWT with a 1-second TTL and validates it immediately with zero verifier leeway; on slower/loaded nightly runners the token expires before validation, causing a spurious failure. |
+| [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | STARTED | 2026-08-04 | | PR #1819's generic ORES_NATS_* shared-domain fallback tier makes 11 service config_parser test suites fail their parse_defaults_returns_expected_values case, because the checkout's real .env NATS URL/subject-prefix now leaks in as a fallback where the test expects the coded default with no overrides. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -59,7 +59,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Test mints a JWT with a 1-second TTL and validates it immediately with zero verifier leeway; on slower/loaded nightly runners the token expires before validation, causing a spurious failure. |
-| [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | STARTED | 2026-08-04 | | PR #1819's generic ORES_NATS_* shared-domain fallback tier makes 11 service config_parser test suites fail their parse_defaults_returns_expected_values case, because the checkout's real .env NATS URL/subject-prefix now leaks in as a fallback where the test expects the coded default with no overrides. |
+| [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | DONE | 2026-08-04 | 2026-08-04 | PR #1819's generic ORES_NATS_* shared-domain fallback tier makes 11 service config_parser test suites fail their parse_defaults_returns_expected_values case, because the checkout's real .env NATS URL/subject-prefix now leaks in as a fallback where the test expects the coded default with no overrides. |
 
 * Achievements
 

--- a/projects/ores.assets/service/tests/config_parser_tests.cpp
+++ b/projects/ores.assets/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.assets.service/config/parser_exception.hpp"
 #include "ores.logging/make_logger.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::assets::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.compute/service/tests/config_parser_tests.cpp
+++ b/projects/ores.compute/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.compute.service/config/parser_exception.hpp"
 #include "ores.logging/make_logger.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::compute::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.dq/service/tests/config_parser_tests.cpp
+++ b/projects/ores.dq/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.dq.service/config/parser_exception.hpp"
 #include "ores.logging/make_logger.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::dq::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.iam/service/tests/config_parser_tests.cpp
+++ b/projects/ores.iam/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.iam.service/config/parser_exception.hpp"
 #include "ores.logging/make_logger.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -37,6 +38,13 @@ using namespace ores::iam::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.refdata/service/tests/config_parser_tests.cpp
+++ b/projects/ores.refdata/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.refdata.service/config/parser.hpp"
 #include "ores.refdata.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::refdata::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.reporting/service/tests/config_parser_tests.cpp
+++ b/projects/ores.reporting/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.reporting.service/config/parser.hpp"
 #include "ores.reporting.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::reporting::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.scheduler/service/tests/config_parser_tests.cpp
+++ b/projects/ores.scheduler/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.scheduler.service/config/parser.hpp"
 #include "ores.scheduler.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::scheduler::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.synthetic/service/tests/config_parser_tests.cpp
+++ b/projects/ores.synthetic/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.synthetic.service/config/parser.hpp"
 #include "ores.synthetic.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::synthetic::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.telemetry/service/tests/config_parser_tests.cpp
+++ b/projects/ores.telemetry/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.telemetry.service/config/parser.hpp"
 #include "ores.telemetry.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::telemetry::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.trading/service/tests/config_parser_tests.cpp
+++ b/projects/ores.trading/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.trading.service/config/parser.hpp"
 #include "ores.trading.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::trading::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;

--- a/projects/ores.variability/service/tests/config_parser_tests.cpp
+++ b/projects/ores.variability/service/tests/config_parser_tests.cpp
@@ -21,6 +21,7 @@
 #include "ores.variability.service/config/parser.hpp"
 #include "ores.variability.service/config/parser_exception.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,13 @@ using namespace ores::variability::service::config;
 
 TEST_CASE("parse_defaults_returns_expected_values", tags) {
     auto lg(ores::logging::make_logger(test_suite));
+
+    // The generic ORES_NATS_* shared-domain fallback tier (PR #1819) makes
+    // this checkout's real .env values visible to every service parser --
+    // clear them so this "no overrides given" case stays hermetic.
+    unsetenv("ORES_NATS_URL");
+    unsetenv("ORES_NATS_SUBJECT_PREFIX");
+    unsetenv("ORES_NATS_WIRE_FORMAT");
 
     const std::vector<std::string> args;
     std::ostringstream info, err;


### PR DESCRIPTION
## Summary

PR #1819's generic ORES_NATS_* shared-domain fallback tier works exactly as designed, but exposed a pre-existing test-isolation gap: 11 config_parser_tests.cpp files assert the coded NATS default with zero CLI overrides, but were never actually environment-isolated -- they only passed before because no service parser recognized a bare ORES_NATS_URL. Once the fallback made it fleet-wide visible, this checkout's real .env value leaked into every one of those tests.

## Changes

- Add unsetenv(ORES_NATS_URL/SUBJECT_PREFIX/WIRE_FORMAT) before the parse_defaults_returns_expected_values case in all 11 affected config_parser_tests.cpp files, matching the existing setenv/unsetenv idiom in ores.nats/tests
- No production code changed -- PR #1819's actual fallback behaviour for real deployments is preserved
- Verification: local build clean (linux-clang-debug-make); ctest 71/71 passed (twice, before and after a main rebase)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/story.html) | BC40520B-4CCF-49B9-B1D2-1908C4915F28 |
| Task | [Scaffold story: Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix_shared_nats_fallback_leaks_env_into_test_defaults/task_scaffold_fix_shared_nats_fallback_leaks_env_into_test_defaults.html) | A979A858-424F-487A-9D3E-EE8D1B79BD35 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)