### PR TITLE
[agile,scheduler] Record scheduler drift task close on inbox story

### DIFF
--- a/doc/agile/product_backlog/inbox/codegen_dx_improvements/story.org
+++ b/doc/agile/product_backlog/inbox/codegen_dx_improvements/story.org
@@ -165,7 +165,7 @@ deliverable.
   other facets safe to regen), =job_definition='s domain column
   shapes (=tenant_id=/=schedule_expression=/=is_active=) don't match
   the hand-written struct's actual types
-  (=utility::uuid::tenant_id=/=cron_expression=/=bool=), so even
+  (=std::optional<boost::uuids::uuid>=/=cron_expression=/=bool=), so even
   domain/repository-entity/mapper regen would emit wrong types. Its
   repository and messaging layers are also hand-maintained, with
   cross-component consumers (=ores.reporting=). No facet is currently

--- a/doc/agile/product_backlog/inbox/codegen_dx_improvements/story.org
+++ b/doc/agile/product_backlog/inbox/codegen_dx_improvements/story.org
@@ -117,7 +117,7 @@ deliverable.
 | [[id:121F5727-E69C-4FA6-B8AD-40F286C22CD2][Fix marketdata entity model drift: update to latest format and regenerate]] | DONE | 2026-07-30 | 2026-07-30 | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.marketdata domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
 | [[id:B8FE7DA1-18D7-4F33-8402-21411A51A8E2][Fix dq entity model drift: update to latest format and regenerate]] | DONE | 2026-07-30 | 2026-07-30 | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.dq domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
 | [[id:1BC20E52-EF45-4F24-B8E3-E72A7E5EDAD9][Fix iam entity model drift: update to latest format and regenerate]] | BACKLOG | | | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.iam domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
-| [[id:6C8E2943-2B2C-4BA6-B510-FDB2C6AA4D88][Fix scheduler entity model drift: update to latest format and regenerate]] | BACKLOG | | | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.scheduler domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
+| [[id:6C8E2943-2B2C-4BA6-B510-FDB2C6AA4D88][Fix scheduler entity model drift: update to latest format and regenerate]] | DONE | 2026-07-31 | 2026-07-31 | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.scheduler domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
 | [[id:A7090308-0E44-49DD-8786-F2300B16F848][Fix analytics entity model drift: update to latest format and regenerate]] | BACKLOG | | | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.analytics domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
 | [[id:60E25913-FED3-41D8-B3D4-A9479F1AA32F][Fix database entity model drift: update to latest format and regenerate]] | BACKLOG | | | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.database domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
 | [[id:21647FE2-9AF6-4F6C-BBA0-5BF96C7BD0B7][Fix compute entity model drift: update to latest format and regenerate]] | BACKLOG | | | Following the same pattern as the refdata sweep (task fix-refdata-model-drift): regenerate every ores.compute domain_entity and junction model against current codegen templates, updating any model found using an outdated format/convention before regenerating, and commit the resulting drift-free tree. compass build and rat must pass after. |
@@ -159,6 +159,20 @@ deliverable.
   it and regenerating restored the feature byte-for-byte. =party= had
   the identical gap, fixed the same way. That backlog item's premise
   is stale; worth re-triaging before picking it up.
+
+- *scheduler's =job_definition= is hand-diverged across every
+  layer, not just SQL.* Unlike =party= (hand-maintained SQL only,
+  other facets safe to regen), =job_definition='s domain column
+  shapes (=tenant_id=/=schedule_expression=/=is_active=) don't match
+  the hand-written struct's actual types
+  (=utility::uuid::tenant_id=/=cron_expression=/=bool=), so even
+  domain/repository-entity/mapper regen would emit wrong types. Its
+  repository and messaging layers are also hand-maintained, with
+  cross-component consumers (=ores.reporting=). No facet is currently
+  safe to regenerate; the model file documents the exclusion in full
+  rather than a full regen being attempted. Needs a proper resync
+  (fixing column shapes, re-adding the hand-written operations to the
+  generated surface) before any facet can be regenerated.
 
 * Out of scope
 

--- a/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
+++ b/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
@@ -72,8 +72,8 @@ Audited every ores.scheduler =domain_entity=/=junction= model against
 current codegen templates and the hand-written C++ it maps to.
 =job_definition= turned out fully hand-diverged: the model's
 =tenant_id=/=schedule_expression=/=is_active= column shapes don't
