### PR TITLE
[ores.eventing,ores.database] Harden the eventing chain against transient notification loss

### DIFF
--- a/doc/agile/product_backlog/inbox/limit_concurrent_running_fleets.org
+++ b/doc/agile/product_backlog/inbox/limit_concurrent_running_fleets.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: BF8714BC-B214-448E-A16C-66EB36C967B1
+:END:
+#+title: Limit concurrent running fleets via fleet slots
+#+description: Bound concurrent fleets to a fixed slot count so service fleets cannot exhaust host memory.
+#+type: capture
+#+level: cross
+#+filetags: :compass:memory:host:
+#+created: 2026-08-28
+#+updated: 2026-08-28
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Add a host-wide fleet-slot limit to =compass services start= so only a
+fixed number of environments can run their service fleets at once.
+The mechanism counts active systemd user units matching
+=ores-<env>.target= (e.g. =ores-brave_hopper.target=,
+=ores-jolly_knuth.target=) before starting a new fleet, and refuses
+with a message naming the running fleets when the limit is reached.
+The check lives in =compass_services.py=, in =_cmd_start=, before
+=systemd_generate.cmd_generate=; the count is a constant in the style
+of =BUILD_LOCK_SLOTS= in =compass.py=. A count-based check (not a
+flock like the build lock) because a fleet outlives the =services
+start= command, so a flock would go stale the moment start exits.
+Suggested limit: 2 fleets.
+
+* Why
+
+On 2026-08-27 two idle fleets (jolly_knuth, brave_hopper) held ~2.5G
+plus ~140 idle postgres backends, pushing the host baseline to ~8G of
+31G. Concurrent builds then spiked anon memory to ~15G and systemd-
+oomd killed cgroups under PSI pressure (emacs.service, build scopes).
+Fleet slots bound the baseline so builds have headroom; the related
+emacs oomd shield is a user-level drop-in at
+=~/.config/systemd/user/emacs.service.d/50-oomd-protect.conf= (not in
+this repo).
+
+* References
+
+- =projects/ores.compass/src/compass_services.py= — =_cmd_start=, fleet target start/stop
+- =projects/ores.compass/src/compass.py= — =BUILD_LOCK_SLOTS=, flock pattern to mirror
+- =~/.config/systemd/user/emacs.service.d/50-oomd-protect.conf= — emacs oomd shield (user-level, not in repo)
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/story.org
+++ b/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/story.org
@@ -21,7 +21,7 @@ The eventing chain (postgres_listener_service, postgres_event_source, event_bus,
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -40,7 +40,7 @@ The eventing chain (postgres_listener_service, postgres_event_source, event_bus,
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:BD63D4C8-4AA2-4613-A63D-DC5969576469][Scaffold story: Harden the eventing chain against transient notification loss]] | DONE | 2026-08-25 | 2026-08-25 | Story scaffolding rides this task: documents, sprint wiring, and the scaffold PR. Close it before merging that PR. |
-| [[id:C9B8F903-27A4-456E-90E7-157507FFC024][Implement eventing chain hardening]] | BACKLOG | | | Initial task for: Harden the eventing chain against transient notification loss |
+| [[id:C9B8F903-27A4-456E-90E7-157507FFC024][Implement eventing chain hardening]] | STARTED | 2026-08-26 | | Initial task for: Harden the eventing chain against transient notification loss |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
+++ b/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
@@ -113,7 +113,11 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 5448091254 | Five local publish_entity_event helpers swallow NATS failures instead of rethrowing | refdata/workspace/trading/compute/analytics application.cpp | Accepted | Delegated each helper to the shared hardened ores::eventing::service::publish_entity_event; removed the now-unused pub_lg(); dropped the wire_codec include |
+| 5448091254 | subscribed_channels_str hand-rolls boost::algorithm::join | postgres_listener_service.cpp | Accepted | Replaced with boost::algorithm::join(channels, ", "); helper removed |
+| 5448091687 | Reconnect-test backend kill is not scoped to the listener (kills every same-user client backend) | postgres_listener_service_tests.cpp | Accepted | connect_utc stamps application_name = ores.database.listener.<pid>; test kills only backends matching that name. sqlgen has no scalar-query API, so the pid is exposed via the stamped name rather than an accessor |
+| 5448091687 | wait_for evaluates the predicate once more after the deadline | postgres_listener_service_tests.cpp | Declined | Harmless: every predicate is an idempotent read |
+| 5448091687 | Reconnect success logs at error severity | postgres_listener_service.cpp | Declined | Intentional: the window lost notifications; the error record is the loss surfacing |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
+++ b/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :eventing_chain_hardening:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-eventing-chain-hardening
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-25
 #+updated: 2026-08-25
-#+environment:
+#+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:639008BB-03A6-4675-AF2F-90A4A699729C][Harden the eventing chain against transient notification loss]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,7 +26,7 @@ The eventing chain (postgres_listener_service, postgres_event_source, event_bus,
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:639008BB-03A6-4675-AF2F-90A4A699729C][Harden the eventing chain against transient notification loss]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
+++ b/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
@@ -118,6 +118,8 @@ via its "Verifies task" field.
 | 5448091687 | Reconnect-test backend kill is not scoped to the listener (kills every same-user client backend) | postgres_listener_service_tests.cpp | Accepted | connect_utc stamps application_name = ores.database.listener.<pid>; test kills only backends matching that name. sqlgen has no scalar-query API, so the pid is exposed via the stamped name rather than an accessor |
 | 5448091687 | wait_for evaluates the predicate once more after the deadline | postgres_listener_service_tests.cpp | Declined | Harmless: every predicate is an idempotent read |
 | 5448091687 | Reconnect success logs at error severity | postgres_listener_service.cpp | Declined | Intentional: the window lost notifications; the error record is the loss surfacing |
