### PR TITLE
[compass] WS-7 change 1: reduce build lock to two slots

### DIFF
--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
@@ -40,9 +40,9 @@ implementation.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Not yet started -- of the two tasks picked up so far, one (migrate the Qt client to systemd) was abandoned and one (decommission audit) is DONE; see their Results. |
+| Now           | Per-environment resource limits task STARTED -- WS-7 change 1 (drop build lock slot c) implemented, first PR in flight. |
 | Waiting on    | Nothing.                               |
-| Next          | Start with WS-7 change 1 (drop build lock slot c) and WS-1 (per-environment Claude slices). |
+| Next          | WS-1 (per-environment Claude slices with limits). |
 | Last touched  | 2026-08-04                               |
 
 * Acceptance
@@ -66,7 +66,7 @@ implementation.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:9913E08D-977A-4C36-8376-62BCEA9A41CB][Per-environment systemd resource limits (Claude slices, services, builds)]] | BACKLOG | | | Implement WS-1 through WS-5 and WS-7 of the resource-management plan: per-environment Claude slices with MemoryHigh/MemoryMax/MemorySwapMax/CPUWeight limits (WS-1); converge compass services onto systemctl --user against the generated ores@ENV.target units, staged behind --legacy (WS-2); compass deploys the generated units instead of printing instructions (WS-3); per-environment status/tree/top views (WS-4); protect Emacs and the interactive session via slice drop-ins (WS-5, unprivileged half); reduce build lock to two slots and run builds inside a memory-capped app-build-ENV.slice (WS-7). See systemd-resource-management-plan.org for full analysis, design decisions, and sequencing. WS-6 (PID 1 ownership) is explicitly deferred and out of scope for this task. |
+| [[id:9913E08D-977A-4C36-8376-62BCEA9A41CB][Per-environment systemd resource limits (Claude slices, services, builds)]] | STARTED | 2026-08-05 | | Implement WS-1 through WS-5 and WS-7 of the resource-management plan: per-environment Claude slices with MemoryHigh/MemoryMax/MemorySwapMax/CPUWeight limits (WS-1); converge compass services onto systemctl --user against the generated ores@ENV.target units, staged behind --legacy (WS-2); compass deploys the generated units instead of printing instructions (WS-3); per-environment status/tree/top views (WS-4); protect Emacs and the interactive session via slice drop-ins (WS-5, unprivileged half); reduce build lock to two slots and run builds inside a memory-capped app-build-ENV.slice (WS-7). See systemd-resource-management-plan.org for full analysis, design decisions, and sequencing. WS-6 (PID 1 ownership) is explicitly deferred and out of scope for this task. |
 | [[id:8D87830E-2DD3-4C3E-B743-3410BB0C1B61][Migrate Qt client to a proper systemd unit]] | ABANDONED | 2026-08-04 | 2026-08-04 | Abandoned: systemd --user sessions on this WSLg/XWayland setup cannot reach the X display (confirmed empirically), a real blocker beyond mere architectural inconsistency. See the task's Result. |
 | [[id:EC737E65-FD0E-46E8-A5A2-807D6BE17E84][Investigate decommissioning ores.controller.service and its DB tables]] | DONE | 2026-08-04 | 2026-08-04 | Binary/code confirmed already fully gone (Sprint 24, PR #1806). service_definitions/dependencies_tbl confirmed still load-bearing (systemd_generate.py's source of truth). service_instances_tbl/service_events_tbl confirmed genuinely dead (zero readers/writers repo-wide) -- filed as a follow-up capture rather than dropped speculatively here. See the task's Result. |
 

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
@@ -7,43 +7,95 @@
 #+level: s1
 #+filetags: :systemd:compass:infrastructure:sprint_25:v0:systemd-resource-management-and-isolation:
 #+owner: marco
-#+branch:
+#+branch: feature/systemd-resource-limits-ws7-1
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-31
 #+updated: 2026-07-31
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE][Systemd resource management and per-environment isolation]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Make =compass= the single wrapper for process lifecycle across the
+fleet, so a runaway environment's memory usage can only kill that
+environment, never Emacs, the host, or another environment's fleet.
+See [[file:../../../../../../systemd-resource-management-plan.org][the design plan]] for the full root-cause analysis (2026-07-31
+machine lockup) and workstream breakdown (WS-1 through WS-7, WS-6
+deferred).
+
+Landed as a sequence of small, independently reviewed PRs following
+the plan's own sequencing, not one large change -- each workstream
+touches a different file/subsystem and has its own verification.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE][Systemd resource management and per-environment isolation]] |
-| Now          | Not yet started.                       |
+| Now          | WS-7 change 1 (drop build lock slot c) implemented; raising as the first PR. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-07-31                               |
+| Next         | WS-1 (per-environment Claude slices with limits). |
+| Last touched | 2026-08-05                               |
 
 * Acceptance
 
