### PR TITLE
[marketdata,sql] Make CRM tick consumption tenant-wide

### DIFF
--- a/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/scenario_verify-holding-company-crm-ticks.org
+++ b/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/scenario_verify-holding-company-crm-ticks.org
@@ -1,0 +1,140 @@
+:PROPERTIES:
+:ID: 40D164E3-D3AA-40E9-B008-F65DFE348056
+:END:
+#+title: Test Scenario: Verify holding company CRM ticks live
+#+description: Manual Qt client verification that the holding company's CRM shows live-ticking rates, fed by the operating offices' FX feeds via crm_ingest_bridge's tenant-wide update(), not just static topology configuration.
+#+type: test_scenario
+#+level: s1
+#+filetags: :holding-company-treasury-functionality:sprint_25:v0:
+#+target_dialog: CrmCrossRatesMatrixMdiWindow
+#+created: 2026-08-05
+#+updated: 2026-08-05
+#+environment:
+#+todo: PENDING | PASSED FAILED
+#+startup: inlineimages
+
+This page documents a test scenario verifying [[id:D073F237-8280-4B64-8CD4-86B18F32294B][Resolve feed-binding party-scoping so holding company CRM can consume FX ticks]] in [[id:C8FA1CE7-F4D7-4D9B-B6A5-1B3A623D7071][Holding company treasury functionality: FX/CRM visibility, Group Treasury book, consolidated reporting]]. It is filled in with the target dialog and checklist of steps before testing starts; the QA Validation Runner panel rewrites =* Results= in place on save.
+
+* Before you start
+
+# System-readiness prerequisites (build, database state, provisioning)
+# belong here, performed by *you* (build/recreate/provision yourself,
+# never hand this to the tester) before opening the client with this
+# scenario -- not folded into Step 1 as a conditional the tester has to
+# evaluate. By the time the tester opens this doc, the system must
+# already be in the state Step 1 assumes. See [[id:0A22B752-D5CF-4B36-8429-2950130AAABD][How do I ready up an
+# environment?]] for the standard confirm/recreate/provision sequence.
+# Delete this whole section if the scenario has no such prerequisites
+# (e.g. it only reads static reference data).
+
+- The database must be freshly provisioned via =--source acme=:
+  =compass db recreate -y -k= then =compass shell -f
+  projects/ores.shell/scripts/library/provisioning/how_do_i_provision_the_system_with_acme_corporation_holding_group.ores=.
+  Confirm the run completes with no failed steps -- each office's
+  =acme_uk.synthetic_feeds: ... completed= (and the equivalent for
+  us/hk) confirms live feeds actually started, which this scenario
+  depends on.
+
+* Scenario Info
+
+# The QA Validation Runner treats *any* non-empty Clients cell below as
+# "this is a multi-client scenario" and then expects every step nested
+# one level deeper, under a per-client heading (Runner source:
+# QaValidationRunnerWidget.cpp, `multi_client =
+# !find_field_value(*info, "Clients").isEmpty()`). Leave the cell
+# genuinely blank — no placeholder text, not even "(single client)" —
+# for the common single-client case; a non-empty cell here with flat
+# `**` steps (no per-client `**`/`***` nesting) silently loads zero
+# steps. Only put text in it when the scenario truly needs several
+# running client instances at once (e.g. a NATS notification lands on
+# a second instance) — list the instance colours/labels, e.g. "blue,
+# red", and nest every step one level deeper under a `**` heading per
+# client as shown further down.
+
+| Field         | Value                                   |
+|---------------+------------------------------------------|
+| Verifies task | [[id:D073F237-8280-4B64-8CD4-86B18F32294B][Resolve feed-binding party-scoping so holding company CRM can consume FX ticks]] |
+| Parent story  | [[id:C8FA1CE7-F4D7-4D9B-B6A5-1B3A623D7071][Holding company treasury functionality: FX/CRM visibility, Group Treasury book, consolidated reporting]]   |
+| Target dialog | CrmCrossRatesMatrixMdiWindow             |
+| Clients       |                                          |
+| State         | PENDING                               |
+
+* Steps
+
+Each step is its own heading — the title should be five to seven
+words so it fits on one line in the QA Validation Runner's step list
+without wrapping or truncating (e.g. "Edit and save the record", not
+a full sentence describing the whole operation). The body below the
+title is a bullet-point checklist, not a prose paragraph: give the
+tester every piece of context needed to execute that one step without
+looking anything up elsewhere — what UI state must already exist,
+exactly what to click or type, and exactly what confirms the step
+passed. The panel writes each step's PASS/FAIL/PENDING outcome and
+notes back as a =*** Result= child heading directly under it.
+
+** Log in as tenant_admin@acme_corporation
+
+- Login dialog: username =tenant_admin@acme_corporation=, password
+  =Secure-Password-123=.
+- Confirm the default/quick-login party is "Acme Corporation Plc"
+  (the holding company) -- this scenario specifically tests that
+  party, not one of the offices. Switch party explicitly if not.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
+** Open majors CRM and confirm live ticking
+
+- Menu: Market Data > Cross-Rates Matrix.
+- Pick =majors=, click Open.
+- Watch the grid for at least 10 seconds. Confirm at least one cell's
+  rate visibly changes (not just present, but actually updating) --
+  this is the real regression check: before the fix, rates for the
+  holding company stayed static/unavailable forever because ticks
+  from the offices' feeds never reached its engines.
+- Footer should read CONNECTED throughout, not DISCONNECTED.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
+** Confirm exotics and scandies also tick
+
+- Repeat for =exotics= and =scandies=: open each, watch for at least
+  one visibly-changing cell within 10 seconds.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
+** Confirm an office's CRM still ticks too
+
+- Switch party to "ACME Corporation UK plc" (or US/HK).
+- Open =majors= again. Confirm it also ticks live -- the tenant-wide
+  fix must not have broken the offices' own (already-working) CRM
+  ticking as a side effect.
+
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
+* Results
+
+| Field         | Value |
+|---------------+-------|
+| Status        | PASSED |
+| Completed at  | 2026-08-05T23:22:16Z |
+| Branch        | feature/resolve-crm-feed-binding-party-scoping |
+| Commit        | 8029b1116 |
+| Worktree      | solid_dirac |
+
+* Notes