+| 5453339136 | Kill scope still matches any listener session of the user (name prefix, not this instance) | postgres_listener_service_tests.cpp | Accepted | connect_utc now stamps a per-instance unique application_name (process pid plus instance counter); the service exposes it via application_name(); the test filters on exact equality. sqlgen has no scalar-read API, so the pid cannot be surfaced; the unique name achieves identical single-backend scoping |
+| 5453339136 | Unrelated backlog capture rides on the branch (fleet-slot limits) | limit_concurrent_running_fleets.org | Declined | Acknowledged: unrelated agile capture from the working session; harmless on the topic branch |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
+++ b/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.org
@@ -8,11 +8,11 @@
 #+filetags: :eventing_chain_hardening:sprint_25:v0:
 #+owner: marco
 #+branch: feature/implement-eventing-chain-hardening
-#+pr:
+#+pr: 1998
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-25
-#+updated: 2026-08-25
+#+updated: 2026-08-28
 #+environment: clever_dijkstra
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
@@ -26,12 +26,12 @@ The eventing chain (postgres_listener_service, postgres_event_source, event_bus,
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                                  |
 | Parent story | [[id:639008BB-03A6-4675-AF2F-90A4A699729C][Harden the eventing chain against transient notification loss]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-25                               |
+| Next         | Nothing.                               |
+| Last touched | 2026-08-28                               |
 
 * Acceptance
 
@@ -45,6 +45,50 @@ The eventing chain (postgres_listener_service, postgres_event_source, event_bus,
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
 plan itself stays — it is the historical record of what we did.)
+
+** Loss window 1: listener reconnect
+
+- Root cause: =postgres_listener_service::listen_loop= drops the
+  connection when =consume_input= fails, runs the 1-5s doubling
+  backoff, then reconnects and re-issues LISTEN. PostgreSQL delivers
+  NOTIFY only to live LISTEN sessions and has no replay for dead
+  sessions, so every notification sent during the outage is lost
+  forever.
+- Decision: recovery at this layer is impossible; surface the loss
+  instead. Each detected loss increments a public counter
+  (=connection_loss_count=) and writes an error log naming the
+  affected channels, so the loss is diagnosable even if the service
+  stops before reconnect. The successful reconnect writes a second
+  error log with the outage duration and channels.
+- Test: =postgres_listener_service_reconnect_surfaces_loss_window=.
+  sqlgen has no client-side disconnect API, so the listener session is
+  killed server-side with =pg_terminate_backend= — a role may signal
+  its own sessions, and the listener connects with the test user's
+  credentials. The test kills the session, sends a NOTIFY during the
+  outage (asserts it never arrives), waits for the reconnect, then
+  sends a second NOTIFY and asserts it arrives exactly once.
+
+** Loss window 2: NATS publish failures
+
+- Root cause: =publish_entity_event= caught the NATS exception, logged
+  it at error, and swallowed it; the event_bus delivery summary then
+  reported partial delivery at debug severity, invisible at default
+  log levels.
+- Decision: =publish_entity_event= rethrows with the subject in the
+  message. Every call site (~150 per-entity registrars) is an event_bus
+  subscriber callback, and the bus catches handler exceptions at error,
+  so a failed publish surfaces at error in both the handler log and
+  the delivery summary. The summary logs at error when delivery is
+  incomplete and at debug when complete.
+- Test: =publish_entity_event_rethrows_on_nats_failure= — a never-
+  connected NATS client fails every publish with NATS_NOT_CONNECTED;
+  the publisher must throw =std::runtime_error=.
+
+** Verification
+
+- Full build, then the targeted suites (=ores.database.tests=,
+  =ores.eventing.api.tests=, =ores.eventing.core.tests=), the eventing
+  integration family (85 tests), and full ctest.
 
 * Notes
 
@@ -63,7 +107,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1998][#1998]] | [ores.eventing,ores.database] Harden the eventing chain against transient notification loss |
 
 * Review
 
@@ -72,3 +116,26 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Implemented both loss-window surfacings. The listener now counts each
+detected connection loss (=connection_loss_count=), logs the affected
+channels at detection, and logs the outage duration and channels at
+reconnect; =publish_entity_event= rethrows NATS failures with the
+subject in the message and the event_bus delivery summary logs at
+error when delivery is incomplete. New tests cover both: the listener
+reconnect test kills the backend server-side, proves the in-flight
+NOTIFY is lost, and proves the post-reconnect NOTIFY arrives exactly
+once; the publisher test proves a NATS_NOT_CONNECTED publish throws.
+Test hygiene fix: the listener test file's =DO $= blocks were invalid
+SQL (=DO $ BEGIN= is a syntax error), which made every probe in the
+new test fail closed and left the pre-existing
+=connect_forces_utc_session= test vacuous; all four blocks now use
+=DO $$=. Verification: full build clean; =ores.database.tests= 17/17
+(including the reconnect test); =ores.eventing.api.tests= and
+=ores.eventing.core.tests= green; the eventing integration family
+(85 tests across iam/refdata/reporting/trading) green; full ctest
+71/71 green on a freshly recreated database. Note: the integration
+family needs the environment NATS server up
+(=nats-server-clever_dijkstra.service=) and a clean database
+(=compass db recreate=) — repeated runs collide on committed test
+data otherwise.

--- a/projects/ores.analytics/service/src/app/application.cpp
+++ b/projects/ores.analytics/service/src/app/application.cpp
@@ -27,9 +27,9 @@
 #include "ores.database/service/context_factory.hpp"
 #include "ores.eventing.api/domain/entity_change_event.hpp"
 #include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
 #include "ores.eventing.core/service/postgres_event_source.hpp"
 #include "ores.eventing.core/service/registrar.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
@@ -49,20 +49,12 @@ namespace {
 constexpr std::string_view service_name = "ores.analytics.service";
 constexpr std::string_view service_version = ORES_VERSION;
 
-auto& pub_lg() {
-    static auto instance = make_logger("ores.analytics.service.app");
-    return instance;
-}
-
 void publish_entity_event(ores::nats::service::client& nats,
                           const std::string& subject,
                           const ev::domain::entity_change_event& notif) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notif), {});
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(pub_lg(), error)
-            << "Failed to publish event to '" << subject << "': " << e.what();
-    }
+    // Delegate to the shared hardened publisher: it rethrows on failure so
+    // the event_bus surfaces the lost notification at error.
+    ev::service::publish_entity_event(nats, subject, notif);
 }
 
 } // namespace

