### PR TITLE
[ores.analytics.quant] Widen statistical test tolerances to multi-sigma bounds

### DIFF
--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
@@ -29,11 +29,11 @@ genuine model errors.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Diagnosed: sub-sigma tolerances.       |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Implement and verify the fix.          |
+| Next          | Nothing.                               |
 | Last touched  | 2026-08-12                               |
 
 * Acceptance
@@ -47,9 +47,19 @@ genuine model errors.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:D98B7262-190B-4204-A1A8-F5A2E6C9D299][Scaffold story: Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA][Implement Hotfix: stochastic process statistical tests fail on macOS CI]] | STARTED | 2026-08-12 | | Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI |
+| [[id:3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA][Implement Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI |
 
 * Decisions
+
+- Widen test tolerances rather than replace =std::normal_distribution=
+  with a platform-independent generator: test-only, minimal hotfix
+  scope; the per-platform draws remain statistically valid samples.
+- BK variance epsilon 1.5e-2 (~4.7 sigma at 200000 paths), matching
+  the sibling Gaussian-OU moments test in the same file.
+- HJM drift margins 1e-2 (>= 3.2 sigma at the noisiest leg). Per-rate
+  margins declined at review: a drift-formula error and the standard
+  error of each mean both scale with the rate's volatility, so
+  detection sensitivity is leg-independent in sigma units.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE
+:END:
+#+title: Story: Hotfix: stochastic process statistical tests fail on macOS CI
+#+description: Sample-variance and drift-mean Monte Carlo tests in ores.analytics.quant fail on macOS because their tolerances are tighter than the tests' own standard error.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:ores.analytics.quant:sprint_25:v0:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment: bright_faraday
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Two Monte Carlo statistical tests in ores.analytics.quant fail on
+macOS CI: the Black-Karasinski sample-variance check and the HJM
+drift-mean check assert tolerances tighter than the tests' own
+standard error. =std::normal_distribution= is implementation-defined,
+so the same =mt19937= seeds produce a different draw sequence under
+libc++ (macOS) than under libstdc++ (Linux), and the macOS draws land
+just outside the bounds. The fix widens the tolerances to multi-sigma
+bounds so the tests pass on every platform while still rejecting
+genuine model errors.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
+| Now           | Diagnosed: sub-sigma tolerances.       |
+| Waiting on    | Nothing.                               |
+| Next          | Implement and verify the fix.          |
+| Last touched  | 2026-08-12                               |
+
+* Acceptance
+
+- ores.analytics.quant tests pass on Linux, macOS, and Windows CI.
+- Statistical assertions still bound genuine deviations (tolerances
+  at or above ~3 sigma of the estimator's standard error).
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:D98B7262-190B-4204-A1A8-F5A2E6C9D299][Scaffold story: Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA][Implement Hotfix: stochastic process statistical tests fail on macOS CI]] | BACKLOG | | | Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.org
@@ -47,7 +47,7 @@ genuine model errors.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:D98B7262-190B-4204-A1A8-F5A2E6C9D299][Scaffold story: Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA][Implement Hotfix: stochastic process statistical tests fail on macOS CI]] | BACKLOG | | | Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI |
+| [[id:3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA][Implement Hotfix: stochastic process statistical tests fail on macOS CI]] | STARTED | 2026-08-12 | | Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
@@ -8,7 +8,7 @@
 #+filetags: :osx-stochastic-process-test-failures:sprint_25:v0:
 #+owner: marco
 #+branch: feature/implement-osx-stochastic-process-test-failures
-#+pr:
+#+pr: 1976
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-12
@@ -109,7 +109,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1976][#1976]] | [ores.analytics.quant] Widen statistical test tolerances to multi-sigma bounds |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :osx-stochastic-process-test-failures:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-osx-stochastic-process-test-failures
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
@@ -35,11 +35,11 @@ still bounding genuine model errors:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] |
-| Now          | Fix verified locally.                  |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | PR.                                    |
+| Next         | Nothing. |
 | Last touched | 2026-08-12                               |
 
 * Acceptance
