### PR TITLE
[agile] Classify changes and run targeted checks in submit-PR skills

### DIFF
--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
@@ -51,7 +51,7 @@ The objective is higher velocity without losing quality. More analysis is needed
 |------+-------+-------+-----+-------------|
 | [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | DONE | 2026-08-11 | 2026-08-11 | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
 | [[id:F0DEA73F-65B2-43C3-A83B-5A211F9C87ED][Scaffold story: Absorb PR checks locally]] | DONE | | 2026-08-11 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:000AD939-CEDD-487E-A23F-EAD86B3F1CE7][Classify changes and run targeted local checks in the submit-PR skills]] | STARTED | 2026-08-11 | | Replace the unconditional build and ctest in pr-raise with change classification: read the changed files, bucket them per the rule table in the CI workflows and local checks knowledge doc (docs / code / ci / python tooling), and run only the matching checks. Record the class and the verification in the PR description. pr-address-review reuses the classification for its per-round verification. |
+| [[id:000AD939-CEDD-487E-A23F-EAD86B3F1CE7][Classify changes and run targeted local checks in the submit-PR skills]] | DONE | 2026-08-11 | 2026-08-11 | Replace the unconditional build and ctest in pr-raise with change classification: read the changed files, bucket them per the rule table in the CI workflows and local checks knowledge doc (docs / code / ci / python tooling), and run only the matching checks. Record the class and the verification in the PR description. pr-address-review reuses the classification for its per-round verification. |
 
 * Decisions
 
@@ -61,6 +61,12 @@ The objective is higher velocity without losing quality. More analysis is needed
   stays as the minimal required check (classify only).
 - GitHub CI keeps the continuous builds, nightlies, site deploy, and
   coverage jobs.
+- The classification rule table lives in the =pr-raise= skill — one
+  place both submit-PR skills read; =pr-address-review= links to it.
+- =ctest= runs via =compass test run= (host-wide build lock); local
+  CDash submissions use =--cdash Experimental=.
+- The PR gate (=pr.yml=) is untouched by the classification task; its
+  reduction is a follow-up task.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.org
@@ -51,6 +51,7 @@ The objective is higher velocity without losing quality. More analysis is needed
 |------+-------+-------+-----+-------------|
 | [[id:1F491E74-E4C3-4F07-9E44-4E7667A613AD][Analyse all CI workflows and map each check to its local equivalent]] | DONE | 2026-08-11 | 2026-08-11 | Inventory every GitHub Actions workflow and check that gates PRs today (site checks, drift checks, build, ctest, code review, pr-gate, ...). For each, decide its fate: run locally before submit, stay on GitHub, or retire. Produce the change-classification rules the submit-PR skills will use. |
 | [[id:F0DEA73F-65B2-43C3-A83B-5A211F9C87ED][Scaffold story: Absorb PR checks locally]] | DONE | | 2026-08-11 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:000AD939-CEDD-487E-A23F-EAD86B3F1CE7][Classify changes and run targeted local checks in the submit-PR skills]] | STARTED | 2026-08-11 | | Replace the unconditional build and ctest in pr-raise with change classification: read the changed files, bucket them per the rule table in the CI workflows and local checks knowledge doc (docs / code / ci / python tooling), and run only the matching checks. Record the class and the verification in the PR description. pr-address-review reuses the classification for its per-round verification. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
@@ -8,7 +8,7 @@
 #+filetags: :local-checks-for-pr-velocity:sprint_25:v0:
 #+owner: marco
 #+branch: feature/classify-changes-and-run-targeted-checks
