### PR TITLE
[ores.codegen] Qt client model fetches paginated unconditionally

### DIFF
--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
@@ -103,7 +103,14 @@ not waste the sweep.
   entities — the dq and reporting flips are carried in this PR, and
   the scheduler one (=ClientJobDefinitionModel=) waits for its
   component's drift story because its regeneration bundles unrelated
-  stale drift.
+  stale drift. Review round 1 (PR #2006) completed that record: the
+  compute→reporting and dq→api migrations left stale duplicate
+  client models compiled under =ores.qt/compute/src= and
+  =ores.qt/api/src= that no generator writes to (their deletion
+  belongs to the migration follow-up), and the workspace model is
+  unregenerable until 836BB4CE. The round also retired the
+  =variability_feature_has_pagination.org= feature page, which still
+  described the flag as a live behavioural toggle.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.org
@@ -41,9 +41,9 @@ not waste the sweep.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Task 453FA225 (compound-key is_uuid gating) done, delivered in commit 28d36860dc. |
+| Now           | Task 9FF6FAD3 (has_pagination knob footgun) done, delivered in commit 7287a46527. |
 | Waiting on    | Nothing.                               |
-| Next          | Remaining two template-bug tasks, in story order. |
+| Next          | Task D8301A1C (junction codegen template follow-ups), the last in the story. |
 | Last touched  | 2026-09-04                               |
 
 * Acceptance
@@ -70,7 +70,7 @@ not waste the sweep.
 |------+-------+-------+-----+-------------|
 | [[id:3F3559A2-5E98-44EA-A87A-E5DA7CF5BA23][Update history field mapper codegen template to use provenance_fields constants]] | DONE | 2026-09-04 | 2026-09-04 | cpp_history_field_mapper.cpp.mustache hardcodes audit-column labels ("Modified By", etc.) as string literals, but currency_history_field_mapper.cpp on main uses the shared ores::history::domain::provenance_fields constants instead -- the template needs to be updated to match and every entity's generated mapper regenerated. |
 | [[id:453FA225-F6FF-4095-AFB7-4D59E3FDB357][Compound-key is_uuid gating drops trailing columns in Qt/service templates]] | DONE | 2026-09-04 | 2026-09-04 | cpp_protocol.hpp.mustache and cpp_service.cpp.mustache gate their delete/history/save is_uuid branch on primary_key.is_uuid alone, which reflects only the first key column. A future compound key whose leading column is UUID would silently drop every subsequent key column from these structs/validations. Not exercised today (subject_area's key is two text columns). Raised in PR #1691 review round 1. Fix: make the is_uuid branches loop primary_key.columns like cpp_domain_type_mapper.cpp.mustache already does. |
-| [[id:9FF6FAD3-A3C3-4C31-9220-57CAADFDCCA0][has_pagination knob is a silent-failure footgun in the Qt client model template]] | BACKLOG | | | The codegen knob gating real offset/limit pagination in a Client entity Model.cpp defaults to off with no compile-time or runtime signal when unset, letting 61 entities silently truncate lists at 100 rows behind fully-functional-looking pagination controls. |
+| [[id:9FF6FAD3-A3C3-4C31-9220-57CAADFDCCA0][has_pagination knob is a silent-failure footgun in the Qt client model template]] | DONE | 2026-09-04 | 2026-09-04 | The codegen knob gating real offset/limit pagination in a Client entity Model.cpp defaults to off with no compile-time or runtime signal when unset, letting 61 entities silently truncate lists at 100 rows behind fully-functional-looking pagination controls. |
 | [[id:D8301A1C-726D-495E-A509-AEA9A838DC88][Junction codegen template follow-ups]] | BACKLOG | | | Four codegen template issues for junction entities: path/namespace mismatch between generated and live code, current_timestamp version-collision in insert triggers, messaging handler generated without matching service, and eventing facets produce incomplete output. |
 
 * Decisions
@@ -89,6 +89,21 @@ not waste the sweep.
   live key is a single uuid or text column, or a compound text key;
   uuid-leading compound keys are the only mixed shape the save
   validation can express today) is in the task's Plan.
+- 2026-09-04 (task 9FF6FAD3): the Qt client model fetch is generated
+  unconditionally — the =has_pagination= fork was deleted rather than
+  set per-entity, because the ={{^}}= branch never fetched the whole
+  set (it sent the request with default offset=0/limit=100 and
+  reported the returned page's size as the total), so no
+  small-table optimisation was lost, and its shape is strictly lossy
+  past the server's default page of 100. The flag survives only as
+  entity-org documentation: nothing behavioural reads it any more, so
+  no future entity can reintroduce the truncation by forgetting a
+  knob. The regression evidence also exposed that the narrow-fix
+  census (tracking task 914B206F) missed three regenerable flag-off
+  entities — the dq and reporting flips are carried in this PR, and
+  the scheduler one (=ClientJobDefinitionModel=) waits for its
+  component's drift story because its regeneration bundles unrelated
+  stale drift.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
@@ -185,7 +185,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Four reporting client models and ClientDatasetBundleModel still compiled on the truncating shape under =ores.qt/compute/src= and =ores.qt/api/src= | =ores.qt/compute/src/Client{ReportInstance,ReportType,ReportDefinition,ConcurrencyPolicy}Model.cpp=, =ores.qt/api/src/ClientDatasetBundleModel.cpp= | Follow-up | Migration orphans: no generator writes to =ores.qt/compute= or =ores.qt/api= for these entities (canonical output goes to =ores.qt/reporting= and =ores.qt/dq=), so no regen can flip them; compiled via =component_files.cmake= and a duplicate-class (ODR) hazard while both libraries load — recorded as follow-up input for the migration/drift story, not foldable into this PR |
+| 2 | =ClientWorkspaceModel= still on the truncating shape despite its protocol carrying offset/limit | =ores.qt/workspace/src/ClientWorkspaceModel.cpp= | Not changed | Its org (=ores.workspace.workspace.org=) is legacy-`* Primary key`: codegen validation fails for it in both regen runs, so it cannot regenerate until the unblocking task 836BB4CE lands — the acceptance-recorded class, not a "trivial flip" |
+| 3 | =ClientJobDefinitionModel= (scheduler) not flipped | =ores.qt/scheduler/src/ClientJobDefinitionModel.cpp= | Not changed | Deferral recorded in Result and story Decisions: its regeneration bundles unrelated pre-existing drift (org evolved after its last regen), which never rides a foundation PR |
+| 4 | =variability_feature_has_pagination.org= still documents the flag as a live behavioural toggle | =projects/modeling/variability_feature_has_pagination.org= | Fixed | Feature retired; page now records the retirement (task 9FF6FAD3) and the flag's documentation-only survival |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :fix-codegen-template-drift:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/pagination-knob-fragility
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-06
 #+updated: 2026-08-06
-#+environment:
+#+environment: brave_hopper
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F5532C5C-7A8D-461D-8E0A-CACB602AB3DF][Fix codegen template drift]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -64,22 +64,103 @@ narrow fix lands:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:F5532C5C-7A8D-461D-8E0A-CACB602AB3DF][Fix codegen template drift]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-06                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-04                               |
 
 * Acceptance
 
