### PR TITLE
[reporting,qt,codegen] Apply safe drift to reporting-cpp — follow-up fixes

### DIFF
--- a/doc/agile/product_backlog/inbox/profile-binding-physical-space.org
+++ b/doc/agile/product_backlog/inbox/profile-binding-physical-space.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: 98D0B4FD-EBF9-4DB4-863F-CF0EACD2A1B2
+:END:
+#+title: Profile Physical-space overrides only read file-level :PROPERTIES:, not * Flags section
+#+description: :profile: declared in the * Flags section works for feature assignments (has_pagination, etc.) but not for Physical space facet enablement (like eventing-integration-test). The codegen's read_physical_space_overrides function only reads doc.file_properties.get("profile"), missing the :profile: that every entity model puts in its * Flags section. Fix read_physical_space_overrides to find :profile: from * Flags, so a single binding point drives both mechanisms.
+#+type: capture
+#+level: cross
+#+filetags: :codegen:variability:dx:
+#+created: 2026-08-08
+#+updated: 2026-08-08
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+The codegen has two profile binding points with different behaviour — adding a
+Physical-space facet override to a profile file only works for entities that
+declare =:profile:= in their file-level =:PROPERTIES:= drawer, which none do:
+
+| Where =:profile:= lives                     | What it drives                                          |
+|---------------------------------------------+---------------------------------------------------------|
+| =* Flags= section =:PROPERTIES:= drawer     | Feature assignments (=has_pagination=, =has_tenant_id=) |
+| File-level =:PROPERTIES:= drawer            | Physical-space facet enablement (=eventing-integration-test=) |
+
+Every entity model declares =:profile:= in its =* Flags= section — that's the
+existing convention. But =read_physical_space_overrides= (org_loader.py:183)
+only reads =doc.file_properties.get("profile")=, missing every entity's profile.
+
+Fix: =read_physical_space_overrides= should also find =:profile:= from the
+=* Flags= section (the same place =_profile_namespace_defaults= reads it), so a
+single binding point in =* Flags= drives both feature assignments and facet
+enablement. Then revert the file-level =:profile:= additions made to the 4
+reporting entity models as a workaround.
+
+* Why
+
+Discovered during the reporting-cpp safe drift task in sprint 25. We added a
+=* Physical space= table to all 6 domain archetype profiles to enable
+=ores.cpp.eventing-integration-test= by default. Entity regeneration produced
+the test files for reporting entities only because we manually added
+=:profile:= to their file-level =:PROPERTIES:= drawers. Other entities
+(e.g. all of refdata) silently got nothing — the profile Physical-space table
+had no effect. The two-binding-point design makes adding a facet to a profile
+require per-entity edits, defeating the purpose of profiles.
+
+* References
+
+- org_loader.py:183 — =read_physical_space_overrides= reads file-level only
+- [[id:1D0B00E4-6032-4DCA-9B66-571DE9F131FC][Simple lookup profile]] — example profile with Physical-space table added
+- [[id:CD698EB1-D411-4BF7-84B0-9794D47C802A][ores.cpp.eventing-integration-test facet]] — the facet gated by this mechanism
+- [[id:E9A2F4B1-7C3D-4E8B-A5F0-2D6C1B8E3A7F][eventing_integration_test feature]] — created alongside this work
+
+* See also
+
+- [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] — the story where this was discovered

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
@@ -83,8 +83,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | FAIL |
-| Notes  | no report definitions show. is this because we do not have reports for ACME corp? we should have the appropriate reports for each entity. |
+| Status | PASS |
 
 ** Open Report Instances and verify list loads
 
@@ -96,7 +95,8 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | FAIL |
+| Notes  | no eventing. manual reload worked though. |
 
 ** Create a new Report Definition
 
@@ -114,7 +114,8 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | FAIL |
+| Notes  | eventing failed, manual reload worked |
 
 ** Edit the Report Definition and verify update
 
@@ -127,7 +128,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | PASS |
 
 ** View Report Definition history
 
@@ -141,7 +142,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | PASS |
 
 ** Delete the Report Definition and confirm removal
 
@@ -153,7 +154,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | PASS |
 
 ** Create a new Concurrency Policy (CRUD end-to-end)
 
@@ -168,16 +169,17 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | FAIL |
+| Notes  | no eventing, manual reload works |
 
 * Results
 
 | Field         | Value |
 |---------------+-------|
 | Status        | FAILED |
-| Completed at  | 2026-08-08T08:55:10Z |
+| Completed at  | 2026-08-08T11:28:04Z |
 | Branch        | fix/reporting-main-break |
-| Commit        | 954cc1375 |
+| Commit        | a5e24fe64 |
 | Worktree      | bright_faraday |
 
 * Notes

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
@@ -6,7 +6,7 @@
 #+type: test_scenario
 #+level: s1
 #+filetags: :refactor_codegen_cpp:sprint_25:v0:
-#+target_dialog: ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Reporting > Report Definitions / Report Instances; Reporting > Report Configuration > Concurrency Policies / Report Types; Reporting > Compute Configuration > Apps / App Versions; Reporting > Pricing Configuration > Model Configurations / Model Products / Model Product Parameters / Pricing Engine Types
+#+target_dialog: ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Analytics > Report Definitions, Analytics > Report Instances, Analytics > Analytics Codes > Report Types, Analytics > Analytics Codes > Concurrency Policies
 #+created: 2026-08-08
 #+updated: 2026-08-08
 #+environment: bright_faraday
@@ -27,7 +27,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 |---------------+------------------------------------------|
 | Verifies task | [[id:193FF620-BB98-4EB4-9124-2D06CA8FFCE0][Apply safe drift to reporting-cpp]] |
 | Parent story  | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]]   |
-| Target dialog | ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Reporting > Report Definitions / Report Instances; Reporting > Report Configuration > Concurrency Policies / Report Types; Reporting > Compute Configuration > Apps / App Versions; Reporting > Pricing Configuration > Model Configurations etc. |
+| Target dialog | ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Analytics > Report Definitions / Report Instances; Analytics > Analytics Codes > Report Types / Concurrency Policies |
 | Clients       |                                          |
 | State         | PENDING                               |
 
@@ -47,7 +47,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 ** Open Concurrency Policies and verify seed data
 
-- Navigate to: Reporting > Report Configuration > Concurrency Policies.
+- Navigate to: Analytics > Analytics Codes > Concurrency Policies.
 - Verify the list window titled "Concurrency Policies" opens.
 - Confirm three entries are present: =skip=, =queue=, =fail=.
 - Open each detail dialog; verify code, name, and description fields display correctly.
@@ -56,11 +56,12 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PASS |
+| Status | FAIL |
+| Notes  | empty; [[file:scenario_verify_reporting_cpp_step2_20260808_030958.png]] |
 
 ** Open Report Types and verify seed data
 
-- Navigate to: Reporting > Report Configuration > Report Types.
+- Navigate to: Analytics > Analytics Codes > Report Types.
 - Verify the list window titled "Report Types" opens.
 - Confirm two entries are present: =risk= and =grid=.
 - Open each detail dialog; verify code, name, and description fields display.
@@ -69,11 +70,11 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PASS |
+| Status | PENDING |
 
 ** Open Report Definitions and verify seed data
 
-- Navigate to: Reporting > Report Definitions.
+- Navigate to: Analytics > Report Definitions.
 - Verify the list window titled "Report Definitions" opens.
 - Confirm the list shows 28 report definitions loaded from seed data.
 - Verify columns: Name, Type, Schedule, Concurrency, Version, Modified By.
@@ -83,12 +84,11 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | FAIL |
-| Notes  | no report definitions show. is this because we do not have reports for ACME corp? we should have the appropriate reports for each entity. |
+| Status | PENDING |
 
 ** Open Report Instances and verify list loads
 
-- Navigate to: Reporting > Report Instances.
+- Navigate to: Analytics > Report Instances.
 - Verify the list window titled "Report Instances" opens.
 - The list may be empty — report instances are created by the scheduler trigger.
 
@@ -175,9 +175,9 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 | Field         | Value |
 |---------------+-------|
 | Status        | FAILED |
-| Completed at  | 2026-08-08T08:55:10Z |
-| Branch        | fix/reporting-main-break |
-| Commit        | 954cc1375 |
+| Completed at  | 2026-08-08T02:10:05Z |
+| Branch        | HEAD |
+| Commit        | 7ca43d490 |
 | Worktree      | bright_faraday |
 
 * Notes

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
@@ -6,7 +6,7 @@
 #+type: test_scenario
 #+level: s1
 #+filetags: :refactor_codegen_cpp:sprint_25:v0:
-#+target_dialog: ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Analytics > Report Definitions, Analytics > Report Instances, Analytics > Analytics Codes > Report Types, Analytics > Analytics Codes > Concurrency Policies
+#+target_dialog: ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Reporting > Report Definitions / Report Instances; Reporting > Report Configuration > Concurrency Policies / Report Types; Reporting > Compute Configuration > Apps / App Versions; Reporting > Pricing Configuration > Model Configurations / Model Products / Model Product Parameters / Pricing Engine Types
 #+created: 2026-08-08
 #+updated: 2026-08-08
 #+environment: bright_faraday
@@ -27,7 +27,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 |---------------+------------------------------------------|
 | Verifies task | [[id:193FF620-BB98-4EB4-9124-2D06CA8FFCE0][Apply safe drift to reporting-cpp]] |
 | Parent story  | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]]   |
-| Target dialog | ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Analytics > Report Definitions / Report Instances; Analytics > Analytics Codes > Report Types / Concurrency Policies |
+| Target dialog | ConcurrencyPolicyDetailDialog, ReportTypeDetailDialog, ReportDefinitionDetailDialog, ReportInstanceDetailDialog — Menus: Reporting > Report Definitions / Report Instances; Reporting > Report Configuration > Concurrency Policies / Report Types; Reporting > Compute Configuration > Apps / App Versions; Reporting > Pricing Configuration > Model Configurations etc. |
 | Clients       |                                          |
 | State         | PENDING                               |
 
@@ -47,7 +47,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 ** Open Concurrency Policies and verify seed data
 
-- Navigate to: Analytics > Analytics Codes > Concurrency Policies.
+- Navigate to: Reporting > Report Configuration > Concurrency Policies.
 - Verify the list window titled "Concurrency Policies" opens.
 - Confirm three entries are present: =skip=, =queue=, =fail=.
 - Open each detail dialog; verify code, name, and description fields display correctly.
@@ -60,7 +60,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 ** Open Report Types and verify seed data
 
-- Navigate to: Analytics > Analytics Codes > Report Types.
+- Navigate to: Reporting > Report Configuration > Report Types.
 - Verify the list window titled "Report Types" opens.
 - Confirm two entries are present: =risk= and =grid=.
 - Open each detail dialog; verify code, name, and description fields display.
@@ -73,7 +73,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 ** Open Report Definitions and verify seed data
 
-- Navigate to: Analytics > Report Definitions.
+- Navigate to: Reporting > Report Definitions.
 - Verify the list window titled "Report Definitions" opens.
 - Confirm the list shows 28 report definitions loaded from seed data.
 - Verify columns: Name, Type, Schedule, Concurrency, Version, Modified By.
@@ -88,7 +88,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 ** Open Report Instances and verify list loads
 
-- Navigate to: Analytics > Report Instances.
+- Navigate to: Reporting > Report Instances.
 - Verify the list window titled "Report Instances" opens.
 - The list may be empty — report instances are created by the scheduler trigger.
 

--- a/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
+++ b/doc/agile/versions/v0/sprint_25/refactor_codegen_cpp/scenario_verify_reporting_cpp.org
@@ -56,8 +56,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | FAIL |
-| Notes  | empty; [[file:scenario_verify_reporting_cpp_step2_20260808_030958.png]] |
+| Status | PASS |
 
 ** Open Report Types and verify seed data
 
@@ -70,7 +69,7 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | PASS |
 
 ** Open Report Definitions and verify seed data
 
@@ -84,7 +83,8 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 
 | Field  | Value |
 |--------+-------|
-| Status | PENDING |
+| Status | FAIL |
+| Notes  | no report definitions show. is this because we do not have reports for ACME corp? we should have the appropriate reports for each entity. |
 
 ** Open Report Instances and verify list loads
 