-match the hand-written =job_definition= struct's
-=utility::uuid::tenant_id=/=cron_expression=/=bool= types, so even the
+match the hand-written =job_definition= struct's actual types
+(=std::optional<boost::uuids::uuid>=/=cron_expression=/=bool=), so even the
 "safe" domain/repository-entity/mapper facets would regenerate wrong
 types, not just wrong formatting. On top of that, repository
 (=read_all_active=, =find_by_name= x2) and messaging
@@ -110,7 +110,11 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | "DO NOT regenerate" note attributes =utility::uuid::tenant_id= to the hand-written struct; actual field type is =std::optional<boost::uuids::uuid>= (the wrapper is what codegen =has_tenant_id= would emit) | ores.scheduler.job_definition.org + task * Plan + story * Decisions | Accepted | Reworded in all three files; model file now also states codegen would emit the wrapper |
+| 2 | Hand-maintained repository/messaging operations described as intro prose, not under the schema's =** Custom repository methods= freeform heading | ores.scheduler.job_definition.org | Accepted | Moved the operation bullets under the existing =** Custom repository methods= section |
+| 3 | Qt facet exclusion not explicitly stated | ores.scheduler.job_definition.org | Accepted | Added one sentence to the exclusion rationale |
+| 4 | =#+updated= / Last touched (2026-07-30) behind the story's close date (2026-07-31) | task_fix-scheduler-model-drift.org | Declined | Matches sibling precedent (=task_fix-refdata-model-drift.org=: created 07-29 vs story End 07-30); the dates record the work period, not the close record; no convention bumps them on close |
+| 5 | =database_name= in Qt tables missing from =* Columns= | ores.scheduler.job_definition.org | Declined | Pre-existing on main (confirmed by the reviewer), out of scope for this bookkeeping PR |
 
 * Result
 

--- a/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
+++ b/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
@@ -8,7 +8,7 @@
 #+filetags: :codegen_dx_improvements:sprint_24:v0:
 #+owner: marco
 #+branch: feature/fix-scheduler-model-drift
-#+pr:
+#+pr: 1934
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-30
@@ -104,7 +104,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1934][#1934]] | [agile,scheduler] Record scheduler drift task close on inbox story |
 
 * Review
 

--- a/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
+++ b/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :codegen_dx_improvements:sprint_24:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-scheduler-model-drift
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-07-30
 #+updated: 2026-07-30
-#+environment:
+#+environment: jolly_knuth
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A083FE26-521D-4046-9E58-AFB901B28809][Codegen developer experience improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -40,11 +40,11 @@ default database actually seeds.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:A083FE26-521D-4046-9E58-AFB901B28809][Codegen developer experience improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-07-30                               |
 
 * Acceptance
@@ -68,9 +68,24 @@ default database actually seeds.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Audited every ores.scheduler =domain_entity=/=junction= model against
+current codegen templates and the hand-written C++ it maps to.
+=job_definition= turned out fully hand-diverged: the model's
+=tenant_id=/=schedule_expression=/=is_active= column shapes don't
+match the hand-written =job_definition= struct's
+=utility::uuid::tenant_id=/=cron_expression=/=bool= types, so even the
+"safe" domain/repository-entity/mapper facets would regenerate wrong
+types, not just wrong formatting. On top of that, repository
+(=read_all_active=, =find_by_name= x2) and messaging
+(=schedule=/=schedule_batch=/=unschedule=, custom =history=, protocol
+structs in =scheduler_protocol.hpp= consumed cross-component by
+=ores.reporting=) are hand-maintained with no generic equivalent.
+Mirrored =party='s hand-maintained-SQL treatment from the refdata
+drift-fix task, but wider in scope: excluded the whole entity from
+regeneration (no facet is currently safe) and recorded the exclusion
+and the reasons in the model file itself, migrating it to the current
+=* Columns=/=:primary_key:= property format along the way. No
+generated code was touched. Confirmed with a full =compass build=.
 
 * Notes
 
@@ -98,3 +113,11 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+=job_definition= is fully hand-diverged (domain, repository, and
+messaging layers all hand-maintained with no safe facet to
+regenerate), so no regeneration was possible or attempted. Migrated
+the model to the current format/property conventions and documented
+the exclusion and its reasons directly in the model file, mirroring
+=party='s hand-maintained-SQL treatment from the refdata drift-fix
+task. No generated code changed. =compass build= passes clean.

--- a/projects/ores.scheduler/modeling/ores.scheduler.job_definition.org
+++ b/projects/ores.scheduler/modeling/ores.scheduler.job_definition.org
@@ -19,34 +19,24 @@ cron expression, SQL command, target database, and active state.
 DO NOT regenerate this entity at all -- every facet is out of sync with
 the hand-maintained C++ (the model's own =tenant_id=/=schedule_expression=/
 =is_active= column shapes don't match the hand-written =job_definition=
-struct's =utility::uuid::tenant_id=/=cron_expression=/=bool= types, so
-even the "safe" domain/repository-entity/mapper facets would regenerate
-*wrong types*, not just wrong formatting) on top of the deeper
-repository/service/messaging divergence below:
-- =job_definition_repository.hpp= hand-implements =read_all_active=
-  (used by =scheduler_loop= to load every job it needs to fire,
-  regardless of tenant) and =find_by_name= x2 (used by
-  =save_definition='s name-collision dedup so an existing job updates
-  in-place instead of hitting a unique-constraint violation).
-- =job_definition_handler.hpp= hand-implements =schedule=/
-  =schedule_batch=/=unschedule= (domain-named, permission-gated
-  wrappers with custom NATS subjects and a batch-save operation with
-  partial-failure reporting) and a custom =history= whose request/
-  response shape differs from the generic one and would collide by
-  name if paste-blocked in alongside it. Their protocol structs live
-  in the separate, hand-maintained =scheduler_protocol.hpp=, consumed
-  not just by this component's own Qt UI (=JobDefinitionController=/
-  =JobDefinitionMdiWindow=/=JobDefinitionDetailDialog=/
-  =JobDefinitionAuditDialog=) and =registrar.cpp=, but cross-component
-  by =ores.reporting='s =report_scheduling_service=.
+struct's actual types: =std::optional<boost::uuids::uuid>=, =cron_expression=,
+=bool=. A regenerated =tenant_id= would come out as the codegen
+=utility::uuid::tenant_id= wrapper, not the hand-written =std::optional=
+type, so even the "safe" domain/repository-entity/mapper facets would
+regenerate *wrong types*, not just wrong formatting) on top of the
+deeper repository/service/messaging divergence documented under
+=** Custom repository methods= below.
 None of this is modeled here yet; regenerating clobbers it with a
 generic CRUD-only stack (and silently wrong column types) that breaks
 all of the above. This model needs a proper resync -- correcting the
 column shapes to match the hand-written struct, then re-adding
 repository/messaging support for the four hand-written operations --