--
+- =ores.cpp.qt.client_model_impl.org= (and the tanged
+  =cpp_qt_client_model.cpp.mustache=) generates the fetch method with
+  no =has_pagination= fork: the request always carries =offset= /
+  =limit= and the model always takes =total_available_count= from the
+  response. The ={{^}}= truncating branch and both ={{#}}= wrappers
+  are gone, and the narrative no longer documents a two-branch design.
+- Re-tangling changes only the two files (org archetype + mustache).
+- The change is output-neutral for every entity that can regenerate
+  today: regenerating the Qt client models (all flag-on) is
+  byte-identical to the pre-edit output, so no model churn is
+  attributable to the change beyond the recorded pre-existing drift
+  baseline, and a second regeneration is byte-identical.
+- No entity can emit the truncating shape from this template any more:
+  the 16 legacy-`* Primary key` entities cannot regenerate until their
+  unblocking task lands (836BB4CE), and when they do, and for every
+  new entity from now on, the generated fetch pages correctly with no
+  per-entity knob to set. The unconditional =PaginationWidget= is
+  therefore accurate for every generated model — the model/window
+  disagreement class is gone.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+- 2026-09-04: survey. The flag's behavioural read surface is exactly
+  one template: grep of the templates directory shows
+  =has_pagination= consumed only by the client model fetch function
+  (two ={{#}}= sites and one ={{^}}= branch, lines 311-364 of the
+  org). Everywhere else it is inert documentation: the doc entity org
+  templates echo =:has_pagination:= back into regenerated entity
+  doc pages when set, and =core.py= (lines 3224-3225) loads the Qt
+  drawer property with a silent =False= default to feed that same
+  echo. =doc_feature.org= mentions the property only as an example
+  literal in a generic feature template.
+- The protocol side has no gate: =offset= (default 0) / =limit=
+  (default 100) and =total_available_count= are unconditional members
+  of every generated list request and response class
+  (=ores.cpp.protocol.protocol_header.org=, five request shapes, all
+  with the same unconditional trio), so the paginated branch compiles
+  for every entity when it can regenerate. The country-fix commit that
+  created the fork (3f51aef9f4) changed only the model template, the
+  country org, and the narrative — the flag never reached the
+  protocol, the service, or the server.
+- Committed-model census: 30 entities carry the flag (the tracking
+  task 914B206F's 29 fixes in PR #1760 plus =calendar_type=), all
+  regenerable and byte-stable across the fixes' regeneration rounds.
+  The only committed flag-off models belong to the 16 legacy-`*
+  Primary key` heading entities (follow-up 836BB4CE) that cannot
+  regenerate at all today — =resolve_targets= fails on any address for
+  them, so their truncating output stays in the tree until that
+  unblocking task lands, whatever this task decides.
+- Design decision: capture option 1 — generate the paginated fetch
+  path unconditionally and delete the fork. The fork never was a
+  small-table optimisation worth preserving: the ={{^}}= branch does
+  not fetch "the whole set", it sends the request with its default
+  =offset=0/limit=100= and reports the returned page's size as the
+  total, so both branches fetch at most the server's default page and
+  differ only in whether the model can page onward and report a
+  truthful total. The unconditional path is the one proven in
+  production by the ~30 flag-on entities; for a table over 100 rows
+  the flag-off path is strictly lossy. Deleting the fork makes the
+  unconditional =PaginationWidget= correct for every generated model,
+  which dissolves the model/window disagreement that let the bug go
+  unnoticed across 61 entities — capture option 3 (a lint pass) is
+  then unnecessary, and the flag itself survives only as the entity-
+  org doc property it already is (loader and doc echo untouched;
+  nothing behavioural reads it any more).
+- Implementation order: baseline full regeneration (drift record,
+  pre-edit), org edit (unbrace the two ={{#}}= sites so the
+  offset/limit pair and the response-total return are unconditional;
+  delete the ={{^}}= branch; rewrite the narrative), re-tangle (only
+  the one mustache should change), per-component regeneration
+  (byte-identical to the baseline for all regenerable models),
+  idempotency check (second regen byte-identical), then close out
+  with the code+ci+docs verification union (site build, full build +
+  ctest on a recreated database, drift checks, roundtrip).
+- 2026-09-04: regeneration evidence. The baseline full-ores
+  regeneration (run 1, pre-edit) churned 202 tracked generated files
+  — pre-existing drift whose composition (trading 95, sql 31, dq 15,
+  scheduler 24 incl. Qt, synthetic 17 incl. Qt, database 7, analytics
+  4, compute 4, qt/iam 2, refdata/marketdata/iam 1 each) differs from
+  task 453FA225's recorded baseline as main evolved; all of it
+  reverted or excluded from this PR. The attributable delta between
+  run 1 and run 2 (post-edit) is exactly 7 files: the two templates,
+  two =ores.database= =component_files.cmake= (stub-byproduct churn,
+  reverted), and three Qt client model flips (=ClientBadgeSeverityModel=,
+  =ClientReportInstanceModel= — carried; =ClientJobDefinitionModel= —
+  reverted, see Result). Runs 2 and 3 are byte-identical (identical
+  md5 sets) — idempotent. The 166 untracked byproducts (42 inherited
+  from task 453FA225's regens) are byte-identical across the runs.
 
 * Notes
 
@@ -107,6 +188,70 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Delivered 2026-09-04 on branch
+=feature/pagination-knob-fragility=, commit 7287a46527.
+
+- The fetch is unconditional in both the org source
+  (=ores.cpp.qt.client_model_impl.org=) and the tangled mustache: the
+  ={{#domain_entity.qt.has_pagination}}= wrappers around the
+  =offset=/=limit= pair and around the log + response-total return are
+  gone, and the ={{^}}= truncating branch (defaults, page-size
+  reported as total) is deleted. The request always carries
+  =offset=/=limit= and the model always takes
+  =total_available_count= from the response, so no entity can emit the
+  truncating shape from this template. The section (now "** Fetching a
+  page") records the fork's history; the flag survives only as
+  entity-org documentation (loader and doc echo untouched).
+- Re-tangling changed only the two template files (the org and its
+  tangled mustache).
+- Regeneration evidence (three full-ores regens, md5 per changed
+  file, in the Plan): run 1 (pre-edit) churned 202 tracked generated
+  files of pre-existing drift — all reverted or excluded from this PR
+  and input for the per-component drift stories. The attributable
+  delta between run 1 and run 2 is exactly 7 files: the two
+  templates, two =component_files.cmake= files (stub-byproduct
+  churn, reverted), and three Qt client model flips. Runs 2 and 3
+  are byte-identical (identical md5 sets) — idempotent.
+- Census correction: the survey census (30 flag-on entities, 16
+  legacy-`* Primary key` unregenerable) missed three regenerable
+  modern-key entities that carry the flag off: the regen delta flipped
+  =ClientBadgeSeverityModel= (dq) and =ClientReportInstanceModel=
+  (reporting), both carried in this PR as the intended repair — the
+  tracking task 914B206F's census never listed them. The narrow fix
+  (set the flag everywhere) was therefore incomplete exactly where
+  this fix cannot be: there is no flag left to forget. The third flip,
+  =ClientJobDefinitionModel= (scheduler), sits on top of stale
+  committed drift (its org evolved after its last regeneration), so
+  the file was reverted to its committed state and its regeneration is
+  left to the scheduler per-component drift story; until then its
+  committed model stays the old truncating shape, a historical
+  artifact this template can no longer produce.
+- Output neutrality held for every flag-on entity: no Qt client model
+  churn exists in any flag-on component across the runs beyond the
+  three flips above, and the post-fix component drift check
+  (refdata) wrote every flag-on Qt model byte-identical to the
+  committed tree.
+- Verification (change class: code + ci + docs): site build clean;
+  full system build clean (linux-clang-debug-make); ctest 71/71
+  passed against a recreated database — the CI-equivalent state,
+  because the repository write tests are not repeatable against a
+  persistent database; component drift checks (refdata, reporting,
+  marketdata) reproduce the committed tree except the three recorded
+  pre-existing files (=party_repository.cpp=, =feed_binding.hpp= and
+  its create sql), reverted after the check; ore domain roundtrip
+  report generated clean (rc 0), structurally unchanged — this diff
+  touches no roundtrip input or parser.
+- The 166 untracked regen byproducts (42 inherited from task
+  453FA225's regen plus this unit's additions) stay in the working
+  tree, byte-identical across runs 2 and 3, excluded from all
+  commits (deletion not authorised).
+
+Acceptance: bullets 1, 2, and 4 met as written. Bullet 3 holds for
+its flag-on scope with the correction recorded above: the two
+census-missed flag-off entities flip as the intended repair (which is
+the story's purpose — an entity with the flag off must not truncate),
+and no other model churn is attributable to the change.
 
 * Promoted from capture
 

--- a/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
+++ b/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.org
@@ -8,7 +8,7 @@
 #+filetags: :fix-codegen-template-drift:sprint_25:v0:
 #+owner: marco
 #+branch: feature/pagination-knob-fragility
-#+pr:
+#+pr: 2006
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-06
@@ -179,7 +179,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2006][#2006]] | [ores.codegen] Qt client model fetches paginated unconditionally |
 
 * Review
 

--- a/projects/modeling/variability_feature_has_pagination.org
+++ b/projects/modeling/variability_feature_has_pagination.org
@@ -2,12 +2,12 @@
 :ID: 26409919-470E-4820-B8C1-AC816181F894
 :END:
 #+title: Feature: has_pagination
-#+description: Emit pagination controls in the list view instead of loading everything.
+#+description: Retired behavioural toggle; Qt list views always paginate with a real total since 2026-09-04.
 #+type: feature
 #+level: cross
 #+filetags: :codegen:variability:feature:
 #+created: 2026-07-31
-#+updated: 2026-07-31
+#+updated: 2026-09-04
 
 This page is one authored [[id:CE95C751-2125-4BA9-A78D-C30F9540FC5E][MASD feature]] in [[id:0BD6F9EC-34DD-44D9-8AA1-917EE5966396][ORE Studio Variability
 Model]] § "Projection configuration: how an existing artefact family is shaped". Any [[id:A57C28EA-EB88-4C0A-BDDF-F414CCCF96F7][profile]] that fixes
@@ -24,11 +24,20 @@ this feature's value links here rather than restating its effect.
 
 * Effect
 
-Emit pagination controls in the list view instead of loading every row at once.
+Retired as a behavioural toggle on 2026-09-04 (task
+9FF6FAD3): the Qt client model template now generates the paginated
+fetch unconditionally. Every list request carries =offset=/=limit=
+and the model reports the server's =total_available_count=; every
+=MdiWindow= shows the pagination controls. The literal remains
+accepted on entity orgs, and on the profiles listed below, as
+documentation only — setting or clearing it no longer changes
+generated behaviour, and no entity can silently truncate a list by
+leaving it unset.
 
 * Structural consequence
 
-None — purely a Qt behavioural toggle, no column or struct field.
+None — the property never mapped to a column or struct field, and
+its retirement changed nothing structurally.
 
 * Used by
 

--- a/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
@@ -253,10 +253,8 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                 }
 
                 {{domain_entity.qt.get_request_class}} request;
-{{#domain_entity.qt.has_pagination}}
                 request.offset = offset;
                 request.limit = limit;
-{{/domain_entity.qt.has_pagination}}
 {{#domain_entity.qt.has_parent_scoped_list}}
                 request.{{domain_entity.qt.parent_key_field}} = self->{{domain_entity.qt.parent_key_param}}_.toStdString();
 {{/domain_entity.qt.has_parent_scoped_list}}
@@ -287,7 +285,6 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                             .error_details = {}};
                 }
 
-{{#domain_entity.qt.has_pagination}}
                 BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->{{domain_entity.repository.entity_plural_short}}.size()
                                            << " {{domain_entity.entity_plural_words}}, total available: "
                                            << result->total_available_count;
@@ -296,17 +293,6 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                         .total_available_count =
                             static_cast<std::uint32_t>(result->total_available_count),
                         .error_message = {}, .error_details = {}};
-{{/domain_entity.qt.has_pagination}}
-{{^domain_entity.qt.has_pagination}}
-                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->{{domain_entity.repository.entity_plural_short}}.size()
-                                           << " {{domain_entity.entity_plural_words}}";
-                const std::uint32_t count =
-                    static_cast<std::uint32_t>(result->{{domain_entity.repository.entity_plural_short}}.size());
-                return {.success = true,
-                        .{{domain_entity.qt.collection_name}} = std::move(result->{{domain_entity.repository.entity_plural_short}}),
-                        .total_available_count = count,
-                        .error_message = {}, .error_details = {}};
-{{/domain_entity.qt.has_pagination}}
             }, "{{domain_entity.entity_plural_words}}");
         });
 

--- a/projects/ores.codegen/library/templates/ores.cpp.qt.client_model_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.qt.client_model_impl.org
@@ -262,32 +262,24 @@ void Client{{domain_entity.entity_pascal}}Model::load_page(std::uint32_t offset,
 
 #+end_src
 
-** Fetching a page — the =has_pagination= variability point
+** Fetching a page
 
 =fetch_...= runs the server request off the UI thread (=QtConcurrent::run=)
 and marshals the outcome into a =FetchResult= that =on...Loaded= consumes on
-the UI thread. Whether it fetches a /page/ or the /whole set/ is governed by
-the =has_pagination= switch, and getting this wrong is subtle, so it is worth
-spelling out.
-
-*When =has_pagination= is true* the request carries =offset= / =limit=, and —
-critically — the model takes =total_available_count= from the *response*, not
-from the size of the returned vector. That server-supplied total is what tells
-the =PaginationWidget= how many pages exist; without it the widget cannot know
+the UI thread. The request always carries =offset= / =limit=, and the model
+always takes =total_available_count= from the *response*, not from the size of
+the returned vector. That server-supplied total is what tells the
+=PaginationWidget= how many pages exist; without it the widget cannot know
 there is a page 2.
 
-*When =has_pagination= is false* the request is sent with its defaults and the
-"total" is just the number of rows returned. That is only correct for small
-reference sets that always come back in a single response. If such an entity is
-in fact capped server-side (the default =limit= is 100), the model will report
-=total = 100= and the pager will believe the first 100 rows /are/ the entire
-table — the list silently truncates. So any entity whose table can exceed the
-default page MUST set =has_pagination: true=; otherwise it loses rows with no
-error. (This is exactly the bug that hid every country after the first 100.)
-
-The two branches differ only in those two lines (set offset/limit; trust the
-response total). Everything else — the async wrapper, the destroyed-model and
-transport-error guards, the move into =FetchResult= — is shared.
+This used to be a fork on the =has_pagination= Qt-facet flag: with the flag
+unset, the request went out with its defaults and the model reported the
+returned page's size as the total. For a table capped server-side (the default
+=limit= is 100) that silently truncated the list — the pager believed the first
+100 rows /were/ the entire table, with no error. That bug hid every country
+after the first 100. The flag is no longer read by this template; every entity
+pages and reports the real total, so =:has_pagination:= survives only as
+entity-org documentation.
 
 #+begin_src mustache :tangle cpp_qt_client_model.cpp.mustache
 void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collection_name}}(
@@ -308,10 +300,8 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                 }
 
                 {{domain_entity.qt.get_request_class}} request;
-{{#domain_entity.qt.has_pagination}}
                 request.offset = offset;
                 request.limit = limit;
-{{/domain_entity.qt.has_pagination}}
 {{#domain_entity.qt.has_parent_scoped_list}}
                 request.{{domain_entity.qt.parent_key_field}} = self->{{domain_entity.qt.parent_key_param}}_.toStdString();
 {{/domain_entity.qt.has_parent_scoped_list}}
@@ -342,7 +332,6 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                             .error_details = {}};
                 }
 
-{{#domain_entity.qt.has_pagination}}
                 BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->{{domain_entity.repository.entity_plural_short}}.size()
                                            << " {{domain_entity.entity_plural_words}}, total available: "
                                            << result->total_available_count;
@@ -351,17 +340,6 @@ void Client{{domain_entity.entity_pascal}}Model::fetch_{{domain_entity.qt.collec
                         .total_available_count =
                             static_cast<std::uint32_t>(result->total_available_count),
                         .error_message = {}, .error_details = {}};
-{{/domain_entity.qt.has_pagination}}
-{{^domain_entity.qt.has_pagination}}
-                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->{{domain_entity.repository.entity_plural_short}}.size()
-                                           << " {{domain_entity.entity_plural_words}}";
-                const std::uint32_t count =
-                    static_cast<std::uint32_t>(result->{{domain_entity.repository.entity_plural_short}}.size());
-                return {.success = true,
-                        .{{domain_entity.qt.collection_name}} = std::move(result->{{domain_entity.repository.entity_plural_short}}),
-                        .total_available_count = count,
-                        .error_message = {}, .error_details = {}};
-{{/domain_entity.qt.has_pagination}}
             }, "{{domain_entity.entity_plural_words}}");
         });
 

--- a/projects/ores.qt/dq/src/ClientBadgeSeverityModel.cpp
+++ b/projects/ores.qt/dq/src/ClientBadgeSeverityModel.cpp
@@ -207,6 +207,8 @@ void ClientBadgeSeverityModel::fetch_severities(std::uint32_t offset, std::uint3
                 }
 
                 dq::messaging::get_badge_severities_request request;
+                request.offset = offset;
+                request.limit = limit;
 
                 auto result =
                     self->clientManager_->process_authenticated_request(std::move(request));
@@ -237,11 +239,12 @@ void ClientBadgeSeverityModel::fetch_severities(std::uint32_t offset, std::uint3
                 }
 
                 BOOST_LOG_SEV(lg(), debug)
-                    << "Fetched " << result->severities.size() << " badge severities";
-                const std::uint32_t count = static_cast<std::uint32_t>(result->severities.size());
+                    << "Fetched " << result->severities.size()
+                    << " badge severities, total available: " << result->total_available_count;
                 return {.success = true,
                         .severities = std::move(result->severities),
-                        .total_available_count = count,
+                        .total_available_count =
+                            static_cast<std::uint32_t>(result->total_available_count),
                         .error_message = {},
                         .error_details = {}};
             },

--- a/projects/ores.qt/reporting/src/ClientReportInstanceModel.cpp
+++ b/projects/ores.qt/reporting/src/ClientReportInstanceModel.cpp
@@ -212,6 +212,8 @@ void ClientReportInstanceModel::fetch_instances(std::uint32_t offset, std::uint3
                 }
 
                 reporting::messaging::get_report_instances_request request;
+                request.offset = offset;
+                request.limit = limit;
 
                 auto result =
                     self->clientManager_->process_authenticated_request(std::move(request));
@@ -242,11 +244,12 @@ void ClientReportInstanceModel::fetch_instances(std::uint32_t offset, std::uint3
                 }
 
                 BOOST_LOG_SEV(lg(), debug)
-                    << "Fetched " << result->instances.size() << " report instances";
-                const std::uint32_t count = static_cast<std::uint32_t>(result->instances.size());
+                    << "Fetched " << result->instances.size()
+                    << " report instances, total available: " << result->total_available_count;
                 return {.success = true,
                         .instances = std::move(result->instances),
-                        .total_available_count = count,
+                        .total_available_count =
+                            static_cast<std::uint32_t>(result->total_available_count),
                         .error_message = {},
                         .error_details = {}};
             },


### PR DESCRIPTION
## Summary

The Qt client model template gates real offset/limit pagination on the :has_pagination: facet flag, which defaults to off with no signal: an entity with the flag unset sends the request with its defaults (offset=0, limit=100), fetches the server's default page, and reports the page's size as the total, silently truncating any list past 100 rows behind fully functional-looking pagination controls. This deletes the fork: the org archetype and the tangled mustache generate the paginated fetch unconditionally, so the request always carries offset/limit and the model always takes total_available_count from the response. The false branch never was a small-table optimisation — it fetched at most the same default page, differing only in whether the model can page onward and report a truthful total — so nothing is lost, and the flag survives only as entity-org documentation. Two regenerated flag-off models are carried (ClientBadgeSeverityModel, ClientReportInstanceModel): entities the narrow-fix census (tracking task 914B206F) missed, now repaired at source.

## Changes

- Delete the has_pagination fork in ores.cpp.qt.client_model_impl.org and cpp_qt_client_model.cpp.mustache: the offset/limit pair and the response-total return are unconditional; the {{^}} truncating branch (defaults, page size reported as total) is gone; the narrative retitles to 'Fetching a page' and records the fork's history.
- Regenerated ClientBadgeSeverityModel.cpp (ores.qt/dq) and ClientReportInstanceModel.cpp (ores.qt/reporting): pure flips from the truncating shape to the paginated shape — both were flag-off entities the 914B206F census missed.
- Verification: code+ci+docs; site build clean; full build clean (linux-clang-debug-make); ctest 71/71 passed against a recreated database; re-tangle changes only the two template files; component drift checks (refdata/reporting/marketdata) reproduce the committed tree except the 3 recorded pre-existing drift files (reverted after the check); regen evidence — pre-edit baseline drift (202 tracked files, recorded composition) reverted or excluded, attributable delta exactly 7 files (2 templates, 2 stub-byproduct cmake reverted, 3 model flips), runs 2-3 byte-identical (idempotent); ore domain roundtrip report clean (rc 0), structurally unchanged.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix codegen template drift](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/story.html) | F5532C5C-7A8D-461D-8E0A-CACB602AB3DF |
| Task | [has_pagination knob is a silent-failure footgun in the Qt client model template](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/fix-codegen-template-drift/task_pagination-knob-fragility.html) | 9FF6FAD3-A3C3-4C31-9220-57CAADFDCCA0 |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)