### PR TITLE
[ores.codegen] Protocol/service templates iterate primary_key.columns for key gates

### DIFF
--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
@@ -41,9 +41,9 @@ not waste the sweep.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Task 3F3559A2 (history mapper provenance fields) in progress. |
+| Now           | Task 453FA225 (compound-key is_uuid gating) done, delivered in commit 28d36860dc. |
 | Waiting on    | Nothing.                               |
-| Next          | Remaining three template-bug tasks, in story order. |
+| Next          | Remaining two template-bug tasks, in story order. |
 | Last touched  | 2026-09-04                               |
 
 * Acceptance
@@ -69,11 +69,26 @@ not waste the sweep.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:3F3559A2-5E98-44EA-A87A-E5DA7CF5BA23][Update history field mapper codegen template to use provenance_fields constants]] | DONE | 2026-09-04 | 2026-09-04 | cpp_history_field_mapper.cpp.mustache hardcodes audit-column labels ("Modified By", etc.) as string literals, but currency_history_field_mapper.cpp on main uses the shared ores::history::domain::provenance_fields constants instead -- the template needs to be updated to match and every entity's generated mapper regenerated. |
-| [[id:453FA225-F6FF-4095-AFB7-4D59E3FDB357][Compound-key is_uuid gating drops trailing columns in Qt/service templates]] | BACKLOG | | | cpp_protocol.hpp.mustache and cpp_service.cpp.mustache gate their delete/history/save is_uuid branch on primary_key.is_uuid alone, which reflects only the first key column. A future compound key whose leading column is UUID would silently drop every subsequent key column from these structs/validations. Not exercised today (subject_area's key is two text columns). Raised in PR #1691 review round 1. Fix: make the is_uuid branches loop primary_key.columns like cpp_domain_type_mapper.cpp.mustache already does. |
+| [[id:453FA225-F6FF-4095-AFB7-4D59E3FDB357][Compound-key is_uuid gating drops trailing columns in Qt/service templates]] | DONE | 2026-09-04 | 2026-09-04 | cpp_protocol.hpp.mustache and cpp_service.cpp.mustache gate their delete/history/save is_uuid branch on primary_key.is_uuid alone, which reflects only the first key column. A future compound key whose leading column is UUID would silently drop every subsequent key column from these structs/validations. Not exercised today (subject_area's key is two text columns). Raised in PR #1691 review round 1. Fix: make the is_uuid branches loop primary_key.columns like cpp_domain_type_mapper.cpp.mustache already does. |
 | [[id:9FF6FAD3-A3C3-4C31-9220-57CAADFDCCA0][has_pagination knob is a silent-failure footgun in the Qt client model template]] | BACKLOG | | | The codegen knob gating real offset/limit pagination in a Client entity Model.cpp defaults to off with no compile-time or runtime signal when unset, letting 61 entities silently truncate lists at 100 rows behind fully-functional-looking pagination controls. |
 | [[id:D8301A1C-726D-495E-A509-AEA9A838DC88][Junction codegen template follow-ups]] | BACKLOG | | | Four codegen template issues for junction entities: path/namespace mismatch between generated and live code, current_timestamp version-collision in insert triggers, messaging handler generated without matching service, and eventing facets produce incomplete output. |
 
 * Decisions
+
+- 2026-09-04 (task 453FA225): the delete/history/save key gates loop
+  =primary_key.columns= with the per-column =is_uuid= form, not a
+  plain column loop, because the delete member name is type-driven:
+  the handler template reads =req->{{delete_request_id_field}}=, which
+  the derivation layer resolves to =ids= for a uuid key whatever the
+  column name — so a plain loop would rename the instrument family's
+  delete member to =instrument_ids= and break its generated handlers.
+  The ={{#entity}}= (lookup) delete gate and ={{#junction}}= section
+  stay on the single-column shape: schema primary keys carry no
+  =columns= list in the loader, so a loop form there would emit
+  nothing for every lookup entity. The key census behind this (every
+  live key is a single uuid or text column, or a compound text key;
+  uuid-leading compound keys are the only mixed shape the save
+  validation can express today) is in the task's Plan.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_compound-key-is-uuid-gating-drops-trailing-columns.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_compound-key-is-uuid-gating-drops-trailing-columns.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :fix-codegen-template-drift:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/compound-key-is-uuid-gating-drops-trailing-columns
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-06
-#+updated: 2026-08-06
-#+environment:
+#+updated: 2026-09-04
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F5532C5C-7A8D-461D-8E0A-CACB602AB3DF][Fix codegen template drift]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,22 +26,117 @@ cpp_protocol.hpp.mustache and cpp_service.cpp.mustache gate their delete/history
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:F5532C5C-7A8D-461D-8E0A-CACB602AB3DF][Fix codegen template drift]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-06                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-04                               |
 
 * Acceptance
 
--
+- Both org archetypes (=ores.cpp.protocol.protocol_header.org=,
+  =ores.cpp.service.service_impl.org=) iterate
+  =primary_key.columns= in the ={{#domain_entity}}= delete/history/
+  save branches, with per-column =is_uuid= selecting the member name
+  (=ids= for a uuid column) or the emptiness check (=is_nil()= vs
+  =.empty()=), so a compound key whose leading column is uuid no
+  longer drops its trailing key columns from the structs or the
+  validations.
+- The ={{#entity}}= (lookup-entity) delete gate and the
+  ={{#junction}}= section are unchanged: schema primary keys carry no
+  =columns= list (single-column shape only), so the loop form cannot
+  apply there, and the junction section has no primary-key gates.
+- Re-tangling changes only the two mustaches. Regenerating the 8
+  components is idempotent: a second regeneration is byte-identical
+  to the first.
+- The regenerated output is confined to the intended fix: protocol
+  delete/history and service save-single output is byte-identical for
+  every entity (uuid-keyed entities keep the =ids= member and the
+  column-named history member), and the only expected churn is the
+  braces the batch-save validation loop gains in uuid-keyed
+  =*_service.cpp= files (the loop must contain every key column's
+  check; the old uuid shortcut emitted one unbraced =if=).
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+- 2026-09-04: task started; surveyed the blast radius. The two
+  templates render only for =domain_entity= models (static mapping
+  =get_cpp_domain_entity_template_mappings= and the physical-space
+  graph agree), except =cpp_protocol.hpp.mustache= also renders for
+  junctions (=ores.cpp.protocol= admits =junction=) and lookup
+  entities (=schema=), firing the mustache's ={{#junction}}= and
+  ={{#entity}}= sections — so all three sections of the protocol
+  mustache are live, one per model kind, and the fix must not touch
+  the two non-domain sections.
+- The is_uuid shortcut lives in exactly four branches across the two
+  orgs: protocol delete request and history request
+  (={{#domain_entity}}=), and service save-single and save-batch
+  validations. The ={{#entity}}= delete branch gates on
+  =primary_key.is_text= instead, with the mirror scalar as fallback;
+  schema (lookup) primary keys carry no =columns= list — the loader
+  produces a single-column dict (=column=/=type=/=is_text=), so a
+  loop form would emit nothing for every lookup entity. That branch
+  stays as-is and is out of scope: schema keys are single-column
+  today and cannot express the compound shape the task repairs.
+- Key census (122 domain-entity orgs across the 8 components): every
+  primary key is a single uuid column (=id=, or =instrument_id= for
+  the trading instrument family), a single text column, or a compound
+  text key (=subject_area='s =name=+=domain_name=). The member-name
+  convention is type-driven for uuid keys — the delete request member
+  is literally =ids= whatever the column name (checked in the
+  generated instrument-family protocol headers), and the handler
+  template reads =req->{{delete_request_id_field}}=, which
+  =core.py= (lines 2411-2413) derives as =ids= for a uuid key — so a
+  column-driven loop would rename the instrument family's delete
+  member to =instrument_ids= and break its generated handlers. The
+  per-column =is_uuid= form keeps =ids= for uuid columns and
+  ={{column}}s= for text columns, matching the derivation layer for
+  every viable shape (uuid-leading compound keys are the only mixed
+  shape the service validation can express today; text-leading keys
+  with a uuid trailing column would already fail the =.empty()= check
+  the old branch emitted).
+- Fix shape per branch, in the org sources only (no core.py change):
+  delete ={{#primary_key.columns}}= loop with per-column ={{#is_uuid}}=
+  emitting =ids= and ={{^is_uuid}}= emitting ={{column}}s=; history
+  plain loop over ={{column}}=; service save-single and save-batch
+  per-column loops with ={{#is_uuid}}.is_nil(){{/is_uuid}}=
+  ={{^is_uuid}}.empty(){{/is_uuid}}= and the per-column
+  =is_identity_group_column= prefix. The batch-save loop takes the
+  braced shape unconditionally (multiple =if= statements in one loop
+  require braces); text-keyed and compound-keyed entities already
+  emit the braced shape, so only uuid-keyed =*_service.cpp= files
+  gain the braces — the intended, visible churn.
+- Baseline regen before the org edit, edit, re-tangle, per-component
+  regen, idempotency check, component drift checks, then close out.
+- 2026-09-04: implementation. The baseline full-ores regeneration
+  dirtied 48 tracked files outside the CI-checked components (dq 24,
+  synthetic 10, qt 9, iam 6, sql 11 file list overlaps, marketdata 1,
+  refdata 1) plus emitted untracked additions (dq eventing integration
+  tests for 9 entities, a monolithic account_party source tree and
+  component stubs under =projects/ores.iam/{include,src,tests}=):
+  =main='s checked-in generated tree does not reproduce from its own
+  templates at full-ores regeneration in the non-CI components, while
+  refdata/reporting/marketdata (the drift-checked three) are clean.
+  All of it reverted or excluded from this PR and recorded here as
+  unrecorded pre-existing drift, input for the per-component drift
+  stories. The org edits themselves changed only the two mustaches on
+  re-tangle (4-file diff: 2 orgs + 2 mustaches).
+- 2026-09-04: regeneration evidence. Regenerating the 8 components
+  after the edit is confined to the intended output: 36 uuid-keyed
+  =*_service.cpp= files gained the braced batch-save loop, and
+  =folder_service.cpp= (synthetic) the same change on top of its
+  recorded include drift, which was reverted out. No
+  =*_protocol.hpp= churned anywhere (protocol delete/history output
+  byte-identical for every entity: uuid keys keep the =ids= member
+  and column-named history member) and no save-single hunk exists in
+  any diff (save-single byte-identical for every entity). Idempotency:
+  three full regenerations; runs 2 and 3 are byte-identical at the
+  content level (full-diff hash 224600e5), run 1 has the identical
+  changed-file set, and the untracked additions are byte-identical
+  across all runs. The verification tree carries exactly the fix
+  diff: 4 template files, 37 service cpps whose every changed line is
+  a batch-save for-loop brace, and the 2 agile docs.
 
 * Notes
 
@@ -69,3 +164,52 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Delivered 2026-09-04 on branch
+=feature/compound-key-is-uuid-gating-drops-trailing-columns=, commit
+28d36860dc.
+
+- Both org sources (=ores.cpp.protocol.protocol_header.org=,
+  =ores.cpp.service.service_impl.org=) iterate =primary_key.columns=
+  in the ={{#domain_entity}}= delete/history/save branches, with
+  per-column =is_uuid= selecting the member name (=ids= for a uuid
+  column, ={{column}}s= for a text column) or the emptiness check
+  (=is_nil()= vs =.empty()=). The ={{#entity}}= delete gate and the
+  ={{#junction}}= section are untouched: schema primary keys carry no
+  =columns= list, and the junction section has no key gates.
+- Re-tangling changed only the two mustaches (4-file diff: the two
+  orgs + the two mustaches). Regenerating the 8 components is
+  idempotent: three full regenerations, runs 2 and 3 byte-identical
+  at the content level (full-diff hash 224600e5), run 1 with the
+  identical changed-file set, and the untracked additions
+  byte-identical across all runs.
+- The regenerated output is confined to the intended churn: 36
+  uuid-keyed =*_service.cpp= files gained the braced batch-save
+  validation loop, and =folder_service.cpp= (synthetic) the same
+  change on top of its recorded include drift, which was reverted
+  out. No =*_protocol.hpp= churned anywhere and no save-single hunk
+  exists in any diff: protocol delete/history and save-single output
+  is byte-identical for every entity.
+- The baseline regeneration (before the edit) dirtied 48 tracked
+  files in the non-CI components plus 42 untracked additions, none
+  of which reproduce from =main='s own templates: unrecorded
+  pre-existing drift (dq/synthetic/qt/iam/sql, plus the recorded
+  marketdata/refdata pair), reverted or excluded from this PR and
+  recorded in the Plan as input for the per-component drift stories.
+  The 42 untracked regen byproducts stay in the working tree
+  (deletion not authorised); they are inert, byte-identical across
+  regenerations, not referenced by any build, and excluded from all
+  commits.
+- Verification (change class: code + ci + docs): site build clean;
+  full system build clean (linux-clang-debug-make); ctest 71/71
+  passed against a recreated database — the CI-equivalent state,
+  because the repository write tests are not repeatable against a
+  persistent database (the first run's =ores.iam.core.tests=
+  duplicate-key failures were the known stale-DB artifact recorded in
+  task 3F3559A2's Result); component drift checks (refdata,
+  reporting, marketdata) clean except the three recorded pre-existing
+  files, which were reverted after the check; ore domain roundtrip
+  report unchanged from its recorded pre-existing state (fidelity
+  gaps against upstream ORE, untouched by this diff).
+
+Acceptance: all four bullets met.

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_compound-key-is-uuid-gating-drops-trailing-columns.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_compound-key-is-uuid-gating-drops-trailing-columns.org
@@ -8,7 +8,7 @@
 #+filetags: :fix-codegen-template-drift:sprint_25:v0:
 #+owner: marco
 #+branch: feature/compound-key-is-uuid-gating-drops-trailing-columns
-#+pr:
+#+pr: 2005
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-06
@@ -155,7 +155,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2005][#2005]] | [ores.codegen] Protocol/service templates iterate primary_key.columns for key gates |
 
 * Review
 

--- a/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
@@ -58,14 +58,9 @@ struct delete_{{entity_singular}}_request {
     using response_type = struct delete_{{entity_singular}}_response;
     static constexpr std::string_view nats_subject =
         "{{component}}.v1.{{entity_plural}}.delete";
-{{#primary_key.is_uuid}}
-    std::vector<std::string> ids;
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
-    std::vector<std::string> {{column}}s;
+    std::vector<std::string> {{#is_uuid}}ids{{/is_uuid}}{{^is_uuid}}{{column}}s{{/is_uuid}};
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
 };
 
 struct delete_{{entity_singular}}_response {
@@ -77,14 +72,9 @@ struct get_{{entity_singular}}_history_request {
     using response_type = struct get_{{entity_singular}}_history_response;
     static constexpr std::string_view nats_subject =
         "{{component}}.v1.{{entity_plural}}.history";
-{{#primary_key.is_uuid}}
-    std::string {{primary_key.column}};
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
     std::string {{column}};
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
 };
 
 struct get_{{entity_singular}}_history_response {

--- a/projects/ores.codegen/library/templates/cpp_service.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_service.cpp.mustache
@@ -142,16 +142,10 @@ std::vector<domain::{{entity_singular}}>
 {{/has_batch_read}}
 
 void {{entity_singular}}_service::save_{{entity_singular_short}}(const domain::{{entity_singular}}& v) {
-{{#primary_key.is_uuid}}
-    if (v.{{#primary_key.is_identity_group_column}}identity.{{/primary_key.is_identity_group_column}}{{primary_key.column}}.is_nil())
-        throw std::invalid_argument("{{entity_title}} {{primary_key.column}} cannot be empty.");
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
-    if (v.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.empty())
+    if (v.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.{{#is_uuid}}is_nil(){{/is_uuid}}{{^is_uuid}}empty(){{/is_uuid}})
         throw std::invalid_argument("{{entity_title}} {{column}} cannot be empty.");
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
     BOOST_LOG_SEV(lg(), debug) << "Saving {{entity_singular_words}}. " << {{{primary_key.value_log_fields}}};
     auto t = v;
     stamp(t, ctx_);
@@ -161,19 +155,12 @@ void {{entity_singular}}_service::save_{{entity_singular_short}}(const domain::{
 
 void {{entity_singular}}_service::save_{{entity_plural_short}}(
     const std::vector<domain::{{entity_singular}}>& {{entity_plural_short}}) {
-{{#primary_key.is_uuid}}
-    for (const auto& e : {{entity_plural_short}})
-        if (e.{{#primary_key.is_identity_group_column}}identity.{{/primary_key.is_identity_group_column}}{{primary_key.column}}.is_nil())
-            throw std::invalid_argument("{{entity_title}} {{primary_key.column}} cannot be empty.");
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
     for (const auto& e : {{entity_plural_short}}) {
 {{#primary_key.columns}}
-        if (e.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.empty())
+        if (e.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.{{#is_uuid}}is_nil(){{/is_uuid}}{{^is_uuid}}empty(){{/is_uuid}})
             throw std::invalid_argument("{{entity_title}} {{column}} cannot be empty.");
 {{/primary_key.columns}}
     }
-{{/primary_key.is_uuid}}
     BOOST_LOG_SEV(lg(), debug) << "Saving " << {{entity_plural_short}}.size()
         << " {{entity_plural_words}}";
     auto ts = {{entity_plural_short}};

--- a/projects/ores.codegen/library/templates/ores.cpp.protocol.protocol_header.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.protocol.protocol_header.org
@@ -89,14 +89,9 @@ struct delete_{{entity_singular}}_request {
     using response_type = struct delete_{{entity_singular}}_response;
     static constexpr std::string_view nats_subject =
         "{{component}}.v1.{{entity_plural}}.delete";
-{{#primary_key.is_uuid}}
-    std::vector<std::string> ids;
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
-    std::vector<std::string> {{column}}s;
+    std::vector<std::string> {{#is_uuid}}ids{{/is_uuid}}{{^is_uuid}}{{column}}s{{/is_uuid}};
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
 };
 
 struct delete_{{entity_singular}}_response {
@@ -108,14 +103,9 @@ struct get_{{entity_singular}}_history_request {
     using response_type = struct get_{{entity_singular}}_history_response;
     static constexpr std::string_view nats_subject =
         "{{component}}.v1.{{entity_plural}}.history";
-{{#primary_key.is_uuid}}
-    std::string {{primary_key.column}};
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
     std::string {{column}};
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
 };
 
 struct get_{{entity_singular}}_history_response {

--- a/projects/ores.codegen/library/templates/ores.cpp.service.service_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.service.service_impl.org
@@ -167,16 +167,10 @@ std::vector<domain::{{entity_singular}}>
 {{/has_batch_read}}
 
 void {{entity_singular}}_service::save_{{entity_singular_short}}(const domain::{{entity_singular}}& v) {
-{{#primary_key.is_uuid}}
-    if (v.{{#primary_key.is_identity_group_column}}identity.{{/primary_key.is_identity_group_column}}{{primary_key.column}}.is_nil())
-        throw std::invalid_argument("{{entity_title}} {{primary_key.column}} cannot be empty.");
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
 {{#primary_key.columns}}
-    if (v.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.empty())
+    if (v.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.{{#is_uuid}}is_nil(){{/is_uuid}}{{^is_uuid}}empty(){{/is_uuid}})
         throw std::invalid_argument("{{entity_title}} {{column}} cannot be empty.");
 {{/primary_key.columns}}
-{{/primary_key.is_uuid}}
     BOOST_LOG_SEV(lg(), debug) << "Saving {{entity_singular_words}}. " << {{{primary_key.value_log_fields}}};
     auto t = v;
     stamp(t, ctx_);
@@ -186,19 +180,12 @@ void {{entity_singular}}_service::save_{{entity_singular_short}}(const domain::{
 
 void {{entity_singular}}_service::save_{{entity_plural_short}}(
     const std::vector<domain::{{entity_singular}}>& {{entity_plural_short}}) {
-{{#primary_key.is_uuid}}
-    for (const auto& e : {{entity_plural_short}})
-        if (e.{{#primary_key.is_identity_group_column}}identity.{{/primary_key.is_identity_group_column}}{{primary_key.column}}.is_nil())
-            throw std::invalid_argument("{{entity_title}} {{primary_key.column}} cannot be empty.");
-{{/primary_key.is_uuid}}
-{{^primary_key.is_uuid}}
     for (const auto& e : {{entity_plural_short}}) {
 {{#primary_key.columns}}
-        if (e.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.empty())
+        if (e.{{#is_identity_group_column}}identity.{{/is_identity_group_column}}{{column}}.{{#is_uuid}}is_nil(){{/is_uuid}}{{^is_uuid}}empty(){{/is_uuid}})
             throw std::invalid_argument("{{entity_title}} {{column}} cannot be empty.");
 {{/primary_key.columns}}
     }
-{{/primary_key.is_uuid}}
     BOOST_LOG_SEV(lg(), debug) << "Saving " << {{entity_plural_short}}.size()
         << " {{entity_plural_words}}";
     auto ts = {{entity_plural_short}};

--- a/projects/ores.dq/core/src/service/dataset_bundle_service.cpp
+++ b/projects/ores.dq/core/src/service/dataset_bundle_service.cpp
@@ -69,9 +69,10 @@ void dataset_bundle_service::save_bundle(const domain::dataset_bundle& v) {
 }
 
 void dataset_bundle_service::save_bundles(const std::vector<domain::dataset_bundle>& bundles) {
-    for (const auto& e : bundles)
+    for (const auto& e : bundles) {
         if (e.id.is_nil())
             throw std::invalid_argument("Dataset Bundle id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << bundles.size() << " dataset bundles";
     auto ts = bundles;
     for (auto& e : ts)

--- a/projects/ores.dq/core/src/service/report_definition_service.cpp
+++ b/projects/ores.dq/core/src/service/report_definition_service.cpp
@@ -71,9 +71,10 @@ void report_definition_service::save_definition(const domain::report_definition&
 
 void report_definition_service::save_definitions(
     const std::vector<domain::report_definition>& definitions) {
-    for (const auto& e : definitions)
+    for (const auto& e : definitions) {
         if (e.id.is_nil())
             throw std::invalid_argument("Report Definition id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << definitions.size() << " report definitions";
     auto ts = definitions;
     for (auto& e : ts)

--- a/projects/ores.dq/core/src/service/synthetic_fx_spot_config_service.cpp
+++ b/projects/ores.dq/core/src/service/synthetic_fx_spot_config_service.cpp
@@ -72,9 +72,10 @@ void synthetic_fx_spot_config_service::save_config(const domain::synthetic_fx_sp
 
 void synthetic_fx_spot_config_service::save_configs(
     const std::vector<domain::synthetic_fx_spot_config>& configs) {
-    for (const auto& e : configs)
+    for (const auto& e : configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("Synthetic FX Spot Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << configs.size() << " synthetic FX spot configs";
     auto ts = configs;
     for (auto& e : ts)

--- a/projects/ores.iam/core/src/service/account_contact_information_service.cpp
+++ b/projects/ores.iam/core/src/service/account_contact_information_service.cpp
@@ -98,9 +98,10 @@ void account_contact_information_service::save_account_contact_information(
 
 void account_contact_information_service::save_account_contact_informations(
     const std::vector<domain::account_contact_information>& account_contact_informations) {
-    for (const auto& e : account_contact_informations)
+    for (const auto& e : account_contact_informations) {
         if (e.id.is_nil())
             throw std::invalid_argument("Account Contact Information id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << account_contact_informations.size()
                                << " account contact informations";
     auto ts = account_contact_informations;

--- a/projects/ores.marketdata/core/src/service/feed_binding_service.cpp
+++ b/projects/ores.marketdata/core/src/service/feed_binding_service.cpp
@@ -70,9 +70,10 @@ void feed_binding_service::save_feed_binding(const domain::feed_binding& v) {
 
 void feed_binding_service::save_feed_bindings(
     const std::vector<domain::feed_binding>& feed_bindings) {
-    for (const auto& e : feed_bindings)
+    for (const auto& e : feed_bindings) {
         if (e.id.is_nil())
             throw std::invalid_argument("Feed Binding id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << feed_bindings.size() << " feed bindings";
     auto ts = feed_bindings;
     for (auto& e : ts)

--- a/projects/ores.marketdata/core/src/service/market_fixing_service.cpp
+++ b/projects/ores.marketdata/core/src/service/market_fixing_service.cpp
@@ -64,9 +64,10 @@ void market_fixing_service::save_market_fixing(const domain::market_fixing& v) {
 
 void market_fixing_service::save_market_fixings(
     const std::vector<domain::market_fixing>& market_fixings) {
-    for (const auto& e : market_fixings)
+    for (const auto& e : market_fixings) {
         if (e.id.is_nil())
             throw std::invalid_argument("Market Fixing id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << market_fixings.size() << " market fixings";
     auto ts = market_fixings;
     for (auto& e : ts)

--- a/projects/ores.marketdata/core/src/service/market_observation_service.cpp
+++ b/projects/ores.marketdata/core/src/service/market_observation_service.cpp
@@ -80,9 +80,10 @@ void market_observation_service::save_market_observation(const domain::market_ob
 
 void market_observation_service::save_market_observations(
     const std::vector<domain::market_observation>& market_observations) {
-    for (const auto& e : market_observations)
+    for (const auto& e : market_observations) {
         if (e.id.is_nil())
             throw std::invalid_argument("Market Observation id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << market_observations.size() << " market observations";
     auto ts = market_observations;
     for (auto& e : ts)

--- a/projects/ores.marketdata/core/src/service/market_series_service.cpp
+++ b/projects/ores.marketdata/core/src/service/market_series_service.cpp
@@ -71,9 +71,10 @@ void market_series_service::save_market_series(const domain::market_series& v) {
 
 void market_series_service::save_market_series(
     const std::vector<domain::market_series>& market_series) {
-    for (const auto& e : market_series)
+    for (const auto& e : market_series) {
         if (e.id.is_nil())
             throw std::invalid_argument("Market Series id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << market_series.size() << " market series";
     auto ts = market_series;
     for (auto& e : ts)

--- a/projects/ores.marketdata/core/src/service/observation_lineage_service.cpp
+++ b/projects/ores.marketdata/core/src/service/observation_lineage_service.cpp
@@ -72,9 +72,10 @@ void observation_lineage_service::save_observation_lineage(const domain::observa
 
 void observation_lineage_service::save_observation_lineages(
     const std::vector<domain::observation_lineage>& observation_lineages) {
-    for (const auto& e : observation_lineages)
+    for (const auto& e : observation_lineages) {
         if (e.id.is_nil())
             throw std::invalid_argument("Observation Lineage id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << observation_lineages.size()
                                << " observation lineages";
     auto ts = observation_lineages;

--- a/projects/ores.refdata/core/src/service/book_service.cpp
+++ b/projects/ores.refdata/core/src/service/book_service.cpp
@@ -91,9 +91,10 @@ void book_service::save_book(const domain::book& v) {
 }
 
 void book_service::save_books(const std::vector<domain::book>& books) {
-    for (const auto& e : books)
+    for (const auto& e : books) {
         if (e.id.is_nil())
             throw std::invalid_argument("Book id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << books.size() << " books";
     auto ts = books;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/business_unit_service.cpp
+++ b/projects/ores.refdata/core/src/service/business_unit_service.cpp
@@ -92,9 +92,10 @@ void business_unit_service::save_business_unit(const domain::business_unit& v) {
 
 void business_unit_service::save_business_units(
     const std::vector<domain::business_unit>& business_units) {
-    for (const auto& e : business_units)
+    for (const auto& e : business_units) {
         if (e.id.is_nil())
             throw std::invalid_argument("Business Unit id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << business_units.size() << " business units";
     auto ts = business_units;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/business_unit_type_service.cpp
+++ b/projects/ores.refdata/core/src/service/business_unit_type_service.cpp
@@ -70,9 +70,10 @@ void business_unit_type_service::save_type(const domain::business_unit_type& v) 
 }
 
 void business_unit_type_service::save_types(const std::vector<domain::business_unit_type>& types) {
-    for (const auto& e : types)
+    for (const auto& e : types) {
         if (e.id.is_nil())
             throw std::invalid_argument("Business Unit Type id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << types.size() << " business unit types";
     auto ts = types;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/calendar_event_service.cpp
+++ b/projects/ores.refdata/core/src/service/calendar_event_service.cpp
@@ -119,9 +119,10 @@ void calendar_event_service::save_calendar_event(const domain::calendar_event& v
 
 void calendar_event_service::save_calendar_events(
     const std::vector<domain::calendar_event>& calendar_events) {
-    for (const auto& e : calendar_events)
+    for (const auto& e : calendar_events) {
         if (e.id.is_nil())
             throw std::invalid_argument("Calendar Event id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << calendar_events.size() << " calendar events";
     auto ts = calendar_events;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/calendar_exception_service.cpp
+++ b/projects/ores.refdata/core/src/service/calendar_exception_service.cpp
@@ -95,9 +95,10 @@ void calendar_exception_service::save_calendar_exception(const domain::calendar_
 
 void calendar_exception_service::save_calendar_exceptions(
     const std::vector<domain::calendar_exception>& calendar_exceptions) {
-    for (const auto& e : calendar_exceptions)
+    for (const auto& e : calendar_exceptions) {
         if (e.id.is_nil())
             throw std::invalid_argument("Calendar Exception id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << calendar_exceptions.size() << " calendar exceptions";
     auto ts = calendar_exceptions;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/calendar_rule_service.cpp
+++ b/projects/ores.refdata/core/src/service/calendar_rule_service.cpp
@@ -93,9 +93,10 @@ void calendar_rule_service::save_calendar_rule(const domain::calendar_rule& v) {
 
 void calendar_rule_service::save_calendar_rules(
     const std::vector<domain::calendar_rule>& calendar_rules) {
-    for (const auto& e : calendar_rules)
+    for (const auto& e : calendar_rules) {
         if (e.id.is_nil())
             throw std::invalid_argument("Calendar Rule id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << calendar_rules.size() << " calendar rules";
     auto ts = calendar_rules;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/counterparty_contact_information_service.cpp
+++ b/projects/ores.refdata/core/src/service/counterparty_contact_information_service.cpp
@@ -147,9 +147,10 @@ void counterparty_contact_information_service::save_counterparty_contact_informa
 void counterparty_contact_information_service::save_counterparty_contact_informations(
     const std::vector<domain::counterparty_contact_information>&
         counterparty_contact_informations) {
-    for (const auto& e : counterparty_contact_informations)
+    for (const auto& e : counterparty_contact_informations) {
         if (e.id.is_nil())
             throw std::invalid_argument("Counterparty Contact Information id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << counterparty_contact_informations.size()
                                << " counterparty contact informations";
     auto ts = counterparty_contact_informations;

--- a/projects/ores.refdata/core/src/service/counterparty_identifier_service.cpp
+++ b/projects/ores.refdata/core/src/service/counterparty_identifier_service.cpp
@@ -138,9 +138,10 @@ void counterparty_identifier_service::save_counterparty_identifier(
 
 void counterparty_identifier_service::save_counterparty_identifiers(
     const std::vector<domain::counterparty_identifier>& counterparty_identifiers) {
-    for (const auto& e : counterparty_identifiers)
+    for (const auto& e : counterparty_identifiers) {
         if (e.id.is_nil())
             throw std::invalid_argument("Counterparty Identifier id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << counterparty_identifiers.size()
                                << " counterparty identifiers";
     auto ts = counterparty_identifiers;

--- a/projects/ores.refdata/core/src/service/counterparty_service.cpp
+++ b/projects/ores.refdata/core/src/service/counterparty_service.cpp
@@ -89,9 +89,10 @@ void counterparty_service::save_counterparty(const domain::counterparty& v) {
 
 void counterparty_service::save_counterparties(
     const std::vector<domain::counterparty>& counterparties) {
-    for (const auto& e : counterparties)
+    for (const auto& e : counterparties) {
         if (e.id.is_nil())
             throw std::invalid_argument("Counterparty id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << counterparties.size() << " counterparties";
     auto ts = counterparties;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/crm_driver_pair_service.cpp
+++ b/projects/ores.refdata/core/src/service/crm_driver_pair_service.cpp
@@ -72,9 +72,10 @@ void crm_driver_pair_service::save_crm_driver_pair(const domain::crm_driver_pair
 
 void crm_driver_pair_service::save_crm_driver_pairs(
     const std::vector<domain::crm_driver_pair>& crm_driver_pairs) {
-    for (const auto& e : crm_driver_pairs)
+    for (const auto& e : crm_driver_pairs) {
         if (e.id.is_nil())
             throw std::invalid_argument("CRM Driver Pair id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << crm_driver_pairs.size() << " CRM driver pairs";
     auto ts = crm_driver_pairs;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/crm_enabled_derived_pair_service.cpp
+++ b/projects/ores.refdata/core/src/service/crm_enabled_derived_pair_service.cpp
@@ -74,9 +74,10 @@ void crm_enabled_derived_pair_service::save_crm_enabled_derived_pair(
 
 void crm_enabled_derived_pair_service::save_crm_enabled_derived_pairs(
     const std::vector<domain::crm_enabled_derived_pair>& crm_enabled_derived_pairs) {
-    for (const auto& e : crm_enabled_derived_pairs)
+    for (const auto& e : crm_enabled_derived_pairs) {
         if (e.id.is_nil())
             throw std::invalid_argument("CRM Enabled Derived Pair id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << crm_enabled_derived_pairs.size()
                                << " CRM enabled derived pairs";
     auto ts = crm_enabled_derived_pairs;

--- a/projects/ores.refdata/core/src/service/crm_topology_config_service.cpp
+++ b/projects/ores.refdata/core/src/service/crm_topology_config_service.cpp
@@ -72,9 +72,10 @@ void crm_topology_config_service::save_crm_topology_config(const domain::crm_top
 
 void crm_topology_config_service::save_crm_topology_configs(
     const std::vector<domain::crm_topology_config>& crm_topology_configs) {
-    for (const auto& e : crm_topology_configs)
+    for (const auto& e : crm_topology_configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("CRM Topology Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << crm_topology_configs.size()
                                << " CRM topology configs";
     auto ts = crm_topology_configs;

--- a/projects/ores.refdata/core/src/service/ir_curve_bootstrap_config_service.cpp
+++ b/projects/ores.refdata/core/src/service/ir_curve_bootstrap_config_service.cpp
@@ -74,9 +74,10 @@ void ir_curve_bootstrap_config_service::save_bootstrap_config(
 
 void ir_curve_bootstrap_config_service::save_bootstrap_configs(
     const std::vector<domain::ir_curve_bootstrap_config>& bootstrap_configs) {
-    for (const auto& e : bootstrap_configs)
+    for (const auto& e : bootstrap_configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("IR Curve Bootstrap Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << bootstrap_configs.size()
                                << " IR curve bootstrap configs";
     auto ts = bootstrap_configs;

--- a/projects/ores.refdata/core/src/service/ir_curve_bootstrap_pillar_service.cpp
+++ b/projects/ores.refdata/core/src/service/ir_curve_bootstrap_pillar_service.cpp
@@ -72,9 +72,10 @@ void ir_curve_bootstrap_pillar_service::save_pillar(const domain::ir_curve_boots
 
 void ir_curve_bootstrap_pillar_service::save_pillars(
     const std::vector<domain::ir_curve_bootstrap_pillar>& pillars) {
-    for (const auto& e : pillars)
+    for (const auto& e : pillars) {
         if (e.id.is_nil())
             throw std::invalid_argument("IR Curve Bootstrap Pillar id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << pillars.size() << " IR curve bootstrap pillars";
     auto ts = pillars;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/party_contact_information_service.cpp
+++ b/projects/ores.refdata/core/src/service/party_contact_information_service.cpp
@@ -133,9 +133,10 @@ void party_contact_information_service::save_party_contact_information(
 
 void party_contact_information_service::save_party_contact_informations(
     const std::vector<domain::party_contact_information>& party_contact_informations) {
-    for (const auto& e : party_contact_informations)
+    for (const auto& e : party_contact_informations) {
         if (e.id.is_nil())
             throw std::invalid_argument("Party Contact Information id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << party_contact_informations.size()
                                << " party contact informations";
     auto ts = party_contact_informations;

--- a/projects/ores.refdata/core/src/service/party_identifier_service.cpp
+++ b/projects/ores.refdata/core/src/service/party_identifier_service.cpp
@@ -127,9 +127,10 @@ void party_identifier_service::save_party_identifier(const domain::party_identif
 
 void party_identifier_service::save_party_identifiers(
     const std::vector<domain::party_identifier>& party_identifiers) {
-    for (const auto& e : party_identifiers)
+    for (const auto& e : party_identifiers) {
         if (e.id.is_nil())
             throw std::invalid_argument("Party Identifier id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << party_identifiers.size() << " party identifiers";
     auto ts = party_identifiers;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/party_service.cpp
+++ b/projects/ores.refdata/core/src/service/party_service.cpp
@@ -85,9 +85,10 @@ void party_service::save_party(const domain::party& v) {
 }
 
 void party_service::save_parties(const std::vector<domain::party>& parties) {
-    for (const auto& e : parties)
+    for (const auto& e : parties) {
         if (e.id.is_nil())
             throw std::invalid_argument("Party id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << parties.size() << " parties";
     auto ts = parties;
     for (auto& e : ts)

--- a/projects/ores.refdata/core/src/service/portfolio_service.cpp
+++ b/projects/ores.refdata/core/src/service/portfolio_service.cpp
@@ -78,9 +78,10 @@ void portfolio_service::save_portfolio(const domain::portfolio& v) {
 }
 
 void portfolio_service::save_portfolios(const std::vector<domain::portfolio>& portfolios) {
-    for (const auto& e : portfolios)
+    for (const auto& e : portfolios) {
         if (e.id.is_nil())
             throw std::invalid_argument("Portfolio id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << portfolios.size() << " portfolios";
     auto ts = portfolios;
     for (auto& e : ts)

--- a/projects/ores.reporting/core/src/service/report_definition_service.cpp
+++ b/projects/ores.reporting/core/src/service/report_definition_service.cpp
@@ -71,9 +71,10 @@ void report_definition_service::save_definition(const domain::report_definition&
 
 void report_definition_service::save_definitions(
     const std::vector<domain::report_definition>& definitions) {
-    for (const auto& e : definitions)
+    for (const auto& e : definitions) {
         if (e.id.is_nil())
             throw std::invalid_argument("Report Definition id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << definitions.size() << " report definitions";
     auto ts = definitions;
     for (auto& e : ts)

--- a/projects/ores.reporting/core/src/service/report_instance_service.cpp
+++ b/projects/ores.reporting/core/src/service/report_instance_service.cpp
@@ -71,9 +71,10 @@ void report_instance_service::save_instance(const domain::report_instance& v) {
 
 void report_instance_service::save_instances(
     const std::vector<domain::report_instance>& instances) {
-    for (const auto& e : instances)
+    for (const auto& e : instances) {
         if (e.id.is_nil())
             throw std::invalid_argument("Report Instance id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << instances.size() << " report instances";
     auto ts = instances;
     for (auto& e : ts)

--- a/projects/ores.synthetic/core/src/service/folder_service.cpp
+++ b/projects/ores.synthetic/core/src/service/folder_service.cpp
@@ -69,9 +69,10 @@ void folder_service::save_folder(const domain::folder& v) {
 }
 
 void folder_service::save_folders(const std::vector<domain::folder>& folders) {
-    for (const auto& e : folders)
+    for (const auto& e : folders) {
         if (e.id.is_nil())
             throw std::invalid_argument("Folder id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << folders.size() << " folders";
     auto ts = folders;
     for (auto& e : ts)

--- a/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/fx_spot_generation_config_service.cpp
@@ -74,9 +74,10 @@ void fx_spot_generation_config_service::save_fx_spot_generation_config(
 
 void fx_spot_generation_config_service::save_fx_spot_generation_configs(
     const std::vector<domain::fx_spot_generation_config>& fx_spot_generation_configs) {
-    for (const auto& e : fx_spot_generation_configs)
+    for (const auto& e : fx_spot_generation_configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("FX Spot Generation Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << fx_spot_generation_configs.size()
                                << " FX spot generation configs";
     auto ts = fx_spot_generation_configs;

--- a/projects/ores.synthetic/core/src/service/gmm_component_service.cpp
+++ b/projects/ores.synthetic/core/src/service/gmm_component_service.cpp
@@ -71,9 +71,10 @@ void gmm_component_service::save_gmm_component(const domain::gmm_component& v) {
 
 void gmm_component_service::save_gmm_components(
     const std::vector<domain::gmm_component>& gmm_components) {
-    for (const auto& e : gmm_components)
+    for (const auto& e : gmm_components) {
         if (e.id.is_nil())
             throw std::invalid_argument("GMM Component id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << gmm_components.size() << " GMM components";
     auto ts = gmm_components;
     for (auto& e : ts)

--- a/projects/ores.synthetic/core/src/service/ir_curve_generation_config_process_parameter_value_service.cpp
+++ b/projects/ores.synthetic/core/src/service/ir_curve_generation_config_process_parameter_value_service.cpp
@@ -84,10 +84,11 @@ void ir_curve_generation_config_process_parameter_value_service::save_process_pa
 void ir_curve_generation_config_process_parameter_value_service::save_process_parameter_values(
     const std::vector<domain::ir_curve_generation_config_process_parameter_value>&
         process_parameter_values) {
-    for (const auto& e : process_parameter_values)
+    for (const auto& e : process_parameter_values) {
         if (e.id.is_nil())
             throw std::invalid_argument(
                 "IR Curve Generation Config Process Parameter Value id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << process_parameter_values.size()
                                << " IR curve generation config process parameter values";
     auto ts = process_parameter_values;

--- a/projects/ores.synthetic/core/src/service/ir_curve_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/ir_curve_generation_config_service.cpp
@@ -74,9 +74,10 @@ void ir_curve_generation_config_service::save_ir_curve_generation_config(
 
 void ir_curve_generation_config_service::save_ir_curve_generation_configs(
     const std::vector<domain::ir_curve_generation_config>& ir_curve_generation_configs) {
-    for (const auto& e : ir_curve_generation_configs)
+    for (const auto& e : ir_curve_generation_configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("IR Curve Generation Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << ir_curve_generation_configs.size()
                                << " IR curve generation configs";
     auto ts = ir_curve_generation_configs;

--- a/projects/ores.synthetic/core/src/service/ir_curve_template_entry_service.cpp
+++ b/projects/ores.synthetic/core/src/service/ir_curve_template_entry_service.cpp
@@ -74,9 +74,10 @@ void ir_curve_template_entry_service::save_ir_curve_template_entry(
 
 void ir_curve_template_entry_service::save_ir_curve_template_entries(
     const std::vector<domain::ir_curve_template_entry>& ir_curve_template_entries) {
-    for (const auto& e : ir_curve_template_entries)
+    for (const auto& e : ir_curve_template_entries) {
         if (e.id.is_nil())
             throw std::invalid_argument("IR Curve Template Entry id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << ir_curve_template_entries.size()
                                << " IR curve template entries";
     auto ts = ir_curve_template_entries;

--- a/projects/ores.synthetic/core/src/service/market_data_generation_config_service.cpp
+++ b/projects/ores.synthetic/core/src/service/market_data_generation_config_service.cpp
@@ -74,9 +74,10 @@ void market_data_generation_config_service::save_market_data_generation_config(
 
 void market_data_generation_config_service::save_market_data_generation_configs(
     const std::vector<domain::market_data_generation_config>& market_data_generation_configs) {
-    for (const auto& e : market_data_generation_configs)
+    for (const auto& e : market_data_generation_configs) {
         if (e.id.is_nil())
             throw std::invalid_argument("Market Data Generation Config id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << market_data_generation_configs.size()
                                << " market data generation configs";
     auto ts = market_data_generation_configs;

--- a/projects/ores.synthetic/core/src/service/yield_curve_process_parameter_definition_service.cpp
+++ b/projects/ores.synthetic/core/src/service/yield_curve_process_parameter_definition_service.cpp
@@ -78,10 +78,11 @@ void yield_curve_process_parameter_definition_service::save_parameter_definition
 
 void yield_curve_process_parameter_definition_service::save_parameter_definitions(
     const std::vector<domain::yield_curve_process_parameter_definition>& parameter_definitions) {
-    for (const auto& e : parameter_definitions)
+    for (const auto& e : parameter_definitions) {
         if (e.id.is_nil())
             throw std::invalid_argument(
                 "Yield Curve Process Parameter Definition id cannot be empty.");
+    }
     BOOST_LOG_SEV(lg(), debug) << "Saving " << parameter_definitions.size()
                                << " yield curve process parameter definitions";
     auto ts = parameter_definitions;


### PR DESCRIPTION
## Summary

cpp_protocol.hpp.mustache and cpp_service.cpp.mustache gated their delete/history/save is_uuid branches on primary_key.is_uuid alone, which reflects only the first key column. A compound key whose leading column is uuid would silently drop every trailing key column from the request structs and the save validations. The org sources now loop primary_key.columns with the per-column is_uuid form, matching the member-name derivation (ids for a uuid column, {{column}}s for a text column, is_nil() vs empty() checks), so no key column can be dropped. The {{#entity}} and {{#junction}} sections are untouched: schema primary keys carry no columns list and the junction section has no key gates.

## Changes

- Protocol delete/history and service save-single output is byte-identical for every entity
- Regenerated output confined to uuid-keyed *_service.cpp batch-save loops gaining braces (37 files); three full regenerations idempotent (runs 2-3 byte-identical)
- Verification: ci+code+docs; site build clean; full build clean (linux-clang-debug-make); ctest 71/71 passed on recreated DB; drift checks (refdata, reporting, marketdata) clean except three recorded pre-existing files; ore domain roundtrip report unchanged from recorded pre-existing state

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix codegen template drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.html) | F5532C5C-7A8D-461D-8E0A-CACB602AB3DF |
| Task | [Compound-key is_uuid gating drops trailing columns in Qt/service templates](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_compound-key-is-uuid-gating-drops-trailing-columns.html) | 453FA225-F6FF-4095-AFB7-4D59E3FDB357 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)