--- a/projects/ores.compute/service/src/app/application.cpp
+++ b/projects/ores.compute/service/src/app/application.cpp
@@ -30,9 +30,9 @@
 #include "ores.database/service/context_factory.hpp"
 #include "ores.eventing.api/domain/entity_change_event.hpp"
 #include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
 #include "ores.eventing.core/service/postgres_event_source.hpp"
 #include "ores.eventing.core/service/registrar.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
@@ -67,20 +67,12 @@ namespace {
 constexpr std::string_view service_name = "ores.compute.service";
 constexpr std::string_view service_version = ORES_VERSION;
 
-auto& pub_lg() {
-    static auto instance = make_logger("ores.compute.service.app");
-    return instance;
-}
-
 void publish_entity_event(ores::nats::service::client& nats,
                           const std::string& subject,
                           const ev::domain::entity_change_event& notif) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notif), {});
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(pub_lg(), error)
-            << "Failed to publish event to '" << subject << "': " << e.what();
-    }
+    // Delegate to the shared hardened publisher: it rethrows on failure so
+    // the event_bus surfaces the lost notification at error.
+    ev::service::publish_entity_event(nats, subject, notif);
 }
 
 } // namespace

--- a/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
+++ b/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
@@ -55,6 +55,11 @@ namespace ores::database::service {
  * 3828BF82); the pool forces it at acquisition, this dedicated
  * connection must do the same.
  *
+ * Also stamps the session's application_name as
+ * "ores.database.listener.<backend pid>" so pg_stat_activity can
+ * identify this backend; the reconnect test scopes its
+ * pg_terminate_backend signal to that name.
+ *
  * Exposed as a free function so tests can assert the session is UTC.
  */
 [[nodiscard]] ORES_DATABASE_EXPORT sqlgen::Result<sqlgen::Ref<sqlgen::postgres::Connection>>

--- a/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
+++ b/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
@@ -55,15 +55,16 @@ namespace ores::database::service {
  * 3828BF82); the pool forces it at acquisition, this dedicated
  * connection must do the same.
  *
- * Also stamps the session's application_name as
- * "ores.database.listener.<backend pid>" so pg_stat_activity can
- * identify this backend; the reconnect test scopes its
- * pg_terminate_backend signal to that name.
+ * Also stamps the session's application_name so pg_stat_activity can
+ * identify this backend. The caller supplies the name: each listener
+ * instance uses one unique to it, and the reconnect test scopes its
+ * pg_terminate_backend signal to that exact name.
  *
  * Exposed as a free function so tests can assert the session is UTC.
  */
 [[nodiscard]] ORES_DATABASE_EXPORT sqlgen::Result<sqlgen::Ref<sqlgen::postgres::Connection>>
-connect_utc(const sqlgen::postgres::Credentials& credentials);
+connect_utc(const sqlgen::postgres::Credentials& credentials,
+            const std::string& application_name);
 
 class ORES_DATABASE_EXPORT postgres_listener_service final {
 private:
@@ -167,6 +168,18 @@ public:
         return connection_loss_count_.load(std::memory_order_relaxed);
     }
 
+    /**
+     * @brief The application_name this listener stamps on its sessions.
+     *
+     * Unique per listener instance (process pid plus an instance counter),
+     * so pg_stat_activity can distinguish this listener from any other
+     * session of the same user; the reconnect test matches its kill signal
+     * on this exact name.
+     */
+    [[nodiscard]] const std::string& application_name() const noexcept {
+        return application_name_;
+    }
+
 private:
     /**
      * @brief Opens the dedicated PostgreSQL connection.
@@ -202,6 +215,11 @@ private:
 private:
     context ctx_;
     notification_callback_t notification_callback_;
+    std::string application_name_;
+
+    // Unique per listener instance; makes application_name_ unambiguous
+    // across processes and concurrent test suites.
+    inline static std::atomic<std::uint64_t> instance_counter_{0};
 
     mutable std::mutex mutex_; ///< Protects connection and channels
     std::optional<rfl::Ref<sqlgen::postgres::Connection>> connection_;

--- a/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
+++ b/projects/ores.database/include/ores.database/service/postgres_listener_service.hpp
@@ -149,6 +149,19 @@ public:
      */
     bool wait_until_ready(std::chrono::milliseconds timeout = std::chrono::seconds(5));
 
