### PR TITLE
[marketdata] Add oresmd correlation asset class: pairwise factor correlation

### DIFF
--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
@@ -65,7 +65,7 @@ oresmd already represents).
 | [[id:B87C97B8-415B-4C7D-9ACB-2B58EEFCB26E][Extend oresmd FX coverage: FX forward points]] | DONE | 2026-08-08 | 2026-08-08 | Represent the 1 of 2 catalogued FX quote types not yet covered: FXFWD/RATE. |
 | [[id:DD35387F-D84B-4392-9C07-8F6F7F2FFF8F][Add oresmd inflation asset class: ZC/YoY swap rate, seasonality]] | DONE | 2026-08-08 | 2026-08-08 | oresmd has no inflation asset class at all today. Add inflation_market_data_identifier covering the 3 catalogued inflation quote types: ZC_INFLATIONSWAP/RATE, YY_INFLATIONSWAP/RATE, SEASONALITY/RATE. |
 | [[id:B91F6F7D-5C8A-4DB0-A5C6-827EEC43BE41][Design and add oresmd volatility-surface sub-schema]] | BACKLOG | | | oresmd only represents swaption RATE_LNVOL today. Design one shared strike/expiry/model-subtype sub-schema and apply it across all 8 catalogued vol sub-families: swaption, cap/floor, FX option, equity option, commodity option, bond option, inflation cap/floor, credit index option (12 quote types total). |
-| [[id:6D1CA504-D70A-4ACB-9560-3C124162FC80][Add oresmd correlation asset class: pairwise factor correlation]] | STARTED | 2026-08-08 | | oresmd has no correlation asset class at all today. Add correlation_market_data_identifier covering CORRELATION/RATE (pairwise correlation between two risk factors, e.g. CCY-CMS-TENOR, FX-FIX-CCY1-CCY2, EQ-TICKER). |
+| [[id:6D1CA504-D70A-4ACB-9560-3C124162FC80][Add oresmd correlation asset class: pairwise factor correlation]] | DONE | 2026-08-08 | 2026-08-08 | oresmd has no correlation asset class at all today. Add correlation_market_data_identifier covering CORRELATION/RATE (pairwise correlation between two risk factors, e.g. CCY-CMS-TENOR, FX-FIX-CCY1-CCY2, EQ-TICKER). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
@@ -65,7 +65,7 @@ oresmd already represents).
 | [[id:B87C97B8-415B-4C7D-9ACB-2B58EEFCB26E][Extend oresmd FX coverage: FX forward points]] | DONE | 2026-08-08 | 2026-08-08 | Represent the 1 of 2 catalogued FX quote types not yet covered: FXFWD/RATE. |
 | [[id:DD35387F-D84B-4392-9C07-8F6F7F2FFF8F][Add oresmd inflation asset class: ZC/YoY swap rate, seasonality]] | DONE | 2026-08-08 | 2026-08-08 | oresmd has no inflation asset class at all today. Add inflation_market_data_identifier covering the 3 catalogued inflation quote types: ZC_INFLATIONSWAP/RATE, YY_INFLATIONSWAP/RATE, SEASONALITY/RATE. |
 | [[id:B91F6F7D-5C8A-4DB0-A5C6-827EEC43BE41][Design and add oresmd volatility-surface sub-schema]] | BACKLOG | | | oresmd only represents swaption RATE_LNVOL today. Design one shared strike/expiry/model-subtype sub-schema and apply it across all 8 catalogued vol sub-families: swaption, cap/floor, FX option, equity option, commodity option, bond option, inflation cap/floor, credit index option (12 quote types total). |