--
+(From the plan's own =* Acceptance=, carried here verbatim as this
+task's bar for DONE.)
+
+- =compass claude= launches into =app-claude-<env>.slice=, and
+  =systemctl --user show= on that slice reports a non-infinite
+  =MemoryMax=.
+- =compass services start= results in service processes whose
+  =/proc/<pid>/cgroup= is under the environment's slice, regardless of
+  whether it was invoked from Emacs, a Claude session, or a bare shell.
+- =compass services status= shows exactly the current environment's
+  fleet, including when nothing is running.
+- Deliberately exhausting memory in one environment kills only that
+  environment; Emacs and other fleets survive. Tested explicitly, with
+  =MemoryMax= temporarily lowered so the test is quick and safe.
+- =compass build --status= reports two slots, and a running build
+  appears under =app-build-<env>.slice= in =systemd-cgls=.
+- No =compass= subcommand requires root for normal operation.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Sequencing per the design plan's =* Sequencing= section:
+
+1. *WS-7 change 1* -- drop build lock slot =c= (two slots instead of
+   three). Small, immediately reduces peak memory.
+2. *WS-1* -- per-environment Claude slices with limits.
+3. *WS-5* (unprivileged half) -- =emacs.service= drop-in.
+4. *WS-4* -- per-environment status/tree/top views.
+5. *WS-7 remainder* -- builds into their own memory-capped slice.
+6. *WS-3* -- =compass systemd deploy=.
+7. *WS-2* -- converge =compass services= onto systemd (the large one,
+   staged behind =--legacy=).
+8. *WS-5* (root half) -- once run with root, verify propagation.
+9. *WS-6* -- deferred; only if still needed after the above.
+
+Each numbered step lands as its own PR against this task's branch
+lineage (a fresh branch per step, closed/reopened as needed), with
+its own local verification and review round, per this repo's normal
+task-to-merged-PR lifecycle.
 
 * Notes
+
+** WS-7 change 1: drop build lock slot 'c'
+
+=BUILD_LOCK_SLOTS= in =projects/ores.compass/src/compass.py= reduced
+from three slots (=a=-j3, b=-j2, c=-j2=, 7 cores in flight) to two
+(=a=-j3, b=-j2=, 5 cores in flight), matching the plan's DD/WS-7
+change 1 exactly. =cmd_build='s docstring and
+=doc/recipes/cmake/how_do_i_build_the_system.org= already described
+"two slots"/"two environments" -- they were already correct, so no
+further doc drift to fix here (the plan's claim that the docstring
+was stale referred to language now already updated). Verified with
+=compass build --status=: shows exactly two slots (=a=, =b=), no =c=.
 
 * Test Scenarios
 

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
@@ -8,7 +8,7 @@
 #+filetags: :systemd:compass:infrastructure:sprint_25:v0:systemd-resource-management-and-isolation:
 #+owner: marco
 #+branch: feature/systemd-resource-limits-ws7-1
-#+pr:
+#+pr: 1842
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-31
@@ -112,7 +112,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1842][#1842]] | [compass] WS-7 change 1: reduce build lock to two slots |
 
 * Review
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -5957,12 +5957,13 @@ def _systemctl_is_active(unit) -> bool:
     return _systemctl_state(unit) == "active"
 
 
-# Three build-lock slots so up to three environments on this host can build
-# at once without oversubscribing it: slot 'a' gets -j3, slot 'b' gets -j2,
-# slot 'c' gets -j2 (7 cores in flight, max, on this 8-core host). Another
-# slot could be added the same way if the host ever has more headroom --
-# nothing else assumes exactly three.
-BUILD_LOCK_SLOTS = (("a", 3), ("b", 2), ("c", 2))
+# Two build-lock slots so up to two environments on this host can build at
+# once without oversubscribing it: slot 'a' gets -j3, slot 'b' gets -j2 (5
+# cores in flight, max, on this 8-core host), leaving headroom for Emacs,
+# the interactive session, and any running fleet. Another slot could be
+# added the same way if the host ever has more headroom -- nothing else
+# assumes exactly two.
+BUILD_LOCK_SLOTS = (("a", 3), ("b", 2))
 BUILD_LOCK_POLL_INTERVAL = 1.0
 
 


### PR DESCRIPTION
## Summary

First staged PR of the per-environment systemd resource limits task: drops build lock slot 'c' per the resource-management plan's WS-7 change 1.

## Changes

- BUILD_LOCK_SLOTS reduced from 3 slots (a=-j3,b=-j2,c=-j2, 7 jobs) to 2 (a=-j3,b=-j2, 5 jobs)
- Verification: compass build --status shows exactly two slots (a, b), no c; python3 -c ast.parse syntax check clean; no test suite covers compass.py build-lock logic

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Systemd resource management and per-environment isolation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.html) | 344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE |
| Task | [Per-environment systemd resource limits (Claude slices, services, builds)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.html) | 9913E08D-977A-4C36-8376-62BCEA9A41CB |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)