### PR TITLE
[agile] Scaffold hotfix: Windows build fails on std::getenv deprecation

### DIFF
--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -103,6 +103,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:74A90E3D-32BC-4174-8926-C2F4D06D171B][Hotfix: NATS cert generation fails on macOS/Windows (missing `ip` command)]] | DONE | 2026-08-11 | 2026-08-11 | NATS certificate generation fails on macOS and Windows because `_local_ipv4_addresses` shells out to the Linux-only `ip` binary and never reaches its gethostname fallback. |
 | [[id:34FFCE53-473A-4532-95D2-4A8448CB4F19][Hotfix: rate_tree fails to compile on Windows]] | DONE | 2026-08-11 | 2026-08-11 | rate_tree.cpp calls std::to_string without including the string header, breaking the MSVC build. |
 | [[id:4A047F18-0AE2-4DDF-9AC9-04AFAAF233AE][Hotfix: stochastic process statistical tests fail on macOS CI]] | DONE | 2026-08-12 | 2026-08-12 | Sample-variance and drift-mean Monte Carlo tests in ores.analytics.quant fail on macOS because their tolerances are tighter than the tests' own standard error. |
+| [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] | BACKLOG | | | Windows CI compiles with -Werror -Wdeprecated-declarations: std::getenv is deprecated in MSVC's STL in favour of _dupenv_s. The generated eventing integration tests (and two hand-written ores.synthetic tests) call std::getenv, so every such file fails the Windows build, e.g. account_type_eventing_integration_tests.cpp:60. |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/story.org
+++ b/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/story.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA
+:END:
+#+title: Story: Hotfix: Windows build fails on std::getenv deprecation
+#+description: Windows CI compiles with -Werror -Wdeprecated-declarations: std::getenv is deprecated in MSVC's STL in favour of _dupenv_s. The generated eventing integration tests (and two hand-written ores.synthetic tests) call std::getenv, so every such file fails the Windows build, e.g. account_type_eventing_integration_tests.cpp:60.
+#+type: story
+#+level: s2
+#+filetags: :sprint_25:v0:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment: bright_faraday
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The Windows CI build fails on every test file that calls
+=std::getenv=: Windows Clang compiles with
+=-Werror -Wdeprecated-declarations=, and MSVC's STL deprecates
+=std::getenv= in favour of =_dupenv_s=. The NATS eventing integration
+tests (~85 generated files) and two hand-written ores.synthetic
+service tests all call it. The fix replaces =std::getenv= with the
+portable =ores::platform::environment::environment= wrapper in the
+codegen template and regenerates, so the Windows build compiles again.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-08-12                               |
+
+* Acceptance
+
+- The Windows CI build compiles every test target that previously
+  failed on the =std::getenv= deprecation warning.
+- The codegen template is the single source of the fix: regenerated
+  test files match the template (zero-diff drift check).
+- Test behaviour is unchanged: NATS connection options still resolve
+  from the process environment the same way.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:7012042B-7BAC-4989-BE1F-C2679821ABC0][Scaffold story: Hotfix: Windows build fails on std::getenv deprecation]] | STARTED | 2026-08-12 | | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
+| [[id:AEA7E72A-5254-481F-9E27-AA51DC2BA7C8][Implement Hotfix: Windows build fails on std::getenv deprecation]] | BACKLOG | | | Initial task for: Hotfix: Windows build fails on std::getenv deprecation |
+
+* Decisions
+
+- Fix the codegen template and regenerate, rather than hand-editing
+  the ~85 generated test files: the template is the single source and
+  CI's drift check enforces it.
+- Use =environment::get_value_or_default(name, "")= so the existing
+  empty-string semantics of the =env()= lambda are preserved exactly
+  (the URL fallback to =nats://localhost:4222= depends on it).
+- =systemd_notify.cpp= already uses =ores.platform::environment=; no
+  change needed there.
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_implement_windows-getenv-deprecation.org
+++ b/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_implement_windows-getenv-deprecation.org
@@ -1,0 +1,110 @@
+:PROPERTIES:
+:ID: AEA7E72A-5254-481F-9E27-AA51DC2BA7C8
+:END:
+#+title: Task: Implement Hotfix: Windows build fails on std::getenv deprecation
+#+description: Initial task for: Hotfix: Windows build fails on std::getenv deprecation
+#+type: task
+#+level: s1
+#+filetags: :windows-getenv-deprecation:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Replace every =std::getenv= call in test code that Windows compiles
+with =ores::platform::environment::environment::get_value_or_default=
+so the =-Werror= deprecation failure on Windows Clang goes away:
+
+- the codegen template =ores.cpp.eventing-integration-test.nats_integration_test.org=
+  (tangled to =cpp_nats_integration_test.cpp.mustache=), which feeds
+  ~85 generated =*_eventing_integration_tests.cpp= files across
+  ores.iam, ores.refdata, ores.reporting, and ores.trading;
+- the two hand-written ores.synthetic service tests
+  (=feed_config_handler_tests.cpp=, =folder_feed_control_handler_tests.cpp=),
+  which carry a copy of the same =env()= lambda.
+
+=systemd_notify.cpp= already uses the ores.platform wrapper; no change.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-12                               |
+
+* Acceptance
+
+- No =std::getenv= remains in any C++ source under =projects/=
+  (grep clean).
+- Generated test files are produced by the updated template: the
+  template-drift check reports zero diff.
+- The changed test targets build and pass on Linux; the fix is
+  portable by construction (the wrapper already guards Windows with
+  =_putenv_s=).
+
+* Plan
+
+Root cause: MSVC's STL marks =std::getenv= deprecated in favour of
+=_dupenv_s=, and Windows CI compiles with =-Werror=, so every file
+that calls it fails the build (first observed in
+=account_type_eventing_integration_tests.cpp:60=). The failing files
+are codegen-generated from the
+=ores.cpp.eventing-integration-test.nats_integration_test= archetype:
+the =env()= lambda with =std::getenv= lives in the org template, so
+the fix belongs there, not in the generated files (CI enforces a
+zero-diff drift check).
+
+Steps:
+
+1. Edit the org template: replace the =std::getenv= lambda with
+   =ores::platform::environment::environment::get_value_or_default(name, "")=
+   and add the =ores.platform/environment/environment.hpp= include.
+2. Re-tangle: =compass build --direct tangle_codegen_templates=.
+3. Regenerate per component with the codegen
+   (=--address ores.cpp.eventing-integration-test=) and inspect the
+   diff: every generated file should show only the include, the
+   lambda replacement, and the =<cstdlib>= include drop if unused.
+4. Hand-fix the two ores.synthetic service tests (same lambda,
+   same replacement).
+5. Verify: grep for remaining =std::getenv=, build the affected test
+   targets, run the drift check.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_implement_windows-getenv-deprecation.org
+++ b/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_implement_windows-getenv-deprecation.org
@@ -8,7 +8,7 @@
 #+filetags: :windows-getenv-deprecation:sprint_25:v0:
 #+owner: marco
 #+branch:
-#+pr:
+#+pr: 1978
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-12
@@ -99,7 +99,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1978][#1978]] | [agile] Scaffold hotfix: Windows build fails on std::getenv deprecation |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_scaffold_windows-getenv-deprecation.org
+++ b/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_scaffold_windows-getenv-deprecation.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 7012042B-7BAC-4989-BE1F-C2679821ABC0
+:END:
+#+title: Task: Scaffold story: Hotfix: Windows build fails on std::getenv deprecation
+#+description: Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR.
+#+type: task
+#+level: s1
+#+filetags: :windows-getenv-deprecation:sprint_25:v0:
+#+owner: marco
+#+branch: hotfix/windows-getenv-deprecation
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-08-12                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_scaffold_windows-getenv-deprecation.org
+++ b/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_scaffold_windows-getenv-deprecation.org
@@ -26,11 +26,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA][Hotfix: Windows build fails on std::getenv deprecation]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-08-12                               |
 
 * Acceptance