-| [[id:6D1CA504-D70A-4ACB-9560-3C124162FC80][Add oresmd correlation asset class: pairwise factor correlation]] | BACKLOG | | | oresmd has no correlation asset class at all today. Add correlation_market_data_identifier covering CORRELATION/RATE (pairwise correlation between two risk factors, e.g. CCY-CMS-TENOR, FX-FIX-CCY1-CCY2, EQ-TICKER). |
+| [[id:6D1CA504-D70A-4ACB-9560-3C124162FC80][Add oresmd correlation asset class: pairwise factor correlation]] | STARTED | 2026-08-08 | | oresmd has no correlation asset class at all today. Add correlation_market_data_identifier covering CORRELATION/RATE (pairwise correlation between two risk factors, e.g. CCY-CMS-TENOR, FX-FIX-CCY1-CCY2, EQ-TICKER). |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
@@ -26,11 +26,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE quote-type coverage]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-30                               |
 
 * Acceptance
@@ -69,3 +69,10 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Delivered new correlation asset class: =correlation_market_data_identifier=
+and =correlation_market_data_requirement= added as 7th variant member.
+=correlation_quote_type= (=pairwise=) with =quote_key_correlation=
+=format("CORRELATION/RATE/{}", factor_pair)=. =factor_pair= carries the
+descriptive factor-pair string. Full parser+to_uri+resolver wiring.
+145 test cases, 258 assertions, all passing.

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :extend-oresmd-full-quote-type-coverage:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/correlation-asset-class
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-30
 #+updated: 2026-07-30
-#+environment:
+#+environment: merry_newton
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE quote-type coverage]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE quote-type coverage]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
@@ -66,7 +66,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | factor_pair opaque vs 6-seg ORE key | projections | Declined | Task uses composite strings per its own worked examples |
+| 2 | bare else unsafe for future variants | projections, resolver | Accepted | Changed to explicit if constexpr |
+| 3 | redundant quote_type nullopt check | projections | Accepted | Removed, consistent with single-enum default |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.org
@@ -8,7 +8,7 @@
 #+filetags: :extend-oresmd-full-quote-type-coverage:sprint_24:v0:
 #+owner: marco
 #+branch: feature/correlation-asset-class
-#+pr:
+#+pr: 1912
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-30
@@ -60,7 +60,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1912][#1912]] | [marketdata] Add oresmd correlation asset class: pairwise factor correlation |
 
 * Review
 

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/domain/market_data_identifier.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/domain/market_data_identifier.hpp
@@ -124,7 +124,18 @@ struct inflation_market_data_identifier final {
 };
 
 /**
- * @brief Tagged union of the six per-asset-class identifier structs.
+ * @brief A fully-resolved oresmd identifier for a pairwise correlation (asset_class=correlation).
+ */
+struct correlation_market_data_identifier final {
+    std::string factor_pair;
+    instrument_type type = instrument_type::quote;
+    std::optional<domain::correlation_quote_type> quote_type;
+
+    bool operator==(const correlation_market_data_identifier&) const = default;
+};
+
+/**
+ * @brief Tagged union of the seven per-asset-class identifier structs.
  *
  * Deliberately *not* a common base class with virtual dispatch: the URI's `asset_class`
  * authority component already tells a consumer which concrete struct applies, and
@@ -137,7 +148,8 @@ using market_data_identifier = std::variant<fx_market_data_identifier,
                                             equity_market_data_identifier,
                                             credit_market_data_identifier,
                                             commodity_market_data_identifier,
-                                            inflation_market_data_identifier>;
+                                            inflation_market_data_identifier,
+                                            correlation_market_data_identifier>;
 
 }
 

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/domain/market_data_requirement.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/domain/market_data_requirement.hpp
@@ -100,8 +100,17 @@ struct inflation_market_data_requirement final {
     bool operator==(const inflation_market_data_requirement&) const = default;
 };
 
+/** @brief A logical, possibly-partial oresmd requirement for a correlation instrument. */
+struct correlation_market_data_requirement final {
+    std::optional<std::string> factor_pair;
+    std::optional<instrument_type> type;
+    std::optional<correlation_quote_type> quote_type;
+
+    bool operator==(const correlation_market_data_requirement&) const = default;
+};
+
 /**
- * @brief Tagged union of the six per-asset-class requirement structs -- see
+ * @brief Tagged union of the seven per-asset-class requirement structs -- see
  * market_data_identifier.hpp for the rationale against a common base class.
  */
 using market_data_requirement = std::variant<fx_market_data_requirement,
@@ -109,7 +118,8 @@ using market_data_requirement = std::variant<fx_market_data_requirement,
                                              equity_market_data_requirement,
                                              credit_market_data_requirement,
                                              commodity_market_data_requirement,
-                                             inflation_market_data_requirement>;
+                                             inflation_market_data_requirement,
+                                             correlation_market_data_requirement>;
 
 }
 

