### PR TITLE
[agile] Add retest scenario for PR #1915's fix

### DIFF
--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/scenario_verify_dq_shared_tenant_edit_fix.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/scenario_verify_dq_shared_tenant_edit_fix.org
@@ -1,0 +1,116 @@
+:PROPERTIES:
+:ID: EBF4E9D0-1359-458C-A045-696E3F5A9630
+:END:
+#+title: Test Scenario: Verify PR #1915's shared-tenant edit fix across all 10 extended tables
+#+description: Edit a seeded row of every table PR #1915 extended the per-tenant-copy fix to (data_domain, subject_area, coding_scheme_authority_type, coding_scheme, origin/nature/treatment_dimension, methodology, badge_severity, badge_definition) and confirm none produce a duplicate row -- the same bug class fixed for artefact_type/dataset_bundle.
+#+type: test_scenario
+#+level: s1
+#+filetags: :entity-classification-drift-dq:sprint_25:v0:
+#+target_dialog:
+#+created: 2026-08-08
+#+updated: 2026-08-08
+#+environment:
+#+todo: PENDING | PASSED FAILED
+#+startup: inlineimages
+
+This page documents a test scenario verifying [[id:163AC07E-19E4-4486-A503-8170D9B46108][Task: Bind ores.dq entities to profiles; verify zero-diff regen]] in [[id:A452F2A7-D9CB-48E6-8B23-4509AFFC5699][Story: Entity classification and drift baseline: ores.dq]]. It is filled in with the target dialog and checklist of steps before testing starts; the QA Validation Runner panel rewrites =* Results= in place on save.
+
+* Before you start
+
+- Build must include PR #1915's merge commit (d4800ebca or later on
+  =main=). Confirm via =compass build= (full build, green).
+- The database must be freshly provisioned with Acme Corporation:
+  =compass db recreate -y -k= then =compass shell -f
+  projects/ores.shell/scripts/library/provisioning/how_do_i_provision_the_system_with_acme_corporation_holding_group.ores=.
+  Confirm the run completes with no failed steps before starting.
+- Services must be running: =compass services start= — confirm
+  =ores.dq.service= and =nats-server= reach =running= via =compass
+  services status=.
+
+* Scenario Info
+
+| Field         | Value                                   |
+|---------------+------------------------------------------|
+| Verifies task | [[id:163AC07E-19E4-4486-A503-8170D9B46108][Task: Bind ores.dq entities to profiles; verify zero-diff regen]] |
+| Parent story  | [[id:A452F2A7-D9CB-48E6-8B23-4509AFFC5699][Story: Entity classification and drift baseline: ores.dq]]   |
+| Target dialog | =DataDomainDetailDialog= / =SubjectAreaDetailDialog= / =CodingSchemeDetailDialog= / =MethodologyDetailDialog= / =BadgeDefinitionDetailDialog= and 6 siblings (Data Quality > Data Catalogue / Classifications / Badges) |
+| Clients       |                                          |
+| State         | PENDING                               |
+
+* Steps
+
+Each step edits one seeded (pre-existing, not tester-created) row of
+the named entity, changes a text field, and saves. Confirms (all
+steps): the list shows exactly *one* row for that code/name afterwards
+— not two rows with the same code and different Modified By values
+(the bug: editing a system-tenant-seeded row through the Qt UI could
+never close the original, leaving both visible as "current").
+
+** Log in as tenant_admin@acme_corporation
+
+- Username: =tenant_admin@acme_corporation=
+- Password: =Secure-Password-123=
+- Confirms: login succeeds and the main window loads with the Data
+  Quality menu present.
+
+** Edit a seeded data domain
+
+- Navigate: Data Quality > Data Catalogue > Data Domains.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded subject area
+
+- Navigate: Data Quality > Data Catalogue > Subject Areas.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded methodology
+
+- Navigate: Data Quality > Data Catalogue > Methodologies.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded origin dimension
+
+- Navigate: Data Quality > Data Catalogue > Origin Dimensions.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded nature dimension
+
+- Navigate: Data Quality > Data Catalogue > Nature Dimensions.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded treatment dimension
+
+- Navigate: Data Quality > Data Catalogue > Treatment Dimensions.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded coding scheme
+
+- Navigate: Data Quality > Classifications > Coding Schemes.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded coding scheme authority type
+
+- Navigate: Data Quality > Classifications > Coding Scheme Authority Types.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded badge severity
+
+- Navigate: Data Quality > Badges > Badge Severities.
+- Double-click any pre-existing row, change the Description, Save.
+
+** Edit a seeded badge definition
+
+- Navigate: Data Quality > Badges > Badge Definitions.
+- Double-click any pre-existing row, change the Description, Save.
+
+* Results
+
+| Field         | Value |
+|---------------+-------|
+| Status        |       |
+| Completed at  |       |
+| Branch        |       |
+| Commit        |       |
+| Worktree      |       |
+
+* Notes

