### PR TITLE
[ores.qt.synthetic] Fix MSVC build: disambiguate scope identifier in ScopeLabel.hpp

### DIFF
--- a/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/story.org
@@ -1,0 +1,47 @@
+:PROPERTIES:
+:ID: 07179FD0-044E-48B6-8526-D456EFA99443
+:END:
+#+title: Story: Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier
+#+description: Windows (MSVC) build breaks on ScopeLabel.hpp:34 — the using-declaration 'using ores::synthetic::domain::scope' and the parameter also named 'scope' collide. MSVC resolves 'scope' in 'switch (scope)' as the type rather than the variable, producing C2059/C2143/C2046 cascade errors. Clang and GCC accept the construct without warning.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:build:msvc:sprint_25:v0:
+#+created: 2026-08-05
+#+updated: 2026-08-05
+#+environment: eager_maxwell
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so MSVC can compile it.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-08-05                               |
+
+* Acceptance
+
+- Windows CI goes green on the ScopeLabel.hpp translation unit
+- Linux (Clang/GCC) build remains green
+- No behavioural change — the function returns the same labels as before
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:BCE63A39-4C66-4DE5-A845-C9B0B3BB12C4][Implement Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] | STARTED | 2026-08-05 | | Initial task for: Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/story.org
@@ -21,11 +21,11 @@ Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so 
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Nothing. |
 | Last touched  | 2026-08-05                               |
 
 * Acceptance
