### PR TITLE
[compass] Fix nats-server unit readiness gate to stop fleet-start races

### DIFF
--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
@@ -49,7 +49,7 @@ first start attempt.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | BACKLOG | | | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
+| [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | STARTED | 2026-08-04 | | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
 | [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | DONE | 2026-08-04 | 2026-08-04 | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
 | [[id:A54DB993-A61C-44D3-AEE0-964EBD457D0E][Make DB connection pool size runtime-configurable]] | DONE | 2026-08-04 | 2026-08-04 | Move pool_size out of the codegen template literal into database_options/database_configuration, sourced from a CLI flag and ORES_<APP>_DB_POOL_SIZE env var. |
 | [[id:4544572F-7C42-4A37-8440-C11B58511C94][Unify application.cpp and service initialisation across services]] | BACKLOG | | | Clean up application.cpp and service initialisation across all services (including the divergent ores.cli, ores.shell, ores.compute/wrapper shapes), finding commonalities: extract common code to a shared utility, codegen boilerplate that is identical across services, and reduce remaining variation to a minimum handled via variability switches. |

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.org
@@ -49,7 +49,7 @@ first start attempt.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | STARTED | 2026-08-04 | | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
+| [[id:17CCD236-D3F3-49F6-8250-FFDCD94625A2][Audit compass services start systemd integration]] | DONE | 2026-08-04 | 2026-08-04 | Review how compass services start manages systemd units and the service target, confirm it still follows idiomatic systemd practice, and fix any drift. |
 | [[id:E3E201CD-6A62-4772-8307-730D763BBEE9][Lower default per-service DB connection pool size]] | DONE | 2026-08-04 | 2026-08-04 | Reduce the hardcoded pool_size (4) in the service-app codegen template to shrink each environment's steady-state Postgres connection footprint. |
 | [[id:A54DB993-A61C-44D3-AEE0-964EBD457D0E][Make DB connection pool size runtime-configurable]] | DONE | 2026-08-04 | 2026-08-04 | Move pool_size out of the codegen template literal into database_options/database_configuration, sourced from a CLI flag and ORES_<APP>_DB_POOL_SIZE env var. |
 | [[id:4544572F-7C42-4A37-8440-C11B58511C94][Unify application.cpp and service initialisation across services]] | BACKLOG | | | Clean up application.cpp and service initialisation across all services (including the divergent ores.cli, ores.shell, ores.compute/wrapper shapes), finding commonalities: extract common code to a shared utility, codegen boilerplate that is identical across services, and reduce remaining variation to a minimum handled via variability switches. |
@@ -64,6 +64,13 @@ first start attempt.
   (bright_faraday, shared-domain fallback tier in
   =environment_mapper_factory=) merges, since that PR is the natural
   home for the fallback mechanism rather than building a one-off.
+
+- The 5-of-22-units-race symptom traced to =nats-server='s own unit
+  lacking any readiness signal (=Type=simple=, matching its upstream
+  unit — no sd_notify support), not to anything wrong in the fleet's
+  dependency graph. Fixed with an =ExecStartPost== port-listen probe
+  on the generated =nats-server= unit rather than touching the
+  domain-service units, which were already correctly ordered.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :systemd:ops:reduce_db_connection_pool_load:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/audit-services-start-systemd
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
 #+updated: 2026-08-04
-#+environment:
+#+environment: eager_maxwell
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ Review the generated systemd units and the per-environment target's wiring drive
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
@@ -66,11 +66,13 @@ Fix: converted the daemon's missing readiness signal into a real
 systemd-level gate via =ExecStartPost== on the =nats-server= unit — a
 short shell loop polling =ss -tln= for the port, failing the unit
 itself (and thus its own start job) if the port never opens within
-30s. =ExecStartPost== runs synchronously as part of the unit's own
-start job, so this makes systemd's "active" state track true
-readiness, protecting every =Requires=nats-server= dependent through
-the normal unit graph — not just the one external caller who happens
-to poll for it.
+60s (matching =compass_services.py='s own =_wait_for_listen()=
+tolerance for the same check — see PR #1838 review round 1, below).
+=ExecStartPost== runs synchronously as part of the unit's own start
+job, so this makes systemd's "active" state track true readiness,
+protecting every =Requires=nats-server= dependent through the normal
+unit graph — not just the one external caller who happens to poll
+for it.
 
 Verified: 4 consecutive =compass services stop= / =start= cycles, 0
 retries needed (previously 5/22 raced). =systemd-analyze --user
@@ -103,7 +105,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | ExecStartPost probe (30s) stricter than compass_services.py's established 60s tolerance for the same check | systemd_generate.py | Fixed | Bumped to 60s (seq 1 600), matching _wait_for_listen's default; re-verified live (0 NATS-related races on the following stop/start cycle) |
+| 2 | Failure-detection latency for a genuinely dead nats-server (probe still polls full timeout before failing) | systemd_generate.py | Declined | Not worth the added complexity for a rare misconfig case already caught by systemd-analyze verify/manual testing |
+| 3 | StartLimitBurst/IntervalSec interaction shifts with a longer per-attempt probe | systemd_generate.py | Acknowledged | Noted, not a regression -- timing changed but the limiter still functions as a backstop |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
@@ -8,7 +8,7 @@
 #+filetags: :systemd:ops:reduce_db_connection_pool_load:sprint_25:v0:
 #+owner: marco
 #+branch: feature/audit-services-start-systemd
-#+pr:
+#+pr: 1838
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -97,7 +97,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1838][#1838]] | [compass] Fix nats-server unit readiness gate to stop fleet-start races |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
+++ b/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.org
@@ -26,11 +26,11 @@ Review the generated systemd units and the per-environment target's wiring drive
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3][Reduce and configure per-service DB connection pool size]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-04                               |
 
 * Acceptance
@@ -41,9 +41,44 @@ Review the generated systemd units and the per-environment target's wiring drive
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Findings from reading =systemd_generate.py= and =compass_services.py=,
+cross-checked against =nats-server='s own upstream unit
+(=/usr/lib/systemd/system/nats-server.service=):
+
+- Domain-service units are correctly ordered: =After=/Requires== on
+  their dependency graph (=ores_controller_service_dependencies_tbl=),
+  and =Type=notify= backed by a real =sd_notify(READY=1)= call
+  (=ores.service/service/systemd_notify.cpp=) — systemd genuinely
+  waits for application readiness, not just process-start, for these.
+- The gap is =nats-server='s own unit: =Type=simple=, matching
+  upstream's own shipped unit (nats-server has no sd_notify support at
+  all), so systemd marks it "active" the instant the process forks —
+  not when it's actually accepting connections. Every dependent
+  transitively relies on that first hop being truly ready.
+- =compass_services.py= already knows this and compensates
+  *externally*: its own =_wait_for_listen()= polls the NATS port after
+  =systemctl start=, and there's a documented "retry once" pass for
+  any unit whose =Requires=nats-server= chain saw a false failure from
+  this exact race (see its own comment at the retry site — this was a
+  known, already-mitigated gap, not an undiscovered bug).
+
+Fix: converted the daemon's missing readiness signal into a real
+systemd-level gate via =ExecStartPost== on the =nats-server= unit — a
+short shell loop polling =ss -tln= for the port, failing the unit
+itself (and thus its own start job) if the port never opens within
+30s. =ExecStartPost== runs synchronously as part of the unit's own
+start job, so this makes systemd's "active" state track true
+readiness, protecting every =Requires=nats-server= dependent through
+the normal unit graph — not just the one external caller who happens
+to poll for it.
+
+Verified: 4 consecutive =compass services stop= / =start= cycles, 0
+retries needed (previously 5/22 raced). =systemd-analyze --user
+verify= clean on all generated units. Quadlet's =nats-server=
+=.container= unit has the same underlying gap (no readiness signal)
+but is out of scope here — it's currently a design/verification
+target for a different story (offload-to-remote-host), not exercised
+by =compass services start= at all; noted for whoever picks that up.
 
 * Notes
 
@@ -71,3 +106,25 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Confirmed the fleet's dependency ordering itself is idiomatic
+(=After=/Requires== plus real =sd_notify= readiness for every domain
+service); the actual gap was =nats-server='s own unit lacking any
+readiness signal, matching its upstream-shipped unit. Fixed by adding
+an =ExecStartPost== readiness probe to the generated =nats-server=
+unit (=systemd_generate.py='s =render_nats_unit=), so systemd's
+"active" state now tracks true listen-readiness rather than
+process-fork, closing the race for every dependent through the
+normal unit graph instead of relying on external polling.
+
+Verified: 4 consecutive =compass services stop=/=start= cycles, 0
+retries (was 5/22 before this fix); =systemd-analyze --user verify=
+clean on all 25 generated units. Pure Python change, no C++ touched;
+no new unit test added (=ores.compass/src/= has no existing test
+harness for this module) — verification is the live-infra smoke test
+above, consistent with how this module has always been validated.
+
+Out of scope, noted for later: Quadlet's =nats-server= =.container=
+unit has the same underlying gap (no readiness signal), but belongs
+to a different story (offload-to-remote-host) and isn't exercised by
+=compass services start= at all.

--- a/projects/ores.compass/src/systemd_generate.py
+++ b/projects/ores.compass/src/systemd_generate.py
@@ -268,7 +268,28 @@ WantedBy={target_name}
     return units
 
 
-def render_nats_unit(checkout_root, env_name, target_name):
+def render_nats_unit(checkout_root, env_name, target_name, nats_port):
+    """nats-server ships Type=simple in its own upstream unit (confirmed
+    against /usr/lib/systemd/system/nats-server.service) -- it has no
+    sd_notify support, so plain Type=simple marks this unit "active" the
+    instant the process forks, not when it's actually accepting
+    connections. Every other unit in the fleet transitively depends on
+    NATS via After=/Requires=, so that gap is a real race: a dependent
+    can be started by systemd before NATS has finished loading certs/
+    JetStream and is actually listening. ExecStartPost= runs
+    synchronously as part of *this* unit's own start job -- a non-zero
+    exit here fails the unit itself, so this converts the daemon's lack
+    of readiness notification into a real systemd-level readiness gate
+    (same TCP-listen check compass_services.py's own _wait_for_listen
+    already does from the outside, just now enforced inside the unit
+    graph so it protects every dependent, not only the one caller that
+    happens to poll for it)."""
+    port_probe = (
+        f'for i in $(seq 1 300); do '
+        f'ss -tlnH "sport = :{nats_port}" | grep -q . && exit 0; '
+        f'sleep 0.1; done; '
+        f'echo "nats-server did not open port {nats_port} within 30s" >&2; exit 1'
+    )
     unit = UNIT_HEADER
     unit += f"""
 [Unit]
@@ -281,6 +302,7 @@ StartLimitBurst=5
 Type=simple
 EnvironmentFile={checkout_root}/.env
 ExecStart=/usr/sbin/nats-server --config {checkout_root}/build/config/nats-{env_name}.conf
+ExecStartPost=/bin/sh -c '{port_probe}'
 Restart=always
 RestartSec=2
 
@@ -365,8 +387,9 @@ def cmd_generate(project_root: Path, env: dict, args) -> int:
         path.write_text(content)
         written.append(name)
 
+    nats_port = env.get("ORES_NATS_PORT", "4222")
     write(_unit_basename("nats-server", env_name) + ".service",
-          render_nats_unit(checkout_root, env_name, target_name))
+          render_nats_unit(checkout_root, env_name, target_name, nats_port))
 
     for d in defs:
         deps_on = deps.get(d["service_name"], [])

--- a/projects/ores.compass/src/systemd_generate.py
+++ b/projects/ores.compass/src/systemd_generate.py
@@ -284,11 +284,19 @@ def render_nats_unit(checkout_root, env_name, target_name, nats_port):
     already does from the outside, just now enforced inside the unit
     graph so it protects every dependent, not only the one caller that
     happens to poll for it)."""
+    # 60s, matching compass_services.py's own _wait_for_listen() default --
+    # the exact same TCP-listen check this probe relocates into the unit
+    # graph -- rather than picking a fresh, tighter tolerance: a cold start
+    # slow enough to need the full 60s here previously succeeded quietly
+    # under that external wait, and a stricter probe would newly fail the
+    # unit's own start job (and, via Requires=, every dependent's first
+    # attempt) for exactly the slow-but-fine case this PR is meant to stop
+    # mis-classifying as a race.
     port_probe = (
-        f'for i in $(seq 1 300); do '
+        f'for i in $(seq 1 600); do '
         f'ss -tlnH "sport = :{nats_port}" | grep -q . && exit 0; '
         f'sleep 0.1; done; '
-        f'echo "nats-server did not open port {nats_port} within 30s" >&2; exit 1'
+        f'echo "nats-server did not open port {nats_port} within 60s" >&2; exit 1'
     )
     unit = UNIT_HEADER
     unit += f"""


### PR DESCRIPTION
## Summary

Audits compass services start's systemd integration, prompted by a recent start where 5 of 22 units raced their first start attempt. Domain-service units were already correctly ordered (After=/Requires= plus real sd_notify readiness) -- the gap was specifically nats-server's own unit lacking any readiness signal, matching its upstream shipped unit (Type=simple, no sd_notify support).

## Changes

- Add an ExecStartPost= port-listen probe to the generated nats-server unit (systemd_generate.py's render_nats_unit), converting its lack of a readiness signal into a real systemd-level gate
- This makes systemd's own active state track true listen-readiness for every Requires=nats-server dependent through the normal unit graph, instead of relying on compass_services.py's external retry-once workaround
- Verification: 4 consecutive compass services stop/start cycles, 0 retries needed (was 5/22 before this fix); systemd-analyze --user verify clean on all 25 generated units; full ctest 71/71 passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Reduce and configure per-service DB connection pool size](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/story.html) | 1B68F0E3-59FE-4BBE-B0BD-7FA80D9713B3 |
| Task | [Audit compass services start systemd integration](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/reduce_db_connection_pool_load/task_audit_services_start_systemd.html) | 17CCD236-D3F3-49F6-8250-FFDCD94625A2 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)