@@ -118,3 +118,10 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Fix verified locally (build green, both suites pass: 34 test cases,
+2084209 assertions) and shipped as PR #1976. Review round: one
+minor observation on per-rate HJM margins, declined with rationale
+(error and standard error both scale with the rate's volatility, so
+detection is leg-independent in sigma units); reviewer approved,
+claude-review and check gates green.

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
@@ -1,0 +1,98 @@
+:PROPERTIES:
+:ID: 3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA
+:END:
+#+title: Task: Implement Hotfix: stochastic process statistical tests fail on macOS CI
+#+description: Initial task for: Hotfix: stochastic process statistical tests fail on macOS CI
+#+type: task
+#+level: s1
+#+filetags: :osx-stochastic-process-test-failures:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Widen the statistical tolerances in the two failing tests so they
+hold for any platform's =std::normal_distribution= sequence while
+still bounding genuine model errors:
+
+- =black_karasinski_process_tests.cpp= (kappa <= 0 walk test):
+  sample variance of 200k paths must match =sigma^2 * dt=; the 3e-3
+  epsilon allows only ~0.95 sigma of the estimator's standard error.
+- =heath_jarrow_morton_process_tests.cpp= (drift grid-integral test):
+  per-tick drift means must match the hand-computed vector; the 2e-3
+  margin is ~0.6 sigma for the largest-vol rate.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] |
+| Now          | Diagnosed: sub-sigma tolerances.       |
+| Waiting on   | Nothing.                               |
+| Next         | Widen tolerances, verify locally.      |
+| Last touched | 2026-08-12                               |
+
+* Acceptance
+
+- Both tests pass on Linux with the current libstdc++ sequence.
+- Tolerances are >= ~3 sigma of the estimator's standard error, so
+  the libc++ (macOS) draw sequence cannot land outside them.
+
+* Plan
+
+Root cause: =std::normal_distribution= is implementation-defined;
+libc++ and libstdc++ map the same =mt19937= output to different normal
+draws. The tests seed each path (seeds 42+i) and were tuned against
+the Linux sequence, with tolerances tighter than the tests' own
+standard error:
+
+- BK variance test (lines 240-267): N = 200000 paths; standard error
+  of the sample variance is =sigma^2 * sqrt(2/N) = 1.42e-4=, but the
+  3e-3 epsilon admits only =1.35e-4= (0.95 sigma). macOS draws gave
+  0.044853 vs the expected 0.045.
+- HJM drift test (lines 163-194): N = 100000 paths; per-tick drift
+  mean for rate 3 has standard error ~3.2e-3, but the margin is 2e-3
+  (0.6 sigma). macOS draws gave mean[1] = 0.04733 vs 0.045.
+
+Fix: widen the bounds to multi-sigma headroom. BK epsilon to 1.5e-2
+(the sibling Gaussian-OU test in the same file already uses 1.5e-2
+for the same estimator at the same path count); HJM margin to 1e-2.
+This makes the failure probability per platform negligible while
+keeping the checks ~4 sigma tight relative to genuine deviations.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.org
@@ -13,7 +13,7 @@
 #+blocked_since:
 #+created: 2026-08-12
 #+updated: 2026-08-12
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -37,9 +37,9 @@ still bounding genuine model errors:
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] |
-| Now          | Diagnosed: sub-sigma tolerances.       |
+| Now          | Fix verified locally.                  |
 | Waiting on   | Nothing.                               |
-| Next         | Widen tolerances, verify locally.      |
+| Next         | PR.                                    |
 | Last touched | 2026-08-12                               |
 
 * Acceptance
@@ -71,6 +71,28 @@ This makes the failure probability per platform negligible while
 keeping the checks ~4 sigma tight relative to genuine deviations.
 
 * Notes
+
+Root cause: the two Monte Carlo tests assert tolerances tighter than
+their own standard error, and =std::normal_distribution= maps the
+same =mt19937= seeds to different draws per standard library, so the
+macOS (libc++) sequence lands outside the bounds the tests were tuned
+to on Linux (libstdc++).
+
+Fix (committed): widen the bounds to multi-sigma headroom, matching
+the sibling conventions in the same files:
+
+- BK kappa <= 0 walk test: variance epsilon 3e-3 → 1.5e-2 (~4.7 sigma
+  at 200000 paths; the Gaussian-OU moments test already uses 1.5e-2
+  for the same estimator and path count).
+- HJM drift test: mean margins 2e-3 → 1e-2 (>= 3.2 sigma at the
+  noisiest rate, sigma = 0.5; the previous margin was ~0.6 sigma).
+  The front-rate zero-mean check gets the same margin.
+
+Verification: `compass build ores.analytics.quant.tests` green;
+running `[black_karasinski_process],[heath_jarrow_morton_process]`
+passes all 34 test cases (2084209 assertions) on Linux. No source
+changes — test-only hotfix; a genuine model error of ~3 sigma or more
+is still rejected.
 
 * Test Scenarios
 