-before any facet of it can be regenerated safely. Mirrors =party='s
-hand-maintained-SQL treatment in the refdata drift-fix task, but wider
-in scope (no facet is currently safe, not just SQL).
+before any facet of it can be regenerated safely. The Qt facet is
+equally excluded: its generated controllers/dialogs bind to the
+hand-maintained =scheduler_protocol.hpp= classes, so a Qt regen would
+emit code against a protocol surface that does not exist. Mirrors
+=party='s hand-maintained-SQL treatment in the refdata drift-fix task,
+but wider in scope (no facet is currently safe, not just SQL).
 
 * Flags
 :PROPERTIES:
@@ -230,6 +220,23 @@ Payload for nats_publish action type.
 | ModifiedBy   | modified_by         | Modified By | string | 120   |
 
 ** Custom repository methods
+
+- =job_definition_repository.hpp= hand-implements =read_all_active=
+  (used by =scheduler_loop= to load every job it needs to fire,
+  regardless of tenant) and =find_by_name= x2 (used by
+  =save_definition='s name-collision dedup so an existing job updates
+  in-place instead of hitting a unique-constraint violation).
+- =job_definition_handler.hpp= hand-implements =schedule=/
+  =schedule_batch=/=unschedule= (domain-named, permission-gated
+  wrappers with custom NATS subjects and a batch-save operation with
+  partial-failure reporting) and a custom =history= whose request/
+  response shape differs from the generic one and would collide by
+  name if paste-blocked in alongside it. Their protocol structs live
+  in the separate, hand-maintained =scheduler_protocol.hpp=, consumed
+  not just by this component's own Qt UI (=JobDefinitionController=/
+  =JobDefinitionMdiWindow=/=JobDefinitionDetailDialog=/
+  =JobDefinitionAuditDialog=) and =registrar.cpp=, but cross-component
+  by =ores.reporting='s =report_scheduling_service=.
 
 * See also
 

