### PR TITLE
[agile] Close fix_protocol_template: gaps already resolved

### DIFF
--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.org
@@ -9,6 +9,7 @@
 #+branch: feature/refactor-codegen-cpp
 #+created: 2026-05-30
 #+updated: 2026-08-04
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -145,7 +146,7 @@ trading, iam, dq, and all remaining components.
 | [[id:D2E8F4A1-9B3C-4D7F-6A5B-8E1C7D3F9A2B][Fix model consistency and register C++ components in manifest.py]] | DONE | 2026-05-30 | 2026-05-30 | Verify and fix component_include/component_core in all 75 models; add all components to manifest.py. |
 | [[id:B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F][Resolve breaking API drift]] | DONE | 2026-05-30 | 2026-05-30 | Record explicit template-frozen-vs-production-updated decision per breaking change before writing any production file changes; then execute each decision and update callers. |
 | [[id:615B7214-F87B-49D3-866E-CDC198FF2A06][Org-mode codegen POC — party as unified literate model]] | DONE | 2026-05-31 | 2026-06-12 | Prove single org file can drive both C++ and SQL codegen, with custom methods inline. Blocks the per-component drift tasks because custom methods need a first-class mechanism instead of "restore from HEAD". |
-| [[id:251EDAB8-7AD9-46CA-BEA0-3201C9BC452E][Fix cpp_protocol template to match production conventions]] | BACKLOG | | | The cpp_protocol template has systematic gaps versus production: missing offset/limit pagination fields, missing success/message fields on responses, NATS subjects use underscores instead of hyphens, response data field uses entity_plural_short instead of entity_plural. |
+| [[id:251EDAB8-7AD9-46CA-BEA0-3201C9BC452E][Fix cpp_protocol template to match production conventions]] | DONE | 2026-08-05 | 2026-08-05 | The cpp_protocol template has systematic gaps versus production: missing offset/limit pagination fields, missing success/message fields on responses, NATS subjects use underscores instead of hyphens, response data field uses entity_plural_short instead of entity_plural. |
 | [[id:C8A4D7F1-2E6B-4C3A-8F9D-5B1E3C8D2F7A][Apply safe drift to refdata-cpp (pilot)]] | BACKLOG | | | Pilot. Add template flags refdata needs; update refdata models; pull party_repository custom methods from the org-mode mechanism; build + test + zero-diff invariant. Its own Waiting-on note is stale — the org-mode POC it names is now DONE — but its State field reads BACKLOG (paused, WIP stashed), not blocked; needs re-triage before resuming. |
 | [[id:A7FA27E1-0D47-4BEB-BECA-ED06AA6AB4A7][Apply safe drift to trading-cpp]] | BACKLOG | | | Add service_pagination + service_batch_get template flags; update 21 instrument/lookup models; restore trade_service + fra_instrument_service. |
 | [[id:CE4E14AD-81B5-4D86-9739-26BDDA7172FF][Apply safe drift to iam-cpp]] | BACKLOG | | | Set service_find_prefix on tenant_type and tenant_status. No exclusions. |

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_fix_protocol_template.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_fix_protocol_template.org
@@ -8,7 +8,7 @@
 #+filetags: :refactor_codegen_cpp:sprint_25:v0:
 #+owner: marco
 #+branch: feature/fix-protocol-template
-#+pr:
+#+pr: 1865
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -58,7 +58,7 @@ template and every production file checked — no template edit was needed.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1865][#1865]] | [agile] Close fix_protocol_template: gaps already resolved |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_fix_protocol_template.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_fix_protocol_template.org
@@ -7,40 +7,50 @@
 #+level: s1
 #+filetags: :refactor_codegen_cpp:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-protocol-template
 #+pr:
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
 #+updated: 2026-06-12
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Fix =cpp_protocol.hpp.mustache='s four stated gaps versus production
+(missing offset/limit pagination, missing success/message on responses,
+underscore NATS subjects, wrong response-field naming) so the refdata
+protocol exclusions can be removed and refdata is zero-diff.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-05-31                               |
 
 * Acceptance
 
--
+- =cpp_protocol.hpp.mustache= list requests carry =offset=/=limit=.
+- Every response struct carries =success=/=message=.
+- NATS subjects are hyphen/underscore-clean, matching production convention.
+- Response data field naming matches production for every entity.
+- =check_component_drift.py --components refdata= reports zero drift.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Explored the template and a broad sample of production refdata protocol
+files (plain, =as_of=, compound-name, and text-PK entities) plus the
+junction/entity template sections, and ran the component's drift check
+before writing any code. All four gaps were already absent from both the
+template and every production file checked — no template edit was needed.
 
 * Notes
 
@@ -57,3 +67,26 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Already fixed, no code change needed. All four gaps this task describes
+(missing offset/limit, missing success/message, underscore NATS subjects,
+wrong response-field naming) were resolved by commit =540c548cf9=
+([refdata] Fix messaging templates and generate country messaging
+artefacts, 2026-06-26) — after this task doc's =#+updated: 2026-06-12=
+timestamp, which is why it was never flipped to DONE at the time.
+
+Verification performed this session:
+- Read =cpp_protocol.hpp.mustache= end to end (=domain_entity=, =junction=,
+  =entity= sections): pagination, success/message, and hyphen-clean
+  subjects present throughout.
+- Ran =check_component_drift.py --components refdata=: zero drift (=git
+  diff= empty except this task's own bookkeeping edits; =git status=
+  confirmed no untracked/new files either, so junction entities
+  legitimately don't emit a protocol facet — not a gap).
+- Manually diffed/spot-checked =asset_class_code=, =book_status=, =book=,
+  =calendar=, =currency=, and =currency_pair_convention= protocol headers
+  against template output — all match exactly, including the
+  =entity_plural_short= response-field convention.
+
+No template change, no refdata model change, no removal of exclusions
+needed since none currently exist for refdata protocol generation.


### PR DESCRIPTION
## Summary

The cpp_protocol template's four stated gaps (offset/limit pagination, success/message fields, hyphen-clean NATS subjects, response-field naming) were already fixed by commit 540c548cf9 before this task's tracking doc was updated. Verified no code change is needed and closed the task with findings recorded.

## Changes

- Read cpp_protocol.hpp.mustache end to end across all three model-type sections (domain_entity, junction, entity)
- Ran check_component_drift.py --components refdata: zero drift
- Manually spot-checked 6 diverse production refdata protocol headers against template output
- Verification: docs-only change (no template/model code touched); refdata drift check clean (zero diff)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Refactor ores.codegen C++ generation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/story.html) | 3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E |
| Task | [Fix cpp_protocol template to match production conventions](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/task_fix_protocol_template.html) | 251EDAB8-7AD9-46CA-BEA0-3201C9BC452E |
| Environment | bright_faraday | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)