### PR TITLE
[synthetic,ores.sql] Allow FOMC-dated tenor for OIS IR curve configs

### DIFF
--- a/doc/agile/versions/v0/sprint_25/acme_corporation_followups/story.org
+++ b/doc/agile/versions/v0/sprint_25/acme_corporation_followups/story.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_25:v0:
 #+created: 2026-08-03
 #+updated: 2026-08-03
-#+environment: prime_origin
+#+environment: eager_maxwell
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.

--- a/doc/agile/versions/v0/sprint_25/acme_corporation_followups/task_fix_acme_provisioning_recipe.org
+++ b/doc/agile/versions/v0/sprint_25/acme_corporation_followups/task_fix_acme_provisioning_recipe.org
@@ -31,7 +31,7 @@ One recipe, one command, deterministic ACME group every time: holding company + 
 | Now          | Nothing. |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing. |
-| Last touched | 2026-08-09                               |
+| Last touched | 2026-08-14                               |
 
 * Acceptance
 
@@ -76,6 +76,10 @@ via its "Verifies task" field.
 | 3 | Timeout-budget comment claims per-party 10-minute waits; actual waits are 1500s base, 600s LEI, 120s default per-party | provision_commands.cpp | Accepted | Fixed in 8b58315bdd |
 | 4 | Orphaned step-0 row left in_progress when start aborts after step persistence | workflow_engine.cpp | Accepted | Fixed in c13538bd7c |
 | 5 | No-steps recovery branch never publishes a status event | workflow_engine.cpp | Accepted | Fixed in c47cc88f8d |
