### PR TITLE
[agile] Analyse CI workflows and map each check to its local equivalent

### DIFF
--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
@@ -49,10 +49,17 @@ The objective is higher velocity without losing quality. More analysis is needed
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | STARTED | 2026-08-11 | | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
+| [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | DONE | 2026-08-11 | 2026-08-11 | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
 | [[id:F0DEA73F-65B2-43C3-A83B-5A211F9C87ED][Scaffold story: Absorb PR checks locally]] | DONE | | 2026-08-11 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
 
 * Decisions
+
+- The analysis and the change-classification rule table live in the
+  [[id:BC85C0DF-99BE-4079-A649-88A236AE0ACF][CI workflows and local checks]] knowledge doc; the implementation tasks follow it.
+- Checks retire from the PR gate in favor of local runs; =pr-gate=
+  stays as the minimal required check (classify only).
+- GitHub CI keeps the continuous builds, nightlies, site deploy, and
+  coverage jobs.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
@@ -30,9 +30,9 @@ The objective is higher velocity without losing quality. More analysis is needed
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Not yet started.                       |
+| Now           | Analysis task DONE; implementation tasks follow. |
 | Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
+| Next          | Add the implementation tasks from the analysis.   |
 | Last touched  | 2026-08-11                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
@@ -28,7 +28,7 @@ The objective is higher velocity without losing quality. More analysis is needed
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -49,7 +49,7 @@ The objective is higher velocity without losing quality. More analysis is needed
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | BACKLOG | | | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
+| [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | STARTED | 2026-08-11 | | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
 | [[id:F0DEA73F-65B2-43C3-A83B-5A211F9C87ED][Scaffold story: Absorb PR checks locally]] | DONE | | 2026-08-11 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
@@ -8,7 +8,7 @@
 #+filetags: :local-checks-for-pr-velocity:sprint_25:v0:
 #+owner: marco
 #+branch: feature/analyse-ci-workflows-and-local-mapping
-#+pr:
+#+pr: 1960
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-11
@@ -72,7 +72,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1960][#1960]] | [agile] Analyse CI workflows and map each check to its local equivalent |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :local-checks-for-pr-velocity:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/analyse-ci-workflows-and-local-mapping
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-11
 #+updated: 2026-08-11
-#+environment:
+#+environment: solid_dirac
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -32,7 +32,7 @@ Define the change-classification rules the submit-PR skills will use: doc-only c
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
@@ -32,11 +32,11 @@ Define the change-classification rules the submit-PR skills will use: doc-only c
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-11                               |
 
 * Acceptance
@@ -47,9 +47,13 @@ Define the change-classification rules the submit-PR skills will use: doc-only c
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The analysis is recorded in the
+[[id:BC85C0DF-99BE-4079-A649-88A236AE0ACF][CI workflows and local checks]]
+knowledge doc: the full inventory of PR-gating checks, the fate of each
+(local / GitHub / retired), the change-classification rule table the
+submit-PR skills use, and the open questions the implementation tasks
+resolve. The story's =* Decisions= distills the durable choices at
+close.
 
 * Notes
 
@@ -77,3 +81,12 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Analysis delivered (see the PRs table): every check that gates a PR
+today is inventoried with its fate — run locally, stay on GitHub, or
+retire. The change-classification rule table (docs / code / ci /
+python tooling, mixed = union) is written. The analysis lives in the
+[[id:BC85C0DF-99BE-4079-A649-88A236AE0ACF][CI workflows and local checks]]
+knowledge doc, which the follow-up implementation tasks reference. All
+acceptance bullets are met. The story stays STARTED: the implementation
+tasks that absorb the checks locally are added next.

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.org
@@ -78,7 +78,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Story Status table stale: Now/Next still say "Not yet started" although the analysis is DONE and Decisions are recorded | story.org | accepted | Now/Next updated: analysis done, implementation tasks next |
 
 * Result
 

--- a/doc/knowledge/architecture/ci-workflows-and-local-checks.org
+++ b/doc/knowledge/architecture/ci-workflows-and-local-checks.org
@@ -1,0 +1,119 @@
+:PROPERTIES:
+:ID: BC85C0DF-99BE-4079-A649-88A236AE0ACF
+:END:
+#+title: CI workflows and local checks
+#+description: Every GitHub Actions workflow and check that gates a PR today, its fate after the absorb-PR-checks-locally story (run locally before submit, stay on GitHub, or retire), and the change-classification rules the submit-PR skills use to decide what to run.
+#+type: knowledge
+#+level: cross
+#+filetags: :ci:devops:pr:velocity:
+#+created: 2026-08-11
+#+updated: 2026-08-11
+
+* Summary
+
+The PR gate on GitHub runs six jobs: classify, site, roundtrip,
+cmake-sources-drift, codegen-drift, and pr-gate, plus an automatic
+Claude code review on every PR event. Only the site job adds real
+signal for docs-only changes; the drift checks catch stale generated
+files. The [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][absorb-PR-checks-locally story]] moves these checks local:
+the submit-PR skills classify the change and run only the matching
+checks before raising the PR. GitHub keeps the continuous builds,
+nightlies, site deploy, coverage, and housekeeping bots. This document
+is the inventory, the fate of every check, and the classification rule
+table.
+
+* Detail
+
+** The PR gate today
+
+The =pr.yml= workflow gates every pull request to =main=:
+
+| Job               | Runs when            | What it checks                                                        | Cost     |
+|-------------------+----------------------+-----------------------------------------------------------------------+----------|
+| classify          | always               | Path classifier; buckets every changed file into docs/code/ci         | ~3s      |
+| site              | docs or ci changed   | Site build + link check via CTestSite.cmake; submits to CDash as the "Site" group; no Doxygen | ~20 min  |
+| roundtrip         | code or ci changed   | =python3 scripts/ore_domain_roundtrip_check.py=                       | ~1 min   |
+| cmake-sources-drift | code or ci changed | =regenerate_cmake_component_files.py --all --check=; every component_files.cmake is up to date | ~1 min |
+| codegen-drift     | always               | =check_component_drift.py --components refdata,reporting,marketdata=; generated code matches templates | ~2 min |
+| pr-gate           | always               | Aggregates the jobs above; the branch-protection required check       | ~4s      |
+
+Two more workflows touch PR branches:
+
+- =claude-code-review.yml= runs the automatic Claude review on every
+  PR event (opened, synchronize, ready_for_review, reopened) — ~1-2 min.
+- =misspell.yml= runs the misspell fixer on every push to every branch
+  and opens auto-fix PRs (a bot, not a gate).
+
+** Fate of each check
+
+| Check                 | Fate         | Where it runs instead / rationale |
+|-----------------------+--------------+-----------------------------------|
+| classify              | stays        | Dispatcher for the minimal gate; the local skills mirror the same rules (see below). |
+| site                  | retired      | Local: =compass build --direct site= (same emacs export; ~5-10 min locally). Optional CDash submission as experimental. |
+| roundtrip             | retired      | Local: =python3 scripts/ore_domain_roundtrip_check.py=. |
+| cmake-sources-drift   | retired      | Local: =python3 projects/ores.codegen/scripts/regenerate_cmake_component_files.py --all --check=; the =codegen-sync-cmake-sources= skill wraps it. |
+| codegen-drift         | retired      | Local: tangle codegen templates (=compass build --direct codegen_templates=) then =check_component_drift.py= with the same components. |
+| pr-gate               | stays (minimal) | Aggregates only classify; keeps branch protection a single required check at ~7s. |
+| claude-code-review    | retired      | Local: the =code-review= skill runs before submit; findings go into the task's =* Review= table and are addressed in the round. The on-demand =@claude= trigger (=claude.yml=) stays. |
+| misspell              | retired      | Local misspell check folded into the review pass. |
+| site-cdash (Doxygen)  | stays        | =build-site.yml= builds the full site + Doxygen and deploys on main push. |
+| continuous-* (linux/macos/windows) | stays | Every 2/3/12h + tags: full build matrix + ctest, submitted to CDash as continuous. |
+| nightly-linux         | stays        | Daily: full build + =ctest -VV= to CDash Nightly + valgrind dynamic analysis. |
+| nightly-format        | stays        | Daily clang-format drift → auto-fix PR; local =tangle_clang_format= exists. |
+| ore_coverage          | stays        | Coverage on main push. |
+| shell-script-drift / template-drift | stays | Cheap main-push checks; local tangle equivalents exist (=tangle_shell_scripts=, =tangle_codegen_templates=). |
+| codeql-analysis, stale | stays       | Manual security scan; housekeeping bot. |
+
+** Change-classification rules
+
+The submit-PR skill classifies the diff and runs only the matching
+checks. The classes mirror =pr.yml='s classify buckets, with one
+addition (python tooling):
+
+| Class           | Paths                                                             | Checks the submit-PR skill runs                        |
+|-----------------+-------------------------------------------------------------------+--------------------------------------------------------|
+| docs            | =doc/*=, =assets/*=, =.claude/*=, =*.md=, =*.org=, =projects/*/modeling/*= (org/puml/png), =external/*= vendored | site build; review; misspell |
+| code (C++)      | =projects/ores.*= C++ sources, headers, =*.cmake=, =CMakeLists.txt= | full build + ctest; roundtrip; cmake-sources-drift; codegen-drift; review; misspell; CDash experimental |
+| ci              | =.github/*=, =projects/ores.codegen/library/templates/*=         | site; roundtrip; drift checks; review                  |
+| python tooling  | =projects/ores.compass/*=, =projects/ores.codegen/*= (non-template) | component test suite; drift checks; review; misspell  |
+
+A mixed change runs the union of its classes' checks.
+
+Gap the current classify rules hide: =pr.yml= buckets =ores.compass=
+and =ores.codegen= changes as docs, so the PR gate never runs their
+test suites. The local classification fixes this with the python
+tooling class above.
+
+** Local verification flow
+
+1. Classify the diff with the rule table.
+2. Run the checks for the class (site build, or build + =ctest --preset=).
+3. Submit the build to CDash as experimental for visibility
+   (=ctest --script CTest.cmake= with the experimental group; exact
+   invocation refined in the implementation task).
+4. Run the review skill locally; record findings in the task's
+   =* Review= table; address them.
+5. Record the verification in the PR description as a
+   =--change= bullet (e.g. "Verification: doc-only change; local site
+   build clean").
+6. Raise the PR. GitHub runs only classify + pr-gate; merge when
+   green. Continuous builds and nightlies stay on GitHub.
+
+** Open questions for the implementation tasks
+
+- Keep =pr-gate= as the required check with only classify inside, or
+  drop it and let the review be the gate? The story's default: keep
+  the minimal gate.
+- How experimental submissions are tagged and filtered out of the
+  continuous/nightly dashboards on CDash.
+- The classify rules live in two places (pr.yml and the skill); keep
+  them in sync, or extract a shared rules file the workflow and the
+  skill both read.
+- Which exact test suites run for python tooling changes
+  (compass, codegen).
+
+* See also
+
+- [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] — the story this analysis feeds.
+- [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] — the driving task.
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the knowledge index.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -232,6 +232,9 @@ How the codebase is put together.
   feed config parameters.
 - [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — preset menu, output directory layout, the
   conventions every component build follows.
+- [[id:BC85C0DF-99BE-4079-A649-88A236AE0ACF][CI workflows and local checks]] — every PR-gating check, its fate
+  (local / GitHub / retired), and the change-classification rules the
+  submit-PR skills use.
 - [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity lifecycle]] — layer ordering, type mappings, and service
   conventions for creating a full-stack entity.
 - [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — =ores.qt.api= contract, IPlugin


### PR DESCRIPTION
## Summary

Full analysis of the PR gate: every check inventoried with its fate (run locally, stay on GitHub, or retire), and the change-classification rule table the submit-PR skills will use to run only the checks a change needs. Recorded in a knowledge doc the implementation tasks reference.

## Changes

- Inventory of every PR-gating check with its fate: local, GitHub, or retired
- Change-classification rule table: docs / code (C++) / ci / python tooling; mixed changes run the union
- Verification: doc-only change; local site build clean (compass build --direct site)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Absorb PR checks locally: targeted checks, local review, CDash submissions](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.html) | 368E2B3E-CD2C-4FD5-90DD-D0E935810F4D |
| Task | [Analyse all CI workflows and map each check to its local equivalent](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_analyse-ci-workflows-and-local-mapping.html) | 1F491E74-E4C3-4F07-9E44-4E7667A613AD |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)