@@ -175,9 +175,9 @@ This page documents a test scenario verifying [[id:193FF620-BB98-4EB4-9124-2D06C
 | Field         | Value |
 |---------------+-------|
 | Status        | FAILED |
-| Completed at  | 2026-08-08T02:10:05Z |
-| Branch        | HEAD |
-| Commit        | 7ca43d490 |
+| Completed at  | 2026-08-08T08:55:10Z |
+| Branch        | fix/reporting-main-break |
+| Commit        | 954cc1375 |
 | Worktree      | bright_faraday |
 
 * Notes

--- a/projects/modeling/variability_feature_eventing_integration_test.org
+++ b/projects/modeling/variability_feature_eventing_integration_test.org
@@ -1,0 +1,51 @@
+:PROPERTIES:
+:ID: E9A2F4B1-7C3D-4E8B-A5F0-2D6C1B8E3A7F
+:END:
+#+title: Feature: eventing_integration_test
+#+description: Enable per-entity Catch2 integration test proving the DB-write → pg_notify → postgres_event_source → event_bus → NATS-publish pipeline end to end.
+#+type: feature
+#+level: cross
+#+filetags: :codegen:variability:feature:
+#+created: 2026-08-08
+#+updated: 2026-08-08
+
+This page is one authored [[id:CE95C751-2125-4BA9-A78D-C30F9540FC5E][MASD feature]] in [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability
+Model]] § "Projection configuration: how an existing artefact family is shaped". Any [[id:A57C28EA-EB88-4C0A-BDDF-F414CCCF96F7][profile]] that fixes
+this feature's value links here rather than restating its effect.
+
+* Identity
+
+| Field | Value |
+|-------+-------|
+| Literal name | =:ores.cpp.eventing-integration-test.enabled:= |
+| Bundle | =ores.cpp.testing= |
+| Type | bool |
+| Default | false |
+
+* Effect
+
+Enables the =ores.cpp.eventing-integration-test= facet, which generates a
+=projects/{component_core_dir}/tests/{entity}_eventing_integration_tests.cpp=
+Catch2 test case per entity. The test writes the entity via its repository,
+waits for the resulting NATS entity-changed notification on the wire, and
+asserts the payload matches — no mocks, real Postgres LISTEN/NOTIFY, real
+NATS. Guards against regressions in the full eventing pipeline (PG trigger →
+event source → event bus → NATS publish) that unit tests alone cannot catch.
+
+* Structural consequence
+
+Adds one test source file per entity. Requires a running NATS server and
+Postgres with LISTEN/NOTIFY support during test execution.
+
+* Used by
+
+- [[id:1D0B00E4-6032-4DCA-9B66-571DE9F131FC][Simple lookup]]
+- [[id:EB5118BB-925A-4414-AB38-FFF15DAFDF0C][Workspace-scoped lookup]]
+- [[id:F8C3D2A1-5E4B-4C7D-9F1E-6B5A3D8C2E9F][Fully-featured lookup]]
+- [[id:A1B2C3D4-5E6F-4A7B-8C9D-0E1F2A3B4C5D][UUID-identified lookup]]
+- [[id:B2C3D4E5-6F7A-4B8C-9D0E-1F2A3B4C5D6E][FK-scoped child]]
+- [[id:C3D4E5F6-7A8B-4C9D-0E1F-2A3B4C5D6E7F][Self-referencing hierarchy]]
+
+* See also
+
+- [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the bundle this feature belongs to.

--- a/projects/modeling/variability_fk_scoped_child.org
+++ b/projects/modeling/variability_fk_scoped_child.org
@@ -44,6 +44,12 @@ here is left to the model's own choice:
 | [[id:9D8D1849-D721-47D1-B477-95058D1FAC32][has_explorer_api]] | true |
 | [[id:A12F591B-DF0E-4112-8457-550FA9323DDF][parent_entity_singular]] | required, string — the adopting entity's own parent entity name (e.g. =portfolio= for =book=); this profile fixes that the value must be set, not which literal string, since that is necessarily specific to the adopting entity |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/modeling/variability_fully_featured_lookup.org
+++ b/projects/modeling/variability_fully_featured_lookup.org
@@ -44,6 +44,12 @@ here is left to the model's own choice:
 | [[id:74EB0234-97F3-459C-8806-5A979B9E5A22][has_csv_xml_io]] | true |
 | [[id:5A843D4A-2FF7-4410-8B70-A29FD01622FD][has_version_navigation]] | true |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/modeling/variability_self_referencing_hierarchy.org
+++ b/projects/modeling/variability_self_referencing_hierarchy.org
@@ -50,6 +50,12 @@ here is left to the model's own choice:
 | [[id:9307F2AC-EFBE-4D4A-873A-C609CD94C363][has_uuid_primary_key]] | true |
 | [[id:6EDA740C-D053-4E1B-98EB-E1AD87B6A639][has_change_reason_cache]] | true |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/modeling/variability_simple_lookup.org
+++ b/projects/modeling/variability_simple_lookup.org
@@ -46,6 +46,12 @@ here is left to the model's own choice:
 | [[id:6EDA740C-D053-4E1B-98EB-E1AD87B6A639][has_change_reason_cache]] | true |
 | [[id:26409919-470E-4820-B8C1-AC816181F894][has_pagination]] | true |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/modeling/variability_uuid_identified_lookup.org
+++ b/projects/modeling/variability_uuid_identified_lookup.org
@@ -41,6 +41,12 @@ here is left to the model's own choice:
 | [[id:6EDA740C-D053-4E1B-98EB-E1AD87B6A639][has_change_reason_cache]] | true |
 | [[id:26409919-470E-4820-B8C1-AC816181F894][has_pagination]] | true |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/modeling/variability_workspace_scoped_lookup.org
+++ b/projects/modeling/variability_workspace_scoped_lookup.org
@@ -47,6 +47,12 @@ here is left to the model's own choice:
 | [[id:6EDA740C-D053-4E1B-98EB-E1AD87B6A639][has_change_reason_cache]] | true |
 | [[id:26409919-470E-4820-B8C1-AC816181F894][has_pagination]] | true |
 
+* Physical space
+
+| Address | Enabled |
+|---------+---------|
+| =ores.cpp.eventing-integration-test= | true |
+
 * See also
 
 - [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability Model]] — the feature bundles this profile composes.

--- a/projects/ores.dq/api/include/ores.dq.api/messaging/publish_bundle_protocol.hpp
+++ b/projects/ores.dq/api/include/ores.dq.api/messaging/publish_bundle_protocol.hpp
@@ -36,6 +36,8 @@ struct publish_bundle_params {
     std::vector<std::string> opted_in_datasets;
     std::optional<lei_parties_params> lei_parties;
     std::optional<std::string> party_id;
+    std::optional<std::string> tiers;
+    std::optional<std::string> jurisdiction;
 };
 
 inline std::string build_params_json(const publish_bundle_params& params) {

--- a/projects/ores.qt/analytics/src/AnalyticsPlugin.cpp
+++ b/projects/ores.qt/analytics/src/AnalyticsPlugin.cpp
@@ -115,20 +115,19 @@ void AnalyticsPlugin::setup_menus(const shared_menus_context& smc) {
         if (pricingEngineTypeController_)
             pricingEngineTypeController_->showListWindow();
     });
+
+    // Attach Pricing Configuration submenu to Reporting menu — goes
+    // after Report Configuration (attached by ComputePlugin).
+    if (reporting_menu_)
+        reporting_menu_->addMenu(pricing_configuration_menu_);
 }
 
 QList<QMenu*> AnalyticsPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    if (!reporting_menu_ || !pricing_configuration_menu_) {
+    BOOST_LOG_SEV(lg(), debug) << "Reporting menu controls bar position.";
+    if (!reporting_menu_) {
         BOOST_LOG_SEV(lg(), warn) << "Reporting menu not initialised via setup_menus.";
         return {};
     }
-
-    // Pricing Configuration submenu is populated by setup_menus().
-    // Attach it here so it appears after the main-menu items in create_menus() order.
-    reporting_menu_->addMenu(pricing_configuration_menu_);
-
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {reporting_menu_};
 }
 

--- a/projects/ores.qt/analytics/src/AnalyticsPlugin.cpp
+++ b/projects/ores.qt/analytics/src/AnalyticsPlugin.cpp
@@ -56,40 +56,25 @@ void AnalyticsPlugin::on_login(const plugin_context& ctx) {
     BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
-    pricingEngineTypeController_ =
-        std::make_unique<PricingEngineTypeController>(ctx_.main_window,
-                                                      ctx_.mdi_area,
-                                                      ctx_.client_manager,
-                                                      ctx_.change_reason_cache,
-                                                      ctx_.username,
-                                                      this);
+    pricingEngineTypeController_ = std::make_unique<PricingEngineTypeController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
     connectControllerSignals(pricingEngineTypeController_.get());
 
-    pricingModelConfigController_ =
-        std::make_unique<PricingModelConfigController>(ctx_.main_window,
-                                                       ctx_.mdi_area,
-                                                       ctx_.client_manager,
-                                                       ctx_.change_reason_cache,
-                                                       ctx_.username,
-                                                       this);
+    pricingModelConfigController_ = std::make_unique<PricingModelConfigController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
     connectControllerSignals(pricingModelConfigController_.get());
 
-    pricingModelProductController_ =
-        std::make_unique<PricingModelProductController>(ctx_.main_window,
-                                                        ctx_.mdi_area,
-                                                        ctx_.client_manager,
-                                                        ctx_.change_reason_cache,
-                                                        ctx_.username,
-                                                        this);
+    pricingModelProductController_ = std::make_unique<PricingModelProductController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
     connectControllerSignals(pricingModelProductController_.get());
 
     pricingModelProductParameterController_ =
-        std::make_unique<PricingModelProductParameterController>(ctx_.main_window,
-                                                                 ctx_.mdi_area,
-                                                                 ctx_.client_manager,
-                                                                 ctx_.change_reason_cache,
-                                                                 ctx_.username,
-                                                                 this);
+        std::make_unique<PricingModelProductParameterController>(
+            ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+            ctx_.change_reason_cache, ctx_.username, this);
     connectControllerSignals(pricingModelProductParameterController_.get());
 }
 
@@ -130,19 +115,20 @@ void AnalyticsPlugin::setup_menus(const shared_menus_context& smc) {
         if (pricingEngineTypeController_)
             pricingEngineTypeController_->showListWindow();
     });
-
-    // Attach Pricing Configuration submenu to Reporting menu — goes
-    // after Report Configuration (attached by ComputePlugin).
-    if (reporting_menu_)
-        reporting_menu_->addMenu(pricing_configuration_menu_);
 }
 
 QList<QMenu*> AnalyticsPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Reporting menu controls bar position.";
-    if (!reporting_menu_) {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
+    if (!reporting_menu_ || !pricing_configuration_menu_) {
         BOOST_LOG_SEV(lg(), warn) << "Reporting menu not initialised via setup_menus.";
         return {};
     }
+
+    // Pricing Configuration submenu is populated by setup_menus().
+    // Attach it here so it appears after the main-menu items in create_menus() order.
+    reporting_menu_->addMenu(pricing_configuration_menu_);
+
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {reporting_menu_};
 }
 

--- a/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyController.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ConcurrencyPolicyController.hpp
@@ -78,6 +78,12 @@ private slots:
     void onRevertVersion(const reporting::domain::concurrency_policy& policy);
     void onOpenVersion(const reporting::domain::concurrency_policy& policy, int versionNumber);
 
+private slots:
+    void onNotificationReceived(const QString& eventType,
+                                const QDateTime& timestamp,
+                                const QStringList& entityIds,
+                                const QString& tenantId);
+
 private:
     void showAddWindow();
     void showDetailWindow(const reporting::domain::concurrency_policy& policy);

--- a/projects/ores.qt/compute/include/ores.qt/ReportInstanceController.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportInstanceController.hpp
@@ -84,6 +84,13 @@ private:
     void showHistoryWindow(const reporting::domain::report_instance& instance);
 
     ChangeReasonCache* changeReasonCache_{nullptr};
+private slots:
+    void onNotificationReceived(const QString& eventType,
+                                const QDateTime& timestamp,
+                                const QStringList& entityIds,
+                                const QString& tenantId);
+
+private:
     ReportInstanceMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt/compute/include/ores.qt/ReportTypeController.hpp
+++ b/projects/ores.qt/compute/include/ores.qt/ReportTypeController.hpp
@@ -84,6 +84,13 @@ private:
     void showHistoryWindow(const QString& code);
 
     ChangeReasonCache* changeReasonCache_{nullptr};
+private slots:
+    void onNotificationReceived(const QString& eventType,
+                                const QDateTime& timestamp,
+                                const QStringList& entityIds,
+                                const QString& tenantId);
+
+private:
     ReportTypeMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt/compute/src/ComputePlugin.cpp
+++ b/projects/ores.qt/compute/src/ComputePlugin.cpp
@@ -186,40 +186,69 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
         reporting_menu_ = smc.reporting_menu;
 
         auto* actConsole =
-            smc.reporting_menu->addAction(ico(Icon::ServerLink), tr("&Compute Console"));
+            reporting_menu_->addAction(ico(Icon::ServerLink), tr("&Compute Console"));
         connect(actConsole, &QAction::triggered, this, [this]() {
             if (computeConsoleController_)
                 computeConsoleController_->showConsole();
         });
 
         auto* actDashboard =
-            smc.reporting_menu->addAction(ico(Icon::Chart), tr("Compute &Dashboard"));
+            reporting_menu_->addAction(ico(Icon::Chart), tr("Compute &Dashboard"));
         connect(actDashboard, &QAction::triggered, this, [this]() {
             if (computeDashboardController_)
                 computeDashboardController_->showDashboard();
         });
 
-        smc.reporting_menu->addSeparator();
+        // Compute Configuration submenu — attached here so it sits under
+        // the compute items, before the section separator.
+        if (smc.compute_configuration_menu) {
+            compute_configuration_menu_ = smc.compute_configuration_menu;
+            reporting_menu_->addMenu(compute_configuration_menu_);
+        }
+
+        reporting_menu_->addSeparator();
 
         act_report_definitions_ =
-            smc.reporting_menu->addAction(ico(Icon::ChartMultiple), tr("Report &Definitions"));
+            reporting_menu_->addAction(ico(Icon::ChartMultiple), tr("Report &Definitions"));
         connect(act_report_definitions_, &QAction::triggered, this, [this]() {
             if (reportDefinitionController_)
                 reportDefinitionController_->showListWindow();
         });
 
         act_report_instances_ =
-            smc.reporting_menu->addAction(ico(Icon::Record), tr("Report &Instances"));
+            reporting_menu_->addAction(ico(Icon::Record), tr("Report &Instances"));
         connect(act_report_instances_, &QAction::triggered, this, [this]() {
             if (reportInstanceController_)
                 reportInstanceController_->showListWindow();
         });
+
+        // Report Configuration submenu — attached here so it sits under
+        // the report items, after the section separator.
+        if (smc.report_configuration_menu) {
+            report_configuration_menu_ = smc.report_configuration_menu;
+            reporting_menu_->addMenu(report_configuration_menu_);
+        }
     }
 
-    // ---- Report Configuration: report types + concurrency policies ------
-    if (smc.report_configuration_menu) {
-        report_configuration_menu_ = smc.report_configuration_menu;
+    // ---- Compute Configuration submenu: apps + app versions -------------
+    if (smc.compute_configuration_menu) {
+        auto* actAppVersions =
+            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("App &Versions"));
+        connect(actAppVersions, &QAction::triggered, this, [this]() {
+            if (appVersionController_)
+                appVersionController_->showListWindow();
+        });
 
+        auto* actApps =
+            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("&Apps"));
+        connect(actApps, &QAction::triggered, this, [this]() {
+            if (appController_)
+                appController_->showListWindow();
+        });
+    }
+
+    // ---- Report Configuration submenu: report types + concurrency policies
+    if (smc.report_configuration_menu) {
         auto* actConcurrencyPolicies =
             smc.report_configuration_menu->addAction(ico(Icon::Settings), tr("&Concurrency Policies"));
         connect(actConcurrencyPolicies, &QAction::triggered, this, [this]() {
@@ -232,24 +261,6 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
         connect(actReportTypes, &QAction::triggered, this, [this]() {
             if (reportTypeController_)
                 reportTypeController_->showListWindow();
-        });
-    }
-
-    // ---- Compute Configuration: apps + app versions ---------------------
-    if (smc.compute_configuration_menu) {
-        compute_configuration_menu_ = smc.compute_configuration_menu;
-
-        auto* actAppVersions =
-            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("App &Versions"));
-        connect(actAppVersions, &QAction::triggered, this, [this]() {
-            if (appVersionController_)
-                appVersionController_->showListWindow();
-        });
-
-        auto* actApps = smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("&Apps"));
-        connect(actApps, &QAction::triggered, this, [this]() {
-            if (appController_)
-                appController_->showListWindow();
         });
     }
 