--- a/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_scaffold_osx-stochastic-process-test-failures.org
+++ b/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_scaffold_osx-stochastic-process-test-failures.org
@@ -1,0 +1,78 @@
+:PROPERTIES:
+:ID: D98B7262-190B-4204-A1A8-F5A2E6C9D299
+:END:
+#+title: Task: Scaffold story: Hotfix: stochastic process statistical tests fail on macOS CI
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :osx-stochastic-process-test-failures:sprint_25:v0:
+#+owner: marco
+#+branch: hotfix/osx-stochastic-process-test-failures
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Scaffold the hotfix story on a =hotfix/= branch: story and task
+documents, sprint wiring, and the working branch.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-08-12                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Story scaffolded on =hotfix/osx-stochastic-process-test-failures= off
+origin/main: story.org, scaffold and implement tasks, sprint.org
+Hotfixes row set to STARTED (2026-08-12). Story Goal/Acceptance and
+implement-task Goal/Plan filled with the diagnosis (sub-sigma
+tolerances vs. the tests' own standard error).

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -102,6 +102,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:3EA23D13-8892-46C3-9B73-D511847E5536][Hotfix: Valgrind flags NATS one-time init blocks as leaks on eventing tests]] | DONE | 2026-08-10 | 2026-08-10 | CDash dynamic analysis flags 21 still-reachable leak records on three components (ores.trading.core.tests, ores.reporting.core.tests, ores.refdata.core.tests), all from the NATS C library one-time global init (nats_openLib) reached via the eventing client connect. Add narrow suppressions to build/valgrind/custom.supp and create a valgrind recipe. |
 | [[id:74A90E3D-32BC-4174-8926-C2F4D06D171B][Hotfix: NATS cert generation fails on macOS/Windows (missing `ip` command)]] | DONE | 2026-08-11 | 2026-08-11 | NATS certificate generation fails on macOS and Windows because `_local_ipv4_addresses` shells out to the Linux-only `ip` binary and never reaches its gethostname fallback. |
 | [[id:34FFCE53-473A-4532-95D2-4A8448CB4F19][Hotfix: rate_tree fails to compile on Windows]] | DONE | 2026-08-11 | 2026-08-11 | rate_tree.cpp calls std::to_string without including the string header, breaking the MSVC build. |
+| [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] | STARTED | 2026-08-12 | | Sample-variance and drift-mean Monte Carlo tests in ores.analytics.quant fail on macOS because their tolerances are tighter than the tests' own standard error. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -102,7 +102,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:3EA23D13-8892-46C3-9B73-D511847E5536][Hotfix: Valgrind flags NATS one-time init blocks as leaks on eventing tests]] | DONE | 2026-08-10 | 2026-08-10 | CDash dynamic analysis flags 21 still-reachable leak records on three components (ores.trading.core.tests, ores.reporting.core.tests, ores.refdata.core.tests), all from the NATS C library one-time global init (nats_openLib) reached via the eventing client connect. Add narrow suppressions to build/valgrind/custom.supp and create a valgrind recipe. |
 | [[id:74A90E3D-32BC-4174-8926-C2F4D06D171B][Hotfix: NATS cert generation fails on macOS/Windows (missing `ip` command)]] | DONE | 2026-08-11 | 2026-08-11 | NATS certificate generation fails on macOS and Windows because `_local_ipv4_addresses` shells out to the Linux-only `ip` binary and never reaches its gethostname fallback. |
 | [[id:34FFCE53-473A-4532-95D2-4A8448CB4F19][Hotfix: rate_tree fails to compile on Windows]] | DONE | 2026-08-11 | 2026-08-11 | rate_tree.cpp calls std::to_string without including the string header, breaking the MSVC build. |
