### PR TITLE
[agile] Fill in LEI step's Result

### DIFF
--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/scenario_verify_dq_bug_fixes.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/scenario_verify_dq_bug_fixes.org
@@ -154,6 +154,12 @@ This page documents a test scenario verifying [[id:163AC07E-19E4-4486-A503-8170D
   staging table, feeding a different UI, the GLEIF counterparty
   picker) and has been removed rather than given a broken read path.
 
+*** Result
+
+| Field  | Value |
+|--------+-------|
+| Status | PASS |
+
 ** Confirm report definitions has no menu entry
 
 - Open every submenu under Data Quality (Badges, Classifications,
@@ -186,9 +192,9 @@ This page documents a test scenario verifying [[id:163AC07E-19E4-4486-A503-8170D
 | Field         | Value |
 |---------------+-------|
 | Status        | PASSED |
-| Completed at  | 2026-08-08T18:16:29Z |
-| Branch        | feature/fix-dq-shared-edit-and-lei-ui |
-| Commit        | 25bbbbe61 |
+| Completed at  | 2026-08-08T22:14:53Z |
+| Branch        | main |
+| Commit        | d4800ebca |
 | Worktree      | jolly_knuth |
 
 * Notes

--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.org
@@ -8,7 +8,7 @@
 #+filetags: :codegen:drift:tooling:sprint_25:v0:entity-classification-drift-dq:
 #+owner: marco
 #+branch: feature/bind-dq-sql-entities-to-profiles
-#+pr: 1920
+#+pr: 1922
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-04
@@ -221,6 +221,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/1922][#1922]] | [agile] Fill in LEI step's Result |
 | [[https://github.com/OreStudio/OreStudio/pull/1920][#1920]] | [agile] Add retest scenario for PR #1915's fix |
 | [[https://github.com/OreStudio/OreStudio/pull/1915][#1915]] | [dq,qt,sql] Fix shared-tenant edit duplicates; remove broken LEI browsing UI |
 | [[https://github.com/OreStudio/OreStudio/pull/1910][#1910]] | [agile] Add retest scenario for PR #1898's bug fixes |


### PR DESCRIPTION
## Summary

Small QA-panel data fix: the LEI menu-absence step's Result was missing on the already-merged scenario_verify_dq_bug_fixes doc.

## Changes

- (Fill in.)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Entity classification and drift baseline: ores.dq](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/story.html) | A452F2A7-D9CB-48E6-8B23-4509AFFC5699 |
| Task | [Bind ores.dq entities to profiles; verify zero-diff regen](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-dq/task_bind-dq-entities-to-profiles.html) | 163AC07E-19E4-4486-A503-8170D9B46108 |
| Environment | jolly_knuth | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)