### PR TITLE
[compass] WS-1: per-environment Claude slices with limits

### DIFF
--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.org
@@ -40,9 +40,9 @@ implementation.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Per-environment resource limits task STARTED -- WS-7 change 1 (drop build lock slot c) implemented, first PR in flight. |
+| Now           | Per-environment resource limits task STARTED -- WS-7 change 1 (merged) and WS-1 (per-environment Claude slices) implemented, second PR in flight. |
 | Waiting on    | Nothing.                               |
-| Next          | WS-1 (per-environment Claude slices with limits). |
+| Next          | WS-5 (unprivileged half): emacs.service protection drop-in. |
 | Last touched  | 2026-08-04                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
@@ -153,6 +153,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Docstring names the future drop-in dir "app-claude.slice.d/" (missing trailing dash), inconsistent with the actual dash-truncated template it describes | compass_claude.py | Fixed | Corrected to "app-claude-.slice.d/". |
+| 2 | Env names containing a literal dash would create an extra implicit intermediate slice level (harmless -- the drop-in still applies at every level, and no current env name uses dashes) | compass_claude.py | Declined | Genuinely latent, not hit by any real environment today (all use underscores); not worth a speculative guard for an input that can't currently occur. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
@@ -8,7 +8,7 @@
 #+filetags: :systemd:compass:infrastructure:sprint_25:v0:systemd-resource-management-and-isolation:
 #+owner: marco
 #+branch: feature/systemd-resource-limits-ws1