-| [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] | STARTED | 2026-08-12 | | Sample-variance and drift-mean Monte Carlo tests in ores.analytics.quant fail on macOS because their tolerances are tighter than the tests' own standard error. |
+| [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Sample-variance and drift-mean Monte Carlo tests in ores.analytics.quant fail on macOS because their tolerances are tighter than the tests' own standard error. |
 
 * Achievements
 

--- a/projects/ores.analytics.quant/tests/black_karasinski_process_tests.cpp
+++ b/projects/ores.analytics.quant/tests/black_karasinski_process_tests.cpp
@@ -252,8 +252,12 @@ TEST_CASE("black_karasinski_process with kappa <= 0 degenerates to a driftless r
         zero_kappa.add(std::log(a.next()));
         negative_kappa.add(std::log(b.next()));
     }
-    CHECK(zero_kappa.sample_variance() == Catch::Approx(sigma * sigma * dt).epsilon(3e-3));
-    CHECK(negative_kappa.sample_variance() == Catch::Approx(sigma * sigma * dt).epsilon(3e-3));
+    // 1.5e-2 is ~4.7 sigma of the estimator at 200000 paths (the same
+    // headroom the Gaussian-OU moments test uses above); sub-sigma bounds
+    // flake because std::normal_distribution draws differ per standard
+    // library, so the same seeds produce different samples on macOS.
+    CHECK(zero_kappa.sample_variance() == Catch::Approx(sigma * sigma * dt).epsilon(1.5e-2));
+    CHECK(negative_kappa.sample_variance() == Catch::Approx(sigma * sigma * dt).epsilon(1.5e-2));
 
     black_karasinski_process p(-0.2, std::log(0.04), 0.3, 0.05, 42, dt);
     for (int i = 0; i < 100; ++i) {

--- a/projects/ores.analytics.quant/tests/heath_jarrow_morton_process_tests.cpp
+++ b/projects/ores.analytics.quant/tests/heath_jarrow_morton_process_tests.cpp
@@ -184,12 +184,16 @@ TEST_CASE("hjm drift matches the grid integral statistically", "[heath_jarrow_mo
     }
 
     const Eigen::VectorXd& mean = increments.mean;
-    REQUIRE(mean[0] == Catch::Approx(0.0).margin(2e-3));
-    REQUIRE(mean[1] == Catch::Approx(0.045).margin(2e-3));
-    REQUIRE(mean[2] == Catch::Approx(0.14).margin(2e-3));
-    REQUIRE(mean[3] == Catch::Approx(0.425).margin(2e-3));
+    // 1e-2 is >= 3.2 sigma of the noisiest mean (rate 3: sigma = 0.5,
+    // standard error ~3.2e-3 at 100000 paths); sub-sigma bounds flake
+    // because std::normal_distribution draws differ per standard
+    // library, so the same seeds produce different samples on macOS.
+    REQUIRE(mean[0] == Catch::Approx(0.0).margin(1e-2));
+    REQUIRE(mean[1] == Catch::Approx(0.045).margin(1e-2));
+    REQUIRE(mean[2] == Catch::Approx(0.14).margin(1e-2));
+    REQUIRE(mean[3] == Catch::Approx(0.425).margin(1e-2));
 
-    REQUIRE(front_increment.mean == Catch::Approx(0.0).margin(2e-3));
+    REQUIRE(front_increment.mean == Catch::Approx(0.0).margin(1e-2));
     REQUIRE(front_increment.sample_variance() == Catch::Approx(0.2 * 0.2 * 0.25).epsilon(1e-2));
 }
 


### PR DESCRIPTION
## Summary

Two Monte Carlo statistical tests in ores.analytics.quant fail on macOS CI: black_karasinski_process_tests.cpp:255-256 (sample variance, got 0.044853 vs 0.045) and heath_jarrow_morton_process_tests.cpp:188 (HJM drift mean, got 0.04733 vs 0.045). Root cause: the tolerances are tighter than the estimators' own standard error (BK variance check about 0.95 sigma, HJM drift check about 0.6 sigma), and std::normal_distribution is implementation-defined, so the same mt19937 seeds produce different draws under libc++ (macOS) than under libstdc++ (Linux). The fix widens the bounds to multi-sigma headroom, matching sibling conventions in the same files; no source changes, so genuine model errors of about 3 sigma or more are still rejected.

## Changes

- Widen the Black-Karasinski sample-variance epsilon from 3e-3 to 1.5e-2 (about 4.7 sigma at 200000 paths, matching the Gaussian-OU moments test in the same file).
- Widen the HJM drift-mean margins from 2e-3 to 1e-2 (at least 3.2 sigma at the noisiest rate, sigma = 0.5; the previous margin was about 0.6 sigma).
- Add comments documenting the sigma headroom and the per-standard-library draw difference.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: stochastic process statistical tests fail on macOS CI](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/story.html) | 4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE |
| Task | [Implement Hotfix: stochastic process statistical tests fail on macOS CI](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/osx-stochastic-process-test-failures/task_implement_osx-stochastic-process-test-failures.html) | 3DE5BBB9-13CD-41FF-9F69-855CF34A7FAA |
| Environment | bright_faraday | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)