@@ -69,3 +69,10 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Story and task docs scaffolded on =hotfix/windows-getenv-deprecation=
+(off origin/main), sprint Hotfixes wiring updated, story STARTED with
+the implement task in BACKLOG. The doc-add-memory flow also ran in
+this session: memory =Use ores.platform for cross-platform
+functionality= recorded and wired into the Project memory inventory.
+Scaffold PR opened from this branch.

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -121,6 +121,7 @@ of these exclusions, push back: the right home is somewhere else.
 - [[id:A422E0ED-7D4D-4581-A7D5-B9DD05D39F33][Toolchain gaps are work items, never licenses for workarounds]] — implement through the toolchain or capture and ask; never hand-roll =.org= files or UUIDs.
 - [[id:D2733820-85A1-49E5-8F1E-214D1A511A75][Don't use cat/--help after compass show/recipe]] — act on what it says directly; if something is missing, file a capture.
 - [[id:975C94B2-06AC-4073-B187-ED4779FCAC7B][Close task bookkeeping when raising the PR, not after review]] — do the task close-out as part of =pr-raise=, before pushing; no separate close-task commit tacked onto the end of the review round.
+- [[id:B4E38241-6AD1-4859-9610-033CC39C0AF4][Use ores.platform for cross-platform functionality]] — always use ores.platform for getenv and any other cross-platform functionality it supports, rather than the native approach.
 
 ** User
 

--- a/doc/llm/memory/ores-platform-for-cross-platform.org
+++ b/doc/llm/memory/ores-platform-for-cross-platform.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID: B4E38241-6AD1-4859-9610-033CC39C0AF4
+:END:
+#+title: Use ores.platform for cross-platform functionality
+#+description: Always use ores.platform for getenv and any other cross-platform functionality it supports, rather than the native approach.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-08-12
+#+updated: 2026-08-12
+
+Always use ores::platform::environment::environment (ores.platform) for getenv and any other cross-platform functionality that ores.platform supports, rather than the native approach (std::getenv, setenv, unsetenv, etc.).
+
+*Why:* Windows Clang compiles with -Werror -Wdeprecated-declarations: std::getenv is deprecated in MSVC's STL (it flags it in favour of _dupenv_s), so any native call breaks the Windows CI build. ores.platform wraps the platform-specific implementation (std::getenv/setenv/unsetenv on Unix, _putenv_s on Windows) behind one portable API. Previous incidents: setenv/unsetenv POSIX-only compile failures (PR #1876), std::getenv deprecation error in account_type_eventing_integration_tests.cpp:60.
+
+*How to apply:* When writing code that reads or writes environment variables, prefer ores::platform::environment::environment::get_value / get_value_or_default / set_value / unset_value over std::getenv/setenv/unsetenv and _putenv_s. Also check ores.platform for any other cross-platform primitive (paths, filesystem, etc.) before reaching for a native or POSIX-only call.


### PR DESCRIPTION
## Summary

Scaffolds the Windows std::getenv deprecation hotfix: story and task docs under sprint 25, sprint Hotfixes wiring, and the project memory recording the ores.platform preference for cross-platform functionality. Fix (codegen template + regenerate) lands in the follow-up PR.

## Changes

- docs

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: Windows build fails on std::getenv deprecation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/story.html) | F4EBF3D7-D1D1-4E22-BCFA-63970685ECFA |
| Task | [Implement Hotfix: Windows build fails on std::getenv deprecation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/windows-getenv-deprecation/task_implement_windows-getenv-deprecation.html) | AEA7E72A-5254-481F-9E27-AA51DC2BA7C8 |
| Environment | bright_faraday | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)