-#+pr: 1842
+#+pr: 1845
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-31
@@ -146,6 +146,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1845][#1845]] | [compass] WS-1: per-environment Claude slices with limits |
 | [[https://github.com/OreStudio/OreStudio/pull/1842][#1842]] | [compass] WS-7 change 1: reduce build lock to two slots |
 
 * Review

--- a/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
+++ b/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :systemd:compass:infrastructure:sprint_25:v0:systemd-resource-management-and-isolation:
 #+owner: marco
-#+branch: feature/systemd-resource-limits-ws7-1
+#+branch: feature/systemd-resource-limits-ws1
 #+pr: 1842
 #+blocked_on:
 #+blocked_since:
@@ -37,9 +37,9 @@ touches a different file/subsystem and has its own verification.
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE][Systemd resource management and per-environment isolation]] |
-| Now          | WS-7 change 1 (drop build lock slot c) implemented; raising as the first PR. |
+| Now          | WS-1 (per-environment Claude slices with limits) implemented; raising as the second PR. |
 | Waiting on   | Nothing.                               |
-| Next         | WS-1 (per-environment Claude slices with limits). |
+| Next         | WS-5 (unprivileged half): emacs.service protection drop-in. |
 | Last touched | 2026-08-05                               |
 
 * Acceptance
@@ -96,6 +96,40 @@ change 1 exactly. =cmd_build='s docstring and
 further doc drift to fix here (the plan's claim that the docstring
 was stale referred to language now already updated). Verified with
 =compass build --status=: shows exactly two slots (=a=, =b=), no =c=.
+
+** WS-1: per-environment Claude slices with limits
+
+=compass_claude.py= changes, matching the plan's three changes
+exactly:
+
+1. =_SLICE_NAME= (module constant) replaced with =_slice_name(env_name)=,
+   nesting each session in =app-claude-<env>.slice= instead of the flat
+   =app-claude.slice=. systemd creates the per-environment slice
+   implicitly from the =--slice=app-claude-<env>.slice= passed to
+   =systemd-run=; no new unit file needed.
+2. New checked-in drop-in source,
+   =projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf=
+   (dash-truncated template — applies to every =app-claude-<env>.slice=
+   with one file), carrying =MemoryHigh=6G=/=MemoryMax=9G=/
+   =MemorySwapMax=2G=/=CPUWeight=100= verbatim from the plan.
+3. =_ensure_slice_deployed()= generalised from a single
+   =(source, dest)= pair to a manifest list, so the slice unit and the
+   limits drop-in both sync (independently — only copies+reloads what
+   actually changed) in one pass.
+
+Verified directly (not via a live =compass claude= launch, to avoid
+disrupting this session's own running scope): called
+=compass_claude._ensure_slice_deployed()= directly, confirmed both
+files land correctly under =~/.config/systemd/user/=, then started a
+throwaway =systemd-run --user --scope --slice=app-claude-brave_hopper.slice
+/bin/true= and confirmed via =systemctl --user show= that
+=MemoryMax=9663676416= (9G), =MemoryHigh=6442450944= (6G),
+=MemorySwapMax=2147483648= (2G), =CPUWeight=100= all apply —
+matching the plan's own worked example. Confirmed =app-claude.slice=
+itself is unaffected (=MemoryMax=infinity=, accounting only), and
+that pre-existing, already-running Claude sessions (launched before
+this change) correctly remain under the old flat slice — no live
+session was disrupted by testing this.
 
 * Test Scenarios
 

--- a/doc/recipes/compass/how_do_i_launch_claude_in_a_systemd_scope.org
+++ b/doc/recipes/compass/how_do_i_launch_claude_in_a_systemd_scope.org
@@ -2,12 +2,12 @@
 :ID: 3FED1AAE-009B-4307-866C-E1C092EA17BE
 :END:
 #+title: How do I launch Claude Code inside a systemd scope?
-#+description: Use compass claude to launch Claude Code as a transient systemd --user scope under app-claude.slice, isolating it from systemd-oomd kills of the parent (e.g. Emacs).
+#+description: Use compass claude to launch Claude Code as a transient systemd --user scope under a per-environment app-claude-<env>.slice, isolating it from systemd-oomd kills of the parent (e.g. Emacs) and capping its memory so a runaway session can only kill itself.
 #+type: recipe
 #+level: cross
-#+filetags: :compass:recipe:
+#+filetags: :compass:recipe:systemd:
 #+created: 2026-07-29
-#+updated: 2026-07-29
+#+updated: 2026-08-05
 
 =compass claude= wraps the =claude= binary so an interactive session
 never inherits its parent's cgroup — no manual =systemd-run= flags,
@@ -18,7 +18,8 @@ compass.sh and the slice unit source.
 
 How do I launch Claude Code so systemd-oomd can kill a runaway
 session without taking down the process that spawned it (e.g.
-Emacs)?
+Emacs), and so a memory-hungry session can't take the whole machine
+down with it?
 
 * Answer
 
@@ -33,16 +34,29 @@ replacement for the =claude= binary:
 ./compass.sh claude -p "some prompt"
 #+end_src
 
-On first use it deploys =app-claude.slice= to
-=~/.config/systemd/user/= (re-syncing it if the checked-in source
-changes) and runs a daemon-reload, then launches Claude as a
-transient =systemd-run --user --scope= under that slice. Every
-session gets its own scope (=claude-<pid>=), so it is a sibling of
-=emacs.service= under =app.slice= rather than a child — oomd
-evaluates it as its own kill candidate instead of taking out the
-whole parent unit. No =MemoryHigh=/=MemoryMax= is set: this is
-isolation only, the OOM killer still does its job at the finer
-per-scope granularity.
+On first use it deploys =app-claude.slice= and the
+=app-claude-.slice.d/50-limits.conf= drop-in to
+=~/.config/systemd/user/= (re-syncing either if the checked-in
+source changes) and runs a daemon-reload, then launches Claude as a
+transient =systemd-run --user --scope= under
+=app-claude-<env>.slice= (=<env>= from =ORES_ENV_NAME= in the
+checkout's =.env=). Every session gets its own scope
+(=claude-<env>-<pid>=), so it is a sibling of =emacs.service= under
+=app.slice= rather than a child — oomd evaluates it as its own kill
+candidate instead of taking out the whole parent unit.
+
+The per-environment slice is what actually carries the limits: the
+dash-truncated drop-in (=app-claude-.slice.d/=) applies to every
+=app-claude-<env>.slice= systemd creates on demand, with no
+per-environment unit file needed. It sets =MemoryHigh=6G=
+(soft — reclaim/throttle) and =MemoryMax=9G=/=MemorySwapMax=2G=
+(hard — cgroup-local OOM), plus =CPUWeight=100= (proportional, so an
+idle machine's =-j3= build bursts are unaffected). This is the
+containment half of the design; =app-claude.slice= itself carries no
+caps, only accounting — see
+[[file:../../../systemd-resource-management-plan.org][the resource-management plan]] (WS-1) for the full rationale and
+why isolation (which slice) and containment (a memory ceiling) are
+two separate concerns.
 
 When there is no usable user systemd manager (e.g. over ssh without
 lingering, some cron/container setups), it falls back to an
@@ -55,6 +69,7 @@ Inspect live accounting with:
 
 #+begin_src sh :results verbatim
 systemd-cgtop --user
+systemctl --user show app-claude-<env>.slice -p MemoryMax -p CPUWeight
 #+end_src
 
 * Script
@@ -64,15 +79,20 @@ systemd-cgtop --user
 dispatched from
 [[proj:projects/ores.compass/src/compass.py][=projects/ores.compass/src/compass.py=]].
 The slice unit source is
-[[proj:projects/ores.compass/src/systemd/app-claude.slice][=projects/ores.compass/src/systemd/app-claude.slice=]].
+[[proj:projects/ores.compass/src/systemd/app-claude.slice][=projects/ores.compass/src/systemd/app-claude.slice=]]; the
+per-environment limits drop-in is
+[[proj:projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf][=projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf=]].
 
 * Tested by
 
 Manual: =compass claude --version= deploys/refreshes the slice unit
-and execs =claude --version= inside a =claude-<pid>.scope= confirmed
-active via =systemctl --user list-units=; re-running is a no-op on
-the slice file (content compared, no redundant daemon-reload).
+and drop-in and execs =claude --version= inside a
+=claude-<env>-<pid>.scope= confirmed active via =systemctl --user
+list-units=, with =systemctl --user show
+app-claude-<env>.slice -p MemoryMax -p CPUWeight= confirming the
+drop-in's limits apply; re-running is a no-op when both files are
+unchanged (content compared per-file, no redundant daemon-reload).
 
 * See also
 
--
+- [[file:../../../systemd-resource-management-plan.org][Plan: systemd resource management and per-environment isolation]] — the design doc this recipe implements (WS-1).

--- a/projects/ores.compass/src/compass_claude.py
+++ b/projects/ores.compass/src/compass_claude.py
@@ -12,10 +12,15 @@ emacs.service under app.slice rather than a child, so oomd evaluates it as its
 own kill candidate and takes out the actual offender instead of the editor.
 A scope contains all descendants, so anything Claude spawns is isolated too.
 
-The slice itself (app-claude.slice, see systemd/app-claude.slice next to this
-file) turns on accounting only -- no MemoryHigh/MemoryMax -- this is
-isolation, not a resource cap; the OOM killer still does its job at the finer
-per-scope granularity.
+Each session actually lands in a per-environment child slice,
+app-claude-<env>.slice (app-claude.slice itself, see systemd/app-claude.slice
+next to this file, turns on accounting only, no caps). The per-environment
+slice carries the real limits, from the app-claude-.slice.d/50-limits.conf
+drop-in next to this file: MemoryHigh/MemoryMax/MemorySwapMax/CPUWeight. That
+is the difference between isolation (which slice a session is a sibling of)
+and containment (a memory ceiling that makes the cgroup-local OOM fire before
+kernel-wide OOM does) -- see systemd-resource-management-plan.org for why
+both matter.
 
 This is opt-in: it changes nothing for anyone invoking the regular `claude`
 binary directly. Use `compass claude` (or `compass.sh claude`) when you want
@@ -33,8 +38,23 @@ import shutil
 import subprocess
 from pathlib import Path
 
-_SLICE_NAME = "app-claude.slice"
-_SLICE_SRC = Path(__file__).resolve().parent / "systemd" / _SLICE_NAME
+_SLICE_ROOT = "app-claude"
+_SLICE_NAME = f"{_SLICE_ROOT}.slice"
+_SYSTEMD_SRC_DIR = Path(__file__).resolve().parent / "systemd"
+_SLICE_SRC = _SYSTEMD_SRC_DIR / _SLICE_NAME
+_LIMITS_DROPIN_REL = Path(f"{_SLICE_ROOT}-.slice.d") / "50-limits.conf"
+_LIMITS_DROPIN_SRC = _SYSTEMD_SRC_DIR / _LIMITS_DROPIN_REL
+
+
+def _slice_name(env_name: str) -> str:
+    """The per-environment slice a Claude session for env_name lands in.
+
+    systemd creates app-claude-<env>.slice (and its app-claude.slice
+    parent) implicitly from this name -- no per-environment unit file is
+    needed, only the dash-truncated drop-in at
+    app-claude-.slice.d/50-limits.conf (see _ensure_slice_deployed).
+    """
+    return f"{_SLICE_ROOT}-{env_name}.slice"
 
 
 def run(argv, project_root=None) -> int:
@@ -50,7 +70,7 @@ def run(argv, project_root=None) -> int:
         cmd = [
             "systemd-run", "--user", "--scope", "-q", "--collect",
             f"--unit=claude-{env_name}-{os.getpid()}",
-            f"--slice={_SLICE_NAME}",
+            f"--slice={_slice_name(env_name)}",
             f"--description=Claude Code session ({env_name}, pid {os.getpid()})",
             real, *argv,
         ]
@@ -97,17 +117,30 @@ def _has_user_systemd() -> bool:
 
 
 def _ensure_slice_deployed() -> None:
-    """Copy the checked-in slice unit to ~/.config/systemd/user/ if it is
-    missing or stale, and daemon-reload so systemd-run sees it immediately.
+    """Copy every checked-in unit/drop-in this module owns to
+    ~/.config/systemd/user/ if missing or stale, and daemon-reload once if
+    anything changed so systemd-run sees it immediately.
+
+    Manifest of (source, destination-relative-path) pairs -- add future
+    app-claude.slice.d/ drop-ins here rather than writing a new one-off
+    deploy function.
     """
     dest_dir = Path.home() / ".config" / "systemd" / "user"
-    dest = dest_dir / _SLICE_NAME
+    manifest = [
+        (_SLICE_SRC, Path(_SLICE_NAME)),
+        (_LIMITS_DROPIN_SRC, _LIMITS_DROPIN_REL),
+    ]
 
-    if dest.exists() and filecmp.cmp(_SLICE_SRC, dest, shallow=False):
-        return
+    changed = False
+    for src, dest_rel in manifest:
+        dest = dest_dir / dest_rel
+        if dest.exists() and filecmp.cmp(src, dest, shallow=False):
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)
+        changed = True
 
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(_SLICE_SRC, dest)
-    subprocess.run(["systemctl", "--user", "daemon-reload"],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                    check=False)
+    if changed:
+        subprocess.run(["systemctl", "--user", "daemon-reload"],
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                        check=False)

--- a/projects/ores.compass/src/compass_claude.py
+++ b/projects/ores.compass/src/compass_claude.py
@@ -122,7 +122,7 @@ def _ensure_slice_deployed() -> None:
     anything changed so systemd-run sees it immediately.
 
     Manifest of (source, destination-relative-path) pairs -- add future
-    app-claude.slice.d/ drop-ins here rather than writing a new one-off
+    app-claude-.slice.d/ drop-ins here rather than writing a new one-off
     deploy function.
     """
     dest_dir = Path.home() / ".config" / "systemd" / "user"

--- a/projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf
+++ b/projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf
@@ -1,0 +1,36 @@
+# Deployed by `compass claude` to
+# ~/.config/systemd/user/app-claude-.slice.d/50-limits.conf.
+# Source of truth: projects/ores.compass/src/systemd/app-claude-.slice.d/50-limits.conf.
+#
+# The dash-truncated slice name (app-claude-.slice.d/) is a systemd template
+# drop-in: it applies to every app-claude-<env>.slice (app-claude-swift_curie,
+# app-claude-brave_hopper, ...) without a per-environment unit file. See
+# systemd-resource-management-plan.org WS-1 for the verification that this
+# works, including with underscores in environment names.
+#
+# Unlike app-claude.slice (accounting only, no caps), this is the load-
+# bearing limit: it makes a runaway environment's own cgroup OOM fire
+# instead of the kernel picking a victim machine-wide (which is what took
+# the box down on 2026-07-31 -- see the plan for the full incident).
+
+[Slice]
+MemoryAccounting=yes
+CPUAccounting=yes
+IOAccounting=yes
+TasksAccounting=yes
+
+# Soft ceiling: reclaim and throttle, survives a fat LTO link.
+MemoryHigh=6G
+# Hard ceiling: cgroup-local OOM. This is what keeps a runaway
+# environment from reaching Emacs.
+MemoryMax=9G
+# 64 GiB of low-priority swap on this box; bound the thrash.
+MemorySwapMax=2G
+
+# Proportional, so -j3 bursts are unaffected on an idle machine.
+CPUWeight=100
+IOWeight=50
+TasksMax=4096
+
+ManagedOOMMemoryPressure=kill
+ManagedOOMMemoryPressureLimit=50%


### PR DESCRIPTION
## Summary

Second staged PR of the per-environment systemd resource limits task: nests each Claude session in a per-environment slice and gives it real memory/CPU limits via a template drop-in.

## Changes

- _SLICE_NAME constant replaced with _slice_name(env_name); systemd-run now targets the per-environment slice
- New app-claude-.slice.d/50-limits.conf template drop-in (dash-truncated, covers every environment with one file)
- _ensure_slice_deployed() generalised to sync a manifest of source and dest pairs instead of a single file
- Verification: called the deploy function directly to avoid disrupting this session's own running scope; confirmed both files deployed; started a throwaway systemd-run scope and confirmed via systemctl show that all four limits apply; confirmed the parent slice is unaffected and pre-existing running sessions undisturbed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Systemd resource management and per-environment isolation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/story.html) | 344FF2CC-E27B-4EE7-AAED-F6E2BE77FABE |
| Task | [Per-environment systemd resource limits (Claude slices, services, builds)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/systemd-resource-management-and-isolation/task_systemd-per-environment-resource-limits.html) | 9913E08D-977A-4C36-8376-62BCEA9A41CB |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)