### PR TITLE
[agile,ores.marketdata] Close out oresmd story loose ends

### DIFF
--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.org
@@ -24,7 +24,8 @@ completeness is the goal; XML/conversion coverage is tracked
 separately (e.g. the [[id:A202712C-9CFD-48DC-9014-40BA5A9408C6][ORE
 curve-config/market-data XML round-trip task]] this story was split off
 from, which stays scoped to =YieldCurve= plus whatever asset classes
-oresmd already represents).
+oresmd already represents; that task has since been =ABANDONED=, its
+=* Result= recording why).
 
 * Status
 
@@ -39,20 +40,34 @@ oresmd already represents).
 
 * Acceptance
 
-- [ ] Every catalogued quote type has a corresponding, constructible
+- [X] Every catalogued quote type has a corresponding, constructible
   oresmd identifier shape (a variant member, or new fields/enum values
   on an existing one) with unit tests confirming it can be built and,
   where the catalogue gives a worked key example, projects to the
-  documented ORE key string.
-- [ ] =market_data_urn.org= (id:C3E053CA-0D4B-480B-9119-E11530160EC1)
+  documented ORE key string. -- with two documented caveats:
+  =RATING/TRANSITION_PROBABILITY= is descoped (the credit identifier
+  has no =provider=/=from_rating=/=to_rating= fields to carry it --
+  recorded in the credit task's =* Result= and the credit spec's enum
+  footer, tracked for its own task); and the shared
+  =volatility_surface_point= sub-schema lands on every identifier
+  struct, but only swaption vol projects a quote key today (see the vol
+  task's =* Result=) -- every non-swaption vol shape is constructible
+  and unit-tested, without a projection.
+- [X] =market_data_urn.org= (id:C3E053CA-0D4B-480B-9119-E11530160EC1)
   is updated per family as its task lands -- new asset classes get new
   "Worked examples" sections in the same style as the existing five;
   extended asset classes get their new fields documented in "Grammar"
-  and "Field justification" the same way existing fields are.
-- [ ] No existing asset class's current fields/behaviour regress --
+  and "Field justification" the same way existing fields are. (All
+  seven families now have worked-example sections -- inflation and
+  correlation added, the five originals extended; "Grammar"/"Field
+  justification" gained the =quote=/=model= fields; "Data model" now
+  covers all seven structs.)
+- [X] No existing asset class's current fields/behaviour regress --
   every extension is additive (new optional fields, new enum values),
   matching this story's own established "resolution is strictly
-  additive" principle.
+  additive" principle. (Verified mechanically: regeneration of every
+  generated oresmd file is byte-identical to the pre-story hand-crafted
+  originals -- the =codegen-drift= gate's zero-diff check.)
 
 * Tasks
 
@@ -100,8 +115,9 @@ oresmd already represents).
 - Full =curveconfig.xml=/=todaysmarket.xml=/market-data-quote-string
   *conversion* code for every family -- tracked, where it belongs, in
   the [[id:A202712C-9CFD-48DC-9014-40BA5A9408C6][ORE curve-config/market-data
-  XML round-trip task]] (scoped to =YieldCurve= for now) and future
-  tasks once each family's own ORES domain model exists.
+  XML round-trip task]] (scoped to =YieldCurve= for now; that task is
+  since =ABANDONED=, its =* Result= recording why) and future tasks
+  once each family's own ORES domain model exists.
 - Building the ORES domain models each new asset class's real data
   would live in (e.g. an actual inflation curve entity, a correlation
   matrix entity) -- this story only extends oresmd's *identifier*

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_close-out-oresmd-story-loose-ends.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_close-out-oresmd-story-loose-ends.org
@@ -8,7 +8,7 @@
 #+filetags: :market-data:identifiers:oresmd:oresmd-full-quote-type-coverage:sprint_25:v0:
 #+owner: marco
 #+branch: feature/oresmd-bookkeeping-loose-ends