+    /**
+     * @brief Number of connection losses detected since construction.
+     *
+     * Each loss drops every NOTIFY in flight until the reconnect and
+     * re-LISTEN complete; PostgreSQL has no replay for dead sessions, so
+     * each loss is a surfaced loss window, not a recovered one. The
+     * operator-facing record of each window is the error log written at
+     * detection and at reconnect.
+     */
+    [[nodiscard]] std::uint64_t connection_loss_count() const noexcept {
+        return connection_loss_count_.load(std::memory_order_relaxed);
+    }
+
 private:
     /**
      * @brief Opens the dedicated PostgreSQL connection.
@@ -191,6 +204,10 @@ private:
 
     std::thread listener_thread_;
     std::atomic<bool> running_;
+
+    std::atomic<std::uint64_t> connection_loss_count_{0};
+    // Set on loss detection, read on reconnect; accessed by listen_loop only.
+    std::chrono::steady_clock::time_point loss_start_{};
 
     std::condition_variable ready_cv_; ///< Signaled when listener is ready
     bool ready_{false};                ///< True when listener is actively polling

--- a/projects/ores.database/src/service/postgres_listener_service.cpp
+++ b/projects/ores.database/src/service/postgres_listener_service.cpp
@@ -53,6 +53,16 @@ connect_utc(const sqlgen::postgres::Credentials& credentials) {
         return sqlgen::error("Failed to set session timezone to UTC: " +
                              std::string(tz_result.error().what()));
     }
+
+    // Stamp the session so pg_stat_activity identifies the listener backend;
+    // the reconnect test scopes its pg_terminate_backend signal to this name.
+    auto name_result = (*conn_result)
+                           ->execute("SELECT set_config('application_name', "
+                                     "'ores.database.listener.' || pg_backend_pid()::text, false)");
+    if (!name_result) {
+        return sqlgen::error("Failed to set application_name: " +
+                             std::string(name_result.error().what()));
+    }
     return conn_result;
 }
 

--- a/projects/ores.database/src/service/postgres_listener_service.cpp
+++ b/projects/ores.database/src/service/postgres_listener_service.cpp
@@ -20,29 +20,14 @@
 #include "ores.database/service/postgres_listener_service.hpp"
 #include "ores.database/domain/session_utilities.hpp"
 #include <algorithm>
+#include <boost/algorithm/string/join.hpp>
 #include <chrono>
 #include <list>
-#include <sstream>
 #include <thread>
 
 namespace ores::database::service {
 
 using namespace ores::logging;
-
-namespace {
-
-// Builds the comma-separated channel list for loss-window diagnostics.
-std::string subscribed_channels_str(const std::vector<std::string>& channels) {
-    std::ostringstream oss;
-    for (std::size_t i = 0; i < channels.size(); ++i) {
-        if (i > 0)
-            oss << ", ";
-        oss << channels[i];
-    }
-    return oss.str();
-}
-
-}
 
 postgres_listener_service::postgres_listener_service(context ctx, notification_callback_t callback)
     : ctx_(std::move(ctx))
@@ -236,7 +221,7 @@ void postgres_listener_service::listen_loop() {
                 loss_start_ = std::chrono::steady_clock::now();
                 BOOST_LOG_SEV(lg(), error)
                     << "Listener connection lost while listening on channels ["
-                    << subscribed_channels_str(subscribed_channels_)
+                    << boost::algorithm::join(subscribed_channels_, ", ")
                     << "]; notifications in flight may be lost";
             } else {
                 backoff = min_backoff; // reset on successful poll
@@ -270,7 +255,7 @@ void postgres_listener_service::listen_loop() {
             BOOST_LOG_SEV(lg(), error)
                 << "Reconnected after " << loss_duration.count()
                 << "ms; notifications sent on channels ["
-                << subscribed_channels_str(subscribed_channels_)
+                << boost::algorithm::join(subscribed_channels_, ", ")
                 << "] during the outage are lost (PostgreSQL has no replay)";
             BOOST_LOG_SEV(lg(), info) << "Listener reconnected. Reissuing LISTENs.";
             issue_pending_listens();

--- a/projects/ores.database/src/service/postgres_listener_service.cpp
+++ b/projects/ores.database/src/service/postgres_listener_service.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <list>
 #include <thread>
+#include <unistd.h>
 
 namespace ores::database::service {
 
@@ -32,6 +33,8 @@ using namespace ores::logging;
 postgres_listener_service::postgres_listener_service(context ctx, notification_callback_t callback)
     : ctx_(std::move(ctx))
     , notification_callback_(std::move(callback))
+    , application_name_("ores.database.listener." + std::to_string(::getpid()) + "." +
+                        std::to_string(instance_counter_.fetch_add(1)))
     , connection_(std::nullopt)
     , running_(false) {
     BOOST_LOG_SEV(lg(), debug) << "Listener service created.";
@@ -43,7 +46,8 @@ postgres_listener_service::~postgres_listener_service() {
 }
 
 sqlgen::Result<sqlgen::Ref<sqlgen::postgres::Connection>>
-connect_utc(const sqlgen::postgres::Credentials& credentials) {
+connect_utc(const sqlgen::postgres::Credentials& credentials,
+            const std::string& application_name) {
     auto conn_result = sqlgen::postgres::connect(credentials);
     if (!conn_result)
         return conn_result;
@@ -57,8 +61,8 @@ connect_utc(const sqlgen::postgres::Credentials& credentials) {
     // Stamp the session so pg_stat_activity identifies the listener backend;
     // the reconnect test scopes its pg_terminate_backend signal to this name.
     auto name_result = (*conn_result)
-                           ->execute("SELECT set_config('application_name', "
-                                     "'ores.database.listener.' || pg_backend_pid()::text, false)");
+                           ->execute("SELECT set_config('application_name', '" + application_name +
+                                     "', false)");
     if (!name_result) {
         return sqlgen::error("Failed to set application_name: " +
                              std::string(name_result.error().what()));
@@ -76,7 +80,7 @@ bool postgres_listener_service::open_connection() {
 
     BOOST_LOG_SEV(lg(), debug) << "Opening dedicated listener connection.";
 
-    auto result = connect_utc(ctx_.credentials());
+    auto result = connect_utc(ctx_.credentials(), application_name_);
     if (!result) {
         BOOST_LOG_SEV(lg(), error) << "Failed to connect to database: " << result.error().what();
         return false;
@@ -254,7 +258,7 @@ void postgres_listener_service::listen_loop() {
                 break;
 
             std::lock_guard lock(mutex_);
-            auto result = connect_utc(ctx_.credentials());
+            auto result = connect_utc(ctx_.credentials(), application_name_);
             if (!result) {
                 BOOST_LOG_SEV(lg(), error) << "Reconnect failed: " << result.error().what();
                 continue; // will retry after next backoff

--- a/projects/ores.database/src/service/postgres_listener_service.cpp
+++ b/projects/ores.database/src/service/postgres_listener_service.cpp
@@ -22,11 +22,27 @@
 #include <algorithm>
 #include <chrono>
 #include <list>
+#include <sstream>
 #include <thread>
 
 namespace ores::database::service {
 
 using namespace ores::logging;
+
+namespace {
+
+// Builds the comma-separated channel list for loss-window diagnostics.
+std::string subscribed_channels_str(const std::vector<std::string>& channels) {
+    std::ostringstream oss;
+    for (std::size_t i = 0; i < channels.size(); ++i) {
+        if (i > 0)
+            oss << ", ";
+        oss << channels[i];
+    }
+    return oss.str();
+}
+
+}
 
 postgres_listener_service::postgres_listener_service(context ctx, notification_callback_t callback)
     : ctx_(std::move(ctx))
@@ -216,6 +232,12 @@ void postgres_listener_service::listen_loop() {
                 BOOST_LOG_SEV(lg(), error) << "Connection error while consuming input.";
                 connection_ = std::nullopt;
                 connection_ok = false;
+                ++connection_loss_count_;
+                loss_start_ = std::chrono::steady_clock::now();
+                BOOST_LOG_SEV(lg(), error)
+                    << "Listener connection lost while listening on channels ["
+                    << subscribed_channels_str(subscribed_channels_)
+                    << "]; notifications in flight may be lost";
             } else {
                 backoff = min_backoff; // reset on successful poll
                 batch = (*connection_)->get_notifications();
@@ -243,6 +265,13 @@ void postgres_listener_service::listen_loop() {
                 continue; // will retry after next backoff
             }
             connection_ = std::move(*result);
+            const auto loss_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - loss_start_);
+            BOOST_LOG_SEV(lg(), error)
+                << "Reconnected after " << loss_duration.count()
+                << "ms; notifications sent on channels ["
+                << subscribed_channels_str(subscribed_channels_)
+                << "] during the outage are lost (PostgreSQL has no replay)";
             BOOST_LOG_SEV(lg(), info) << "Listener reconnected. Reissuing LISTENs.";
             issue_pending_listens();
             continue;

--- a/projects/ores.database/tests/postgres_listener_service_tests.cpp
+++ b/projects/ores.database/tests/postgres_listener_service_tests.cpp
@@ -260,7 +260,7 @@ TEST_CASE("postgres_listener_service_connect_forces_utc_session", tags) {
     database_helper h;
     const auto& credentials = h.context().credentials();
 
-    auto conn_result = connect_utc(credentials);
+    auto conn_result = connect_utc(credentials, "ores.database.test.session");
     REQUIRE(conn_result);
 
     // Behavioral assertion: in a UTC session the sentinel function equals the
@@ -296,20 +296,21 @@ TEST_CASE("postgres_listener_service_reconnect_surfaces_loss_window", tags) {
     listener.start();
     REQUIRE(listener.wait_until_ready());
 
-    // The listener stamps its session's application_name (connect_utc), so
-    // pg_stat_activity identifies the backend exactly: same user and
-    // database, not our own pid, and a listener-stamped name. The name
-    // embeds the backend pid, so a concurrent test suite's sessions -- or
-    // any other connection of this user -- never match and are never
-    // signalled. A role may terminate its own sessions, so the DML test
-    // user can signal the listener backend.
+    // The listener stamps each session with an application_name unique to
+    // this instance (process pid plus an instance counter), so
+    // pg_stat_activity identifies exactly this listener's backend: same
+    // user and database, not our own pid, and this exact name. Sibling
+    // listeners from concurrently-running suites carry their own names and
+    // are never matched, and plain connections of this user never match
+    // either. A role may terminate its own sessions, so the DML test user
+    // can signal the listener backend.
     auto control = sqlgen::postgres::connect(credentials);
     REQUIRE(control);
 
     const std::string backend_filter =
         "usename = current_user AND datname = current_database() "
         "AND pid <> pg_backend_pid() "
-        "AND application_name LIKE 'ores.database.listener.%'";
+        "AND application_name = '" + listener.application_name() + "'";
 
     const std::string expect_present =
         "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_stat_activity WHERE " + backend_filter +

--- a/projects/ores.database/tests/postgres_listener_service_tests.cpp
+++ b/projects/ores.database/tests/postgres_listener_service_tests.cpp
@@ -22,15 +22,32 @@
 #include "ores.testing/database_helper.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <functional>
 #include <future>
+#include <mutex>
 #include <sqlgen/postgres.hpp>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace {
 
 const std::string test_suite("ores.database.service.tests");
 const std::string tags("[service][postgres_listener]");
+
+/**
+ * @brief Polls a predicate every 100ms until it returns true or the timeout
+ * elapses.
+ */
+bool wait_for(const std::function<bool()>& predicate, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate())
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return predicate();
+}
 
 /**
  * @brief Sends a NOTIFY on a channel using a separate connection.
@@ -251,8 +268,99 @@ TEST_CASE("postgres_listener_service_connect_forces_utc_session", tags) {
     // (the server default is Europe/London) the naive literal folds away and
     // the DO block succeeds -- which would fail the REQUIRE_FALSE below.
     auto result = (*conn_result)
-                      ->execute("DO $ BEGIN IF ores_utility_infinity_timestamp_fn() = "
+                      ->execute("DO $$ BEGIN IF ores_utility_infinity_timestamp_fn() = "
                                 "'9999-12-31 23:59:59'::timestamptz THEN RAISE EXCEPTION 'utc'; "
-                                "END IF; END $;");
+                                "END IF; END $$;");
     REQUIRE_FALSE(result);
+}
+
+TEST_CASE("postgres_listener_service_reconnect_surfaces_loss_window", tags) {
+    std::string channel_name =
+        "test_channel_reconnect_" +
+        std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    const std::string lost_payload = R"({"entity":"ores.database.lost"})";
+    const std::string recovered_payload = R"({"entity":"ores.database.recovered"})";
+
+    std::vector<std::string> received;
+    std::mutex received_mutex;
+    auto callback = [&](const std::string&, const std::string& payload) {
+        std::lock_guard lock(received_mutex);
+        received.push_back(payload);
+    };
+
+    database_helper h;
+    const auto& credentials = h.context().credentials();
+
+    postgres_listener_service listener(h.context(), callback);
+    listener.subscribe(channel_name);
+    listener.start();
+    REQUIRE(listener.wait_until_ready());
+
+    // Every same-user client backend on this database except our own is the
+    // listener's session. A role may terminate its own sessions, so the DML
+    // test user can signal the listener backend. Concurrent test suites
+    // share the user; their own listeners survive the same signal by
+    // reconnecting.
+    auto control = sqlgen::postgres::connect(credentials);
+    REQUIRE(control);
+
+    const std::string backend_filter =
+        "usename = current_user AND datname = current_database() "
+        "AND pid <> pg_backend_pid() AND backend_type = 'client backend'";
+
+    const std::string expect_present =
+        "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_stat_activity WHERE " + backend_filter +
+        ") THEN RAISE EXCEPTION 'listener backend not found'; END IF; END $$;";
+    const std::string terminate_all =
+        "DO $$ BEGIN PERFORM pg_terminate_backend(pid) FROM pg_stat_activity WHERE " +
+        backend_filter + "; END $$;";
+    const std::string expect_gone =
+        "DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_stat_activity WHERE " + backend_filter +
+        ") THEN RAISE EXCEPTION 'listener backend still present'; END IF; END $$;";
+
+    // Precondition: the listener session is registered in pg_stat_activity.
+    REQUIRE(wait_for([&] { return bool((*control)->execute(expect_present)); },
+                     std::chrono::seconds(10)));
+
+    // Kill the listener session. PostgreSQL delivers NOTIFY only to live
+    // LISTEN sessions, so everything sent from here until the reconnect is
+    // a lost window.
+    auto terminated = (*control)->execute(terminate_all);
+    REQUIRE(terminated);
+
+    // Wait until the session is gone before sending the in-flight NOTIFY,
+    // so the loss is guaranteed rather than racy.
+    REQUIRE(wait_for([&] { return bool((*control)->execute(expect_gone)); },
+                     std::chrono::seconds(10)));
+
+    // Sent while the listener is down: lost forever. The surfacing is the
+    // counter and the error logs, not a recovery.
+    send_notify(credentials, channel_name, lost_payload);
+
+    // The listener detects the loss on its next poll and records the window.
+    REQUIRE(wait_for([&] { return listener.connection_loss_count() >= 1; },
+                     std::chrono::seconds(10)));
+
+    // Wait until the listener session is back, then let the reissued LISTEN
+    // land before sending the recovery notification.
+    REQUIRE(wait_for([&] { return bool((*control)->execute(expect_present)); },
+                     std::chrono::seconds(10)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    send_notify(credentials, channel_name, recovered_payload);
+
+    // The recovered notification must arrive exactly once; the lost one
+    // must never arrive.
+    REQUIRE(wait_for([&] {
+                         std::lock_guard lock(received_mutex);
+                         return received.size() == 1;
+                     },
+                     std::chrono::seconds(10)));
+    {
+        std::lock_guard lock(received_mutex);
+        REQUIRE(received.size() == 1);
+        REQUIRE(received[0] == recovered_payload);
+    }
+
+    listener.stop();
 }

--- a/projects/ores.database/tests/postgres_listener_service_tests.cpp
+++ b/projects/ores.database/tests/postgres_listener_service_tests.cpp
@@ -296,22 +296,25 @@ TEST_CASE("postgres_listener_service_reconnect_surfaces_loss_window", tags) {
     listener.start();
     REQUIRE(listener.wait_until_ready());
 
-    // Every same-user client backend on this database except our own is the
-    // listener's session. A role may terminate its own sessions, so the DML
-    // test user can signal the listener backend. Concurrent test suites
-    // share the user; their own listeners survive the same signal by
-    // reconnecting.
+    // The listener stamps its session's application_name (connect_utc), so
+    // pg_stat_activity identifies the backend exactly: same user and
+    // database, not our own pid, and a listener-stamped name. The name
+    // embeds the backend pid, so a concurrent test suite's sessions -- or
+    // any other connection of this user -- never match and are never
+    // signalled. A role may terminate its own sessions, so the DML test
+    // user can signal the listener backend.
     auto control = sqlgen::postgres::connect(credentials);
     REQUIRE(control);
 
     const std::string backend_filter =
         "usename = current_user AND datname = current_database() "
-        "AND pid <> pg_backend_pid() AND backend_type = 'client backend'";
+        "AND pid <> pg_backend_pid() "
+        "AND application_name LIKE 'ores.database.listener.%'";
 
     const std::string expect_present =
         "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_stat_activity WHERE " + backend_filter +
         ") THEN RAISE EXCEPTION 'listener backend not found'; END IF; END $$;";
-    const std::string terminate_all =
+    const std::string terminate_listener =
         "DO $$ BEGIN PERFORM pg_terminate_backend(pid) FROM pg_stat_activity WHERE " +
         backend_filter + "; END $$;";
     const std::string expect_gone =
@@ -325,7 +328,7 @@ TEST_CASE("postgres_listener_service_reconnect_surfaces_loss_window", tags) {
     // Kill the listener session. PostgreSQL delivers NOTIFY only to live
     // LISTEN sessions, so everything sent from here until the reconnect is
     // a lost window.
-    auto terminated = (*control)->execute(terminate_all);
+    auto terminated = (*control)->execute(terminate_listener);
     REQUIRE(terminated);
 
     // Wait until the session is gone before sending the in-flight NOTIFY,

--- a/projects/ores.eventing/api/include/ores.eventing.api/service/event_bus.hpp
+++ b/projects/ores.eventing/api/include/ores.eventing.api/service/event_bus.hpp
@@ -183,8 +183,10 @@ public:
      * @param event The event instance to publish.
      *
      * All registered handlers for this event type will be invoked synchronously.
-     * Exceptions thrown by handlers are caught and logged, but do not prevent
-     * other handlers from being called.
+     * Exceptions thrown by handlers are caught and logged at error, but do not
+     * prevent other handlers from being called. When any handler fails, the
+     * delivery summary is logged at error as well, so partial delivery is
+     * visible at default log severity.
      */
     template <typename Event>
     void publish(const Event& event) {
@@ -231,9 +233,15 @@ public:
             }
         }
 