--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
@@ -214,7 +214,8 @@ via its "Verifies task" field.
 | Scenario | State | Notes |
 |----------+-------+-------|
 | [[id:E3AC8CAB-2908-4407-8DC6-16C0000A092E][Verify ores.dq commissioned entities]] | FAILED | CRUD+history on catalog/data_domain/change_reason/change_reason_category/artefact_type/dataset_bundle; read-only browse on lei_entity/lei_relationship; confirms report_definition/synthetic_fx_spot_config have no Qt UI; two-client eventing check. Found 3 bugs (artefact_type missing fields + no eventing, change_reason/change_reason_category duplicates), all fixed on this PR before merge. |
-| [[id:E691EEB4-9F66-4099-953E-F41F641D45AE][Verify ores.dq PR #1898 bug fixes]] | PENDING | Retest of the 3 bugs found above, plus the steps left PENDING last round (dataset_bundle CRUD, LEI registry read-only, report_definition/synthetic_fx_spot_config absence). |
+| [[id:E691EEB4-9F66-4099-953E-F41F641D45AE][Verify ores.dq PR #1898 bug fixes]] | PASSED | Retest of the 3 bugs found above, plus the steps left PENDING last round (dataset_bundle CRUD, LEI registry read-only, report_definition/synthetic_fx_spot_config absence). All 8 steps passed. |
+| [[id:EBF4E9D0-1359-458C-A045-696E3F5A9630][Verify PR #1915's shared-tenant edit fix]] | PENDING | Edits a seeded row of all 10 tables PR #1915 extended the per-tenant-copy fix to (data_domain, subject_area, methodology, origin/nature/treatment_dimension, coding_scheme, coding_scheme_authority_type, badge_severity, badge_definition); confirms none produce a duplicate row. |
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
@@ -8,7 +8,7 @@
 #+filetags: :codegen:drift:tooling:sprint_25:v0:entity-classification-drift-dq:
 #+owner: marco
 #+branch: feature/bind-dq-sql-entities-to-profiles
-#+pr: 1915
+#+pr: 1920
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -221,6 +221,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1920][#1920]] | [agile] Add retest scenario for PR #1915's fix |
 | [[https://github.com/OreStudio/OreStudio/pull/1915][#1915]] | [dq,qt,sql] Fix shared-tenant edit duplicates; remove broken LEI browsing UI |
 | [[https://github.com/OreStudio/OreStudio/pull/1910][#1910]] | [agile] Add retest scenario for PR #1898's bug fixes |
 | [[https://github.com/OreStudio/OreStudio/pull/1898][#1898]] | [dq] Bind ores.dq entities to profiles; commission full C++/Qt stack |


### PR DESCRIPTION
## Summary

Adds a focused QA scenario doc to verify PR #1915's shared-tenant duplicate-on-edit fix across all 10 extended tables.

## Changes

- New scenario: edit a seeded row of data_domain, subject_area, methodology, origin/nature/treatment_dimension, coding_scheme, coding_scheme_authority_type, badge_severity, badge_definition
- Correct scenario_verify_dq_bug_fixes's tracked state to PASSED

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Entity classification and drift baseline: ores.dq](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/story.html) | A452F2A7-D9CB-48E6-8B23-4509AFFC5699 |
| Task | [Bind ores.dq entities to profiles; verify zero-diff regen](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.html) | 163AC07E-19E4-4486-A503-8170D9B46108 |
| Environment | jolly_knuth | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)