+| 6 | Stale codegen'd header: tenor/role/process_type docs out of sync with the .org | ir_curve_generation_config.hpp | Accepted | Regenerated via ores.cpp.domain |
+| 7 | FOMC allowance widened to all 19 OIS families; only sofr has meeting-dated pillar machinery | synthetic_ir_curve_generation_configs_create.sql | Accepted | Check scoped to index_family = 'sofr' |
+| 8 | Doc overclaims schema enforcement of the FOMC exception | ir_curve_generation_config.org | Accepted | Doc rewritten to state the sofr-only scope the constraint enforces |
+| 9 | Task Status table stale vs story.org STARTED | task_fix_acme_provisioning_recipe.org | Accepted | State flipped to STARTED; Now/Next/Last touched updated |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/acme_corporation_followups/task_fix_acme_provisioning_recipe.org
+++ b/doc/agile/versions/v0/sprint_25/acme_corporation_followups/task_fix_acme_provisioning_recipe.org
@@ -65,6 +65,7 @@ via its "Verifies task" field.
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/1983][#1983]] | [ores.iam] Surface exact workflow failure reasons on provisioning |
+| [[https://github.com/OreStudio/OreStudio/pull/1984][#1984]] | [synthetic,ores.sql] Allow FOMC-dated tenor for OIS IR curve configs |
 
 * Review
 

--- a/projects/ores.sql/create/synthetic/synthetic_ir_curve_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_ir_curve_generation_configs_create.sql
@@ -75,7 +75,7 @@ create table if not exists "ores_synthetic_ir_curve_generation_configs_tbl" (
     check ("id" <> ores_utility_nil_uuid_fn()),
     check ("currency_code" <> ''),
     check ("index_family" in ('libor', 'euribor', 'sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor')),
-    check (("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" = '')),
+    check (("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" in ('', 'FOMC'))),
     check ("role" in ('discount', 'projection', 'self_discounting')),
     check ("source_name" <> ''),
     check ("ticks_per_hour" > 0),

--- a/projects/ores.sql/create/synthetic/synthetic_ir_curve_generation_configs_create.sql
+++ b/projects/ores.sql/create/synthetic/synthetic_ir_curve_generation_configs_create.sql
@@ -75,7 +75,7 @@ create table if not exists "ores_synthetic_ir_curve_generation_configs_tbl" (
     check ("id" <> ores_utility_nil_uuid_fn()),
     check ("currency_code" <> ''),
     check ("index_family" in ('libor', 'euribor', 'sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor')),
-    check (("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" in ('', 'FOMC'))),
+    check (("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" = '') or ("index_family" = 'sofr' and "tenor" in ('', 'FOMC'))),
     check ("role" in ('discount', 'projection', 'self_discounting')),
     check ("source_name" <> ''),
     check ("ticks_per_hour" > 0),

--- a/projects/ores.synthetic/api/include/ores.synthetic.api/domain/ir_curve_generation_config.hpp
+++ b/projects/ores.synthetic/api/include/ores.synthetic.api/domain/ir_curve_generation_config.hpp
@@ -93,7 +93,13 @@ struct ir_curve_generation_config final {
      * @brief Tenor of this curve's floating-rate index (references tenor.code, e.g. "3M", "6M"),
      * required when index_family is a term family (libor/euribor), empty for overnight families
      * (sofr/estr/sonia/tona, which have no tenor dimension) -- mirrors oresmd's own
-     * index_family-conditional grammar. Empty string, not SQL NULL: the codegen used here has no
+     * index_family-conditional grammar. The literal discriminator "FOMC" is valid only for
+     * index_family sofr (schema-enforced): it keys a meeting-dated curve variant for the same
+     * (currency_code, index_family) (e.g. the USD-SOFR FOMC-dated short end, whose template entries
+     * resolve to meeting-dated pillars 1F..8F via tenor_resolution), so the config publishes its
+     * own distinct series identity instead of colliding with the standard curve's empty-tenor row.
+     * Other overnight families must leave tenor empty: no tenor_resolution meeting-dated pillar
+     * machinery exists for them. Empty string, not SQL NULL: the codegen used here has no
      * true-nullable text support, same pattern as vintage_source/vintage_date. Not DB-FK-validated
      * against tenor, matching the precedent set by ir_curve_template_entry's own
      * start_tenor_code/end_tenor_code (also soft FKs to tenor.code, resolved only at the
@@ -108,24 +114,23 @@ struct ir_curve_generation_config final {
      * self_discounting for backward-compatible seed data (the shape every existing synthetic IR
      * curve config already assumes: one curve serving both purposes). Fixed 3-value vocabulary
      * intrinsic to this record, not a reference to another entity -- no soft FK, validated by a
-     * plain SQL check rather than a lookup-table trigger. feed_controller's collision check keys
-     * on (qualifier, role), not qualifier alone, so a discount config and a projection config for
-     * the same (currency_code, index_family, tenor) can run side by side.
+     * plain SQL check rather than a lookup-table trigger. curve_feed_controller's collision check
+     * deliberately excludes role from its conflict key, so a discount config and a projection
+     * config for the same (currency_code, index_family, tenor) can run side by side.
      */
     std::string role = "self_discounting";
 
     /**
      * @brief Short-rate process engine driving this curve (references
-     * yield_curve_process_type.code: BLACK_KARASINSKI, VASICEK, COX_INGERSOLL_ROSS,
-     * HULL_WHITE, or TWO_FACTOR_GAUSSIAN) -- selects among ores.analytics.quant's
-     * IYieldCurveProcess engines. The engine's parameters are not stored as columns on this record;
-     * each process type has a yield_curve_process_parameter_definition catalogue (name,
-     * description, min/max, defaults) and this config's values live as
-     * ir_curve_generation_config_process_parameter_value rows, one per parameter, joined onto the
-     * definitions at feed-start time by map_parameters_to_yield_curve_process() -- the same
-     * one-config- many-children shape fx_spot_generation_config uses for its gmm_component rows.
-     * Adding a new process type (or parameter) is therefore purely seed data: no ALTER TABLE, no
-     * codegen.
+     * yield_curve_process_type.code: VASICEK, COX_INGERSOLL_ROSS, HULL_WHITE, or
+     * TWO_FACTOR_GAUSSIAN) -- selects among ores.analytics.quant's IYieldCurveProcess engines. The
+     * engine's parameters are not stored as columns on this record; each process type has a
+     * yield_curve_process_parameter_definition catalogue (name, description, min/max, defaults) and
+     * this config's values live as ir_curve_generation_config_process_parameter_value rows, one per
+     * parameter, joined onto the definitions at feed-start time by
+     * map_parameters_to_yield_curve_process() -- the same one-config- many-children shape
+     * fx_spot_generation_config uses for its gmm_component rows. Adding a new process type (or
+     * parameter) is therefore purely seed data: no ALTER TABLE, no codegen.
      */
     std::string process_type = "VASICEK";
 

--- a/projects/ores.synthetic/modeling/ores.synthetic.ir_curve_generation_config.org
+++ b/projects/ores.synthetic/modeling/ores.synthetic.ir_curve_generation_config.org
@@ -120,7 +120,13 @@ Tenor of this curve's floating-rate index (references =tenor.code=,
 e.g. "3M", "6M"), required when =index_family= is a term family
 (=libor=/=euribor=), empty for overnight families (=sofr=/=estr=/=sonia=/=tona=,
 which have no tenor dimension) -- mirrors oresmd's own
-=index_family=-conditional grammar. Empty string, not SQL NULL: the
+=index_family=-conditional grammar. The literal discriminator ="FOMC"=
+is the one exception for overnight families: it keys a meeting-dated
+curve variant for the same =(currency_code, index_family)= (e.g. the
+USD-SOFR FOMC-dated short end, whose template entries resolve to
+meeting-dated pillars 1F..8F via =tenor_resolution=), so the config
+publishes its own distinct series identity instead of colliding with
+the standard curve's empty-tenor row. Empty string, not SQL NULL: the
 codegen used here has no true-nullable text support, same pattern as
 =vintage_source=/=vintage_date=. Not DB-FK-validated against =tenor=,
 matching the precedent set by =ir_curve_template_entry='s own
@@ -391,7 +397,7 @@ std::nullopt
 |----------------------------------------------------------|
 | "currency_code" <> ''                                    |
 | "index_family" in ('libor', 'euribor', 'sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') |
-| ("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" = '') |
+| ("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" in ('', 'FOMC')) |
 | "role" in ('discount', 'projection', 'self_discounting') |
 | "source_name" <> ''                                       |
 | "ticks_per_hour" > 0                                       |

--- a/projects/ores.synthetic/modeling/ores.synthetic.ir_curve_generation_config.org
+++ b/projects/ores.synthetic/modeling/ores.synthetic.ir_curve_generation_config.org
@@ -121,12 +121,14 @@ e.g. "3M", "6M"), required when =index_family= is a term family
 (=libor=/=euribor=), empty for overnight families (=sofr=/=estr=/=sonia=/=tona=,
 which have no tenor dimension) -- mirrors oresmd's own
 =index_family=-conditional grammar. The literal discriminator ="FOMC"=
-is the one exception for overnight families: it keys a meeting-dated
-curve variant for the same =(currency_code, index_family)= (e.g. the
-USD-SOFR FOMC-dated short end, whose template entries resolve to
-meeting-dated pillars 1F..8F via =tenor_resolution=), so the config
+is valid only for =index_family= =sofr= (schema-enforced): it keys a
+meeting-dated curve variant for the same =(currency_code, index_family)=
+(e.g. the USD-SOFR FOMC-dated short end, whose template entries resolve
+to meeting-dated pillars 1F..8F via =tenor_resolution=), so the config
 publishes its own distinct series identity instead of colliding with
-the standard curve's empty-tenor row. Empty string, not SQL NULL: the
+the standard curve's empty-tenor row. Other overnight families must
+leave =tenor= empty: no =tenor_resolution= meeting-dated pillar
+machinery exists for them. Empty string, not SQL NULL: the
 codegen used here has no true-nullable text support, same pattern as
 =vintage_source=/=vintage_date=. Not DB-FK-validated against =tenor=,
 matching the precedent set by =ir_curve_template_entry='s own
@@ -397,7 +399,7 @@ std::nullopt
 |----------------------------------------------------------|
 | "currency_code" <> ''                                    |
 | "index_family" in ('libor', 'euribor', 'sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') |
-| ("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('sofr', 'estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" in ('', 'FOMC')) |
+| ("index_family" in ('libor', 'euribor') and "tenor" <> '') or ("index_family" in ('estr', 'sonia', 'tona', 'saron', 'aonia', 'corra', 'honia', 'sora', 'swestr', 'nowa', 'kofr', 'mibor', 'zaronia', 'destr', 'polonia', 'nzonia', 'shibor', 'tiie', 'taibor') and "tenor" = '') or ("index_family" = 'sofr' and "tenor" in ('', 'FOMC')) |
 | "role" in ('discount', 'projection', 'self_discounting') |
 | "source_name" <> ''                                       |
 | "ticks_per_hour" > 0                                       |


### PR DESCRIPTION
## Summary

The FOMC-dated USD/SOFR short-end config seeds tenor 'FOMC' as the discriminator that keys its own series identity (US/SOFR-FOMC), but the generated check on ores_synthetic_ir_curve_generation_configs_tbl required an empty tenor for every OIS family. Every Acme provisioning therefore failed at the synthetic.themes.realistic_2026 publish with a check-constraint violation -- first surfaced end-to-end now that the provisioning failure-reporting fix (PR #1983) lets the run reach the synthetic step and report honestly.

## Changes

- Model: ir_curve_generation_config tenor check admits 'FOMC' alongside the empty tenor for OIS index families; tenor column doc describes the meeting-dated curve variant
- Regenerated ores.sql create file from the model

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Acme Corporation follow-ups: manual chapter, logo fixes, synthetic feeds](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/acme_corporation_followups/story.html) | BC5582FB-1648-42F2-9D6A-B6DB6EEBC676 |
| Task | [Fix ACME provisioning recipe to be deterministic, curated, and self-contained](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/acme_corporation_followups/task_fix_acme_provisioning_recipe.html) | CA9CB414-9F61-4395-8183-A134BE9A2B9B |
| Environment | eager_maxwell | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)