--- a/projects/ores.marketdata/api/include/ores.marketdata.api/domain/oresmd_enums.hpp
+++ b/projects/ores.marketdata/api/include/ores.marketdata.api/domain/oresmd_enums.hpp
@@ -140,6 +140,14 @@ enum class inflation_quote_type {
     seasonality ///< SEASONALITY/RATE (seasonality adjustment factor).
 };
 
+/**
+ * @brief The `quote` query key for correlation instruments — the ORE TYPE. Correlation-only;
+ * only meaningful when `type=quote`.
+ */
+enum class correlation_quote_type {
+    pairwise ///< CORRELATION/RATE (pairwise factor correlation).
+};
+
 }
 
 #endif

--- a/projects/ores.marketdata/core/src/oresmd/oresmd_parser.cpp
+++ b/projects/ores.marketdata/core/src/oresmd/oresmd_parser.cpp
@@ -224,6 +224,25 @@ market_data_identifier parse_credit(const boost::urls::url_view& u, const query_
     return id;
 }
 
+market_data_identifier parse_correlation(const boost::urls::url_view& u, const query_params& qp) {
+    reject_if_present("correlation", "ccy", qp.ccy);
+    reject_if_present("correlation", "index", qp.index);
+    reject_if_present("correlation", "tenor", qp.tenor);
+    reject_if_present("correlation", "role", qp.role);
+    reject_if_present("correlation", "metric", qp.metric);
+    reject_if_present("correlation", "point", qp.point);
+    correlation_market_data_identifier id;
+    id.factor_pair = to_upper(first_segment(u));
+    id.type = parse_type(qp);
+    if (qp.quote) {
+        if (id.type != instrument_type::quote)
+            BOOST_THROW_EXCEPTION(
+                oresmd_exception("oresmd://correlation/... 'quote' is only meaningful when type=quote."));
+        id.quote_type = parse_enum<correlation_quote_type>("quote", *qp.quote);
+    }
+    return id;
+}
+
 market_data_identifier parse_inflation(const boost::urls::url_view& u, const query_params& qp) {
     // Validation: only quote, type, and point are meaningful for inflation.
     reject_if_present("inflation", "ccy", qp.ccy);
@@ -305,6 +324,8 @@ market_data_identifier oresmd_parser::parse(const domain::oresmd_uri& uri) {
         return parse_commodity(u, qp);
     if (asset_token == "inflation")
         return parse_inflation(u, qp);
+    if (asset_token == "correlation")
+        return parse_correlation(u, qp);
 
     BOOST_THROW_EXCEPTION(
         oresmd_exception(std::format("Unrecognised oresmd asset class: {}", asset_token)));
@@ -360,6 +381,11 @@ domain::oresmd_uri oresmd_parser::to_uri(const domain::market_data_identifier& i
                 u.params().append({"type", std::string(magic_enum::enum_name(id.type))});
                 append_enum_if(u, "quote", id.quote_type);
                 append_if(u, "point", id.point);
+            } else if constexpr (std::is_same_v<T, correlation_market_data_identifier>) {
+                u.set_host("correlation");
+                u.segments().push_back(to_lower(id.factor_pair));
+                u.params().append({"type", std::string(magic_enum::enum_name(id.type))});
+                append_enum_if(u, "quote", id.quote_type);
             }
         },
         identifier);