-#+pr:
+#+pr: 1948
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-10
@@ -105,7 +105,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1948][#1948]] | [agile,ores.marketdata] Close out oresmd story loose ends |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_close-out-oresmd-story-loose-ends.org
+++ b/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_close-out-oresmd-story-loose-ends.org
@@ -1,0 +1,144 @@
+:PROPERTIES:
+:ID: 8ECE84FD-D5F6-41B2-AAEB-F63BB1E9D09C
+:END:
+#+title: Task: Close out oresmd story loose ends
+#+description: Story D566131C is DONE but two loose ends remained: its acceptance checkboxes unticked with market_data_urn.org never updated per family, and a story link resolving to the wrong document via an org-ID collision. Close both.
+#+type: task
+#+level: s1
+#+filetags: :market-data:identifiers:oresmd:oresmd-full-quote-type-coverage:sprint_25:v0:
+#+owner: marco
+#+branch: feature/oresmd-bookkeeping-loose-ends
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-10
+#+updated: 2026-08-10
+#+environment: merry_newton
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE quote-type coverage]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Story [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full
+ORE quote-type coverage]] is =DONE= (all nine tasks merged), but two
+loose ends were left:
+
+- The story's acceptance bullets were unticked, and its
+  =market_data_urn.org= (id:C3E053CA-0D4B-480B-9119-E11530160EC1)
+  contract had not been updated per family -- last touched 2026-07-27,
+  before any of the story's August tasks landed, so it still said five
+  asset classes and had no worked examples for inflation or
+  correlation.
+- The story's out-of-scope link to the abandoned ORE
+  curve-config/market-data XML round-trip task (id:A202712C-9CFD-48DC-9014-40BA5A9408C6)
+  resolved to the wrong document -- the correlation quote-type spec
+  carried that task's =:ID:=, since the specs were templated from task
+  docs and inherited their IDs.
+
+Close both: bring the design doc up to date per family, reconcile the
+acceptance checkboxes with delivered scope honestly, and fix the
+colliding spec IDs so the story's links resolve to the abandoned task
+doc again.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE quote-type coverage]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-08-10                               |
+
+* Acceptance
+
+- [X] The five colliding =*_quote_type.org= spec =:ID:=s (correlation,
+  equity, inflation, commodity, credit) replaced with fresh UUIDs;
+  nothing references the specs by ID (the batch manifest keys them by
+  filename), verified codegen-neutral via the =codegen-drift= gate's
+  zero-diff regeneration.
+- [X] =market_data_urn.org= updated per family: new "Worked examples"
+  sections for inflation and correlation in the same style as the
+  existing five; extended families documented with their new =quote=/
+  =model= fields in "Grammar" and "Field justification"; "Data model"
+  covers all seven identifier structs plus the shared
+  =volatility_surface_point= sub-schema; =#+updated:= bumped.
+- [X] Story's acceptance bullets ticked with honest caveats:
+  =RATING/TRANSITION_PROBABILITY= descoped (credit task Result + spec
+  enum footer), and only swaption vol projects a quote key today (vol
+  task Result); no regression claimed without the drift gate's evidence.
+- [X] Story's references to the split-off XML round-trip task resolve
+  to it again and flag its =ABANDONED= state.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+- Fix the spec ID collisions first: regenerate and diff to prove the
+  :ID: changes are codegen-neutral.
+- Re-read each spec's Test cases and the projections implementation,
+  then update =market_data_urn.org= per family -- new sections where
+  the story's acceptance demands them, extensions to the existing
+  Grammar/Field justification rows.
+- Reconcile the story's acceptance bullets against delivered scope,
+  ticking only what is true as written or with an explicit honest
+  note.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Closed both loose ends on story
+[[id:D566131C-D08C-4AFE-950E-B3DD26EB2C24][Extend oresmd to full ORE
+quote-type coverage]]:
+
+- *Spec ID collisions fixed*: five of the seven =*_quote_type.org=
+  specs (correlation, equity, inflation, commodity, credit) carried
+  task-doc =:ID:=s inherited from templating. Each got a fresh UUID.
+  Verified codegen-neutral: regenerating every oresmd output file in
+  place produced no diff beyond the :ID: edits themselves, and the
+  =codegen-drift= gate reports "No drift: regenerated output matches
+  the checked-in tree".
+- *=market_data_urn.org= brought up to date*: new "Worked examples"
+  sections for inflation (zc/yy swap, seasonality -- the one 5-segment
+  shape with a literal =MULT=) and correlation (factor-pair entity);
+  the existing five families extended with =quote=/=model= worked rows;
+  "Grammar" documents =quote= and =model=; "Field justification" gains
+  rows for both; "Data model" now covers all seven identifier structs
+  and the shared =volatility_surface_point= sub-schema; =#+updated:=
+  bumped to 2026-08-10.
+- *Acceptance reconciled honestly*: all three bullets ticked -- bullet
+  1 with two explicit caveats (=RATING/TRANSITION_PROBABILITY=
+  descoped, needs provider/from_rating/to_rating the credit identifier
+  has no equivalent for; only swaption vol projects a quote key today),
+  bullet 3 with the drift gate's zero-diff evidence. The story's
+  references to the split-off XML round-trip task now resolve to the
+  abandoned task doc (id:A202712C-9CFD-48DC-9014-40BA5A9408C6) and flag
+  its =ABANDONED= state.