-#+pr:
+#+pr: 1966
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-11
@@ -71,7 +71,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1966][#1966]] | [agile] Classify changes and run targeted checks in submit-PR skills |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
@@ -26,11 +26,11 @@ The pr-raise skill now mandates the full build and ctest for every PR, even doc-
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-11                               |
 
 * Acceptance
@@ -43,9 +43,16 @@ The pr-raise skill now mandates the full build and ctest for every PR, even doc-
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+- The classification rule table lives in =pr-raise= (one place both
+  submit-PR skills read); =pr-address-review= links to it.
+- =ctest= goes via =compass=, never raw: the new =compass test run=
+  acquires the host-wide build lock and runs ctest; =--cdash GROUP=
+  runs the CTest.cmake script form (the same shape CI uses) for CDash
+  submissions.
+- The knowledge doc's local-flow step 3 records the refined CDash
+  invocation; the shared-rules open question resolves to "the skill
+  owns the rules" until the gate-reduction task decides whether
+  =pr.yml= needs its own copy.
 
 * Notes
 
@@ -73,3 +80,15 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+=pr-raise= now classifies the diff (docs / code (C++) / ci / python
+tooling; mixed = union) and runs only the matching checks. The rule
+table lives in =pr-raise= alone; =pr-address-review= links to it.
+=ctest= goes via the new =compass test run= (host-wide build lock;
+=--cdash GROUP= for the CTest.cmake script form), never raw.
+
+Verification for this change (python tooling + docs classes): compass
+suite 114 passed / 1 skipped; regenerate + codegen drift clean (no
+in-tree changes); local site build clean. All acceptance bullets met.
+The story stays STARTED: the gate-reduction task (=pr.yml=) and the
+local-review task follow.

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
@@ -80,6 +80,9 @@ via its "Verifies task" field.
 | 1 | =_cmd_test_run= crashes when the build lock is unavailable (no =fcntl=): unguarded =lock_file.close()= and a =ores-build.log.None= path | compass.py | accepted | Guarded like =cmd_build=; regression test =test_run_degrades_without_fcntl= added |
 | 2 | Knowledge doc local-flow step 2 still says "build + =ctest --preset=" | ci-workflows-and-local-checks.org | accepted | Now: =compass build= + =compass test run= |
 | 3 | ctest runs twice per PR (plain run + CDash script form) | pr-raise/SKILL.org | declined | Intentional: plain run for fast feedback; the script form rebuilds incrementally and submits for CDash visibility (story acceptance) |
+| 4 | Codegen-drift step runs =build --direct codegen_templates=, a target that does not exist (only =tangle_codegen_templates=) — following the skill skips the check | pr-raise/SKILL.org | accepted | Added =codegen_templates= alias to =BUILD_TARGET_ALIASES=; =test_direct_build.py= asserts every alias resolves to a known direct-build target |
+| 5 | Classification table has no catch-all bucket, unlike =pr.yml='s classify =*) code=true= default — unmatched paths map to zero classes and skip all checks | pr-raise/SKILL.org, ci-workflows-and-local-checks.org | accepted | Added "anything else" row (code class checks) to both tables |
+| 6 | =_cmd_test_run= duplicates =cmd_build='s lock/log lifecycle; factor into a shared helper | compass.py | declined | Two call sites only; factoring awaits a third caller (reviewer: not blocking) |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
@@ -77,7 +77,9 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =_cmd_test_run= crashes when the build lock is unavailable (no =fcntl=): unguarded =lock_file.close()= and a =ores-build.log.None= path | compass.py | accepted | Guarded like =cmd_build=; regression test =test_run_degrades_without_fcntl= added |
+| 2 | Knowledge doc local-flow step 2 still says "build + =ctest --preset=" | ci-workflows-and-local-checks.org | accepted | Now: =compass build= + =compass test run= |
+| 3 | ctest runs twice per PR (plain run + CDash script form) | pr-raise/SKILL.org | declined | Intentional: plain run for fast feedback; the script form rebuilds incrementally and submits for CDash visibility (story acceptance) |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
+++ b/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: 000AD939-CEDD-487E-A23F-EAD86B3F1CE7
+:END:
+#+title: Task: Classify changes and run targeted local checks in the submit-PR skills
+#+description: Replace the unconditional build and ctest in pr-raise with change classification: read the changed files, bucket them per the rule table in the CI workflows and local checks knowledge doc (docs / code / ci / python tooling), and run only the matching checks. Record the class and the verification in the PR description. pr-address-review reuses the classification for its per-round verification.
+#+type: task
+#+level: s1
+#+filetags: :local-checks-for-pr-velocity:sprint_25:v0:
+#+owner: marco
+#+branch: feature/classify-changes-and-run-targeted-checks
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-11
+#+updated: 2026-08-11
+#+environment: solid_dirac
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The pr-raise skill now mandates the full build and ctest for every PR, even doc-only ones. Replace that: classify the changed files, run only the checks the class needs, and record the verification in the PR description. pr-address-review reuses the classification for its per-round verification.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:368E2B3E-CD2C-4FD5-90DD-D0E935810F4D][Absorb PR checks locally: targeted checks, local review, CDash submissions]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-11                               |
+
+* Acceptance
+
+- The pr-raise skill classifies the changed files into docs / code (C++) / ci / python tooling; a mixed change runs the union of its classes.
+- Only the checks that match the class run locally: a doc-only change runs the site build and nothing heavier.
+- The classification rules live in one place that both submit-PR skills read, resolving the shared-rules open question.
+- The change class and the verification are recorded in the PR description as a --change bullet.
+- pr-address-review applies the same classification to its per-round local verification.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/knowledge/architecture/ci-workflows-and-local-checks.org
+++ b/doc/knowledge/architecture/ci-workflows-and-local-checks.org
@@ -87,7 +87,8 @@ tooling class above.
 ** Local verification flow
 
 1. Classify the diff with the rule table.