--- a/projects/ores.marketdata/core/src/oresmd/oresmd_projections.cpp
+++ b/projects/ores.marketdata/core/src/oresmd/oresmd_projections.cpp
@@ -381,7 +381,7 @@ std::optional<std::string> quote_key_inflation(const inflation_market_data_ident
 }
 
 std::optional<std::string> quote_key_correlation(const correlation_market_data_identifier& id) {
-    if (id.type != instrument_type::quote || !id.quote_type)
+    if (id.type != instrument_type::quote)
         return std::nullopt;
     return std::format("CORRELATION/RATE/{}", id.factor_pair);
 }
@@ -436,7 +436,7 @@ oresmd_projections::to_quote_key(const domain::market_data_identifier& identifie
                 return quote_key_commodity(id);
             else if constexpr (std::is_same_v<T, inflation_market_data_identifier>)
                 return quote_key_inflation(id);
-            else
+            else if constexpr (std::is_same_v<T, correlation_market_data_identifier>)
                 return quote_key_correlation(id);
         },
         identifier);

--- a/projects/ores.marketdata/core/src/oresmd/oresmd_projections.cpp
+++ b/projects/ores.marketdata/core/src/oresmd/oresmd_projections.cpp
@@ -380,6 +380,12 @@ std::optional<std::string> quote_key_inflation(const inflation_market_data_ident
                        id.index_code, to_upper(*id.point));
 }
 
+std::optional<std::string> quote_key_correlation(const correlation_market_data_identifier& id) {
+    if (id.type != instrument_type::quote || !id.quote_type)
+        return std::nullopt;
+    return std::format("CORRELATION/RATE/{}", id.factor_pair);
+}
+
 std::optional<std::string> quote_key_commodity(const commodity_market_data_identifier& id) {
     if (id.type != instrument_type::quote)
         return std::nullopt;
@@ -428,8 +434,10 @@ oresmd_projections::to_quote_key(const domain::market_data_identifier& identifie
                 return quote_key_credit(id);
             else if constexpr (std::is_same_v<T, commodity_market_data_identifier>)
                 return quote_key_commodity(id);
-            else
+            else if constexpr (std::is_same_v<T, inflation_market_data_identifier>)
                 return quote_key_inflation(id);
+            else
+                return quote_key_correlation(id);
         },
         identifier);
 }

--- a/projects/ores.marketdata/core/src/oresmd/oresmd_resolver.cpp
+++ b/projects/ores.marketdata/core/src/oresmd/oresmd_resolver.cpp
@@ -170,7 +170,7 @@ oresmd_resolver::resolve(const domain::market_data_requirement& requirement,
                 return resolve_commodity(req, defaults);
             else if constexpr (std::is_same_v<T, inflation_market_data_requirement>)
                 return resolve_inflation(req, defaults);
-            else
+            else if constexpr (std::is_same_v<T, correlation_market_data_requirement>)
                 return resolve_correlation(req, defaults);
         },
         requirement);

--- a/projects/ores.marketdata/core/src/oresmd/oresmd_resolver.cpp
+++ b/projects/ores.marketdata/core/src/oresmd/oresmd_resolver.cpp
@@ -112,6 +112,17 @@ market_data_identifier resolve_credit(const credit_market_data_requirement& req,
     return id;
 }
 
+market_data_identifier resolve_correlation(const correlation_market_data_requirement& req,
+                                            const market_data_identifier& defaults) {
+    const auto* d = std::get_if<correlation_market_data_identifier>(&defaults);
+    correlation_market_data_identifier id;
+    id.factor_pair = pick_mandatory_string(
+        req.factor_pair, d ? d->factor_pair : std::string{}, "factor_pair");
+    id.type = pick(req.type, d ? std::optional(d->type) : std::nullopt, "type");
+    id.quote_type = pick_optional(req.quote_type, d ? d->quote_type : std::nullopt);
+    return id;
+}
+
 market_data_identifier resolve_inflation(const inflation_market_data_requirement& req,
                                           const market_data_identifier& defaults) {
     const auto* d = std::get_if<inflation_market_data_identifier>(&defaults);
@@ -157,8 +168,10 @@ oresmd_resolver::resolve(const domain::market_data_requirement& requirement,
                 return resolve_credit(req, defaults);
             else if constexpr (std::is_same_v<T, commodity_market_data_requirement>)
                 return resolve_commodity(req, defaults);
-            else
+            else if constexpr (std::is_same_v<T, inflation_market_data_requirement>)
                 return resolve_inflation(req, defaults);
+            else
+                return resolve_correlation(req, defaults);
         },
         requirement);
 }