@@ -268,17 +279,7 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
 }
 
 QList<QMenu*> ComputePlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Attaching configuration submenus to Reporting menu.";
-
-    // Attach submenus in alphabetical order — each was populated by
-    // setup_menus() before any plugin's create_menus() runs.
-    if (reporting_menu_) {
-        if (compute_configuration_menu_)
-            reporting_menu_->addMenu(compute_configuration_menu_);
-        if (report_configuration_menu_)
-            reporting_menu_->addMenu(report_configuration_menu_);
-    }
-
+    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
     return {};
 }
 

--- a/projects/ores.qt/compute/src/ComputePlugin.cpp
+++ b/projects/ores.qt/compute/src/ComputePlugin.cpp
@@ -186,69 +186,40 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
         reporting_menu_ = smc.reporting_menu;
 
         auto* actConsole =
-            reporting_menu_->addAction(ico(Icon::ServerLink), tr("&Compute Console"));
+            smc.reporting_menu->addAction(ico(Icon::ServerLink), tr("&Compute Console"));
         connect(actConsole, &QAction::triggered, this, [this]() {
             if (computeConsoleController_)
                 computeConsoleController_->showConsole();
         });
 
         auto* actDashboard =
-            reporting_menu_->addAction(ico(Icon::Chart), tr("Compute &Dashboard"));
+            smc.reporting_menu->addAction(ico(Icon::Chart), tr("Compute &Dashboard"));
         connect(actDashboard, &QAction::triggered, this, [this]() {
             if (computeDashboardController_)
                 computeDashboardController_->showDashboard();
         });
 
-        // Compute Configuration submenu — attached here so it sits under
-        // the compute items, before the section separator.
-        if (smc.compute_configuration_menu) {
-            compute_configuration_menu_ = smc.compute_configuration_menu;
-            reporting_menu_->addMenu(compute_configuration_menu_);
-        }
-
-        reporting_menu_->addSeparator();
+        smc.reporting_menu->addSeparator();
 
         act_report_definitions_ =
-            reporting_menu_->addAction(ico(Icon::ChartMultiple), tr("Report &Definitions"));
+            smc.reporting_menu->addAction(ico(Icon::ChartMultiple), tr("Report &Definitions"));
         connect(act_report_definitions_, &QAction::triggered, this, [this]() {
             if (reportDefinitionController_)
                 reportDefinitionController_->showListWindow();
         });
 
         act_report_instances_ =
-            reporting_menu_->addAction(ico(Icon::Record), tr("Report &Instances"));
+            smc.reporting_menu->addAction(ico(Icon::Record), tr("Report &Instances"));
         connect(act_report_instances_, &QAction::triggered, this, [this]() {
             if (reportInstanceController_)
                 reportInstanceController_->showListWindow();
         });
-
-        // Report Configuration submenu — attached here so it sits under
-        // the report items, after the section separator.
-        if (smc.report_configuration_menu) {
-            report_configuration_menu_ = smc.report_configuration_menu;
-            reporting_menu_->addMenu(report_configuration_menu_);
-        }
     }
 
-    // ---- Compute Configuration submenu: apps + app versions -------------
-    if (smc.compute_configuration_menu) {
-        auto* actAppVersions =
-            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("App &Versions"));
-        connect(actAppVersions, &QAction::triggered, this, [this]() {
-            if (appVersionController_)
-                appVersionController_->showListWindow();
-        });
-
-        auto* actApps =
-            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("&Apps"));
-        connect(actApps, &QAction::triggered, this, [this]() {
-            if (appController_)
-                appController_->showListWindow();
-        });
-    }
-
-    // ---- Report Configuration submenu: report types + concurrency policies
+    // ---- Report Configuration: report types + concurrency policies ------
     if (smc.report_configuration_menu) {
+        report_configuration_menu_ = smc.report_configuration_menu;
+
         auto* actConcurrencyPolicies =
             smc.report_configuration_menu->addAction(ico(Icon::Settings), tr("&Concurrency Policies"));
         connect(actConcurrencyPolicies, &QAction::triggered, this, [this]() {
@@ -261,6 +232,24 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
         connect(actReportTypes, &QAction::triggered, this, [this]() {
             if (reportTypeController_)
                 reportTypeController_->showListWindow();
+        });
+    }
+
+    // ---- Compute Configuration: apps + app versions ---------------------
+    if (smc.compute_configuration_menu) {
+        compute_configuration_menu_ = smc.compute_configuration_menu;
+
+        auto* actAppVersions =
+            smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("App &Versions"));
+        connect(actAppVersions, &QAction::triggered, this, [this]() {
+            if (appVersionController_)
+                appVersionController_->showListWindow();
+        });
+
+        auto* actApps = smc.compute_configuration_menu->addAction(ico(Icon::TasksApp), tr("&Apps"));
+        connect(actApps, &QAction::triggered, this, [this]() {
+            if (appController_)
+                appController_->showListWindow();
         });
     }
 
@@ -279,7 +268,17 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
 }
 
 QList<QMenu*> ComputePlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
+    BOOST_LOG_SEV(lg(), debug) << "Attaching configuration submenus to Reporting menu.";
+
+    // Attach submenus in alphabetical order — each was populated by
+    // setup_menus() before any plugin's create_menus() runs.
+    if (reporting_menu_) {
+        if (compute_configuration_menu_)
+            reporting_menu_->addMenu(compute_configuration_menu_);
+        if (report_configuration_menu_)
+            reporting_menu_->addMenu(report_configuration_menu_);
+    }
+
     return {};
 }
 

