### PR TITLE
[ci] Add workflow_dispatch trigger to nightly-linux

### DIFF
--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -24,6 +24,7 @@ env:
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   check_changes:


### PR DESCRIPTION
Missed the nightly run while CI was disabled. Adding workflow_dispatch so it can be triggered manually.