--- a/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/story.org
+++ b/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :sprint_25:v0:
 #+created: 2026-08-04
-#+updated: 2026-08-05
+#+updated: 2026-08-06
 #+environment: solid_dirac
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
@@ -30,18 +30,18 @@ built in this story -- see the investigation task and Out of scope.
 |---------------+----------------------------------------|
 | State         | STARTED                                |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | CRM topology now publishes for the holding company; verified end-to-end. Next: feed-binding scoping so it actually ticks. |
+| Now           | Holding company CRM now ticks live, fed by the offices' feeds. Next: Group Treasury book scaffolding. |
 | Waiting on    | Nothing.                               |
-| Next          | Pick up "Resolve feed-binding party-scoping so holding company CRM can consume FX ticks". |
-| Last touched  | 2026-08-05                             |
+| Next          | Pick up "Scaffold a Group Treasury book/portfolio for the holding company". |
+| Last touched  | 2026-08-06                             |
 
 * Acceptance
 
 - A treasury user logged in at Acme Corporation Plc (the holding
   party) can open the Cross-Rates Matrix and see live FX rates for
   its subsidiaries' currencies (GBP/USD/HKD at minimum), without
-  switching party. [Topology: DONE. Live ticks: pending the
-  feed-binding-scoping task.]
+  switching party. [DONE -- topology + tenant-wide tick consumption,
+  verified live via a 4/4-passed test scenario.]
 - Acme Corporation Plc has its own Group Treasury book/portfolio,
   scoped to parent-level treasury activity (not a trading desk).
 - The user manual documents the holding company's role and how it
@@ -56,7 +56,7 @@ built in this story -- see the investigation task and Out of scope.
 |------+-------+-------+-----+-------------|
 | [[id:41733D1E-E9B7-457E-8CAE-4F05FB654AF1][Define holding company treasury data model additions]] | DONE | 2026-08-04 | 2026-08-04 | Design task: confirmed the Group Treasury book/portfolio shape (one DIVISION-type unit, one portfolio, two Banking-classified books, all GBP) and decided tenant-wide FX tick consumption for CRM matching over per-party feed bindings. |
 | [[id:1F682C23-F76E-4701-A8CD-520AE073D45A][Publish CRM topology for the holding company party]] | DONE | 2026-08-05 | 2026-08-05 | Holding company now gets majors/exotics/scandies CRM topology during provisioning, same as each office. Getting a clean end-to-end run also required fixing four unrelated pre-existing regressions (asset_class/derivation_kind/scope/binding_mode) and a duplicate-menu bug (stale AdminPlugin build artifact). Verified via DB query and a 4/4-passed Qt client test scenario. |