--- a/projects/ores.qt/compute/src/ConcurrencyPolicyController.cpp
+++ b/projects/ores.qt/compute/src/ConcurrencyPolicyController.cpp
@@ -24,6 +24,7 @@
 #include "ores.qt/ConcurrencyPolicyMdiWindow.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.reporting.api/eventing/concurrency_policy_changed_event.hpp"
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QPointer>
@@ -31,6 +32,13 @@
 namespace ores::qt {
 
 using namespace ores::logging;
+
+namespace {
+
+constexpr std::string_view concurrency_policy_event_name =
+    eventing::domain::event_traits<reporting::eventing::concurrency_policy_changed_event>::name;
+
+} // namespace
 
 ConcurrencyPolicyController::ConcurrencyPolicyController(QMainWindow* mainWindow,
                                                          QMdiArea* mdiArea,
@@ -44,6 +52,23 @@ ConcurrencyPolicyController::ConcurrencyPolicyController(QMainWindow* mainWindow
     , listMdiSubWindow_(nullptr) {
 
     BOOST_LOG_SEV(lg(), debug) << "ConcurrencyPolicyController created";
+
+    if (clientManager_) {
+        connect(clientManager_,
+                &ClientManager::notificationReceived,
+                this,
+                &ConcurrencyPolicyController::onNotificationReceived);
+
+        auto subscribeAll = [self = QPointer<ConcurrencyPolicyController>(this)]() {
+            if (!self) return;
+            BOOST_LOG_SEV(lg(), info) << "Subscribing to concurrency policy change events";
+            self->clientManager_->subscribeToEvent(std::string{concurrency_policy_event_name});
+        };
+        connect(clientManager_, &ClientManager::loggedIn, this, subscribeAll);
+        connect(clientManager_, &ClientManager::reconnected, this, subscribeAll);
+        if (clientManager_->isConnected())
+            subscribeAll();
+    }
 }
 
 void ConcurrencyPolicyController::showListWindow() {
@@ -437,6 +462,21 @@ void ConcurrencyPolicyController::onRevertVersion(
 
 EntityListMdiWindow* ConcurrencyPolicyController::listWindow() const {
     return listWindow_;
+}
+
+void ConcurrencyPolicyController::onNotificationReceived(const QString& eventType,
+                                                          const QDateTime& timestamp,
+                                                          const QStringList& entityIds,
+                                                          const QString& /*tenantId*/) {
+    if (eventType.toStdString() != concurrency_policy_event_name)
+        return;
+
+    BOOST_LOG_SEV(lg(), info) << "Received concurrency_policy_changed notification at "
+                              << timestamp.toString(Qt::ISODate).toStdString() << " with "
+                              << entityIds.size() << " id(s)";
+
+    if (listWindow_)
+        listWindow_->markAsStale();
 }
 
 }

--- a/projects/ores.qt/compute/src/ReportInstanceController.cpp
+++ b/projects/ores.qt/compute/src/ReportInstanceController.cpp
@@ -24,6 +24,7 @@
 #include "ores.qt/ReportInstanceDetailDialog.hpp"
 #include "ores.qt/ReportInstanceHistoryDialog.hpp"
 #include "ores.qt/ReportInstanceMdiWindow.hpp"
+#include "ores.reporting.api/eventing/report_instance_changed_event.hpp"
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QPointer>
@@ -31,6 +32,13 @@
 namespace ores::qt {
 
 using namespace ores::logging;
+
+namespace {
+
+constexpr std::string_view report_instance_event_name =
+    eventing::domain::event_traits<reporting::eventing::report_instance_changed_event>::name;
+
+} // namespace
 
 ReportInstanceController::ReportInstanceController(QMainWindow* mainWindow,
                                                    QMdiArea* mdiArea,
@@ -44,6 +52,23 @@ ReportInstanceController::ReportInstanceController(QMainWindow* mainWindow,
     , listMdiSubWindow_(nullptr) {
 
     BOOST_LOG_SEV(lg(), debug) << "ReportInstanceController created";
+
+    if (clientManager_) {
+        connect(clientManager_,
+                &ClientManager::notificationReceived,
+                this,
+                &ReportInstanceController::onNotificationReceived);
+
+        auto subscribeAll = [self = QPointer<ReportInstanceController>(this)]() {
+            if (!self) return;
+            BOOST_LOG_SEV(lg(), info) << "Subscribing to report instance change events";
+            self->clientManager_->subscribeToEvent(std::string{report_instance_event_name});
+        };
+        connect(clientManager_, &ClientManager::loggedIn, this, subscribeAll);
+        connect(clientManager_, &ClientManager::reconnected, this, subscribeAll);
+        if (clientManager_->isConnected())
+            subscribeAll();
+    }
 }
 
 void ReportInstanceController::showListWindow() {
@@ -436,6 +461,21 @@ void ReportInstanceController::onRevertVersion(const reporting::domain::report_i
 
 EntityListMdiWindow* ReportInstanceController::listWindow() const {
     return listWindow_;
+}
+
+void ReportInstanceController::onNotificationReceived(const QString& eventType,
+                                                       const QDateTime& timestamp,
+                                                       const QStringList& entityIds,
+                                                       const QString& /*tenantId*/) {
+    if (eventType.toStdString() != report_instance_event_name)
+        return;
+
+    BOOST_LOG_SEV(lg(), info) << "Received report_instance_changed notification at "
+                              << timestamp.toString(Qt::ISODate).toStdString() << " with "
+                              << entityIds.size() << " id(s)";
+
+    if (listWindow_)
+        listWindow_->markAsStale();
 }
 
 }

--- a/projects/ores.qt/compute/src/ReportTypeController.cpp
+++ b/projects/ores.qt/compute/src/ReportTypeController.cpp
@@ -24,6 +24,7 @@
 #include "ores.qt/ReportTypeDetailDialog.hpp"
 #include "ores.qt/ReportTypeHistoryDialog.hpp"
 #include "ores.qt/ReportTypeMdiWindow.hpp"
+#include "ores.reporting.api/eventing/report_type_changed_event.hpp"
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QPointer>
@@ -31,6 +32,13 @@
 namespace ores::qt {
 
 using namespace ores::logging;
+
+namespace {
+
+constexpr std::string_view report_type_event_name =
+    eventing::domain::event_traits<reporting::eventing::report_type_changed_event>::name;
+
+} // namespace
 
 ReportTypeController::ReportTypeController(QMainWindow* mainWindow,
                                            QMdiArea* mdiArea,
@@ -44,6 +52,23 @@ ReportTypeController::ReportTypeController(QMainWindow* mainWindow,
     , listMdiSubWindow_(nullptr) {
 
     BOOST_LOG_SEV(lg(), debug) << "ReportTypeController created";
+
+    if (clientManager_) {
+        connect(clientManager_,
+                &ClientManager::notificationReceived,
+                this,
+                &ReportTypeController::onNotificationReceived);
+
+        auto subscribeAll = [self = QPointer<ReportTypeController>(this)]() {
+            if (!self) return;
+            BOOST_LOG_SEV(lg(), info) << "Subscribing to report type change events";
+            self->clientManager_->subscribeToEvent(std::string{report_type_event_name});
+        };
+        connect(clientManager_, &ClientManager::loggedIn, this, subscribeAll);
+        connect(clientManager_, &ClientManager::reconnected, this, subscribeAll);
+        if (clientManager_->isConnected())
+            subscribeAll();
+    }
 }
 
 void ReportTypeController::showListWindow() {
@@ -432,6 +457,21 @@ void ReportTypeController::onRevertVersion(const reporting::domain::report_type&
 
 EntityListMdiWindow* ReportTypeController::listWindow() const {
     return listWindow_;
+}
+
+void ReportTypeController::onNotificationReceived(const QString& eventType,
+                                                   const QDateTime& timestamp,
+                                                   const QStringList& entityIds,
+                                                   const QString& /*tenantId*/) {
+    if (eventType.toStdString() != report_type_event_name)
+        return;
+
+    BOOST_LOG_SEV(lg(), info) << "Received report_type_changed notification at "
+                              << timestamp.toString(Qt::ISODate).toStdString() << " with "
+                              << entityIds.size() << " id(s)";
+
+    if (listWindow_)
+        listWindow_->markAsStale();
 }
 
 }

--- a/projects/ores.reporting/core/include/ores.reporting.core/messaging/report_definition_handler.hpp
+++ b/projects/ores.reporting/core/include/ores.reporting.core/messaging/report_definition_handler.hpp
@@ -195,112 +195,52 @@ public:
     void schedule(ores::nats::message msg) {
         BOOST_LOG_SEV(report_definition_handler_lg(), debug) << "Handling " << msg.subject;
         auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!req_ctx_expected) {
-            error_reply(nats_, msg, req_ctx_expected.error());
-            return;
-        }
+        if (!req_ctx_expected) { error_reply(nats_, msg, req_ctx_expected.error()); return; }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "reporting::report_definitions:write")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
+        if (!has_permission(req_ctx, "reporting::report_definitions:write")) { error_reply(nats_, msg, ores::service::error_code::forbidden); return; }
         if (auto req = decode<schedule_report_definitions_request>(msg)) {
             service::report_definition_service svc(req_ctx);
             auto delegated = svc_nats_.with_delegation(ores::nats::service::extract_bearer(msg));
             service::report_scheduling_service scheduler(ctx_, delegated);
             const auto& actor = delegated_actor(req_ctx);
-            int scheduled_count = 0;
-            std::vector<std::string> failed_ids;
-            std::string first_error;
+            int scheduled_count = 0; std::vector<std::string> failed_ids; std::string first_error;
             for (const auto& id : req->ids) {
                 try {
                     auto def = svc.get_definition(id);
-                    if (!def)
-                        continue;
+                    if (!def) continue;
                     auto result = scheduler.schedule_one(*def, actor);
-                    if (!result) {
-                        BOOST_LOG_SEV(report_definition_handler_lg(), error)
-                            << "Failed to schedule definition " << id << ": " << result.error();
-                        failed_ids.push_back(id);
-                        if (first_error.empty())
-                            first_error = result.error();
-                    } else if (*result) {
-                        ++scheduled_count;
-                    }
-                } catch (const std::exception& e) {
-                    BOOST_LOG_SEV(report_definition_handler_lg(), error)
-                        << "Failed to schedule definition " << id << ": " << e.what();
-                    failed_ids.push_back(id);
-                    if (first_error.empty())
-                        first_error = e.what();
-                }
+                    if (!result) { failed_ids.push_back(id); if (first_error.empty()) first_error = result.error(); }
+                    else if (*result) ++scheduled_count;
+                } catch (const std::exception& e) { failed_ids.push_back(id); if (first_error.empty()) first_error = e.what(); }
             }
-            reply(nats_,
-                  msg,
-                  schedule_report_definitions_response{.success = failed_ids.empty(),
-                                                       .message = first_error,
-                                                       .scheduled_count = scheduled_count,
-                                                       .failed_ids = std::move(failed_ids)});
-        } else {
-            BOOST_LOG_SEV(report_definition_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-        }
+            reply(nats_, msg, schedule_report_definitions_response{.success = failed_ids.empty(), .message = first_error, .scheduled_count = scheduled_count, .failed_ids = std::move(failed_ids)});
+        } else { BOOST_LOG_SEV(report_definition_handler_lg(), warn) << "Failed to decode: " << msg.subject; }
         BOOST_LOG_SEV(report_definition_handler_lg(), debug) << "Completed " << msg.subject;
     }
 
     void unschedule(ores::nats::message msg) {
         BOOST_LOG_SEV(report_definition_handler_lg(), debug) << "Handling " << msg.subject;
         auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!req_ctx_expected) {
-            error_reply(nats_, msg, req_ctx_expected.error());
-            return;
-        }
+        if (!req_ctx_expected) { error_reply(nats_, msg, req_ctx_expected.error()); return; }
         const auto& req_ctx = *req_ctx_expected;
-        if (!has_permission(req_ctx, "reporting::report_definitions:delete")) {
-            error_reply(nats_, msg, ores::service::error_code::forbidden);
-            return;
-        }
+        if (!has_permission(req_ctx, "reporting::report_definitions:delete")) { error_reply(nats_, msg, ores::service::error_code::forbidden); return; }
         if (auto req = decode<unschedule_report_definitions_request>(msg)) {
             service::report_definition_service svc(req_ctx);
             auto delegated = svc_nats_.with_delegation(ores::nats::service::extract_bearer(msg));
             service::report_scheduling_service scheduler(ctx_, delegated);
             const auto& actor = delegated_actor(req_ctx);
-            int unscheduled_count = 0;
-            std::vector<std::string> failed_ids;
-            std::string first_error;
+            int unscheduled_count = 0; std::vector<std::string> failed_ids; std::string first_error;
             for (const auto& id : req->ids) {
                 try {
                     auto def = svc.get_definition(id);
-                    if (!def)
-                        continue;
+                    if (!def) continue;
                     auto result = scheduler.unschedule_one(*def, actor);
-                    if (!result) {
-                        BOOST_LOG_SEV(report_definition_handler_lg(), error)
-                            << "Failed to unschedule definition " << id << ": " << result.error();
-                        failed_ids.push_back(id);
-                        if (first_error.empty())
-                            first_error = result.error();
-                    } else if (*result) {
-                        ++unscheduled_count;
-                    }
-                } catch (const std::exception& e) {
-                    BOOST_LOG_SEV(report_definition_handler_lg(), error)
-                        << "Failed to unschedule definition " << id << ": " << e.what();
-                    failed_ids.push_back(id);
-                    if (first_error.empty())
-                        first_error = e.what();
-                }
+                    if (!result) { failed_ids.push_back(id); if (first_error.empty()) first_error = result.error(); }
+                    else if (*result) ++unscheduled_count;
+                } catch (const std::exception& e) { failed_ids.push_back(id); if (first_error.empty()) first_error = e.what(); }
             }
-            reply(nats_,
-                  msg,
-                  unschedule_report_definitions_response{.success = failed_ids.empty(),
-                                                         .message = first_error,
-                                                         .unscheduled_count = unscheduled_count,
-                                                         .failed_ids = std::move(failed_ids)});
-        } else {
-            BOOST_LOG_SEV(report_definition_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-        }
+            reply(nats_, msg, unschedule_report_definitions_response{.success = failed_ids.empty(), .message = first_error, .unscheduled_count = unscheduled_count, .failed_ids = std::move(failed_ids)});
+        } else { BOOST_LOG_SEV(report_definition_handler_lg(), warn) << "Failed to decode: " << msg.subject; }
         BOOST_LOG_SEV(report_definition_handler_lg(), debug) << "Completed " << msg.subject;
     }
 

--- a/projects/ores.reporting/core/include/ores.reporting.core/messaging/report_instance_handler.hpp
+++ b/projects/ores.reporting/core/include/ores.reporting.core/messaging/report_instance_handler.hpp
@@ -202,105 +202,43 @@ public:
     void trigger(ores::nats::message msg) {
         BOOST_LOG_SEV(report_instance_handler_lg(), debug) << "Handling " << msg.subject;
         auto req_ctx_expected = ores::service::service::make_request_context(ctx_, msg, verifier_);
-        if (!req_ctx_expected) {
-            error_reply(nats_, msg, req_ctx_expected.error());
-            return;
-        }
+        if (!req_ctx_expected) { error_reply(nats_, msg, req_ctx_expected.error()); return; }
         const auto& req_ctx = *req_ctx_expected;
         if (auto trigger_msg = decode<trigger_report_instance_message>(msg)) {
             try {
                 service::report_definition_service def_svc(req_ctx);
                 const auto def = def_svc.get_definition(trigger_msg->report_definition_id);
-                if (!def) {
-                    BOOST_LOG_SEV(report_instance_handler_lg(), warn)
-                        << "Definition not found: " << trigger_msg->report_definition_id;
-                    return;
-                }
-
+                if (!def) { BOOST_LOG_SEV(report_instance_handler_lg(), warn) << "Definition not found: " << trigger_msg->report_definition_id; return; }
                 service::report_instance_service inst_svc(req_ctx);
                 const auto active = inst_svc.list_instances(0, 1);
                 const bool has_active = !active.empty();
-
-                boost::uuids::string_generator uuid_gen;
                 const auto pending_id = instance_states_.require("pending");
                 boost::uuids::uuid initial_state = pending_id;
                 bool should_dispatch = true;
-
-                if (!has_active) {
-                    initial_state = pending_id;
-                    should_dispatch = true;
-                } else if (def->concurrency_policy == "queue") {
-                    initial_state = instance_states_.require("queued");
-                    should_dispatch = false;
-                } else if (def->concurrency_policy == "skip") {
-                    initial_state = instance_states_.require("skipped");
-                    should_dispatch = false;
-                } else {
-                    initial_state = instance_states_.require("failed");
-                    should_dispatch = false;
-                }
-
+                if (!has_active) { initial_state = pending_id; should_dispatch = true; }
+                else if (def->concurrency_policy == "queue") { initial_state = instance_states_.require("queued"); should_dispatch = false; }
+                else if (def->concurrency_policy == "skip") { initial_state = instance_states_.require("skipped"); should_dispatch = false; }
+                else { initial_state = instance_states_.require("failed"); should_dispatch = false; }
                 boost::uuids::random_generator rg;
                 domain::report_instance inst;
-                inst.id = rg();
-                inst.tenant_id = def->tenant_id;
-                inst.party_id = def->party_id;
-                inst.definition_id = def->id;
-                inst.name = def->name;
-                inst.description = def->description;
-                inst.fsm_state_id = initial_state;
-                inst.trigger_run_id = trigger_msg->job_instance_id;
+                inst.id = rg(); inst.tenant_id = def->tenant_id; inst.party_id = def->party_id;
+                inst.definition_id = def->id; inst.name = def->name; inst.description = def->description;
+                inst.fsm_state_id = initial_state; inst.trigger_run_id = trigger_msg->job_instance_id;
                 inst.started_at = std::chrono::system_clock::now();
-                inst.modified_by = ctx_.service_account();
-                inst.performed_by = ctx_.service_account();
-                inst.change_reason_code = "system.scheduler_trigger";
-                inst.change_commentary = "Created by scheduler trigger";
-
+                inst.modified_by = ctx_.service_account(); inst.performed_by = ctx_.service_account();
+                inst.change_reason_code = "system.scheduler_trigger"; inst.change_commentary = "Created by scheduler trigger";
                 inst_svc.save_instance(inst);
-
                 const auto inst_id_str = boost::uuids::to_string(inst.id);
-                BOOST_LOG_SEV(report_instance_handler_lg(), info)
-                    << "Created report instance " << inst_id_str << " for definition " << def->id
-                    << " state="
-                    << (should_dispatch ?
-                            "pending" :
-                            (def->concurrency_policy == "queue" ? "queued" :
-                             def->concurrency_policy == "skip"  ? "skipped" :
-                                                                  def->concurrency_policy))
-                    << " (job_instance_id=" << trigger_msg->job_instance_id << ")";
-
+                BOOST_LOG_SEV(report_instance_handler_lg(), info) << "Created report instance " << inst_id_str;
                 if (should_dispatch) {
                     const auto wf_instance_id = boost::uuids::to_string(rg());
-
-                    report_execution_request exec_req{.report_instance_id = inst_id_str,
-                                                      .definition_id =
-                                                          trigger_msg->report_definition_id,
-                                                      .tenant_id = trigger_msg->tenant_id,
-                                                      .correlation_id = inst_id_str};
-
-                    ores::workflow::messaging::start_workflow_message swm{
-                        .type = "report_execution_workflow",
-                        .tenant_id = trigger_msg->tenant_id,
-                        .request_json = rfl::json::write(exec_req),
-                        .correlation_id = inst_id_str,
-                        .instance_id = wf_instance_id};
-
-                    nats_.js_publish(
-                        ores::workflow::messaging::start_workflow_message::nats_subject,
-                        ores::nats::default_wire_codec().encode(swm));
-
-                    BOOST_LOG_SEV(report_instance_handler_lg(), info)
-                        << "Dispatched report_execution_workflow for instance " << inst_id_str
-                        << " wf_instance=" << wf_instance_id;
+                    report_execution_request exec_req{.report_instance_id = inst_id_str, .definition_id = trigger_msg->report_definition_id, .tenant_id = trigger_msg->tenant_id, .correlation_id = inst_id_str};
+                    ores::workflow::messaging::start_workflow_message swm{.type = "report_execution_workflow", .tenant_id = trigger_msg->tenant_id, .request_json = rfl::json::write(exec_req), .correlation_id = inst_id_str, .instance_id = wf_instance_id};
+                    nats_.js_publish(ores::workflow::messaging::start_workflow_message::nats_subject, ores::nats::default_wire_codec().encode(swm));
+                    BOOST_LOG_SEV(report_instance_handler_lg(), info) << "Dispatched workflow for instance " << inst_id_str;
                 }
-            } catch (const std::exception& e) {
-                BOOST_LOG_SEV(report_instance_handler_lg(), error)
-                    << "Failed to create report instance for trigger: " << e.what();
-            }
-        } else {
-            BOOST_LOG_SEV(report_instance_handler_lg(), warn)
-                << "Failed to decode: " << msg.subject;
-        }
+            } catch (const std::exception& e) { BOOST_LOG_SEV(report_instance_handler_lg(), error) << "Trigger failed: " << e.what(); }
+        } else { BOOST_LOG_SEV(report_instance_handler_lg(), warn) << "Failed to decode: " << msg.subject; }
     }
 
 private:

--- a/projects/ores.reporting/core/tests/CMakeLists.txt
+++ b/projects/ores.reporting/core/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ set_target_properties(${tests_target_name}
 target_link_libraries(${tests_target_name}
     PRIVATE
         ${lib_target_name}
+        ores.eventing.core.lib
+        ores.nats.lib
         ores.refdata.core.lib
         ores.utility.lib
         ores.testing.lib

--- a/projects/ores.reporting/core/tests/component_files.cmake
+++ b/projects/ores.reporting/core/tests/component_files.cmake
@@ -17,7 +17,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 set(files
+    "concurrency_policy_eventing_integration_tests.cpp"
     "main.cpp"
+    "report_definition_eventing_integration_tests.cpp"
+    "report_instance_eventing_integration_tests.cpp"
+    "report_type_eventing_integration_tests.cpp"
     "repository_report_definition_repository_tests.cpp"
     "repository_report_type_repository_tests.cpp"
 )

--- a/projects/ores.reporting/core/tests/concurrency_policy_eventing_integration_tests.cpp
+++ b/projects/ores.reporting/core/tests/concurrency_policy_eventing_integration_tests.cpp
@@ -1,0 +1,164 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.database/domain/context.hpp"
+#include "ores.eventing.api/domain/entity_change_event.hpp"
+#include "ores.eventing.api/domain/event_traits.hpp"
+#include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
+#include "ores.eventing.core/service/postgres_event_source.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.reporting.api/domain/concurrency_policy.hpp"
+#include "ores.reporting.api/domain/concurrency_policy_json_io.hpp" // IWYU pragma: keep.
+#include "ores.reporting.api/eventing/concurrency_policy_changed_event.hpp"
+#include "ores.reporting.api/generators/concurrency_policy_generator.hpp"
+#include "ores.reporting.core/repository/concurrency_policy_repository.hpp"
+#include "ores.testing/make_generation_context.hpp"
+#include "ores.testing/scoped_database_helper.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <boost/uuid/uuid_io.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <thread>
+
+// Proves the "write an entity, observe its NATS entity-changed
+// notification" pattern end to end for concurrency_policy -- the
+// production DB-write -> pg_notify -> postgres_event_source ->
+// event_bus -> NATS publish chain, assembled directly here the same
+// way the production event-registrar wires it.
+
+namespace {
+
+const std::string_view test_suite("reporting.tests");
+const std::string tags("[eventing][integration]");
+
+
+// Reads NATS connection settings the same way every service resolves
+// them at startup -- CMake bakes every .env variable into the ctest
+// process environment, so these are populated identically for both
+// `compass build` local runs and CI.
+ores::nats::config::nats_options test_nats_options() {
+    auto env = [](const char* name) -> std::string {
+        const char* v = std::getenv(name);
+        return v ? std::string(v) : std::string();
+    };
+
+    ores::nats::config::nats_options opts;
+    opts.url = env("ORES_NATS_URL");
+    if (opts.url.empty())
+        opts.url = "nats://localhost:4222";
+    opts.subject_prefix = env("ORES_NATS_SUBJECT_PREFIX");
+    opts.tls_ca_cert = env("ORES_NATS_TLS_CA");
+    opts.tls_client_cert = env("ORES_NATS_TLS_CERT");
+    opts.tls_client_key = env("ORES_NATS_TLS_KEY");
+    return opts;
+}
+
+}
+
+using namespace ores::reporting::generators;
+using ores::reporting::domain::concurrency_policy;
+using ores::reporting::repository::concurrency_policy_repository;
+using ores::testing::scoped_database_helper;
+using namespace ores::logging;
+
+TEST_CASE("write_concurrency_policy_publishes_nats_changed_event", tags) {
+    auto lg(make_logger(test_suite));
+
+    scoped_database_helper h;
+    auto ctx = ores::testing::make_generation_context(h);
+    auto& party_ctx = h.context();
+
+    // 1. Wire the same DB-notify -> event_bus -> NATS-publish chain the
+    // production event-registrar wires in the live service, assembled
+    // directly in the test instead of via a running process.
+    namespace ev = ores::eventing;
+    ev::service::event_bus bus;
+    ev::service::postgres_event_source event_source(party_ctx, bus);
+
+    ores::nats::service::client nats(test_nats_options());
+    nats.connect();
+    REQUIRE(nats.is_connected());
+
+    auto sub = bus.subscribe<ores::reporting::eventing::concurrency_policy_changed_event>(
+        [&nats](const ores::reporting::eventing::concurrency_policy_changed_event& e) {
+            ev::service::publish_entity_event(
+                nats,
+                std::string(ev::domain::event_traits<
+                            ores::reporting::eventing::concurrency_policy_changed_event>::name),
+                ev::domain::entity_change_event{.entity = "ores.reporting.concurrency_policy",
+                                                .timestamp = e.timestamp,
+                                                .entity_ids = e.codes,
+                                                .tenant_id = e.tenant_id});
+        });
+
+    event_source.register_mapping<ores::reporting::eventing::concurrency_policy_changed_event>(
+        "ores.reporting.concurrency_policy", "ores_reporting_concurrency_policies");
+
+    // 2. Subscribe as an external observer would, on the relative subject --
+    // client::subscribe() prepends the subject_prefix itself.
+    auto observer = nats.subscribe_buffered(
+        std::string(ev::domain::event_traits<
+                    ores::reporting::eventing::concurrency_policy_changed_event>::name),
+        10);
+
+    // The listener thread issues LISTEN asynchronously on its own
+    // dedicated connection. Block until it has actually done so before
+    // writing -- Postgres does not queue NOTIFYs sent before a matching
+    // LISTEN is registered.
+    event_source.start();
+    REQUIRE(event_source.wait_until_ready());
+
+    // 3. Write -- triggers the entity's notify trigger -> pg_notify ->
+    // the chain wired above -> NATS.
+    auto v = generate_synthetic_concurrency_policy(ctx);
+    v.change_reason_code = "system.test";
+    const auto id_str = v.code;
+    BOOST_LOG_SEV(lg, debug) << "Concurrency Policy: " << v;
+
+    concurrency_policy_repository repo;
+    repo.write(party_ctx, v);
+
+    // 4. Poll the observer's buffer for the notification. Generous
+    // timeout: trigger -> pg_notify -> 100ms listener poll -> event_bus
+    // -> NATS round trip, all real, no mocks.
+    std::vector<ores::nats::message> received;
+    for (int i = 0; i < 50 && received.empty(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        auto snap = observer.snapshot();
+        for (const auto& msg : snap) {
+            auto decoded =
+                ores::nats::default_wire_codec().decode<ev::domain::entity_change_event>(msg.data);
+            if (decoded && decoded->entity == "ores.reporting.concurrency_policy") {
+                for (const auto& changed_id : decoded->entity_ids) {
+                    if (changed_id == id_str)
+                        received.push_back(msg);
+                }
+            }
+        }
+    }
+
+    event_source.stop();
+
+    REQUIRE_FALSE(received.empty());
+    BOOST_LOG_SEV(lg, info) << "Received " << received.size()
+                            << " matching NATS notification(s) for concurrency_policy " << id_str;
+}

--- a/projects/ores.reporting/core/tests/report_definition_eventing_integration_tests.cpp
+++ b/projects/ores.reporting/core/tests/report_definition_eventing_integration_tests.cpp
@@ -1,0 +1,164 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.database/domain/context.hpp"
+#include "ores.eventing.api/domain/entity_change_event.hpp"
+#include "ores.eventing.api/domain/event_traits.hpp"
+#include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
+#include "ores.eventing.core/service/postgres_event_source.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.reporting.api/domain/report_definition.hpp"
+#include "ores.reporting.api/domain/report_definition_json_io.hpp" // IWYU pragma: keep.
+#include "ores.reporting.api/eventing/report_definition_changed_event.hpp"
+#include "ores.reporting.api/generators/report_definition_generator.hpp"
+#include "ores.reporting.core/repository/report_definition_repository.hpp"
+#include "ores.testing/make_generation_context.hpp"
+#include "ores.testing/scoped_database_helper.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <boost/uuid/uuid_io.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <thread>
+
+// Proves the "write an entity, observe its NATS entity-changed
+// notification" pattern end to end for report_definition -- the
+// production DB-write -> pg_notify -> postgres_event_source ->
+// event_bus -> NATS publish chain, assembled directly here the same
+// way the production event-registrar wires it.
+
+namespace {
+
+const std::string_view test_suite("reporting.tests");
+const std::string tags("[eventing][integration]");
+
+
+// Reads NATS connection settings the same way every service resolves
+// them at startup -- CMake bakes every .env variable into the ctest
+// process environment, so these are populated identically for both
+// `compass build` local runs and CI.
+ores::nats::config::nats_options test_nats_options() {
+    auto env = [](const char* name) -> std::string {
+        const char* v = std::getenv(name);
+        return v ? std::string(v) : std::string();
+    };
+
+    ores::nats::config::nats_options opts;
+    opts.url = env("ORES_NATS_URL");
+    if (opts.url.empty())
+        opts.url = "nats://localhost:4222";
+    opts.subject_prefix = env("ORES_NATS_SUBJECT_PREFIX");
+    opts.tls_ca_cert = env("ORES_NATS_TLS_CA");
+    opts.tls_client_cert = env("ORES_NATS_TLS_CERT");
+    opts.tls_client_key = env("ORES_NATS_TLS_KEY");
+    return opts;
+}
+
+}
+
+using namespace ores::reporting::generators;
+using ores::reporting::domain::report_definition;
+using ores::reporting::repository::report_definition_repository;
+using ores::testing::scoped_database_helper;
+using namespace ores::logging;
+
+TEST_CASE("write_report_definition_publishes_nats_changed_event", tags) {
+    auto lg(make_logger(test_suite));
+
+    scoped_database_helper h;
+    auto ctx = ores::testing::make_generation_context(h);
+    auto& party_ctx = h.context();
+
+    // 1. Wire the same DB-notify -> event_bus -> NATS-publish chain the
+    // production event-registrar wires in the live service, assembled
+    // directly in the test instead of via a running process.
+    namespace ev = ores::eventing;
+    ev::service::event_bus bus;
+    ev::service::postgres_event_source event_source(party_ctx, bus);
+
+    ores::nats::service::client nats(test_nats_options());
+    nats.connect();
+    REQUIRE(nats.is_connected());
+
+    auto sub = bus.subscribe<ores::reporting::eventing::report_definition_changed_event>(
+        [&nats](const ores::reporting::eventing::report_definition_changed_event& e) {
+            ev::service::publish_entity_event(
+                nats,
+                std::string(ev::domain::event_traits<
+                            ores::reporting::eventing::report_definition_changed_event>::name),
+                ev::domain::entity_change_event{.entity = "ores.reporting.report_definition",
+                                                .timestamp = e.timestamp,
+                                                .entity_ids = e.definition_ids,
+                                                .tenant_id = e.tenant_id});
+        });
+
+    event_source.register_mapping<ores::reporting::eventing::report_definition_changed_event>(
+        "ores.reporting.report_definition", "ores_reporting_report_definitions");
+
+    // 2. Subscribe as an external observer would, on the relative subject --
+    // client::subscribe() prepends the subject_prefix itself.
+    auto observer = nats.subscribe_buffered(
+        std::string(ev::domain::event_traits<
+                    ores::reporting::eventing::report_definition_changed_event>::name),
+        10);
+
+    // The listener thread issues LISTEN asynchronously on its own
+    // dedicated connection. Block until it has actually done so before
+    // writing -- Postgres does not queue NOTIFYs sent before a matching
+    // LISTEN is registered.
+    event_source.start();
+    REQUIRE(event_source.wait_until_ready());
+
+    // 3. Write -- triggers the entity's notify trigger -> pg_notify ->
+    // the chain wired above -> NATS.
+    auto v = generate_synthetic_report_definition(ctx);
+    v.change_reason_code = "system.test";
+    const auto id_str = boost::uuids::to_string(v.id);
+    BOOST_LOG_SEV(lg, debug) << "Report Definition: " << v;
+
+    report_definition_repository repo;
+    repo.write(party_ctx, v);
+
+    // 4. Poll the observer's buffer for the notification. Generous
+    // timeout: trigger -> pg_notify -> 100ms listener poll -> event_bus
+    // -> NATS round trip, all real, no mocks.
+    std::vector<ores::nats::message> received;
+    for (int i = 0; i < 50 && received.empty(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        auto snap = observer.snapshot();
+        for (const auto& msg : snap) {
+            auto decoded =
+                ores::nats::default_wire_codec().decode<ev::domain::entity_change_event>(msg.data);
+            if (decoded && decoded->entity == "ores.reporting.report_definition") {
+                for (const auto& changed_id : decoded->entity_ids) {
+                    if (changed_id == id_str)
+                        received.push_back(msg);
+                }
+            }
+        }
+    }
+
+    event_source.stop();
+
+    REQUIRE_FALSE(received.empty());
+    BOOST_LOG_SEV(lg, info) << "Received " << received.size()
+                            << " matching NATS notification(s) for report_definition " << id_str;
+}

--- a/projects/ores.reporting/core/tests/report_instance_eventing_integration_tests.cpp
+++ b/projects/ores.reporting/core/tests/report_instance_eventing_integration_tests.cpp
@@ -1,0 +1,164 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.database/domain/context.hpp"
+#include "ores.eventing.api/domain/entity_change_event.hpp"
+#include "ores.eventing.api/domain/event_traits.hpp"
+#include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
+#include "ores.eventing.core/service/postgres_event_source.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.reporting.api/domain/report_instance.hpp"
+#include "ores.reporting.api/domain/report_instance_json_io.hpp" // IWYU pragma: keep.
+#include "ores.reporting.api/eventing/report_instance_changed_event.hpp"
+#include "ores.reporting.api/generators/report_instance_generator.hpp"
+#include "ores.reporting.core/repository/report_instance_repository.hpp"
+#include "ores.testing/make_generation_context.hpp"
+#include "ores.testing/scoped_database_helper.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <boost/uuid/uuid_io.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <thread>
+
+// Proves the "write an entity, observe its NATS entity-changed
+// notification" pattern end to end for report_instance -- the
+// production DB-write -> pg_notify -> postgres_event_source ->
+// event_bus -> NATS publish chain, assembled directly here the same
+// way the production event-registrar wires it.
+
+namespace {
+
+const std::string_view test_suite("reporting.tests");
+const std::string tags("[eventing][integration]");
+
+
+// Reads NATS connection settings the same way every service resolves
+// them at startup -- CMake bakes every .env variable into the ctest
+// process environment, so these are populated identically for both
+// `compass build` local runs and CI.
+ores::nats::config::nats_options test_nats_options() {
+    auto env = [](const char* name) -> std::string {
+        const char* v = std::getenv(name);
+        return v ? std::string(v) : std::string();
+    };
+
+    ores::nats::config::nats_options opts;
+    opts.url = env("ORES_NATS_URL");
+    if (opts.url.empty())
+        opts.url = "nats://localhost:4222";
+    opts.subject_prefix = env("ORES_NATS_SUBJECT_PREFIX");
+    opts.tls_ca_cert = env("ORES_NATS_TLS_CA");
+    opts.tls_client_cert = env("ORES_NATS_TLS_CERT");
+    opts.tls_client_key = env("ORES_NATS_TLS_KEY");
+    return opts;
+}
+
+}
+
+using namespace ores::reporting::generators;
+using ores::reporting::domain::report_instance;
+using ores::reporting::repository::report_instance_repository;
+using ores::testing::scoped_database_helper;
+using namespace ores::logging;
+
+TEST_CASE("write_report_instance_publishes_nats_changed_event", tags) {
+    auto lg(make_logger(test_suite));
+
+    scoped_database_helper h;
+    auto ctx = ores::testing::make_generation_context(h);
+    auto& party_ctx = h.context();
+
+    // 1. Wire the same DB-notify -> event_bus -> NATS-publish chain the
+    // production event-registrar wires in the live service, assembled
+    // directly in the test instead of via a running process.
+    namespace ev = ores::eventing;
+    ev::service::event_bus bus;
+    ev::service::postgres_event_source event_source(party_ctx, bus);
+
+    ores::nats::service::client nats(test_nats_options());
+    nats.connect();
+    REQUIRE(nats.is_connected());
+
+    auto sub = bus.subscribe<ores::reporting::eventing::report_instance_changed_event>(
+        [&nats](const ores::reporting::eventing::report_instance_changed_event& e) {
+            ev::service::publish_entity_event(
+                nats,
+                std::string(ev::domain::event_traits<
+                            ores::reporting::eventing::report_instance_changed_event>::name),
+                ev::domain::entity_change_event{.entity = "ores.reporting.report_instance",
+                                                .timestamp = e.timestamp,
+                                                .entity_ids = e.instance_ids,
+                                                .tenant_id = e.tenant_id});
+        });
+
+    event_source.register_mapping<ores::reporting::eventing::report_instance_changed_event>(
+        "ores.reporting.report_instance", "ores_reporting_report_instances");
+
+    // 2. Subscribe as an external observer would, on the relative subject --
+    // client::subscribe() prepends the subject_prefix itself.
+    auto observer = nats.subscribe_buffered(
+        std::string(ev::domain::event_traits<
+                    ores::reporting::eventing::report_instance_changed_event>::name),
+        10);
+
+    // The listener thread issues LISTEN asynchronously on its own
+    // dedicated connection. Block until it has actually done so before
+    // writing -- Postgres does not queue NOTIFYs sent before a matching
+    // LISTEN is registered.
+    event_source.start();
+    REQUIRE(event_source.wait_until_ready());
+
+    // 3. Write -- triggers the entity's notify trigger -> pg_notify ->
+    // the chain wired above -> NATS.
+    auto v = generate_synthetic_report_instance(ctx);
+    v.change_reason_code = "system.test";
+    const auto id_str = boost::uuids::to_string(v.id);
+    BOOST_LOG_SEV(lg, debug) << "Report Instance: " << v;
+
+    report_instance_repository repo;
+    repo.write(party_ctx, v);
+
+    // 4. Poll the observer's buffer for the notification. Generous
+    // timeout: trigger -> pg_notify -> 100ms listener poll -> event_bus
+    // -> NATS round trip, all real, no mocks.
+    std::vector<ores::nats::message> received;
+    for (int i = 0; i < 50 && received.empty(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        auto snap = observer.snapshot();
+        for (const auto& msg : snap) {
+            auto decoded =
+                ores::nats::default_wire_codec().decode<ev::domain::entity_change_event>(msg.data);
+            if (decoded && decoded->entity == "ores.reporting.report_instance") {
+                for (const auto& changed_id : decoded->entity_ids) {
+                    if (changed_id == id_str)
+                        received.push_back(msg);
+                }
+            }
+        }
+    }
+
+    event_source.stop();
+
+    REQUIRE_FALSE(received.empty());
+    BOOST_LOG_SEV(lg, info) << "Received " << received.size()
+                            << " matching NATS notification(s) for report_instance " << id_str;
+}

--- a/projects/ores.reporting/core/tests/report_type_eventing_integration_tests.cpp
+++ b/projects/ores.reporting/core/tests/report_type_eventing_integration_tests.cpp
@@ -1,0 +1,164 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.database/domain/context.hpp"
+#include "ores.eventing.api/domain/entity_change_event.hpp"
+#include "ores.eventing.api/domain/event_traits.hpp"
+#include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
+#include "ores.eventing.core/service/postgres_event_source.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/wire_codec.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.reporting.api/domain/report_type.hpp"
+#include "ores.reporting.api/domain/report_type_json_io.hpp" // IWYU pragma: keep.
+#include "ores.reporting.api/eventing/report_type_changed_event.hpp"
+#include "ores.reporting.api/generators/report_type_generator.hpp"
+#include "ores.reporting.core/repository/report_type_repository.hpp"
+#include "ores.testing/make_generation_context.hpp"
+#include "ores.testing/scoped_database_helper.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include <boost/uuid/uuid_io.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <thread>
+
+// Proves the "write an entity, observe its NATS entity-changed
+// notification" pattern end to end for report_type -- the
+// production DB-write -> pg_notify -> postgres_event_source ->
+// event_bus -> NATS publish chain, assembled directly here the same
+// way the production event-registrar wires it.
+
+namespace {
+
+const std::string_view test_suite("reporting.tests");
+const std::string tags("[eventing][integration]");
+
+
+// Reads NATS connection settings the same way every service resolves
+// them at startup -- CMake bakes every .env variable into the ctest
+// process environment, so these are populated identically for both
+// `compass build` local runs and CI.
+ores::nats::config::nats_options test_nats_options() {
+    auto env = [](const char* name) -> std::string {
+        const char* v = std::getenv(name);
+        return v ? std::string(v) : std::string();
+    };
+
+    ores::nats::config::nats_options opts;
+    opts.url = env("ORES_NATS_URL");
+    if (opts.url.empty())
+        opts.url = "nats://localhost:4222";
+    opts.subject_prefix = env("ORES_NATS_SUBJECT_PREFIX");
+    opts.tls_ca_cert = env("ORES_NATS_TLS_CA");
+    opts.tls_client_cert = env("ORES_NATS_TLS_CERT");
+    opts.tls_client_key = env("ORES_NATS_TLS_KEY");
+    return opts;
+}
+
+}
+
+using namespace ores::reporting::generators;
+using ores::reporting::domain::report_type;
+using ores::reporting::repository::report_type_repository;
+using ores::testing::scoped_database_helper;
+using namespace ores::logging;
+
+TEST_CASE("write_report_type_publishes_nats_changed_event", tags) {
+    auto lg(make_logger(test_suite));
+
+    scoped_database_helper h;
+    auto ctx = ores::testing::make_generation_context(h);
+    auto& party_ctx = h.context();
+
+    // 1. Wire the same DB-notify -> event_bus -> NATS-publish chain the
+    // production event-registrar wires in the live service, assembled
+    // directly in the test instead of via a running process.
+    namespace ev = ores::eventing;
+    ev::service::event_bus bus;
+    ev::service::postgres_event_source event_source(party_ctx, bus);
+
+    ores::nats::service::client nats(test_nats_options());
+    nats.connect();
+    REQUIRE(nats.is_connected());
+
+    auto sub = bus.subscribe<ores::reporting::eventing::report_type_changed_event>(
+        [&nats](const ores::reporting::eventing::report_type_changed_event& e) {
+            ev::service::publish_entity_event(
+                nats,
+                std::string(ev::domain::event_traits<
+                            ores::reporting::eventing::report_type_changed_event>::name),
+                ev::domain::entity_change_event{.entity = "ores.reporting.report_type",
+                                                .timestamp = e.timestamp,
+                                                .entity_ids = e.codes,
+                                                .tenant_id = e.tenant_id});
+        });
+
+    event_source.register_mapping<ores::reporting::eventing::report_type_changed_event>(
+        "ores.reporting.report_type", "ores_reporting_report_types");
+
+    // 2. Subscribe as an external observer would, on the relative subject --
+    // client::subscribe() prepends the subject_prefix itself.
+    auto observer = nats.subscribe_buffered(
+        std::string(
+            ev::domain::event_traits<ores::reporting::eventing::report_type_changed_event>::name),
+        10);
+
+    // The listener thread issues LISTEN asynchronously on its own
+    // dedicated connection. Block until it has actually done so before
+    // writing -- Postgres does not queue NOTIFYs sent before a matching
+    // LISTEN is registered.
+    event_source.start();
+    REQUIRE(event_source.wait_until_ready());
+
+    // 3. Write -- triggers the entity's notify trigger -> pg_notify ->
+    // the chain wired above -> NATS.
+    auto v = generate_synthetic_report_type(ctx);
+    v.change_reason_code = "system.test";
+    const auto id_str = v.code;
+    BOOST_LOG_SEV(lg, debug) << "Report Type: " << v;
+
+    report_type_repository repo;
+    repo.write(party_ctx, v);
+
+    // 4. Poll the observer's buffer for the notification. Generous
+    // timeout: trigger -> pg_notify -> 100ms listener poll -> event_bus
+    // -> NATS round trip, all real, no mocks.
+    std::vector<ores::nats::message> received;
+    for (int i = 0; i < 50 && received.empty(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        auto snap = observer.snapshot();
+        for (const auto& msg : snap) {
+            auto decoded =
+                ores::nats::default_wire_codec().decode<ev::domain::entity_change_event>(msg.data);
+            if (decoded && decoded->entity == "ores.reporting.report_type") {
+                for (const auto& changed_id : decoded->entity_ids) {
+                    if (changed_id == id_str)
+                        received.push_back(msg);
+                }
+            }
+        }
+    }
+
+    event_source.stop();
+
+    REQUIRE_FALSE(received.empty());
+    BOOST_LOG_SEV(lg, info) << "Received " << received.size()
+                            << " matching NATS notification(s) for report_type " << id_str;
+}

--- a/projects/ores.reporting/modeling/ores.reporting.concurrency_policy.org
+++ b/projects/ores.reporting/modeling/ores.reporting.concurrency_policy.org
@@ -1,5 +1,6 @@
 :PROPERTIES:
 :ID: 4597D5A9-C591-4992-ABEE-8822C10D8D96
+:profile: simple-lookup
 :END:
 #+title: ores.reporting.concurrency_policy
 #+description: Codegen entity model for the reporting =concurrency_policy= table. Drives the C++ domain class, mapper, repository, service, generator, Qt UI, and SQL schema generation from a single literate source.

--- a/projects/ores.reporting/modeling/ores.reporting.report_definition.org
+++ b/projects/ores.reporting/modeling/ores.reporting.report_definition.org
@@ -1,5 +1,6 @@
 :PROPERTIES:
 :ID: FB4A11C5-07EA-4923-B8AC-65F46EBA517C
+:profile: uuid-identified-lookup
 :END:
 #+title: ores.reporting.report_definition
 #+description: Codegen entity model for the reporting =report_definition= table. Drives the C++ domain class, mapper, repository, service, generator, Qt UI, and SQL schema generation from a single literate source.

--- a/projects/ores.reporting/modeling/ores.reporting.report_instance.org
+++ b/projects/ores.reporting/modeling/ores.reporting.report_instance.org
@@ -1,5 +1,6 @@
 :PROPERTIES:
 :ID: 9FCCF6C8-9C10-403B-BDA4-C3E28706BD67
+:profile: fk-scoped-child
 :END:
 #+title: ores.reporting.report_instance
 #+description: Codegen entity model for the reporting =report_instance= table. Drives the C++ domain class, mapper, repository, service, generator, Qt UI, and SQL schema generation from a single literate source.

--- a/projects/ores.reporting/modeling/ores.reporting.report_type.org
+++ b/projects/ores.reporting/modeling/ores.reporting.report_type.org
@@ -1,5 +1,6 @@
 :PROPERTIES:
 :ID: 24095456-2653-4289-93C6-FB3963785CC9
+:profile: simple-lookup
 :END:
 #+title: ores.reporting.report_type
 #+description: Codegen entity model for the reporting =report_type= table. Drives the C++ domain class, mapper, repository, service, generator, Qt UI, and SQL schema generation from a single literate source.

--- a/projects/ores.reporting/service/src/app/application.cpp
+++ b/projects/ores.reporting/service/src/app/application.cpp
@@ -107,6 +107,13 @@ boost::asio::awaitable<void> application::run(boost::asio::io_context& io_ctx,
             });
         });
 
+    // Publish report_definition changed events to NATS so the Qt client
+    // can auto-refresh the list. Runs alongside the scheduling subscriber
+    // above (event_bus supports multiple subscribers per event type).
+    auto rd_nats_sub =
+        ores::reporting::service::messaging::register_report_definition_event_mapping(
+            event_source, event_bus, nats);
+
     // Wire eventing for the remaining entities — publishes changed events
     // to NATS so the Qt client can refresh lists without manual reload.
     auto cp_changed_sub =

--- a/projects/ores.reporting/service/src/app/application.cpp
+++ b/projects/ores.reporting/service/src/app/application.cpp
@@ -25,8 +25,15 @@
 #include "ores.iam.client/client/service_token_provider.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.nats/service/nats_client.hpp"
+#include "ores.reporting.api/eventing/concurrency_policy_changed_event.hpp"
 #include "ores.reporting.api/eventing/report_definition_changed_event.hpp"
+#include "ores.reporting.api/eventing/report_instance_changed_event.hpp"
+#include "ores.reporting.api/eventing/report_type_changed_event.hpp"
 #include "ores.reporting.core/messaging/registrar.hpp"
+#include "ores.reporting.service/messaging/concurrency_policy_event_registrar.hpp"
+#include "ores.reporting.service/messaging/report_definition_event_registrar.hpp"
+#include "ores.reporting.service/messaging/report_instance_event_registrar.hpp"
+#include "ores.reporting.service/messaging/report_type_event_registrar.hpp"
 #include "ores.reporting.core/service/report_scheduling_service.hpp"
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
@@ -99,6 +106,18 @@ boost::asio::awaitable<void> application::run(boost::asio::io_context& io_ctx,
                     boost::asio::detached);
             });
         });
+
+    // Wire eventing for the remaining entities — publishes changed events
+    // to NATS so the Qt client can refresh lists without manual reload.
+    auto cp_changed_sub =
+        ores::reporting::service::messaging::register_concurrency_policy_event_mapping(
+            event_source, event_bus, nats);
+    auto ri_changed_sub =
+        ores::reporting::service::messaging::register_report_instance_event_mapping(
+            event_source, event_bus, nats);
+    auto rt_changed_sub =
+        ores::reporting::service::messaging::register_report_type_event_mapping(
+            event_source, event_bus, nats);
 
     event_source.start();
 

--- a/projects/ores.shell/scripts/library/provisioning/how_do_i_provision_the_system_with_acme_corporation_holding_group.ores
+++ b/projects/ores.shell/scripts/library/provisioning/how_do_i_provision_the_system_with_acme_corporation_holding_group.ores
@@ -12,4 +12,5 @@ logout
 
 login tenant_admin@acme_corporation Secure-Password-123
 provision tenant --source acme
+bundles publish risk_management --wait
 logout

--- a/projects/ores.shell/src/app/commands/bundles_commands.cpp
+++ b/projects/ores.shell/src/app/commands/bundles_commands.cpp
@@ -86,6 +86,8 @@ void bundles_commands::process_publish(std::ostream& out,
                               {.name = "root-lei", .requires_value = true, .default_value = ""},
                               {.name = "party-id", .requires_value = true, .default_value = ""},
                               {.name = "dataset", .requires_value = true, .default_value = ""},
+                              {.name = "tiers", .requires_value = true, .default_value = ""},
+                              {.name = "jurisdiction", .requires_value = true, .default_value = ""},
                               {.name = "timeout",
                                .requires_value = true,
                                .default_value = std::to_string(default_wait_timeout.count())}});
@@ -126,6 +128,10 @@ void bundles_commands::process_publish(std::ostream& out,
             dq::messaging::lei_parties_params{.root_lei = parsed->flag("root-lei")};
     if (!parsed->flag("party-id").empty())
         params.party_id = parsed->flag("party-id");
+    if (!parsed->flag("tiers").empty())
+        params.tiers = parsed->flag("tiers");
+    if (!parsed->flag("jurisdiction").empty())
+        params.jurisdiction = parsed->flag("jurisdiction");
 
     dq::messaging::publish_bundle_request req;
     req.bundle_code = code;
@@ -133,7 +139,8 @@ void bundles_commands::process_publish(std::ostream& out,
     req.published_by = session.auth().username;
     req.atomic = true;
     const bool has_params = !params.opted_in_datasets.empty() || params.lei_parties.has_value() ||
-                            params.party_id.has_value();
+                            params.party_id.has_value() || params.tiers.has_value() ||
+                            params.jurisdiction.has_value();
     if (has_params)
         req.params_json = dq::messaging::build_params_json(params);
 

--- a/projects/ores.sql/create/dq/dq_create.sql
+++ b/projects/ores.sql/create/dq/dq_create.sql
@@ -125,6 +125,7 @@
 
 -- Analytics artefact tables
 \ir ./dq_report_definitions_artefact_create.sql
+\ir ./dq_report_definitions_artefact_tier_alter.sql
 
 -- Synthetic market data artefact tables
 \ir ./dq_synthetic_fx_spot_configs_artefact_create.sql

--- a/projects/ores.sql/create/dq/dq_report_definitions_artefact_tier_alter.sql
+++ b/projects/ores.sql/create/dq/dq_report_definitions_artefact_tier_alter.sql
@@ -1,0 +1,34 @@
+-- -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+--
+-- Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+--
+-- This program is free software; you can redistribute it and/or modify it under
+-- the terms of the GNU General Public License as published by the Free Software
+-- Foundation; either version 3 of the License, or (at your option) any later
+-- version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU General Public License along with
+-- this program; if not, write to the Free Software Foundation, Inc., 51
+-- Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+--
+
+-- =============================================================================
+-- Report Definition Artefacts — tier and jurisdiction columns
+-- =============================================================================
+-- Adds audience-tier and jurisdiction filtering so the same artefact catalogue
+-- can be published selectively: holding companies get strategic reports,
+-- trading desks get desk-level analytics, and every entity gets common reports.
+
+alter table if exists ores_dq_report_definitions_artefact_tbl
+    add column if not exists tier text not null default 'trading',
+    add column if not exists applicable_jurisdiction text null;
+
+comment on column ores_dq_report_definitions_artefact_tbl.tier is
+    'Audience tier: common, regulatory, strategic, or trading. Used to filter artefacts during per-entity provisioning.';
+comment on column ores_dq_report_definitions_artefact_tbl.applicable_jurisdiction is
+    'ISO 3166 alpha-2 country code for jurisdiction-specific regulatory reports (e.g. GB, US, HK). NULL for reports that apply universally.';

--- a/projects/ores.sql/create/reporting/reporting_publish_from_dq_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_publish_from_dq_create.sql
@@ -95,8 +95,9 @@ begin
     from ores_dq_report_definitions_artefact_tbl a
     where a.dataset_id = p_dataset_id
       and a.tier = any(string_to_array(
-          coalesce(p_params->>'tiers', 'common,regulatory,strategic,trading'), ', '))
-      and (a.applicable_jurisdiction is null
+          coalesce(nullif(p_params->>'tiers', ''), 'common,regulatory,strategic,trading'), ','))
+      and (p_params->>'jurisdiction' is null
+           or a.applicable_jurisdiction is null
            or a.applicable_jurisdiction = p_params->>'jurisdiction')
     order by a.display_order, a.name;
 

--- a/projects/ores.sql/create/reporting/reporting_publish_from_dq_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_publish_from_dq_create.sql
@@ -74,7 +74,11 @@ begin
         return;
     end if;
 
-    -- Bulk insert all report definitions for this party
+    -- Bulk insert report definitions filtered by tier and jurisdiction.
+    -- p_params may contain:
+    --   tiers:       comma-separated tier list (default: all four)
+    --   jurisdiction: ISO 3166 alpha-2 for jurisdiction-specific reports
+    --   party_id:    optional explicit root party override
     insert into ores_reporting_report_definitions_tbl (
         tenant_id, id, version, party_id, name,
         description, report_type, schedule_expression, concurrency_policy,
@@ -90,6 +94,10 @@ begin
         'system.external_data_import', 'Published from DQ dataset'
     from ores_dq_report_definitions_artefact_tbl a
     where a.dataset_id = p_dataset_id
+      and a.tier = any(string_to_array(
+          coalesce(p_params->>'tiers', 'common,regulatory,strategic,trading'), ', '))
+      and (a.applicable_jurisdiction is null
+           or a.applicable_jurisdiction = p_params->>'jurisdiction')
     order by a.display_order, a.name;
 
     get diagnostics v_inserted = row_count;

--- a/projects/ores.sql/populate/reporting/reporting_report_definitions_populate.sql
+++ b/projects/ores.sql/populate/reporting/reporting_report_definitions_populate.sql
@@ -19,13 +19,18 @@
  */
 
 /**
- * Report Definition Seed Population Script
+ * Report Definition Seed Population Script — Tiered
  *
  * Registers the ore.report_definitions dataset and seeds the artefact table
- * with the 28 standard ORE analytics report definitions. These cover the full
- * trading desk analytic cycle from market data calibration through regulatory
- * capital, plus the intraday Headline Position report. All use
- * report_type='risk' and concurrency_policy='skip'.
+ * with 30 report definitions across four audience tiers:
+ *
+ *   Common      — every entity (data quality, system health, audit)
+ *   Regulatory  — all regulated entities (SA-CCR, leverage, FRTB, LCR, etc.)
+ *   Strategic   — holding company only (group consolidation, board dashboard)
+ *   Trading     — trading desks only (market risk, sensitivities, XVA, calibration)
+ *
+ * Per-entity provisioning filters by tier so a holding company gets strategic
+ * oversight reports while a trading desk gets desk-level analytics.
  *
  * Execution order within reporting_populate.sql:
  *   report_types → concurrency_policies → report_definitions (this file)
@@ -47,6 +52,7 @@ BEGIN
         'OreStudio Development Team'
     );
 END $$;
+
 -- =============================================================================
 -- Dataset Registration
 -- =============================================================================
@@ -66,7 +72,7 @@ BEGIN
         'Raw',
         'OreStudio Code Generation Methodology',
         'ORE Analytics Report Definitions',
-        'Default set of 27 ORE risk analytics report definitions covering calibration, valuation, sensitivities, counterparty credit risk, market risk, scenario analysis, and regulatory capital.',
+        '30 tiered ORE report definitions covering common operational reports, regulatory capital, strategic consolidation, and trading-desk analytics. Tier-filtered during per-entity provisioning.',
         'ORESTUDIO',
         'Seed data for party provisioning wizard report setup',
         current_date,
@@ -74,11 +80,10 @@ BEGIN
         'report_definitions'
     );
 END $$;
--- =============================================================================
--- Artefact Seed Data
--- =============================================================================
 
--- --- ORE Report Definition Artefacts ---
+-- =============================================================================
+-- Artefact Seed Data — 30 reports across 4 tiers
+-- =============================================================================
 
 do $$
 declare
@@ -104,135 +109,186 @@ begin
         return;
     end if;
 
-    raise debug 'Populating report definitions for dataset: ore.report_definitions';
+    raise debug 'Populating 30 tiered report definitions for dataset: ore.report_definitions';
 
     insert into ores_dq_report_definitions_artefact_tbl (
         dataset_id, tenant_id, id, version,
-        name, description, report_type, schedule_expression, concurrency_policy, display_order
+        name, description, report_type, schedule_expression, concurrency_policy,
+        display_order, tier, applicable_jurisdiction
     )
     values
-    -- Market data & calibration (5-6 am)
+    -- =========================================================================
+    -- Common — every entity (3 reports)
+    -- =========================================================================
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Data Quality Completeness',
+     'Validates all required market data, reference data, and trade data is present across the entity. Flags gaps in instrument codes, missing curve pillars, stale fixings, and orphaned trades. Runs early so downstream analytics have a clean data baseline.',
+     'risk', '0 5 * * 1-5', 'skip', 5, 'common', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'System Health',
+     'Monitors service availability, NATS message latency, database connection pool saturation, and per-service error rates. Produces a traffic-light dashboard: green (all healthy), amber (degraded), red (down). Alerts on sustained error-rate spikes above 5%.',
+     'risk', '30 5 * * 1-5', 'skip', 10, 'common', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Audit Trail Summary',
+     'Daily summary of all create, update, and delete operations across all domain entities for the entity. Broken down by service, actor, and change reason category. Supports SOX and SOC 2 compliance requirements for change logging.',
+     'risk', '0 6 * * 1-5', 'skip', 15, 'common', null),
+
+    -- =========================================================================
+    -- Regulatory — all regulated entities (7 reports)
+    -- =========================================================================
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'SA-CCR Exposure',
+     'Standardised Approach for Counterparty Credit Risk: computes Exposure-at-Default (EAD), Replacement Cost (RC), and Potential Future Exposure (PFE) per netting set under Basel III/IV supervisory rules. Required for Risk-Weighted Asset (RWA) and leverage ratio calculations. Replaces the legacy Current Exposure Method (CEM).',
+     'risk', '0 6 * * 1-5', 'skip', 20, 'regulatory', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Leverage Ratio',
+     'Computes the Basel III leverage ratio: Tier 1 capital divided by total exposure measure (on- and off-balance sheet, derivatives, SFTs). Alerts if the ratio approaches the 3% minimum threshold. Required for all regulated entities under CRR/Basel III pillar 2.',
+     'risk', '0 6 * * 1-5', 'skip', 25, 'regulatory', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'FRTB SA Capital',
+     'Fundamental Review of the Trading Book — Standardised Approach: computes market risk capital using supervisory-prescribed sensitivity-based method (SBM) across delta, vega, and curvature risk for all risk classes (GIRR, CSR, FX, EQ, CMDTY). Floor model and fallback for desks not approved for IMA.',
+     'risk', '0 7 * * 1-5', 'skip', 30, 'regulatory', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Liquidity Coverage',
+     'Liquidity Coverage Ratio (LCR): High-Quality Liquid Assets divided by net cash outflows over a 30-day stress horizon. Flags when HQLA buffer drops below 100% minimum. Required under Basel III for all regulated deposit-taking and investment firms.',
+     'risk', '0 7 * * 1-5', 'skip', 35, 'regulatory', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Large Exposures',
+     'Monitors single-counterparty exposure concentration against the 25% of Tier 1 capital regulatory limit. Aggregates across all netting sets, SFTs, and indirect exposures for each legal entity counterparty. Produces breach alerts and a top-20 concentration report.',
+     'risk', '0 7 * * 1-5', 'skip', 40, 'regulatory', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'MIFID II Transaction Reporting',
+     'Trade transparency reporting under MIFID II / MIFIR Article 26. Produces transaction reports for submission to the FCA Approved Reporting Mechanism (ARM). Covers all financial instruments traded on a UK/EEA trading venue. UK entities only.',
+     'risk', '0 8 * * 1-5', 'skip', 45, 'regulatory', 'GB'),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'CFTC Swap Data Reporting',
+     'Swap transaction reporting under CFTC Part 43/45 rules. Produces real-time public and regulatory reports for all swap transactions to a registered Swap Data Repository (SDR). Covers all CFTC-jurisdiction swaps. US entities only.',
+     'risk', '0 8 * * 1-5', 'skip', 50, 'regulatory', 'US'),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'HKMA Trade Repository',
+     'OTC derivatives transaction reporting under HKMA Securities and Futures (OTC Derivative Transactions — Reporting and Record Keeping Obligations) Rules. Reports to the HKTR via the DTCC GTR. HK entities only.',
+     'risk', '0 8 * * 1-5', 'skip', 55, 'regulatory', 'HK'),
+
+    -- =========================================================================
+    -- Strategic — holding company only (4 reports)
+    -- =========================================================================
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Group Consolidated Exposure',
+     'Aggregate exposure across all subsidiaries by asset class, currency, and counterparty. Eliminates intercompany positions per IFRS 10 consolidation rules. Provides the single group-wide risk view for the board and regulators. Holding company only.',
+     'risk', '0 8 * * 1-5', 'skip', 60, 'strategic', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Board Risk Dashboard',
+     'One-page executive summary for the board risk committee: group VaR (99% 1-day), total exposure by asset class, consolidated P&L, capital ratios (CET1, leverage, LCR), top 10 counterparty exposures, and month-on-month trend arrows. Holding company only.',
+     'risk', '0 8 * * 1-5', 'skip', 65, 'strategic', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Cross-Entity Counterparty Concentration',
+     'Aggregates single-name counterparty exposure across all legal entities in the group. Flags names exceeding 25% of consolidated Tier 1 capital. Identifies hidden concentration where individual subsidiary exposures appear within limits but group aggregate breaches the threshold. Holding company only.',
+     'risk', '0 8 * * 1-5', 'skip', 70, 'strategic', null),
+
+    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
+     'Intercompany Exposure Matrix',
+     'Matrix of exposures between all group entities for consolidation elimination. Identifies circular funding, transfer pricing mismatches, and netting inefficiencies across the group. Monthly cadence (not daily — intercompany positions churn slowly). Holding company only.',
+     'risk', '0 6 * * 1,15', 'skip', 75, 'strategic', null),
+
+    -- =========================================================================
+    -- Trading — trading desks only (16 reports)
+    -- =========================================================================
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Model Calibration',
      'Calibrates interest rate, FX, and volatility models (LGM, Hull-White, SABR, Black-Scholes) to live market data. Outputs calibrated parameters and fit quality metrics (RMSE). Must run before exposure simulation, XVA, and sensitivity analytics that depend on calibrated model parameters.',
-     'risk', '0 5 * * 1-5', 'skip', 10),
+     'risk', '0 5 * * 1-5', 'skip', 80, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Yield Curves',
      'Bootstraps discount and projection yield curves from market instruments (deposits, FRAs, swaps, OIS, bonds). Outputs the full term structure of interest rates used by all pricing engines. Essential prerequisite for NPV, sensitivity, and Monte Carlo exposure analytics.',
-     'risk', '0 5 * * 1-5', 'skip', 20),
+     'risk', '0 5 * * 1-5', 'skip', 85, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'FX Spot Rates',
      'Loads and validates FX spot rates for all active currency pairs from market data feeds. Provides consistent FX conversion for multi-currency portfolio valuation, sensitivities, and regulatory capital calculations that require base-currency aggregation.',
-     'risk', '0 5 * * 1-5', 'skip', 30),
+     'risk', '0 5 * * 1-5', 'skip', 90, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Volatility Surfaces',
-     'Constructs implied volatility surfaces for interest rates, FX, and equity from market option quotes. Applies smile interpolation (SVI, SABR) and arbitrage-free calibration. Required for options pricing, vega sensitivities, stressed VaR, and FRTB vega capital computation.',
-     'risk', '0 5 * * 1-5', 'skip', 40),
+     'Constructs implied volatility surfaces for interest rates, FX, and equity from market option quotes. Applies smile interpolation (SVI, SABR) and arbitrage-free calibration. Required for options pricing, vega sensitivities, stressed VaR, and FRTB vega capital.',
+     'risk', '0 5 * * 1-5', 'skip', 95, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Credit Curves',
      'Bootstraps CDS-implied survival probability curves and hazard rate curves for each counterparty and entity. Calibrates credit models (Jarrow-Turnbull, Hull-White credit) to market spreads. Prerequisite for CVA, DVA, FVA, and regulatory SA-CVA capital computations.',
-     'risk', '0 5 * * 1-5', 'skip', 50),
-    -- Portfolio valuation (6-7 am)
+     'risk', '0 5 * * 1-5', 'skip', 100, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'NPV',
      'Full mark-to-market portfolio valuation producing present values for all active trades. Applies validated yield curves and FX rates. Provides the daily P&L baseline, feeds downstream sensitivities, and serves as the reference for risk-neutral pricing across all asset classes.',
-     'risk', '0 6 * * 1-5', 'skip', 60),
+     'risk', '0 6 * * 1-5', 'skip', 105, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Cashflows',
      'Projects all future contractual cashflows across the portfolio: fixed, floating, contingent, and collateral flows. Used for liquidity risk, funding cost estimation, hedge effectiveness testing, and IFRS 9 / IFRS 7 cashflow disclosure.',
-     'risk', '0 6 * * 1-5', 'skip', 70),
-    -- Sensitivities (7-8 am)
+     'risk', '0 6 * * 1-5', 'skip', 110, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Delta and Gamma',
      'Computes first-order (delta) and second-order (gamma) price sensitivities to interest rates, FX, and credit spreads using bump-and-revalue. Produces risk ladder reports by tenor bucket and currency. Feeds hedging, P&L attribution, and FRTB sensitivity-based method capital.',
-     'risk', '0 7 * * 1-5', 'skip', 80),
+     'risk', '0 7 * * 1-5', 'skip', 115, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Vega',
      'Computes first-order sensitivity of portfolio value to implied volatility across all relevant expiry and strike dimensions. Aggregated by asset class, risk factor, and tenor. Required for volatility hedging and FRTB SBM vega capital.',
-     'risk', '0 7 * * 1-5', 'skip', 90),
+     'risk', '0 7 * * 1-5', 'skip', 120, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Bucketed DV01',
      'Key-rate DV01 (dollar value of one basis point) decomposition across standardised tenor buckets (1M, 3M, 6M, 1Y, 2Y, 5Y, 10Y, 20Y, 30Y). Provides a granular interest rate risk profile per currency, netting set, and book. Core input to duration management and FRTB delta capital.',
-     'risk', '0 7 * * 1-5', 'skip', 100),
-    -- Counterparty credit risk (8-9 am)
+     'risk', '0 7 * * 1-5', 'skip', 125, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Exposure',
-     'Monte Carlo simulation of future exposure profiles (EE, PFE, EPE, ENE) at the netting-set level using risk-factor simulation. Drives CVA/DVA valuation, regulatory capital under SA-CCR, and internal credit limits. Computationally intensive; scheduled before XVA to provide input exposure paths.',
-     'risk', '0 8 * * 1-5', 'skip', 110),
+     'Monte Carlo simulation of future exposure profiles (EE, PFE, EPE, ENE) at the netting-set level using risk-factor simulation. Drives CVA/DVA valuation, regulatory capital under SA-CCR, and internal credit limits. Computationally intensive; uses queue concurrency to serialise with other long-running reports.',
+     'risk', '0 8 * * 1-5', 'queue', 130, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'CVA',
-     'Credit Valuation Adjustment — the market value of counterparty default risk embedded in OTC derivatives. Computed as the risk-neutral expectation of loss given default, integrating EPE profiles with counterparty survival probability and LGD. Required for IFRS 13 fair value disclosure and regulatory capital under SA-CVA and BA-CVA.',
-     'risk', '0 8 * * 1-5', 'skip', 120),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'DVA',
-     'Debt Valuation Adjustment — the own-credit component of OTC derivative fair value, reflecting the benefit to the portfolio holder from the institution''s own default risk. Symmetric counterpart to CVA. Required for IFRS 13 compliance and bilateral CVA (BCVA) reporting.',
-     'risk', '0 8 * * 1-5', 'skip', 130),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'FVA',
-     'Funding Valuation Adjustment — the cost or benefit of funding uncollateralised or partially collateralised derivative positions at the institution''s unsecured borrowing rate. Decomposes into FCA (funding cost) and FBA (funding benefit). Material for institutions with significant uncollateralised derivative books.',
-     'risk', '0 8 * * 1-5', 'skip', 140),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'KVA',
-     'Capital Valuation Adjustment — the cost of holding regulatory capital against a derivative position over its lifetime, discounted at the hurdle rate. Reflects the economic cost of capital consumed by the trade under SA-CCR or IMM, including CVA capital charges. Used in strategic pricing and deal profitability analysis.',
-     'risk', '0 8 * * 1-5', 'skip', 150),
-    -- Market risk (9-10 am)
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Historical VaR',
-     'Historical simulation Value-at-Risk at 99% (regulatory) and 95% (internal) confidence levels over a 250-day look-back. Applies full revaluation for non-linear exposures. Produces VaR by risk factor, desk, and portfolio. Primary input to Basel III Internal Models Approach capital.',
-     'risk', '0 9 * * 1-5', 'skip', 160),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Parametric VaR',
-     'Delta-normal (parametric) VaR using a covariance matrix of risk-factor returns. Faster than historical simulation; used as an intraday risk estimate and for limit monitoring. Decomposes into marginal VaR and component VaR by position for attribution and hedging analysis.',
-     'risk', '0 9 * * 1-5', 'skip', 170),
+     'CVA/DVA/FVA',
+     'Composite report computing all three valuation adjustments: Credit VA (counterparty default risk), Debit VA (own default risk), and Funding VA (uncollateralised funding cost). Uses exposure profiles from the Exposure report and credit curves from Credit Curves. Essential for IFRS 13 fair value.',
+     'risk', '0 8 * * 1-5', 'queue', 135, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Stressed VaR',
-     'VaR computed over a stressed historical window (typically the 2008 financial crisis or COVID-2020 period) as required by Basel 2.5. Uses full revaluation. Required as a capital add-on under the IMA. Scenario window is updated annually per regulatory review.',
-     'risk', '0 9 * * 1-5', 'skip', 180),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Expected Shortfall',
-     'Expected Shortfall (ES) at 97.5% confidence, the Basel IV FRTB replacement for VaR under IMA. Computed using a 12-month liquidity-adjusted horizon with scenario weighting. Produces partial ES by risk class (GIRR, CSR, FX, EQ, CMDTY) for the FRTB capital formula.',
-     'risk', '0 9 * * 1-5', 'skip', 190),
+     'VaR computed over a stressed historical window (2008 financial crisis or COVID-2020) at 99% confidence, 10-day holding period. Required as a capital add-on under Basel 2.5 IMA. Uses full revaluation for non-linear exposures.',
+     'risk', '0 8 * * 1-5', 'skip', 140, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'P&L Attribution',
-     'Daily attribution of P&L into risk-factor components: delta, gamma, vega, theta, and unexplained residual. Required for FRTB IMA back-testing and P&L attribution test (PLAT) compliance. Compares hypothetical P&L (from sensitivities) against actual P&L to validate model quality.',
-     'risk', '0 9 * * 1-5', 'skip', 200),
+     'Daily decomposition of P&L into risk-factor components: delta, gamma, vega, theta, carry, and unexplained residual. Required for FRTB IMA back-testing and P&L attribution test (PLAT) compliance. Compares hypothetical P&L against actual P&L to validate model quality.',
+     'risk', '0 16 * * 1-5', 'skip', 145, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Back-Testing',
-     'Daily comparison of 1-day 99% VaR against actual and hypothetical P&L over a 250-day rolling window. Counts exceptions and assigns capital multiplier (green/amber/red zone) per Basel internal models framework. Required for ongoing IMA approval and supervisory reporting.',
-     'risk', '0 9 * * 1-5', 'skip', 210),
-    -- Scenario analysis (10-11 am)
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Stress Testing',
-     'Portfolio revaluation under a library of regulatory and internal stress scenarios including: 2008 credit crisis, 2010 European sovereign debt, 2020 COVID shock, and custom management scenarios. Produces P&L impact, VaR delta, and liquidity stress metrics by desk and book.',
-     'risk', '0 10 * * 1-5', 'skip', 220),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'Sensitivity Analysis',
-     'Systematic grid-based sensitivity analysis varying key market factors (rates, spreads, FX, vol) across a user-defined range. Produces heat maps and waterfall charts for risk-factor impact assessment. Complements historical VaR with forward-looking scenario coverage.',
-     'risk', '0 10 * * 1-5', 'skip', 230),
-    -- Regulatory capital (10-11 am)
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'FRTB-SA',
-     'Fundamental Review of the Trading Book (FRTB) Standardised Approach capital charge. Computes the sensitivity-based method (SBM) capital requirement using supervisory prescribed delta, vega, and curvature sensitivities across all risk classes. Floor model and fallback for desks not approved for IMA.',
-     'risk', '0 10 * * 1-5', 'skip', 240),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'SA-CVA',
-     'Standardised CVA (SA-CVA) regulatory capital charge per Basel IV / CRR3. Aggregates CVA delta and vega sensitivities across risk classes using supervisory prescribed delta factors and correlation matrices. Produces the CVA risk capital requirement for institutions that elect or are required to use the SA-CVA approach under FRTB.',
-     'risk', '0 10 * * 1-5', 'skip', 250),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'BA-CVA',
-     'Basic CVA (BA-CVA) regulatory capital charge, the simplified alternative to SA-CVA under Basel IV. Computes capital using supervisory EAD, maturity, and credit risk weights without full sensitivity computation. Applicable to institutions below the material CVA portfolio threshold for SA-CVA.',
-     'risk', '0 10 * * 1-5', 'skip', 260),
-    (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
-     'SA-CCR',
-     'Standardised Approach for Counterparty Credit Risk (SA-CCR) Exposure-at-Default (EAD) calculation per Basel III/IV. Applies supervisory delta, maturity factor, and supervisory factor to each netting set. Required for Risk-Weighted Asset (RWA) and leverage ratio calculations. Replaces the legacy Current Exposure Method (CEM).',
-     'risk', '0 10 * * 1-5', 'skip', 270),
-    -- Intraday reports (continuous / every 10 minutes)
+     'Intraday Risk Monitor',
+     'Real-time risk snapshot updated every 30 minutes during trading hours. Displays key risk metrics: PV, delta ladder, top 10 P&L movers, VaR estimate, and limit-utilisation gauges. Uses queue concurrency to serialise updates. Provides traders and desk heads with continuous risk visibility between end-of-day analytic runs.',
+     'risk', '*/30 8-17 * * 1-5', 'queue', 150, 'trading', null),
+
     (v_dataset_id, v_tenant_id, gen_random_uuid(), 1,
      'Headline Position',
-     'Displays the most important Greeks across the entire deal set for a book or portfolio. The primary real-time risk overview report for traders and risk managers providing high-level sign-off visibility on the current state of risk. Configurable measures (PV, Daily P&L, MTD P&L, YTD P&L, Delta P&L) and aggregation dimensions (Book, Portfolio, Currency Pair, Greek, Unit Hedge). Supports filtering by book and by threshold. Scheduled versions run at EOD and at AM/PM Flash times; EOD run uses the signed-off market data cut.',
-     'risk', '*/10 * * * *', 'skip', 280);
+     'Displays the most important Greeks across the entire deal set for a book or portfolio. The primary real-time risk overview report for traders and risk managers. Configurable measures (PV, Daily P&L, MTD P&L, YTD P&L, Delta P&L) and aggregation dimensions (Book, Portfolio, Currency Pair, Greek, Unit Hedge).',
+     'risk', '*/10 * * * *', 'skip', 155, 'trading', null);
 
-    raise debug 'Inserted 28 report definition artefacts for ore.report_definitions';
+    raise debug 'Inserted 30 tiered report definition artefacts for ore.report_definitions';
 end;
 $$ language plpgsql;
 
@@ -246,3 +302,12 @@ from ores_dq_report_definitions_artefact_tbl a
 join ores_dq_datasets_tbl d on d.id = a.dataset_id
 where d.code = 'ore.report_definitions'
   and d.valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tier breakdown for verification
+select tier, count(*) as count
+from ores_dq_report_definitions_artefact_tbl a
+join ores_dq_datasets_tbl d on d.id = a.dataset_id
+where d.code = 'ore.report_definitions'
+  and d.valid_to = ores_utility_infinity_timestamp_fn()
+group by tier
+order by tier;


### PR DESCRIPTION
## What

Follow-up fixes and improvements from the reporting-cpp safe drift task
(PR #1904 / story 3B8F2A1D):

### Menu reorganisation
- Rename "Analytics" → "Reporting" with domain submenus
- Compute Configuration, Pricing Configuration, Report Configuration

### Tiered report definitions (31 reports, 4 tiers)
- Common (3): Data Quality, System Health, Audit Trail
- Regulatory (8): SA-CCR, Leverage Ratio, FRTB SA, LCR, Large Exposures, MIFID II, CFTC, HKMA
- Strategic (4): Group Exposure, Board Dashboard, Cross-Entity Concentration, Intercompany Matrix
- Trading (16): Model Calibration, Yield Curves, NPV, Delta/Gamma, Vega, DV01, Exposure, CVA/DVA/FVA, Stressed VaR, P&L Attribution, Intraday Monitor, Headline Position
- Schema: tier + applicable_jurisdiction columns on artefact table
- Publish function: tier/jurisdiction filtering via params_json
- Bundle publish: --tiers and --jurisdiction CLI flags
- Acme provisioning: risk_management bundle wired in

### Eventing fixes
- Per-entity event registrars wired in reporting service (were never called)
- report_definition_changed_event now published to NATS (was only internal)
- Qt controllers subscribe to changed events for all 4 entities

### Profile system: eventing-integration-test enabled globally
- Physical-space table added to all 6 domain archetype profiles
- 4 eventing integration tests generated for reporting entities
- CMake: ores.eventing.core + ores.nats added to reporting core tests

### Codegen fixes
- core.py: nullable timestamp is_already_optional excludes timestamps
- Mapper template: timepoint_to_timestamp → datetime::to_db_string
- Profile binding bug captured (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)