-        BOOST_LOG_SEV(lg(), debug)
-            << "Event '" << type_name << "' delivery complete: " << success_count << "/"
-            << handlers_copy.size() << " handlers succeeded";
+        if (success_count < handlers_copy.size()) {
+            BOOST_LOG_SEV(lg(), error)
+                << "Event '" << type_name << "' delivery incomplete: " << success_count << "/"
+                << handlers_copy.size() << " handlers succeeded";
+        } else {
+            BOOST_LOG_SEV(lg(), debug)
+                << "Event '" << type_name << "' delivery complete: " << success_count << "/"
+                << handlers_copy.size() << " handlers succeeded";
+        }
     }
 
     /**

--- a/projects/ores.eventing/core/include/ores.eventing.core/service/entity_event_publisher.hpp
+++ b/projects/ores.eventing/core/include/ores.eventing.core/service/entity_event_publisher.hpp
@@ -30,9 +30,13 @@ namespace ores::eventing::service {
 /**
  * @brief Publishes an entity_change_event to NATS on the given subject.
  *
- * Serializes the notification to JSON and publishes it, logging (rather than
- * throwing) on failure. Shared by every component's per-entity event-mapping
- * registration so the publish/error-handling logic is defined once.
+ * Serializes the notification to JSON and publishes it. On failure it
+ * rethrows with the subject in the message: every call site is an event_bus
+ * subscriber callback, and the bus catches handler exceptions, logs them at
+ * error, and reports the partial delivery in its summary. A failed publish
+ * is therefore never silent. Shared by every component's per-entity
+ * event-mapping registration so the publish/error-handling logic is defined
+ * once.
  */
 ORES_EVENTING_CORE_EXPORT void
 publish_entity_event(ores::nats::service::client& nats,

--- a/projects/ores.eventing/core/tests/component_files.cmake
+++ b/projects/ores.eventing/core/tests/component_files.cmake
@@ -18,5 +18,6 @@
 #
 set(files
     "main.cpp"
+    "entity_event_publisher_tests.cpp"
     "partitioned_cache_tests.cpp"
 )

--- a/projects/ores.eventing/core/tests/entity_event_publisher_tests.cpp
+++ b/projects/ores.eventing/core/tests/entity_event_publisher_tests.cpp
@@ -18,24 +18,31 @@
  *
  */
 #include "ores.eventing.core/service/entity_event_publisher.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
-#include <stdexcept>
+#include "ores.nats/config/nats_options.hpp"
+#include "ores.nats/service/client.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <string>
 
-namespace ores::eventing::service {
+namespace {
 
-void publish_entity_event(ores::nats::service::client& nats,
-                          const std::string& subject,
-                          const domain::entity_change_event& notification) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notification), {});
-    } catch (const std::exception& e) {
-        // The event_bus invokes every publish_entity_event call site and
-        // catches handler exceptions, so a rethrow surfaces the failure in
-        // its handler-error log and delivery summary instead of a silent
-        // error here.
-        throw std::runtime_error("Failed to publish to NATS subject '" + subject +
-                                 "': " + e.what());
-    }
+const std::string tags("[service][entity_event_publisher]");
+
 }
 