--- a/doc/knowledge/domain/market_data_urn.org
+++ b/doc/knowledge/domain/market_data_urn.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :marketdata:identifiers:design:
 #+created: 2026-07-27
-#+updated: 2026-07-27
+#+updated: 2026-08-10
 
 * Summary
 
@@ -23,8 +23,9 @@ own schemas key off that projects deterministically into ORE's index
 name, curve key, and quote key. Because its optional metadata (tenor,
 curve role, index family, ...) lives in the URI's query string rather
 than fixed path positions, the same grammar covers every asset class —
-FX, interest rates, swaptions, equities, credit, commodities — without
-per-asset-class variants or =NONE= placeholders. It generalises the one
+FX, interest rates, swaptions, equities, credit, commodities, inflation,
+correlation — without per-asset-class variants or =NONE= placeholders.
+It generalises the one
 place ORE Studio already gets this right
 ([[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][=fx_spot_generation_config.ore_key=]])
 and supersedes the free-text qualifier in
@@ -162,7 +163,8 @@ oresmd://<asset_class>/<entity>[?<query>]
 
 - =asset_class= (the URI's authority/host component, not a path
   segment — the =//= before it makes it so): one of =ir=, =fx=,
-  =equity=, =credit=, =commodity= — matches the asset-class sections of
+  =equity=, =credit=, =commodity=, =inflation=, =correlation= — matches
+  the asset-class sections of
   [[id:F3010EA7-6A0E-405C-81FA-1EF051749B5E][External market data
   identifiers]] exactly, so every worked example in that document has a
   direct =oresmd= counterpart below. A =boost::urls::url=
@@ -172,7 +174,9 @@ oresmd://<asset_class>/<entity>[?<query>]
   (=usd=) for IR, a 6-character currency pair (=eurusd=) for FX, a
   ticker or index code (=aapl=, =sp5=) for equities, a reference-entity
   name (=itraxx-europe=, =vod=) for credit, a commodity code (=gold=,
-  =wti=) for commodities.
+  =wti=) for commodities, an inflation index code (=ukrpi=) for
+  inflation, and a hyphen-separated factor pair (=ccy-eur-usd=) for
+  correlation.
 - Query parameters (all optional; each asset class documents which it
   uses):
   - =ccy=: settlement/quote currency, when distinct from =entity=
@@ -188,6 +192,16 @@ oresmd://<asset_class>/<entity>[?<query>]
   - =type=: instrument type, one of =fixing= (a rate fixing/index),
     =curve= (a whole curve), =quote= (one raw quote/point), or =vol=
     (a volatility surface point) — used by every asset class.
+  - =quote=: *only meaningful when =type=quote=* — the ORE quote TYPE
+    (e.g. =ir_swap=, =mm=, =cds=, =fwd=), the first segment of ORE's
+    =TYPE/METRIC/...= quote key. A per-asset-class enum, independent of
+    the =metric= column: for an IR =ir_swap= the metric is =RATE=, for a
+    =basis_swap= it is =BASIS_SPREAD=. Absent, it defaults to the asset
+    class's canonical quote type (=spot= for FX/equity/commodity,
+    =cds= for credit), and the projection yields no quote key where no
+    default exists (IR and inflation, whose =quote= is required for a
+    =type=quote= projection); correlation never uses it, since its only
+    quote type is hardcoded =CORRELATION/RATE=.
   - =metric=: *only meaningful when =type=quote=* — disambiguates *what
     kind* of quote =point= refers to, since a coordinate on an IR curve
     is ambiguous between a par rate observed in the market
@@ -195,10 +209,18 @@ oresmd://<asset_class>/<entity>[?<query>]
     curve (=discount_factor=) — see [[*Tenor vs. point, and the
     par-rate/discount-factor ambiguity][below]] for why this is a
     separate field from =tenor=/=point= rather than folded into either.