--- a/projects/ores.scheduler/modeling/ores.scheduler.job_definition.org
+++ b/projects/ores.scheduler/modeling/ores.scheduler.job_definition.org
@@ -16,6 +16,38 @@
 Metadata overlay for a pg_cron cron.job entry. Tracks the job name,
 cron expression, SQL command, target database, and active state.
 
+DO NOT regenerate this entity at all -- every facet is out of sync with
+the hand-maintained C++ (the model's own =tenant_id=/=schedule_expression=/
+=is_active= column shapes don't match the hand-written =job_definition=
+struct's =utility::uuid::tenant_id=/=cron_expression=/=bool= types, so
+even the "safe" domain/repository-entity/mapper facets would regenerate
+*wrong types*, not just wrong formatting) on top of the deeper
+repository/service/messaging divergence below:
+- =job_definition_repository.hpp= hand-implements =read_all_active=
+  (used by =scheduler_loop= to load every job it needs to fire,
+  regardless of tenant) and =find_by_name= x2 (used by
+  =save_definition='s name-collision dedup so an existing job updates
+  in-place instead of hitting a unique-constraint violation).
+- =job_definition_handler.hpp= hand-implements =schedule=/
+  =schedule_batch=/=unschedule= (domain-named, permission-gated
+  wrappers with custom NATS subjects and a batch-save operation with
+  partial-failure reporting) and a custom =history= whose request/
+  response shape differs from the generic one and would collide by
+  name if paste-blocked in alongside it. Their protocol structs live
+  in the separate, hand-maintained =scheduler_protocol.hpp=, consumed
+  not just by this component's own Qt UI (=JobDefinitionController=/
+  =JobDefinitionMdiWindow=/=JobDefinitionDetailDialog=/
+  =JobDefinitionAuditDialog=) and =registrar.cpp=, but cross-component
+  by =ores.reporting='s =report_scheduling_service=.
+None of this is modeled here yet; regenerating clobbers it with a
+generic CRUD-only stack (and silently wrong column types) that breaks
+all of the above. This model needs a proper resync -- correcting the
+column shapes to match the hand-written struct, then re-adding
+repository/messaging support for the four hand-written operations --
+before any facet of it can be regenerated safely. Mirrors =party='s
+hand-maintained-SQL treatment in the refdata drift-fix task, but wider
+in scope (no facet is currently safe, not just SQL).
+
 * Flags
 :PROPERTIES:
 :schema:        public
@@ -24,19 +56,17 @@ cron expression, SQL command, target database, and active state.
 :has_tenant_id: true
 :END:
 
-* Primary key
+* Columns
+
+** id
 :PROPERTIES:
-:column:        id
-:type:          uuid
-:cpp_type:      boost::uuids::uuid
+:type:      uuid
+:cpp_type:  boost::uuids::uuid
 :uuid_check_fn: ores_utility_nil_uuid_fn()
+:primary_key: true
 :END:
 
 UUID primary key for the job definition.
-
-* Natural keys
-
-* Columns
 
 ** party_id
 :PROPERTIES:


### PR DESCRIPTION
## Summary

Folds the still-good commits from the five bookkeeping branches (feature/fx-spot-wire-codec-root-cause, feature/fix-scheduler-model-drift, feature/research-env-provider-prior-art, feature/fix-legacy-primary-key-heading-models, feature/rollout-classification-all-components) into a single change; the remaining commits were superseded by later main history. Closes the scheduler model drift task: the audit found job_definition fully hand-diverged, so no regeneration was attempted; the model file now documents the exclusion and carries the current format/conventions.

## Changes

- Close task fix-scheduler-model-drift on the inbox story: State DONE, audit record in * Plan, * Result section added
- Migrate ores.scheduler.job_definition model to current format (unified * Columns, :primary_key: property), no generated code touched
- Document job_definition's full hand-divergence with a DO NOT regenerate warning in the model file, mirroring party's hand-maintained treatment
- Record the scheduler drift decision in the story's * Decisions
- Verification: local build clean (linux-clang-debug-make); ctest 71/71 passed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Codegen developer experience improvements](https://orestudio.github.io/OreStudio/doc/agile/product_backlog/inbox/codegen_dx_improvements/story.html) | A083FE26-521D-4046-9E58-AFB901B28809 |
| Task | [Fix scheduler entity model drift: update to latest format and regenerate](https://orestudio.github.io/OreStudio/doc/agile/product_backlog/inbox/codegen_dx_improvements/task_fix-scheduler-model-drift.html) | 6C8E2943-2B2C-4BA6-B510-FDB2C6AA4D88 |
| Environment | jolly_knuth | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)