-2. Run the checks for the class (site build, or build + =ctest --preset=).
+2. Run the checks for the class (site build, or =compass build= +
+   =compass test run=).
 3. Submit the build to CDash as experimental for visibility
    (=./compass.sh test run --preset <preset> --cdash Experimental=;
    runs the CTest.cmake script under the build lock, same shape CI

--- a/doc/knowledge/architecture/ci-workflows-and-local-checks.org
+++ b/doc/knowledge/architecture/ci-workflows-and-local-checks.org
@@ -89,8 +89,9 @@ tooling class above.
 1. Classify the diff with the rule table.
 2. Run the checks for the class (site build, or build + =ctest --preset=).
 3. Submit the build to CDash as experimental for visibility
-   (=ctest --script CTest.cmake= with the experimental group; exact
-   invocation refined in the implementation task).
+   (=./compass.sh test run --preset <preset> --cdash Experimental=;
+   runs the CTest.cmake script under the build lock, same shape CI
+   uses).
 4. Run the review skill locally; record findings in the task's
    =* Review= table; address them.
 5. Record the verification in the PR description as a

--- a/doc/knowledge/architecture/ci-workflows-and-local-checks.org
+++ b/doc/knowledge/architecture/ci-workflows-and-local-checks.org
@@ -76,6 +76,7 @@ addition (python tooling):
 | code (C++)      | =projects/ores.*= C++ sources, headers, =*.cmake=, =CMakeLists.txt= | full build + ctest; roundtrip; cmake-sources-drift; codegen-drift; review; misspell; CDash experimental |
 | ci              | =.github/*=, =projects/ores.codegen/library/templates/*=         | site; roundtrip; drift checks; review                  |
 | python tooling  | =projects/ores.compass/*=, =projects/ores.codegen/*= (non-template) | component test suite; drift checks; review; misspell  |
+| anything else   | any path matching no bucket above                                | code class checks; review; misspell                   |
 
 A mixed change runs the union of its classes' checks.
 

--- a/doc/llm/skills/pr-address-review/SKILL.org
+++ b/doc/llm/skills/pr-address-review/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
-#+updated: 2026-07-11
+#+updated: 2026-08-11
 
 #+begin_export markdown
 ---
@@ -54,13 +54,13 @@ Review comments arrived on a PR: handle one complete round — sync, read, decid
 4. /Decide per comment/ — explicit accept or decline; never silently ignore.
 
 5. /Fix/ — one commit per logical fix; never amend on a branch under
-   review. Build and run tests locally before pushing (same preset as
-   =pr-raise=) — this is the only local verification a round gets, so
-   don't skip it. Update the task's =* Review= table (step 7) for this
-   round and include that in the *same* push as the fixes — never push
-   a bookkeeping-only commit after this round's CI has already gone
-   green; that wastes a full CI cycle recording something with no code
-   content. Push.
+   review. Classify the round's fix with the [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][pr-raise]] rule table and
+   run only the matching checks locally before pushing — this is the
+   only local verification a round gets, so don't skip it. Update the
+   task's =* Review= table (step 7) for this round and include that in
+   the *same* push as the fixes — never push a bookkeeping-only commit
+   after this round's CI has already gone green; that wastes a full CI
+   cycle recording something with no code content. Push.
 
 6. /Reply to every comment/ — accepted: "Fixed in <sha> — ..."; declined: "Not changed. <reason>":
 

--- a/doc/llm/skills/pr-raise/SKILL.org
+++ b/doc/llm/skills/pr-raise/SKILL.org
@@ -56,6 +56,11 @@ lifecycle is ordered this way.
    | code (C++)     | =projects/ores.*= C++ sources and headers, =*.cmake=, =CMakeLists.txt= | Full build + ctest; roundtrip; drift checks; CDash experimental |
    | ci             | =.github/*=, =projects/ores.codegen/library/templates/*=      | Site build; roundtrip; drift checks |
    | python tooling | =projects/ores.compass/*=, =projects/ores.codegen/*= (non-template) | Compass test suite; drift checks |
+   | anything else  | any path matching no bucket above                             | Code class checks (full build + ctest; roundtrip; drift checks) |
+
+   The catch-all defaults an unmatched path to the code class, mirroring
+   =pr.yml='s classify default — a change that matches no bucket still
+   gets the full build.
 
    The checks:
 

--- a/doc/llm/skills/pr-raise/SKILL.org
+++ b/doc/llm/skills/pr-raise/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :llm:skill:pr:github:claude:review:
 #+created: 2026-06-07
-#+updated: 2026-07-11
+#+updated: 2026-08-11
 
 #+begin_export markdown
 ---
@@ -35,24 +35,58 @@ lifecycle is ordered this way.
 
 * How to use this skill
 
-1. *MANDATORY — build and run tests locally first, and do not skip
-   this even under time pressure*. CI no longer runs a full C++
-   build/test job on PRs (the old "canary" job was removed — it took
-   too long and slowed down development), so this step is the *only*
-   thing that catches a broken build before review, and the PR
-   description is the only record that it happened. Use =compass
-   build= (not raw =cmake --build=) — it takes the host-wide build
-   lock so this doesn't corrupt or get corrupted by another
-   environment's concurrent build; see [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]]:
+1. *MANDATORY — classify the change and run only the matching checks
+   locally first, and do not skip this even under time pressure*. CI
+   runs only the minimal gate (classify + pr-gate) on PRs, so this
+   step is the *only* thing that catches a broken build before review,
+   and the PR description is the only record that it happened.
+
+   Classify the diff against its branch point:
 
    #+begin_src sh :results verbatim
-   ./compass.sh build --preset <preset>
-   ctest --preset <preset>
+   git diff origin/main...HEAD --name-only
    #+end_src
 
-   Do not raise the PR until both are clean. Note the preset, the
-   build result, and the test tally (e.g. "142/142 passed") — they go
-   into the PR description in step 2.
+   Bucket every changed file with the rule table. A mixed change runs
+   the union of its classes' checks:
+
+   | Class          | Paths                                                         | Checks to run                    |
+   |----------------+---------------------------------------------------------------+----------------------------------|
+   | docs           | =doc/*=, =assets/*=, =.claude/*=, =*.md=, =*.org=, =projects/*/modeling/*= (org/puml/png), =external/*= (vendored) | Site build                       |
+   | code (C++)     | =projects/ores.*= C++ sources and headers, =*.cmake=, =CMakeLists.txt= | Full build + ctest; roundtrip; drift checks; CDash experimental |
+   | ci             | =.github/*=, =projects/ores.codegen/library/templates/*=      | Site build; roundtrip; drift checks |
+   | python tooling | =projects/ores.compass/*=, =projects/ores.codegen/*= (non-template) | Compass test suite; drift checks |
+
+   The checks:
+
+   - *Site build*: =./compass.sh build --direct site=.
+   - *Full build and tests* (code class only; run both via =compass=,
+     never raw =cmake --build= or =ctest= — it takes the host-wide
+     build lock so a concurrent build in another worktree can't
+     corrupt this one; see [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]]):
+
+     #+begin_src sh :results verbatim
+     ./compass.sh build --preset <preset>
+     ./compass.sh test run --preset <preset>
+     #+end_src
+
+   - *Roundtrip*: =python3 scripts/ore_domain_roundtrip_check.py=.
+   - *cmake-sources drift*:
+     =python3 projects/ores.codegen/scripts/regenerate_cmake_component_files.py --all --check=
+     (when a source file was added or removed, regenerate with
+     =--all= instead; see [[id:B45805F2-BAD4-4879-A571-3C962C79670B][codegen-sync-cmake-sources]]).
+   - *codegen drift*: =./compass.sh build --direct codegen_templates=
+     then
+     =python3 projects/ores.codegen/scripts/check_component_drift.py --components refdata,reporting,marketdata=.
+   - *Compass test suite*:
+     =projects/ores.compass/venv/bin/pytest projects/ores.compass/tests -q=.
+   - *CDash experimental* (code class; visibility only):
+     =./compass.sh test run --preset <preset> --cdash Experimental=.
+
+   Do not raise the PR until the checks for the class are clean. Note
+   the class(es), the checks run, and the results (e.g. "doc-only;
+   local site build clean" or "code; build clean (<preset>); ctest
+   142/142 passed") — they go into the PR description in step 2.
 
 2. *Close task/story bookkeeping now, if not already done*. The task
    should already be =DONE= with its =* Result= written and the parent
@@ -60,15 +94,16 @@ lifecycle is ordered this way.
    raising the PR, not after review. If it's not done yet, do it now,
    as part of the same commit set the PR will contain from the start.
 
-3. *Raise the PR*, including the local verification from step 1 as an
-   explicit =--change= bullet so it's visible in the PR description
-   (reviewers and future readers can see it happened without asking):
+3. *Raise the PR*, including the change class and the verification
+   from step 1 as an explicit =--change= bullet so it's visible in the
+   PR description (reviewers and future readers can see it happened
+   without asking):
 
    #+begin_src sh :results verbatim
    ./compass.sh pr create --title "[component] Description" \
      --summary "What changes, why." \
      --change "First change" --change "Second change" \
-     --change "Verification: local build clean (<preset>); ctest <N>/<N> passed"
+     --change "Verification: <class>; <checks run and results>"
    #+end_src
 
    Compass validates the title, builds the body, pushes the branch,

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4877,13 +4877,26 @@ def cmd_test(argv):
     """compass test — test pillar: inspect build test results."""
     ap = argparse.ArgumentParser(
         prog="compass test",
-        description="Test pillar: parse and display Catch2 test results.")
+        description="Test pillar: run ctest under the build lock, or "
+                    "inspect build test results.")
     sub = ap.add_subparsers(dest="subcmd", required=True)
 
-    rp = sub.add_parser("results",
-                        help="Parse test-results*.xml and show an overview of the last test run")
+    rp = sub.add_parser("run",
+                        help="Run ctest under the build lock: 'run [--preset P] "
+                             "[--cdash GROUP] [-- extra ctest args]'")
     rp.add_argument("--preset", default="",
                     help="CMake preset name (default: read ORES_PRESET from .env)")
+    rp.add_argument("--cdash", default="", metavar="GROUP",
+                    help="CDash build group (Experimental, Continuous, Nightly): "
+                         "run the CTest.cmake script form instead of plain ctest; "
+                         "the script builds, tests, and submits to CDash")
+    rp.add_argument("ctest_args", nargs=argparse.REMAINDER,
+                    help="Extra ctest arguments after '--' (e.g. '-VV', '-R foo')")
+
+    rp2 = sub.add_parser("results",
+                         help="Parse test-results*.xml and show an overview of the last test run")
+    rp2.add_argument("--preset", default="",
+                     help="CMake preset name (default: read ORES_PRESET from .env)")
 
     lp = sub.add_parser("logging",
                         help="Toggle test logging: 'logging on [level]', "
@@ -4897,6 +4910,8 @@ def cmd_test(argv):
 
     args = ap.parse_args(argv)
 
+    if args.subcmd == "run":
+        return _cmd_test_run(args)
     if args.subcmd == "results":
         return _cmd_test_results(args)
     if args.subcmd == "logging":
@@ -4935,6 +4950,69 @@ def _cmd_test_logging(args):
     import env_init
     return env_init._logging_only(
         env_file, "enable" if args.action == "on" else "disable", args.level)
+
+
+def _test_run_command(preset, cdash_group, extra):
+    """Build the ctest command for `compass test run`; pure for unit tests.
+
+    Plain form: ctest --preset <preset> [extra...]. CDash form: the
+    CTest.cmake script with the build group and preset as script
+    variables — the same shape CI uses (continuous/nightly workflows),
+    which builds, runs tests, and submits to CDash.
+    """
+    if cdash_group:
+        if cdash_group not in ("Experimental", "Continuous", "Nightly"):
+            raise ValueError(f"Unsupported CDash build group: {cdash_group}")
+        return ["ctest", "--preset", preset, "--script",
+                f"CTest.cmake,build_group={cdash_group},preset={preset}"] + extra
+    return ["ctest", "--preset", preset] + extra
+
+
+def _cmd_test_run(args):
+    """compass test run — run ctest under the host-wide build lock.
+
+    ctest executes the built binaries; a concurrent cmake build in
+    another worktree can replace them mid-run, so the same lock slots
+    `compass build` uses are held for the whole run (see
+    _acquire_build_lock), and output streams to the slot's well-known
+    log — the file `compass build --status` tails.
+
+    --cdash GROUP switches to the CTest.cmake script form: the script
+    builds, tests, and submits to CDash under that group. Local
+    submissions use Experimental for visibility without polluting the
+    continuous/nightly dashboards.
+    """
+    preset = args.preset or _tr_read_preset()
+    if not preset:
+        print("❌ No preset supplied and ORES_PRESET not set in .env.\n"
+              "   Pass --preset <name> or run compass env configure.",
+              file=sys.stderr)
+        return 1
+
+    extra = list(args.ctest_args or [])
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+    try:
+        cmd = _test_run_command(preset, args.cdash, extra)
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+
+    lock_file, slot_name, _ = _acquire_build_lock()
+    log_path = _build_log_path(slot_name)
+    print(f"📝 Test output: {log_path} (tail -f to follow)")
+    log = open(log_path, "w")
+    try:
+        print(f"🔨 {' '.join(cmd)}")
+        rc = _run_logged(cmd, PROJECT_ROOT, log)
+        if rc != 0:
+            print(f"❌ ctest failed with exit code {rc}: {' '.join(cmd)}",
+                  file=sys.stderr)
+            return rc
+        return 0
+    finally:
+        log.close()
+        lock_file.close()
 
 
 def _cmd_test_results(args):
@@ -7136,7 +7214,8 @@ def main():
                                "--user scope, so oomd can kill it without "
                                "taking Emacs down with it")
     subparsers.add_parser("test",
-                          help="Test: 'test results' shows last run overview; "
+                          help="Test: 'test run' runs ctest under the build lock; "
+                               "'test results' shows last run overview; "
                                "'test logging on|off|status' toggles test logging; 'test --help'")
     subparsers.add_parser("site",
                           help="Site: build and serve the org-mode site locally; "

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -5979,6 +5979,7 @@ BUILD_TARGET_ALIASES = {
     "settings": "deploy_settings",
     "skills": "deploy_skills",
     "help": "deploy_help",
+    "codegen_templates": "tangle_codegen_templates",
 }
 
 # Emacs scripts for --direct builds: cmake target name → .el file name.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -4999,20 +4999,25 @@ def _cmd_test_run(args):
         return 1
 
     lock_file, slot_name, _ = _acquire_build_lock()
-    log_path = _build_log_path(slot_name)
-    print(f"📝 Test output: {log_path} (tail -f to follow)")
-    log = open(log_path, "w")
+    log_path = _build_log_path(slot_name) if slot_name else None
+    log = None
+    if log_path is not None:
+        print(f"📝 Test output: {log_path} (tail -f to follow)")
+        log = open(log_path, "w")
     try:
         print(f"🔨 {' '.join(cmd)}")
-        rc = _run_logged(cmd, PROJECT_ROOT, log)
+        rc = (_run_logged(cmd, PROJECT_ROOT, log) if log is not None
+              else subprocess.run(cmd, cwd=PROJECT_ROOT).returncode)
         if rc != 0:
             print(f"❌ ctest failed with exit code {rc}: {' '.join(cmd)}",
                   file=sys.stderr)
             return rc
         return 0
     finally:
-        log.close()
-        lock_file.close()
+        if log is not None:
+            log.close()
+        if lock_file is not None:
+            lock_file.close()
 
 
 def _cmd_test_results(args):

--- a/projects/ores.compass/tests/test_direct_build.py
+++ b/projects/ores.compass/tests/test_direct_build.py
@@ -1,0 +1,28 @@
+"""
+Tests for `compass build --direct` target resolution.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_direct_build.py -v
+No live database or file system access required.
+"""
+
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from compass import BUILD_TARGET_ALIASES, EMACS_BUILD_SCRIPTS  # noqa: E402
+
+
+def test_every_alias_resolves_to_a_direct_build_target():
+    """A dangling alias makes `build --direct <alias>` fail at runtime,
+    so each alias must name a target the emacs dispatcher knows."""
+    for alias, target in BUILD_TARGET_ALIASES.items():
+        assert target in EMACS_BUILD_SCRIPTS, (
+            f"{alias} -> {target} is not a direct-build target"
+        )
+
+
+def test_codegen_templates_alias():
+    """pr-raise's codegen-drift step runs `build --direct codegen_templates`."""
+    assert BUILD_TARGET_ALIASES["codegen_templates"] == "tangle_codegen_templates"

--- a/projects/ores.compass/tests/test_test_run.py
+++ b/projects/ores.compass/tests/test_test_run.py
@@ -37,3 +37,29 @@ def test_cdash_rejects_unknown_group():
 
     with pytest.raises(ValueError):
         _test_run_command("clang-debug", "Staging", [])
+
+
+def test_run_degrades_without_fcntl(monkeypatch):
+    """_acquire_build_lock returns (None, None, jobs) where fcntl is
+    unavailable; the command still runs and cleans up without crashing."""
+    import compass
+
+    captured = {}
+
+    def fake_acquire():
+        return (None, None, 1)
+
+    def fake_preset():
+        return "test-preset"
+
+    def fake_run(cmd, cwd, **kwargs):
+        captured["cmd"] = cmd
+        return type("Proc", (), {"returncode": 0})()
+
+    monkeypatch.setattr(compass, "_acquire_build_lock", fake_acquire)
+    monkeypatch.setattr(compass, "_tr_read_preset", fake_preset)
+    monkeypatch.setattr(compass.subprocess, "run", fake_run)
+
+    rc = compass.cmd_test(["run", "--preset", "test-preset"])
+    assert rc == 0
+    assert captured["cmd"] == ["ctest", "--preset", "test-preset"]

--- a/projects/ores.compass/tests/test_test_run.py
+++ b/projects/ores.compass/tests/test_test_run.py
@@ -1,0 +1,39 @@
+"""
+Tests for `compass test run` command construction.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_test_run.py -v
+No live database or file system access required.
+"""
+
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from compass import _test_run_command  # noqa: E402
+
+
+def test_plain_form():
+    cmd = _test_run_command("clang-debug", "", [])
+    assert cmd == ["ctest", "--preset", "clang-debug"]
+
+
+def test_pass_through_args():
+    cmd = _test_run_command("clang-debug", "", ["-VV", "-R", "foo"])
+    assert cmd == ["ctest", "--preset", "clang-debug", "-VV", "-R", "foo"]
+
+
+def test_cdash_script_form():
+    cmd = _test_run_command("clang-debug", "Experimental", [])
+    assert cmd == [
+        "ctest", "--preset", "clang-debug", "--script",
+        "CTest.cmake,build_group=Experimental,preset=clang-debug",
+    ]
+
+
+def test_cdash_rejects_unknown_group():
+    import pytest
+
+    with pytest.raises(ValueError):
+        _test_run_command("clang-debug", "Staging", [])


### PR DESCRIPTION
## Summary

pr-raise now classifies the diff per the analysis (docs / code (C++) / ci / python tooling; mixed = union) and runs only the matching checks locally. The rule table lives in pr-raise alone; pr-address-review links to it. ctest goes via the new compass test run subcommand (host-wide build lock), with --cdash GROUP for CTest.cmake script submissions.

## Changes

- Change classification in pr-raise: docs / code (C++) / ci / python tooling, mixed = union; only the matching checks run locally
- New compass test run subcommand: ctest under the build lock; --cdash GROUP runs the CTest.cmake script form
- pr-address-review reuses the pr-raise rule table for its per-round verification
- Verification: python tooling + docs; compass suite 114 passed / 1 skipped; regenerate + codegen drift clean; local site build clean

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Absorb PR checks locally: targeted checks, local review, CDash submissions](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/story.html) | 368E2B3E-CD2C-4FD5-90DD-D0E935810F4D |
| Task | [Classify changes and run targeted local checks in the submit-PR skills](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/local-checks-for-pr-velocity/task_classify-changes-and-run-targeted-checks.html) | 000AD939-CEDD-487E-A23F-EAD86B3F1CE7 |
| Environment | solid_dirac | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)