+    A per-asset-class enum (e.g. =basis_spread=, =ratio=, =price=,
+    =yield_spread=); absent, it defaults from the =quote= type's own
+    metric (an =ir_swap= defaults to =rate=, a =basis_swap= to
+    =basis_spread=).
+  - =model=: *only meaningful when =type=vol=* — the volatility model
+    subtype, one of =rate_lnvol=, =rate_nvol=, =rate_slnvol=, =shift=,
+    =price=. Defaults to =rate_lnvol=.
   - =point=: the term-structure or surface coordinate for a =quote=/=vol=
     URI (a swap tenor, a curve point, or a comma-separated surface
-    coordinate like =5y,2y,atm=) — absent for scalar quotes (FX spot,
-    equity spot).
+    coordinate like =5y,2y,atm= — expiry, tenor, strike for =type=vol=)
+    — absent for scalar quotes (FX spot, equity spot, correlation,
+    recovery rate).
 
 ** Tenor vs. point, and the par-rate/discount-factor ambiguity
 
@@ -239,8 +261,10 @@ speculative fields:
 | =tenor= | Closes the tenor-index gap directly: "two configs sharing =currency_code=... can only be told apart if their free-text =index_name= strings happen to differ" — =tenor= is now a distinct, structured query key, so =usd/libor/3m= and =usd/libor/6m= are structurally distinct URIs, not string-lookalikes. |
 | =role= | Closes the discount-vs-projection gap directly: "nothing records that a =USD-LIBOR-3M= curve is a *projection* curve, not the *discount* curve" — =role= is an explicit query key with no default that could be silently wrong. |
 | =type= | Closes: =curve_feed_controller='s qualifier "has no concept of curve family... or of curve role, so it cannot express 'these two curves legitimately coexist'" — by separating *what kind of thing* (fixing/curve/quote/vol) from the coordinates, two records can now share every other field while differing only in =type= without being mistaken for a collision. |