--- a/projects/ores.marketdata/core/tests/oresmd_oresmd_parser_tests.cpp
+++ b/projects/ores.marketdata/core/tests/oresmd_oresmd_parser_tests.cpp
@@ -383,6 +383,19 @@ TEST_CASE("reject_credit_uri_missing_mandatory_ccy", tags) {
         oresmd_exception);
 }
 
+TEST_CASE("parse_correlation_pairwise", tags) {
+    const auto id = oresmd_parser::parse(uri("oresmd://correlation/ccy-eur-usd?type=quote&quote=pairwise"));
+    const auto& cr = std::get<correlation_market_data_identifier>(id);
+    REQUIRE(cr.factor_pair == "CCY-EUR-USD");
+    REQUIRE(cr.quote_type == correlation_quote_type::pairwise);
+}
+
+TEST_CASE("round_trip_correlation", tags) {
+    const auto original = oresmd_parser::parse(uri("oresmd://correlation/ccy-eur-usd?type=quote&quote=pairwise"));
+    const auto roundtripped = oresmd_parser::parse(oresmd_parser::to_uri(original));
+    REQUIRE(original == roundtripped);
+}
+
 TEST_CASE("parse_inflation_zc_swap", tags) {
     const auto id = oresmd_parser::parse(uri("oresmd://inflation/ukrpi?type=quote&quote=zc_swap&point=5y"));
     const auto& inf = std::get<inflation_market_data_identifier>(id);

--- a/projects/ores.marketdata/core/tests/oresmd_oresmd_projections_tests.cpp
+++ b/projects/ores.marketdata/core/tests/oresmd_oresmd_projections_tests.cpp
@@ -325,6 +325,15 @@ TEST_CASE("seasonality_quote_key", tags) {
     REQUIRE(oresmd_projections::to_quote_key(id) == "SEASONALITY/RATE/MULT/UKRPI/JAN");
 }
 
+/*
+ * Correlation asset class (id:D566131C-D08C-4AFE-950E-B3DD26EB2C24).
+ */
+
+TEST_CASE("correlation_pairwise_quote_key", tags) {
+    const auto id = parse("oresmd://correlation/ccy-eur-usd?type=quote&quote=pairwise");
+    REQUIRE(oresmd_projections::to_quote_key(id) == "CORRELATION/RATE/CCY-EUR-USD");
+}
+
 TEST_CASE("commodity_cpr_quote_key", tags) {
     const auto id = parse("oresmd://commodity/wti?ccy=usd&type=quote&quote=cpr&point=5y");
     REQUIRE(oresmd_projections::to_quote_key(id) == "CPR/RATE/WTI/USD/5Y");


### PR DESCRIPTION
## Summary

New correlation asset class (7th variant member). correlation_quote_type (pairwise) with CORRELATION/RATE/FACTOR_PAIR quote key. factor_pair carries the descriptive factor-pair identifier string.

## Changes

- New correlation_market_data_identifier: factor_pair, type, quote_type
- correlation_quote_type enum: pairwise
- Full parser/to_uri/resolver wiring
- Verification: local build clean; ctest 145/145 passed (258 assertions)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Extend oresmd to full ORE quote-type coverage](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.html) | D566131C-D08C-4AFE-950E-B3DD26EB2C24 |
| Task | [Add oresmd correlation asset class: pairwise factor correlation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_correlation-asset-class.html) | 6D1CA504-D70A-4ACB-9560-3C124162FC80 |
| Environment | merry_newton | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)