+TEST_CASE("publish_entity_event_rethrows_on_nats_failure", tags) {
+    // A client that was never connected fails every publish with
+    // NATS_NOT_CONNECTED. The publisher must surface that failure, not
+    // swallow it: the event_bus handler-error path is what makes it visible.
+    ores::nats::service::client nats(ores::nats::config::nats_options{});
+
+    const ores::eventing::domain::entity_change_event ev{
+        "ores.test.entity",
+        std::chrono::system_clock::now(),
+        {"id-1"},
+        "test-tenant"};
+
+    REQUIRE_THROWS_AS(
+        ores::eventing::service::publish_entity_event(nats, "ores.test.v1.events", ev),
+        std::runtime_error);
 }

--- a/projects/ores.refdata/service/src/app/application.cpp
+++ b/projects/ores.refdata/service/src/app/application.cpp
@@ -21,9 +21,9 @@
 #include "ores.database/service/context_factory.hpp"
 #include "ores.eventing.api/domain/entity_change_event.hpp"
 #include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
 #include "ores.eventing.core/service/postgres_event_source.hpp"
 #include "ores.eventing.core/service/registrar.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.refdata.api/eventing/business_centre_changed_event.hpp"
 #include "ores.refdata.api/eventing/counterparty_contact_information_changed_event.hpp"