+| =quote= | A gap surfaced while applying this design: a =type=quote= URI with only =type=/=metric=/=point= does not name *which* ORE quote TYPE it is — the same =point= on the same =metric= can be quoted as different =TYPE/METRIC= pairs (=IR_SWAP/RATE= vs =MM/RATE= vs =ZERO/RATE=). =quote= names that TYPE (the first segment of ORE's quote key) as a per-asset-class enum, so a market observation is pinned to exactly one catalogue quote type; without it, projection would have to guess. |
 | =point= | Closes: =market_series='s "=qualifier= is a single free-text column, not a per-type fixed-dimension tuple" — =point= is the structured slot for exactly the tenor/coordinate =market_series= currently has no dedicated field for. |
 | =metric= | Closes a gap surfaced while applying this design, not the original gap analysis directly: without it, =tenor=+=point= alone cannot distinguish a par-rate quote (=IR_SWAP/RATE=) from a curve-sampled discount factor (=DISCOUNT/RATE=) at the same coordinate — two different ORE quote types the catalogue documents as alternatives to each other, not variants of the same thing. |
+| =model= | A gap surfaced while applying the volatility-surface sub-schema: a =type=vol= URI's =point= coordinate (expiry, tenor, strike) does not name the model whose surface it samples — =RATE_LNVOL=, =RATE_NVOL=, =RATE_SLNVOL=, =SHIFT=, or =PRICE= — and the parser must not silently default it. =model= names that subtype as an enum, defaulting to =rate_lnvol=. |
 
 * Projection rules
 
@@ -291,6 +315,10 @@ comparison table has a direct =oresmd= counterpart here.
 | oresmd URI | Quote key |
 |------------+-----------|
 | =oresmd://fx/eurusd?type=quote= | =FX/RATE/EUR/USD= |
+| =oresmd://fx/eurusd?type=quote&quote=fwd&point=6m= | =FXFWD/RATE/EUR/USD/6M= |
+
+=quote= defaults to =spot=; =fwd= (forward points) is tenor-shaped and
+needs =point=.
 
 ** Interest rates
 
@@ -301,8 +329,19 @@ comparison table has a direct =oresmd= counterpart here.
 | =oresmd://ir/usd?index=sofr&tenor=1d&role=discount&type=fixing= | =USD-SOFR= | =Yield/USD/USD1D= | — |
 | =oresmd://ir/eur?index=euribor&tenor=6m&role=projection&type=fixing= | =EUR-EURIBOR-6M= | =Yield/EUR/EUR6M= | — |
 | =oresmd://ir/eur?index=estr&tenor=1d&role=discount&type=fixing= | =EUR-ESTR= | =Yield/EUR/EUR1D= | — |
-| =oresmd://ir/usd?index=libor&tenor=3m&role=projection&type=quote&metric=par_rate&point=5y= | — | — | =IR_SWAP/RATE/USD/2D/3M/5Y= |
-| =oresmd://ir/usd?index=libor&tenor=3m&role=projection&type=quote&metric=discount_factor&point=6m= | — | — | =DISCOUNT/RATE/USD/USD3M/6M= |
+| =oresmd://ir/usd?index=libor&tenor=3m&role=projection&type=quote&quote=ir_swap&metric=rate&point=5y= | — | — | =IR_SWAP/RATE/USD/2D/3M/5Y= |
+| =oresmd://ir/usd?index=libor&tenor=3m&role=projection&type=quote&quote=discount&metric=rate&point=6m= | — | — | =DISCOUNT/RATE/USD/USD3M/6M= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=mm&metric=rate&point=1m= | — | — | =MM/RATE/EUR/EURIBOR/3M/1M= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=fra&metric=rate&point=6m= | — | — | =FRA/RATE/EUR/EURIBOR/3M/6M= |
+| =oresmd://ir/usd?index=libor&tenor=3m&type=quote&quote=imm_fra&metric=rate&point=5y= | — | — | =IMM_FRA/RATE/USD/LIBOR/3M/5Y= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=basis_swap&metric=basis_spread&point=5y= | — | — | =BASIS_SWAP/BASIS_SPREAD/EUR/EURIBOR/3M/5Y= |
+| =oresmd://ir/eur?tenor=3m&type=quote&quote=cc_basis_swap&metric=basis_spread&point=5y= | — | — | =CC_BASIS_SWAP/BASIS_SPREAD/EUR/3M/5Y= |
+| =oresmd://ir/usd?tenor=3m&type=quote&quote=cc_fix_float_swap&metric=rate&point=5y= | — | — | =CC_FIX_FLOAT_SWAP/RATE/USD/3M/5Y= |
+| =oresmd://ir/usd?tenor=3m&type=quote&quote=bma_swap&metric=ratio&point=5y= | — | — | =BMA_SWAP/RATIO/USD/3M/5Y= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=zero&metric=rate&point=5y= | — | — | =ZERO/RATE/EUR/EURIBOR/3M/5Y= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=zero&metric=yield_spread&point=5y= | — | — | =ZERO/YIELD_SPREAD/EUR/EURIBOR/3M/5Y= |
+| =oresmd://ir/eur?index=euribor&tenor=3m&type=quote&quote=mm_future&metric=price&point=cme= | — | — | =MM_FUTURE/PRICE/EUR/EURIBOR/3M/CME= |
+| =oresmd://ir/usd?index=sofr&tenor=3m&type=quote&quote=oi_future&metric=price&point=cme= | — | — | =OI_FUTURE/PRICE/USD/SOFR/3M/CME= |
 
 *** Tenor-index gap, resolved
 
@@ -330,39 +369,84 @@ similar-looking =index_name= strings happen to mean.
 | oresmd URI | Quote key |
 |------------+-----------|
 | =oresmd://ir/eur?type=vol&point=5y,2y,atm= | =SWAPTION/RATE_LNVOL/EUR/5Y/2Y/ATM= |
+| =oresmd://ir/eur?type=vol&model=rate_nvol&point=5y,2y,atm= | =SWAPTION/RATE_NVOL/EUR/5Y/2Y/ATM= |
 
 (=index=/=tenor=/=role= are absent here — a swaption vol surface point
 is about the underlying swap's expiry/tenor/strike coordinate, carried
 entirely in =point=, not about a benchmark index the way a fixing or
 curve is; this is exactly the per-asset-class conditionality the
-query-parameter grammar exists to express.)
+query-parameter grammar exists to express. =model= names the volatility
+model subtype — =rate_lnvol= by default, or =rate_nvol=/=rate_slnvol=/
+=shift=/=price= — since the same coordinate can be quoted under
+different models. The shared =volatility_surface_point= struct carries
+the three =point= dimensions (expiry, tenor, strike) plus =model_subtype=
+as typed fields.)
 
 ** Equities and indices
 
 | oresmd URI | Quote key |
 |------------+-----------|
 | =oresmd://equity/aapl?ccy=usd&type=quote= | =EQUITY/PRICE/AAPL/USD= |