-| [[id:D073F237-8280-4B64-8CD4-86B18F32294B][Resolve feed-binding party-scoping so holding company CRM can consume FX ticks]] | BACKLOG | | | crm_ingest_bridge::update() looks up rate engines by (tenant_id, party_id) from the tick's own feed_binding.party_id, and only ever finds a match if that party has crm_topology_config rows. Once the holding company gets its own CRM topology (see the publish-crm-topology task), it also needs FX ticks tagged with its own party_id to actually populate rates -- implement the tenant-wide consumption approach the data-model design task settled on: iterate every party in the tick's tenant rather than looking up one (tenant, party) key. |
+| [[id:D073F237-8280-4B64-8CD4-86B18F32294B][Resolve feed-binding party-scoping so holding company CRM can consume FX ticks]] | DONE | 2026-08-05 | 2026-08-06 | crm_ingest_bridge::update() is now tenant-wide (dropped the party_id_str parameter, feeds every party in the tick's tenant with a matching driver edge). Verified with a new unit test and live: holding company CRM ticks within seconds of opening. Also fixed a second, freshly-introduced regression -- a competing PR had "fixed" the same asset_class-validator bug from the opposite end, reverted to match the correct (already-merged) validator fix. |
 | [[id:77D7E549-0793-45F2-B0EC-48E79AB79151][Scaffold a Group Treasury book/portfolio for the holding company]] | BACKLOG | | | Create a business unit/portfolio/book under Acme Corporation Plc's party for intercompany loans and FX hedges the parent itself carries -- mirrors how each operating office already gets its own book/portfolio tree via the risk_management bundle, but scoped to genuine parent-level treasury activity (remittance hedges, intercompany lending), not a trading desk. |
 | [[id:0120CEEF-22D3-4663-ADF3-47D408972DA6][Investigate consolidated group risk reporting]] | BACKLOG | | | Stretch/investigation task, not a build commitment: scope what it would take to roll up the three operating offices' books into a group-level risk view (NPV/VaR/CVA/XVA) at the holding company, and FX translation of subsidiary financials into the group reporting currency (IAS 21-style). Likely too large for this story -- produce findings and spin off a dedicated follow-on story rather than implementing here. |
 | [[id:0A540739-3629-413F-BB78-F6F4E029EFA4][Update user manual with the holding company description]] | BACKLOG | | | Add/update the user manual's Acme Corporation chapter (or a new section) describing the holding company's role and treasury functionality: FX/CRM visibility, the Group Treasury book, and how it differs from the three operating offices -- so a reader understands why the holding party looks and behaves differently from Acme UK/US/HK. |
@@ -99,6 +99,23 @@ built in this story -- see the investigation task and Out of scope.
   fixed a duplicate-menu bug (a stale libores.qt.admin.so build
   artifact from an incomplete AdminPlugin -> IamPlugin rename)
   blocking manual verification specifically.
+- Implemented tenant-wide CRM tick consumption: crm_ingest_bridge::
+  update() dropped its party_id_str parameter, scanning every party
+  under a tick's tenant (engines_map's std::map ordering makes this a
+  contiguous lower_bound() run, not a full scan) instead of looking
+  up a single (tenant, party) key. Verified live: the holding
+  company's CRM now ticks, fed entirely by the three offices' feeds,
+  with no feed_binding of its own. A new unit test covers the
+  cross-party feed explicitly.
+- Live re-verification surfaced a second, unrelated regression: a
+  competing PR (ba638c24d, merged to main independently) had also
+  "fixed" the asset_class-validator mismatch this story's earlier
+  task found (PR #1864), but by changing the DQ-publish writer to
+  FpML-style literals instead of the validator wiring -- the opposite
+  end of the same bug, done in ignorance of the already-merged fix.
+  Both landed on main, leaving a validator expecting short codes and
+  a writer emitting FpML names. Reverted the writer back to short
+  codes, matching the validator fix that had already been reviewed.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/task_resolve-crm-feed-binding-party-scoping.org
+++ b/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/task_resolve-crm-feed-binding-party-scoping.org
@@ -7,41 +7,84 @@
 #+level: s1
 #+filetags: :holding-company-treasury-functionality:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/resolve-crm-feed-binding-party-scoping
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
-#+updated: 2026-08-04
-#+environment:
+#+updated: 2026-08-06
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C8FA1CE7-F4D7-4D9B-B6A5-1B3A623D7071][Holding company treasury functionality: FX/CRM visibility, Group Treasury book, consolidated reporting]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+The holding company's CRM shows live-ticking rates fed by the
+operating offices' FX feeds, not just static/unavailable topology
+configuration -- crm_ingest_bridge::update() feeds every party in a
+tick's tenant, not just the party that owns the originating
+feed_binding.
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| Field        | Value                                   |
+|--------------+------------------------------------------|
+| State        | DONE                                      |
 | Parent story | [[id:C8FA1CE7-F4D7-4D9B-B6A5-1B3A623D7071][Holding company treasury functionality: FX/CRM visibility, Group Treasury book, consolidated reporting]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-04                               |
+| Now          | Implemented, verified end-to-end and live via a Qt client test scenario (4/4 steps PASSED). |
+| Waiting on   | Nothing.                                  |
+| Next         | Nothing -- task complete.                 |
+| Last touched | 2026-08-06                                |
 
 * Acceptance
 
--
+- A live FX tick from any office's feed updates every party's CRM
+  engine in the same tenant that has that pair as a driver edge, not
+  just the originating feed_binding's own party. [DONE -- unit test +
+  live verification.]
+- The holding company's CRM (majors/exotics/scandies) shows visibly
+  changing rates within seconds of opening, not static/unavailable.
+  [DONE -- test scenario 4/4 PASSED.]
+- The offices' own CRM ticking is unaffected by the change. [DONE --
+  test scenario step 4.]
 
 * Plan
 
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+Implemented the tenant-wide approach the data-model design task
+settled on. crm_ingest_bridge (ores.marketdata.service):
+- update() dropped its party_id_str parameter -- takes tenant_id_str
+  only now.
+- engines_map is keyed by (tenant_id_str, party_id_str) in a
+  std::map, whose default ordering on std::pair<string,string> sorts
+  by tenant_id_str first -- every party in a tenant is a contiguous
+  run starting at lower_bound({tenant_id_str, ""}). update() scans
+  just that run (not the whole map), feeding every named engine at
+  every party that has the tick's pair as a driver edge.
+- feed_ingest_loop.cpp's tick handler no longer passes party_uuid to
+  update() (still used elsewhere in the same handler for series/
+  observation writes, so no unused-variable fallout).
+- Added a new unit test constructing two parties in one tenant, each
+  with their own "majors" config and an EUR/USD driver edge, asserting
+  one update() call feeds both.
+
+Getting a clean live re-verification required fixing a second,
+freshly-introduced regression: another PR landed on main
+(ba638c24d, "Consolidate ACME's UK/US/HK configs into one
+tenant-scoped config") that independently "fixed" the same original
+asset_class-validator bug this story's publish-crm-topology task
+found (d606ccc90), but from the opposite end -- instead of fixing the
+validator wiring (my PR #1864), it changed
+marketdata_publish_from_dq_create.sql's writer to emit FpML-style
+literals ('ForeignExchange'/'InterestRate') matching what the *old*
+(pre-#1864) validator expected. Both merged, so main ended up with a
+validator expecting short codes and a writer emitting FpML names --
+reverted the writer back to the short codes ('fx'/'rates') matching
+the now-correct validator.
 
 * Notes
 
@@ -54,7 +97,7 @@ via its "Verifies task" field.
 
 | Scenario | State | Notes |
 |----------+-------+-------|
-|          |       |       |
+| [[id:40D164E3-D3AA-40E9-B008-F65DFE348056][Verify holding company CRM ticks live]] | PASSED | 4/4 steps passed |
 
 * PRs
 
@@ -69,3 +112,20 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+crm_ingest_bridge::update() is now tenant-wide: a live FX tick from
+any office feeds every party in the same tenant with a matching
+driver edge, not just the party whose feed_binding produced the
+tick. Verified with a new unit test (two parties, one tenant, one
+update() call feeds both) and live: fresh end-to-end provisioning,
+holding company logged in as the default party, majors/exotics/
+scandies all visibly ticking within seconds -- Qt client test
+scenario ([[id:40D164E3-D3AA-40E9-B008-F65DFE348056][Verify holding company CRM ticks live]]) 4/4 steps PASSED.
+
+Also fixed a second regression discovered during live
+re-verification: another PR on main (ba638c24d) had independently
+"fixed" the same asset_class-validator mismatch this story's
+publish-crm-topology task already fixed (PR #1864), but by changing
+the writer to FpML-style literals instead of the validator wiring --
+incompatible with #1864's fix once both merged. Reverted the writer
+back to the short codes matching the correct validator.

--- a/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/task_resolve-crm-feed-binding-party-scoping.org
+++ b/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/task_resolve-crm-feed-binding-party-scoping.org
@@ -8,7 +8,7 @@
 #+filetags: :holding-company-treasury-functionality:sprint_25:v0:
 #+owner: marco
 #+branch: feature/resolve-crm-feed-binding-party-scoping
-#+pr:
+#+pr: 1872
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -103,7 +103,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1872][#1872]] | [marketdata,sql] Make CRM tick consumption tenant-wide |
 
 * Review
 

--- a/projects/ores.marketdata/service/include/ores.marketdata.service/app/crm_ingest_bridge.hpp
+++ b/projects/ores.marketdata/service/include/ores.marketdata.service/app/crm_ingest_bridge.hpp
@@ -90,7 +90,9 @@ struct named_rate_view {
  * since feed_ingest_loop must not fail a tick's persist+remap because of
  * an unrelated CRM lookup) -- a single tick may feed several of a
  * party's named engines at once (e.g. EUR/USD is very likely a driver
- * edge of both a "majors" and an "exotics" CRM).
+ * edge of both a "majors" and an "exotics" CRM), and -- unlike every
+ * other method here -- feeds every *party* within the tenant too, not
+ * just one; see update()'s own doc for why.
  */
 class ORES_MARKETDATA_SERVICE_EXPORT crm_ingest_bridge {
 private:
@@ -108,11 +110,18 @@ public:
     /// crm_topology_config_changed_event/crm_driver_pair_changed_event.
     void refresh();
 
-    /// Feeds one driver tick into every named engine for the (tenant,
-    /// party) that has it as a driver edge. See class doc for why this
-    /// never throws.
+    /// Feeds one driver tick into every named engine, for every party,
+    /// within the given tenant that has it as a driver edge -- tenant-wide,
+    /// not scoped to whichever party's feed_binding happened to produce
+    /// the tick. FX/IR market data isn't genuinely party-specific (a
+    /// EUR/USD print is the same real-world rate no matter who's
+    /// subscribed to it); feed_binding.party_id tracks who set up the
+    /// binding, not who's authorized to consume the resulting ticks --
+    /// that's already governed by each party's own crm_topology_config/
+    /// crm_driver_pair rows (RLS-gated), which is exactly what an entry
+    /// existing in this map for a given party already represents. See
+    /// the class doc for why a non-edge pair never throws.
     void update(const std::string& tenant_id_str,
-                const std::string& party_id_str,
                 const std::string& base_currency_code,
                 const std::string& quote_currency_code,
                 double rate,

--- a/projects/ores.marketdata/service/src/app/crm_ingest_bridge.cpp
+++ b/projects/ores.marketdata/service/src/app/crm_ingest_bridge.cpp
@@ -175,26 +175,32 @@ void crm_ingest_bridge::refresh() {
 }
 
 void crm_ingest_bridge::update(const std::string& tenant_id_str,
-                               const std::string& party_id_str,
                                const std::string& base_currency_code,
                                const std::string& quote_currency_code,
                                double rate,
                                std::chrono::system_clock::time_point observed_at) {
     const auto snap = snapshot();
-    const auto it = snap->find(pair_key{tenant_id_str, party_id_str});
-    if (it == snap->end())
-        return; // no CRM configured for this (tenant, party)
 
-    // A single tick may be a driver edge of several of this party's named
-    // CRMs at once (e.g. EUR/USD in both "majors" and "exotics") -- feed
-    // every one of them.
-    for (const auto& named_engine : it->second) {
-        try {
-            named_engine.engine->update(quant::domain::driver_quote{
-                base_currency_code, quote_currency_code, rate, observed_at});
-        } catch (const std::invalid_argument&) {
-            // Not a driver edge of this CRM's topology (or an unknown
-            // currency) -- not every tick is configured in every CRM.
+    // Tenant-wide: engines_map's key is (tenant_id_str, party_id_str), and
+    // std::map's default ordering on std::pair<std::string, std::string>
+    // sorts by tenant_id_str first, so every one of this tenant's parties
+    // is a contiguous run starting at lower_bound(tenant_id_str, "") --
+    // scanning just that run, not the whole map. See update()'s own doc
+    // for why every party, not just one, gets fed.
+    for (auto it = snap->lower_bound(pair_key{tenant_id_str, std::string{}});
+         it != snap->end() && it->first.first == tenant_id_str;
+         ++it) {
+        // A single tick may be a driver edge of several of this party's
+        // named CRMs at once (e.g. EUR/USD in both "majors" and
+        // "exotics") -- feed every one of them.
+        for (const auto& named_engine : it->second) {
+            try {
+                named_engine.engine->update(quant::domain::driver_quote{
+                    base_currency_code, quote_currency_code, rate, observed_at});
+            } catch (const std::invalid_argument&) {
+                // Not a driver edge of this CRM's topology (or an unknown
+                // currency) -- not every tick is configured in every CRM.
+            }
         }
     }
 }

--- a/projects/ores.marketdata/service/src/app/feed_ingest_loop.cpp
+++ b/projects/ores.marketdata/service/src/app/feed_ingest_loop.cpp
@@ -229,11 +229,12 @@ void feed_ingest_loop::subscribe_binding_locked(const std::string& ore_key,
                     << "Failed to persist observation for " << ore_key_copy << ": " << e.what();
             }
 
-            // Offer the tick to the CRM as a candidate driver update. A
-            // no-op if this (tenant, party) has no CRM configured, or the
-            // pair isn't one of its driver edges -- see
-            // crm_ingest_bridge's own class doc for why this never fails
-            // the tick's persist+remap above.
+            // Offer the tick to the CRM as a candidate driver update,
+            // tenant-wide -- every party in the tenant with a matching
+            // driver edge gets it, not just the party that owns this
+            // feed_binding; see crm_ingest_bridge's own class doc for why.
+            // A no-op if no party in this tenant has a CRM configured, or
+            // the pair isn't a driver edge of any of them.
             if (crm_bridge_) {
                 try {
                     const auto kp = parse_ore_key(ore_key_copy);
@@ -241,7 +242,6 @@ void feed_ingest_loop::subscribe_binding_locked(const std::string& ore_key,
                         const auto slash = kp.qualifier.find('/');
                         if (slash != std::string::npos) {
                             crm_bridge_->update(tenant_ctx.tenant_id().to_string(),
-                                                boost::uuids::to_string(party_uuid),
                                                 kp.qualifier.substr(0, slash),
                                                 kp.qualifier.substr(slash + 1),
                                                 tick->mid,

--- a/projects/ores.marketdata/service/tests/app_crm_ingest_bridge_tests.cpp
+++ b/projects/ores.marketdata/service/tests/app_crm_ingest_bridge_tests.cpp
@@ -129,8 +129,8 @@ TEST_CASE("refresh builds an engine from persisted config and driver pairs, upda
     CHECK(before->status == ores::analytics::quant::domain::rate_status::unavailable);
 
     const auto now = std::chrono::system_clock::now();
-    bridge.update(tenant_id_str, party_id_str, "EUR", "USD", 1.10, now);
-    bridge.update(tenant_id_str, party_id_str, "USD", "JPY", 150.0, now);
+    bridge.update(tenant_id_str, "EUR", "USD", 1.10, now);
+    bridge.update(tenant_id_str, "USD", "JPY", 150.0, now);
 
     auto direct = bridge.rate(tenant_id_str, party_id_str, "test", "EUR", "USD");
     REQUIRE(direct.has_value());
@@ -185,7 +185,7 @@ TEST_CASE("update() silently ignores a pair that is not a driver edge", tags) {
 
     // GBP/USD is not a configured driver pair -- must not throw.
     CHECK_NOTHROW(bridge.update(
-        tenant_id_str, party_id_str, "GBP", "USD", 1.25, std::chrono::system_clock::now()));
+        tenant_id_str, "GBP", "USD", 1.25, std::chrono::system_clock::now()));
 }
 
 TEST_CASE("rates() returns every configured pair (driver + enabled derived) in one batch", tags) {
@@ -205,8 +205,8 @@ TEST_CASE("rates() returns every configured pair (driver + enabled derived) in o
     const auto tenant_id_str = f.h.tenant_id().to_string();
     const auto party_id_str = boost::uuids::to_string(f.party_id);
     const auto now = std::chrono::system_clock::now();
-    bridge.update(tenant_id_str, party_id_str, "EUR", "USD", 1.10, now);
-    bridge.update(tenant_id_str, party_id_str, "USD", "JPY", 150.0, now);
+    bridge.update(tenant_id_str, "EUR", "USD", 1.10, now);
+    bridge.update(tenant_id_str, "USD", "JPY", 150.0, now);
 
     const auto results = bridge.rates(tenant_id_str, party_id_str, "test");
 
@@ -244,8 +244,8 @@ TEST_CASE("two enabled configs for the same (tenant, party) build two independen
 
     // A tick on a pair shared by both CRMs feeds both -- but here EUR/USD
     // is only a driver edge of majors, TRY/USD only of exotics.
-    bridge.update(tenant_id_str, party_id_str, "EUR", "USD", 1.10, now);
-    bridge.update(tenant_id_str, party_id_str, "TRY", "USD", 0.030, now);
+    bridge.update(tenant_id_str, "EUR", "USD", 1.10, now);
+    bridge.update(tenant_id_str, "TRY", "USD", 0.030, now);
 
     auto majors_rate = bridge.rate(tenant_id_str, party_id_str, "majors", "EUR", "USD");
     REQUIRE(majors_rate.has_value());
@@ -288,8 +288,8 @@ TEST_CASE(
     const auto tenant_id_str = f.h.tenant_id().to_string();
     const auto party_id_str = boost::uuids::to_string(f.party_id);
     const auto now = std::chrono::system_clock::now();
-    bridge.update(tenant_id_str, party_id_str, "EUR", "USD", 1.10, now);
-    bridge.update(tenant_id_str, party_id_str, "USD", "JPY", 150.0, now);
+    bridge.update(tenant_id_str, "EUR", "USD", 1.10, now);
+    bridge.update(tenant_id_str, "USD", "JPY", 150.0, now);
 
     const auto results = bridge.resolved_rates(tenant_id_str, party_id_str, "test", true);
 
@@ -325,7 +325,7 @@ TEST_CASE("resolved_rates() synthesises no reciprocal when the reverse pair is i
     const auto tenant_id_str = f.h.tenant_id().to_string();
     const auto party_id_str = boost::uuids::to_string(f.party_id);
     bridge.update(
-        tenant_id_str, party_id_str, "EUR", "USD", 1.10, std::chrono::system_clock::now());
+        tenant_id_str, "EUR", "USD", 1.10, std::chrono::system_clock::now());
 
     const auto results = bridge.resolved_rates(tenant_id_str, party_id_str, "test", true);
 
@@ -355,13 +355,13 @@ TEST_CASE("refresh() resets the per-named-engine delta baseline", tags) {
     const auto party_id_str = boost::uuids::to_string(f.party_id);
 
     bridge.update(
-        tenant_id_str, party_id_str, "EUR", "USD", 1.10, std::chrono::system_clock::now());
+        tenant_id_str, "EUR", "USD", 1.10, std::chrono::system_clock::now());
     const auto first = bridge.resolved_rates(tenant_id_str, party_id_str, "test", false);
     REQUIRE(first.size() == 1);
     CHECK_FALSE(first[0].delta_pct.has_value()); // first observation
 
     bridge.update(
-        tenant_id_str, party_id_str, "EUR", "USD", 1.20, std::chrono::system_clock::now());
+        tenant_id_str, "EUR", "USD", 1.20, std::chrono::system_clock::now());
     const auto second = bridge.resolved_rates(tenant_id_str, party_id_str, "test", false);
     REQUIRE(second.size() == 1);
     REQUIRE(second[0].delta_pct.has_value()); // baseline established by `first`
@@ -372,10 +372,54 @@ TEST_CASE("refresh() resets the per-named-engine delta baseline", tags) {
     // the next observation looks like a first observation again.
     bridge.refresh();
     bridge.update(
-        tenant_id_str, party_id_str, "EUR", "USD", 1.25, std::chrono::system_clock::now());
+        tenant_id_str, "EUR", "USD", 1.25, std::chrono::system_clock::now());
     const auto after_refresh = bridge.resolved_rates(tenant_id_str, party_id_str, "test", false);
     REQUIRE(after_refresh.size() == 1);
     CHECK_FALSE(after_refresh[0].delta_pct.has_value());
+}
+
+TEST_CASE("update() is tenant-wide: one tick feeds every party's matching engine", tags) {
+    // A tick's own feed_binding.party_id no longer scopes which party's
+    // CRM engines get fed -- update() only takes tenant_id_str now. Two
+    // parties in the same tenant, each with their own "majors" config and
+    // an EUR/USD driver edge: a single update() call for that pair must
+    // feed both, not just whichever party happened to own the originating
+    // feed_binding.
+    fixture f;
+    crm_topology_config_repository config_repo;
+    crm_driver_pair_repository driver_repo;
+
+    config_repo.write(f.h.context(), f.make_config("USD", "majors"));
+    driver_repo.write(f.h.context(), f.make_driver_pair("EUR", "USD"));
+
+    const auto second_party_id = boost::uuids::random_generator{}();
+    const auto second_config_id = boost::uuids::random_generator{}();
+    auto second_config = f.make_config("USD", "majors");
+    second_config.id = second_config_id;
+    second_config.party_id = second_party_id;
+    config_repo.write(f.h.context(), second_config);
+
+    auto second_driver_pair = f.make_driver_pair("EUR", "USD");
+    second_driver_pair.config_id = second_config_id;
+    second_driver_pair.party_id = second_party_id;
+    driver_repo.write(f.h.context(), second_driver_pair);
+
+    crm_ingest_bridge bridge(f.h.context());
+    bridge.refresh();
+
+    const auto tenant_id_str = f.h.tenant_id().to_string();
+    bridge.update(
+        tenant_id_str, "EUR", "USD", 1.10, std::chrono::system_clock::now());
+
+    const auto first_party_rate =
+        bridge.rate(tenant_id_str, boost::uuids::to_string(f.party_id), "majors", "EUR", "USD");
+    REQUIRE(first_party_rate.has_value());
+    CHECK(first_party_rate->status == ores::analytics::quant::domain::rate_status::fresh);
+
+    const auto second_party_rate = bridge.rate(
+        tenant_id_str, boost::uuids::to_string(second_party_id), "majors", "EUR", "USD");
+    REQUIRE(second_party_rate.has_value());
+    CHECK(second_party_rate->status == ores::analytics::quant::domain::rate_status::fresh);
 }
 
 TEST_CASE("the DB rejects a second active crm_topology_config sharing a party's CRM name", tags) {

--- a/projects/ores.sql/create/marketdata/marketdata_publish_from_dq_create.sql
+++ b/projects/ores.sql/create/marketdata/marketdata_publish_from_dq_create.sql
@@ -118,11 +118,17 @@ begin
         order by dq.series_type, dq.metric, dq.qualifier
     loop
         if r.series_type = 'FX' and r.metric = 'RATE' then
-            v_asset_class := 'ForeignExchange';
+            -- 'fx', not the FpML 'ForeignExchange': asset_class is
+            -- validated against ores_refdata_asset_class_codes_tbl (the
+            -- short-code table mirroring ores::marketdata::domain::
+            -- asset_class exactly -- see marketdata_market_series_
+            -- create.sql's insert trigger), not the unrelated FpML
+            -- Bond/Commodity/.../ForeignExchange/... taxonomy.
+            v_asset_class := 'fx';
             v_series_subclass := 'spot';
             v_is_scalar := true;
         elsif r.series_type = 'RATES' and r.metric = 'YIELD' then
-            v_asset_class := 'InterestRate';
+            v_asset_class := 'rates';
             v_series_subclass := 'yield';
             v_is_scalar := false;
         else


### PR DESCRIPTION
## Summary

The holding company's CRM had topology but never ticked: crm_ingest_bridge::update() only looked up rate engines by the tick's originating feed_binding.party_id, so a party with no feed_binding of its own (like the holding company) could never receive ticks at all. Made update() tenant-wide, and fixed a fresh regression discovered during live re-verification.

## Changes

- crm_ingest_bridge::update() dropped its party_id_str parameter -- scans every party within the tick's tenant (engines_map's std::map ordering makes this a targeted lower_bound() run, not a full scan), feeding every matching engine at every party, not just the originating feed_binding's party.
- New unit test: two parties in one tenant, each with their own driver edge, asserting one update() call feeds both.
- Fixed a second regression found during live re-verification: a competing PR (ba638c24d) had independently fixed the same asset_class-validator mismatch this story's earlier task fixed (PR #1864), but from the opposite end -- changed the DQ-publish writer to FpML literals instead of the validator wiring. Both merged, leaving a validator/writer mismatch; reverted the writer to match the already-reviewed validator fix.
- Verification: local build clean (linux-clang-debug-make); ctest 71/71 passed; live end-to-end provisioning with zero failed steps; Qt client test scenario 4/4 steps PASSED, confirming the holding company's CRM now ticks live, fed by the operating offices' feeds, with no feed_binding of its own.
- Verifies task D073F237; story C8FA1CE7.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Holding company treasury functionality: FX/CRM visibility, Group Treasury book, consolidated reporting](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/story.html) | C8FA1CE7-F4D7-4D9B-B6A5-1B3A623D7071 |
| Task | [Resolve feed-binding party-scoping so holding company CRM can consume FX ticks](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/holding-company-treasury-functionality/task_resolve-crm-feed-binding-party-scoping.html) | D073F237-8280-4B64-8CD4-86B18F32294B |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)