@@ -69,20 +69,12 @@ namespace {
 constexpr std::string_view service_name = "ores.refdata.service";
 constexpr std::string_view service_version = ORES_VERSION;
 
-auto& pub_lg() {
-    static auto instance = make_logger("ores.refdata.service.app");
-    return instance;
-}
-
 void publish_entity_event(ores::nats::service::client& nats,
                           const std::string& subject,
                           const ev::domain::entity_change_event& notif) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notif), {});
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(pub_lg(), error)
-            << "Failed to publish event to '" << subject << "': " << e.what();
-    }
+    // Delegate to the shared hardened publisher: it rethrows on failure so
+    // the event_bus surfaces the lost notification at error.
+    ev::service::publish_entity_event(nats, subject, notif);
 }
 
 } // namespace

--- a/projects/ores.trading/service/src/app/application.cpp
+++ b/projects/ores.trading/service/src/app/application.cpp
@@ -21,9 +21,9 @@
 #include "ores.database/service/context_factory.hpp"
 #include "ores.eventing.api/domain/entity_change_event.hpp"
 #include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
 #include "ores.eventing.core/service/postgres_event_source.hpp"
 #include "ores.eventing.core/service/registrar.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
@@ -64,20 +64,12 @@ namespace {
 constexpr std::string_view service_name = "ores.trading.service";
 constexpr std::string_view service_version = ORES_VERSION;
 
-auto& pub_lg() {
-    static auto instance = make_logger("ores.trading.service.app");
-    return instance;
-}
-
 void publish_entity_event(ores::nats::service::client& nats,
                           const std::string& subject,
                           const ev::domain::entity_change_event& notif) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notif), {});
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(pub_lg(), error)
-            << "Failed to publish event to '" << subject << "': " << e.what();
-    }
+    // Delegate to the shared hardened publisher: it rethrows on failure so
+    // the event_bus surfaces the lost notification at error.
+    ev::service::publish_entity_event(nats, subject, notif);
 }
 
 } // namespace