+| =oresmd://equity/aapl?ccy=usd&type=quote&quote=dividend&point=1y= | =EQUITY_DIVIDEND/RATE/AAPL/USD/1Y= |
+| =oresmd://equity/lufthansa?ccy=eur&type=quote&quote=fwd&point=6m= | =EQUITY_FWD/PRICE/LUFTHANSA/EUR/6M= |
 
 (=ccy= is required here since, unlike IR where =entity= already is the
 currency, an equity's =entity= is a ticker — the quote currency is
-independent information.)
+independent information. =quote= defaults to =spot=; =dividend= and
+=fwd= are tenor-shaped and need =point=.)
 
 ** Credit
 
 | oresmd URI | Quote key |
 |------------+-----------|
 | =oresmd://credit/itraxx-europe?ccy=eur&type=quote&point=sr,5y= | =CDS/CREDIT_SPREAD/ITRAXX-EUROPE/SR/EUR/5Y= |
+| =oresmd://credit/vod?ccy=eur&type=quote&quote=hazard_rate&point=sr,5y= | =HAZARD_RATE/RATE/VOD/SR/EUR/5Y= |
+| =oresmd://credit/vod?ccy=eur&type=quote&quote=recovery_rate&point=sr= | =RECOVERY_RATE/RATE/VOD/SR/EUR= |
+| =oresmd://credit/cdx-na-ig?ccy=usd&type=quote&quote=cds_index&point=5y,0.1= | =CDS_INDEX/BASE_CORRELATION/CDX-NA-IG/5Y/0.1= |
+| =oresmd://credit/2i65byeg6?ccy=usd&type=quote&quote=index_cds_tranche&point=5y,0.07= | =INDEX_CDS_TRANCHE/BASE_CORRELATION/2I65BYEG6/5Y/0.07= |
 
 (=point= carries both the seniority and tenor dimensions here, since
 credit's quote-key shape has one more dimension than IR's — again, the
 query-parameter grammar absorbs this without needing a dedicated
-=seniority= key for every asset class that happens not to need one.)
+=seniority= key for every asset class that happens not to need one.
+=quote= defaults to =cds=; the base-correlation types (=cds_index=,
+=index_cds_tranche=) drop the =ccy= segment from their quote key,
+carrying only the index/tranche + point.)
 
 ** Commodities
 
 | oresmd URI | Quote key |
 |------------+-----------|
 | =oresmd://commodity/gold?ccy=usd&type=quote= | =COMMODITY/PRICE/GOLD/USD= |
+| =oresmd://commodity/wti?ccy=usd&type=quote&quote=fwd&point=6m= | =COMMODITY_FWD/PRICE/WTI/USD/6M= |
+
+=quote= defaults to =spot=; =fwd= and =cpr= are tenor-shaped and need
+=point=.
+
+** Inflation
+
+| oresmd URI | Quote key |
+|------------+-----------|
+| =oresmd://inflation/ukrpi?type=quote&quote=zc_swap&point=5y= | =ZC_INFLATIONSWAP/RATE/UKRPI/5Y= |
+| =oresmd://inflation/ukrpi?type=quote&quote=yy_swap&point=5y= | =YY_INFLATIONSWAP/RATE/UKRPI/5Y= |
+| =oresmd://inflation/ukrpi?type=quote&quote=seasonality&point=jan= | =SEASONALITY/RATE/MULT/UKRPI/JAN= |
+
+The =entity= is the inflation index code (e.g. =ukrpi=); there is no
+=ccy= — the index code already identifies the index. =quote= is
+required (no default). The seasonality shape is the one 5-segment
+exception in the family, with a literal =MULT= segment.
+
+** Correlation
+
+| oresmd URI | Quote key |
+|------------+-----------|
+| =oresmd://correlation/ccy-eur-usd?type=quote&quote=pairwise= | =CORRELATION/RATE/CCY-EUR-USD= |
+
+The =entity= is a hyphen-separated factor pair (=ccy-eur-usd= = EUR vs
+USD), with the factor-class prefix (=ccy=) as its first segment; the
+quote key is the entity itself, uppercase, after =CORRELATION/RATE=.
+=quote= is never used (pairwise is the only quote type); =point= is
+rejected.
 
 * Data model
 