@@ -38,7 +38,7 @@ Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so 
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:BCE63A39-4C66-4DE5-A845-C9B0B3BB12C4][Implement Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] | STARTED | 2026-08-05 | | Initial task for: Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier |
+| [[id:BCE63A39-4C66-4DE5-A845-C9B0B3BB12C4][Implement Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] | DONE | 2026-08-05 | 2026-08-05 | Initial task for: Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
+++ b/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: BCE63A39-4C66-4DE5-A845-C9B0B3BB12C4
+:END:
+#+title: Task: Implement Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier
+#+description: Initial task for: Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier
+#+type: task
+#+level: s1
+#+filetags: :fix_msvc_scope_label_ambiguous_identifier:sprint_25:v0:
+#+owner: marco
+#+branch: feature/fix-msvc-scope-label-ambiguous-identifier
+#+pr: 1870
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-05
+#+updated: 2026-08-05
+#+environment: eager_maxwell
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:07179FD0-044E-48B6-8526-D456EFA99443][Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so MSVC can compile it.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:07179FD0-044E-48B6-8526-D456EFA99443][Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-05                               |
+
+* Acceptance
+
+- Windows CI goes green on the ScopeLabel.hpp translation unit
+- Linux (Clang/GCC) build remains green
+- No behavioural change — the function returns the same labels as before
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1870][#1870]] | [ores.qt.synthetic] Fix MSVC build: disambiguate scope identifier in ScopeLabel.hpp |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
+++ b/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
@@ -26,11 +26,11 @@ Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:07179FD0-044E-48B6-8526-D456EFA99443][Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-05                               |
 
 * Acceptance
@@ -78,5 +78,19 @@ via its "Verifies task" field.
 |---+-----------------+------+----------+-------|
 | 1 | Task state should be DONE, fill in Result section before merging | task_fix_msvc_scope_label_ambiguous_identifier.org | Accepted | Will close task via agile-close-task after review round |
 | 2 | Rename 's' to more descriptive name (scopeValue), matching BindingModeLabel.hpp convention | ScopeLabel.hpp | Accepted | Renamed to scopeValue in 1d72787de |
+| 3 | Task state still STARTED/empty Result; close task and fill Result before merge | task_fix_msvc_scope_label_ambiguous_identifier.org | Accepted | Task closed, Result filled |
 
 * Result
+
+=ScopeLabel.hpp= patched: parameter renamed from =scope= to =scopeValue=
+to disambiguate from the =using ores::synthetic::domain::scope;=
+declaration. MSVC resolved =scope= in =switch (scope)= as the type
+rather than the variable, producing C2059/C2143/C2046 cascade errors.
+
+One file changed, 2 lines. No behavioural change — the function returns
+the same labels for =system=, =tenant=, =party=, and the fallback
+=Unknown= case. Clang and GCC accept both forms.
+
+Verified: Linux CI green (all 8 checks pass). Windows/MSVC verification
+is on the PR's CI — the fix resolves the specific MSVC name-resolution
+ambiguity this compiler is known to reject.

--- a/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
+++ b/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.org
@@ -41,9 +41,17 @@ Restore the Windows build by disambiguating the identifier in ScopeLabel.hpp so 
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Root cause: =ScopeLabel.hpp= declares =using ores::synthetic::domain::scope;=
+and the parameter is also named =scope=. MSVC resolves =scope= in
+=switch (scope)= as the type rather than the variable, producing
+C2059/C2143/C2046 cascade errors. Clang and GCC accept the construct
+without warning — it's a portability bug, not a logic bug.
+
+Fix: rename the parameter to =scopeValue=, disambiguating it from the
+=using=-declared type while keeping a descriptive name that matches the
+convention in the sibling file =BindingModeLabel.hpp= (which uses
+=bindingMode= for the same pattern). No callers are affected since
+parameter names are not part of the call convention.
 
 * Notes
 
@@ -68,6 +76,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Task state should be DONE, fill in Result section before merging | task_fix_msvc_scope_label_ambiguous_identifier.org | Accepted | Will close task via agile-close-task after review round |
+| 2 | Rename 's' to more descriptive name (scopeValue), matching BindingModeLabel.hpp convention | ScopeLabel.hpp | Accepted | Renamed to scopeValue in 1d72787de |
 
 * Result

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -67,6 +67,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 |-------+-------+-------+-----+-------------|
 | [[id:536A6313-18D1-49BD-9CA0-EB0D2E3B2D3C][Hotfix: mint_token_respects_the_requested_ttl flaky on nightly (1s JWT TTL)]] | DONE | 2026-08-04 | 2026-08-04 | Test mints a JWT with a 1-second TTL and validates it immediately with zero verifier leeway; on slower/loaded nightly runners the token expires before validation, causing a spurious failure. |
 | [[id:BC40520B-4CCF-49B9-B1D2-1908C4915F28][Hotfix: shared NATS fallback tier leaks .env into parse-defaults tests]] | DONE | 2026-08-04 | 2026-08-04 | PR #1819's generic ORES_NATS_* shared-domain fallback tier makes 11 service config_parser test suites fail their parse_defaults_returns_expected_values case, because the checkout's real .env NATS URL/subject-prefix now leaks in as a fallback where the test expects the coded default with no overrides. |
+| [[id:07179FD0-044E-48B6-8526-D456EFA99443][Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier]] | BACKLOG | | | Windows (MSVC) build breaks on ScopeLabel.hpp:34 — the using-declaration and parameter named 'scope' collide; MSVC resolves 'scope' in 'switch (scope)' as the type rather than the variable. |
 
 * Achievements
 

--- a/projects/ores.qt/synthetic/include/ores.qt/ScopeLabel.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/ScopeLabel.hpp
@@ -29,9 +29,9 @@ namespace ores::qt {
 /**
  * @brief Human-readable label for a market_data_generation_config's scope.
  */
-inline QString scopeLabel(const ores::synthetic::domain::scope& scope) {
+inline QString scopeLabel(const ores::synthetic::domain::scope& s) {
     using ores::synthetic::domain::scope;
-    switch (scope) {
+    switch (s) {
         case scope::system:
             return QCoreApplication::translate("ScopeLabel", "System");
         case scope::tenant:

--- a/projects/ores.qt/synthetic/include/ores.qt/ScopeLabel.hpp
+++ b/projects/ores.qt/synthetic/include/ores.qt/ScopeLabel.hpp
@@ -29,9 +29,9 @@ namespace ores::qt {
 /**
  * @brief Human-readable label for a market_data_generation_config's scope.
  */
-inline QString scopeLabel(const ores::synthetic::domain::scope& s) {
+inline QString scopeLabel(const ores::synthetic::domain::scope& scopeValue) {
     using ores::synthetic::domain::scope;
-    switch (s) {
+    switch (scopeValue) {
         case scope::system:
             return QCoreApplication::translate("ScopeLabel", "System");
         case scope::tenant:


### PR DESCRIPTION
## Summary

The using-declaration `using ores::synthetic::domain::scope` and the parameter also named `scope` collide under MSVC, which resolves `scope` in `switch (scope)` as the type rather than the variable, producing C2059/C2143/C2046 cascade errors. Clang and GCC accept the construct without warning.

## Changes

- Rename parameter `scope` to `s` in `ScopeLabel.hpp` to disambiguate from the using-declaration

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/story.html) | 07179FD0-044E-48B6-8526-D456EFA99443 |
| Task | [Implement Hotfix: MSVC rejects ScopeLabel.hpp due to ambiguous scope identifier](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix_msvc_scope_label_ambiguous_identifier/task_fix_msvc_scope_label_ambiguous_identifier.html) | BCE63A39-4C66-4DE5-A845-C9B0B3BB12C4 |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)