--- a/projects/ores.workspace/service/src/app/application.cpp
+++ b/projects/ores.workspace/service/src/app/application.cpp
@@ -21,9 +21,9 @@
 #include "ores.database/service/context_factory.hpp"
 #include "ores.eventing.api/domain/entity_change_event.hpp"
 #include "ores.eventing.api/service/event_bus.hpp"
+#include "ores.eventing.core/service/entity_event_publisher.hpp"
 #include "ores.eventing.core/service/postgres_event_source.hpp"
 #include "ores.eventing.core/service/registrar.hpp"
-#include "ores.nats/domain/wire_codec.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.service/service/domain_service_runner.hpp"
 #include "ores.service/service/heartbeat_publisher.hpp"
@@ -60,20 +60,12 @@ namespace {
 constexpr std::string_view service_name = "ores.workspace.service";
 constexpr std::string_view service_version = ORES_VERSION;
 
-auto& pub_lg() {
-    static auto instance = make_logger("ores.workspace.service.app");
-    return instance;
-}
-
 void publish_entity_event(ores::nats::service::client& nats,
                           const std::string& subject,
                           const ev::domain::entity_change_event& notif) {
-    try {
-        nats.publish(subject, ores::nats::default_wire_codec().encode(notif), {});
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(pub_lg(), error)
-            << "Failed to publish event to '" << subject << "': " << e.what();
-    }
+    // Delegate to the shared hardened publisher: it rethrows on failure so
+    // the event_bus surfaces the lost notification at error.
+    ev::service::publish_entity_event(nats, subject, notif);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Hardens the eventing chain so a notification is either delivered or its loss is reported. The listener reconnect window (consume_input failure, backoff, re-LISTEN) drops NOTIFYs in flight with no replay possible, and NATS publish failures were caught and swallowed end to end.

## Changes

- Listener: each detected connection loss increments connection_loss_count and logs the affected channels at error; the successful reconnect logs the outage duration and channels.
- publish_entity_event rethrows NATS failures with the subject in the message; the event_bus delivery summary logs at error when delivery is incomplete.
- Tests: listener reconnect test kills the session server-side and proves loss surfacing and post-reconnect delivery; publisher test proves a NATS_NOT_CONNECTED publish throws. Fixed invalid DO $ blocks in the listener tests (de-vacuated connect_forces_utc_session).
- Verification: full build; ores.database.tests 17/17; eventing api/core suites; eventing integration family (85 tests); full ctest 71/71 on a freshly recreated database.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Harden the eventing chain against transient notification loss](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/story.html) | 639008BB-03A6-4675-AF2F-90A4A699729C |
| Task | [Implement eventing chain hardening](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/eventing_chain_hardening/task_implement_eventing_chain_hardening.html) | C9B8F903-27A4-456E-90E7-157507FFC024 |
| Environment | clever_dijkstra | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)