@@ -380,32 +464,37 @@ Deliberately *no* abstract base class or virtual dispatch: one
 independent, strongly-typed, plain struct per asset class
 (=fx_market_data_identifier=, =ir_market_data_identifier=,
 =equity_market_data_identifier=, =credit_market_data_identifier=,
-=commodity_market_data_identifier=), each exposing *only* the fields
+=commodity_market_data_identifier=, =inflation_market_data_identifier=,
+=correlation_market_data_identifier=), each exposing *only* the fields
 that asset class actually uses (an =fx_market_data_identifier= has no
 =index_family=/=tenor=/=curve_role= members at all, rather than
 =NONE=-valued ones), mirroring the query-parameter grammar's own
-conditionality at the type level. The five identifier structs are tied
-together only as a =std::variant<...>= (aliased =market_data_identifier=
-for readability), never as siblings of a common base — since the URI's
-=asset_class= authority component already tells a consumer which
-concrete struct it is looking at, a base class/virtual interface would
-buy nothing an ordinary tagged union does not already provide, and it
-would come at a real cost: reflection-based serialisation libraries
-(e.g. =rfl=/reflect-cpp, a natural fit for round-tripping these plain
-structs to/from JSON or the database) generally handle plain structs
-and =std::variant= well but do not handle polymorphic class hierarchies
-gracefully. Three free functions do the asset-class dispatch instead of
-a virtual call: =parse_oresmd(uri) -> market_data_identifier= inspects
-the URI's =asset_class= component and constructs the matching concrete
-struct inside the variant; =to_uri(market_data_identifier) -> oresmd_uri=
-does the reverse via =std::visit=; =resolve(market_data_requirement,
-...) -> market_data_identifier= takes a requirement plus whatever
-additional information narrows it (a source, a vintage, an explicit
-choice among the fields still open) and, via =std::visit= over the
-requirement variant, either produces the matching identifier variant
-member or fails if fields remain unresolved.
+conditionality at the type level. Every identifier struct also carries
+a =volatility_surface_point= (expiry, strike, =volatility_model_subtype=,
+the model whose surface the point samples) for =type=vol= instruments,
+though only swaption vol projects a vol quote key today. The seven
+identifier structs are tied together only as a =std::variant<...>=
+(aliased =market_data_identifier= for readability), never as siblings
+of a common base — since the URI's =asset_class= authority component
+already tells a consumer which concrete struct it is looking at, a base
+class/virtual interface would buy nothing an ordinary tagged union does
+not already provide, and it would come at a real cost: reflection-based
+serialisation libraries (e.g. =rfl=/reflect-cpp, a natural fit for
+round-tripping these plain structs to/from JSON or the database)
+generally handle plain structs and =std::variant= well but do not
+handle polymorphic class hierarchies gracefully. Three free functions
+do the asset-class dispatch instead of a virtual call:
+=parse_oresmd(uri) -> market_data_identifier= inspects the URI's
+=asset_class= component and constructs the matching concrete struct
+inside the variant; =to_uri(market_data_identifier) -> oresmd_uri= does
+the reverse via =std::visit=; =resolve(market_data_requirement, ...) ->
+market_data_identifier= takes a requirement plus whatever additional
+information narrows it (a source, a vintage, an explicit choice among
+the fields still open) and, via =std::visit= over the requirement
+variant, either produces the matching identifier variant member or
+fails if fields remain unresolved.
 
-- A parallel =market_data_requirement= variant (same five asset
+- A parallel =market_data_requirement= variant (same seven asset
   classes, same "no base class" shape) mirrors the identifier variant
   field-for-field. Note that "resolved" does *not* mean
   "every field on the identifier class is non-null" — the swaption
@@ -435,7 +524,7 @@ member or fails if fields remain unresolved.
   absorbs those dimensions rather than getting dedicated fields of
   their own.
 
-#+caption: Proposed oresmd type system: five independent, non-inheriting structs per side (identifier/requirement), tied together only as a std::variant per side; free functions (parse_oresmd, to_uri, resolve) dispatch on the URI's asset_class rather than using virtual calls.
+#+caption: Proposed oresmd type system: seven independent, non-inheriting structs per side (identifier/requirement), tied together only as a std::variant per side; free functions (parse_oresmd, to_uri, resolve) dispatch on the URI's asset_class rather than using virtual calls.
 [[proj:doc/knowledge/domain/market_data_urn_types.png]]
 
 Source: [[./market_data_urn_types.puml][=market_data_urn_types.puml=]].

--- a/projects/ores.marketdata/modeling/oresmd/commodity_quote_type.org
+++ b/projects/ores.marketdata/modeling/oresmd/commodity_quote_type.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: C9C888AB-473D-4C91-BC30-9470E4080C5A
+:ID: 74607978-2963-409C-9731-E17F4CA98879
 :END:
 #+title: Commodity oresmd quote type family
 #+description: Quote types for commodity: spot, forward, CPR.

--- a/projects/ores.marketdata/modeling/oresmd/correlation_quote_type.org
+++ b/projects/ores.marketdata/modeling/oresmd/correlation_quote_type.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: A202712C-9CFD-48DC-9014-40BA5A9408C6
+:ID: F0031CB8-3B4E-4FD7-AC40-0F62C51FB332
 :END:
 #+title: Correlation oresmd quote type family
 #+description: Quote types for correlation: pairwise factor correlation.

--- a/projects/ores.marketdata/modeling/oresmd/credit_quote_type.org
+++ b/projects/ores.marketdata/modeling/oresmd/credit_quote_type.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: D7FC7525-5532-4498-8B7B-5F14215C99FD
+:ID: B56A4477-1768-4B03-A2DD-0244AF8FC4FF
 :END:
 #+title: Credit oresmd quote type family
 #+description: Quote types for credit: CDS, hazard rate, recovery rate, index/tranche base correlation.

--- a/projects/ores.marketdata/modeling/oresmd/equity_quote_type.org
+++ b/projects/ores.marketdata/modeling/oresmd/equity_quote_type.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: B87C97B8-415B-4C7D-9ACB-2B58EEFCB26E
+:ID: 1C692310-8CB2-4C93-AF67-F3642066D5D3
 :END:
 #+title: Equity oresmd quote type family
 #+description: Quote types for equity: spot, dividend rate, forward price.

--- a/projects/ores.marketdata/modeling/oresmd/inflation_quote_type.org
+++ b/projects/ores.marketdata/modeling/oresmd/inflation_quote_type.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: B91F6F7D-5C8A-4DB0-A5C6-827EEC43BE41
+:ID: BDE124FE-F386-4F3F-BBD0-A370FAEE2906
 :END:
 #+title: Inflation oresmd quote type family
 #+description: Quote types for inflation: ZC swap, YY swap, seasonality.


### PR DESCRIPTION
## Summary

Story D566131C (Extend oresmd to full ORE quote-type coverage) is DONE, but its acceptance had two loose ends: the checkboxes were unticked and market_data_urn.org was never updated per family, and the story's out-of-scope link to the abandoned XML round-trip task resolved to the wrong document via an org-ID collision. This bookkeeping PR closes both: per-family urn doc update, honest acceptance reconciliation, and colliding spec ID fixes.

## Changes

- market_data_urn.org (id:C3E053CA) updated per family: new 'Worked examples' sections for inflation and correlation in the same style as the existing five; extended families documented with their new =quote=/=model= fields in 'Grammar' and 'Field justification'; 'Data model' now covers all seven identifier structs plus the shared volatility_surface_point sub-schema; #+updated: bumped.
- Story D566131C: all three acceptance bullets ticked with honest caveats (RATING/TRANSITION_PROBABILITY descoped -- needs provider/from_rating/to_rating fields the credit identifier has no equivalent for; only swaption vol projects a quote key today -- see the vol task Result); bullet 3 backed by the drift gate's zero-diff evidence; references to the split-off XML round-trip task now resolve to it and flag its ABANDONED state.
- Fixed org-ID collisions: five oresmd *_quote_type.org specs inherited task-doc :ID:s when templated; each given a fresh UUID. Nothing references the specs by ID (the batch manifest keys them by filename), so the change is codegen-neutral.
- Verification: docs-only branch (no code or templates changed), so no local C++ build was run; the gates this branch can affect ran locally and are clean -- codegen-drift: 'No drift: regenerated output matches the checked-in tree' (all refdata/reporting/marketdata models); cmake-sources-drift: 'All component_files.cmake up to date'.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Extend oresmd to full ORE quote-type coverage](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/story.html) | D566131C-D08C-4AFE-950E-B3DD26EB2C24 |
| Task | [Close out oresmd story loose ends](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/extend-oresmd-full-quote-type-coverage/task_close-out-oresmd-story-loose-ends.html) | 8ECE84FD-D5F6-41B2-AAEB-F63BB1E9D09C |
| Environment | merry_newton | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)