### PR TITLE
[agile] Record PR #2000 merge on the BK task doc

### DIFF
--- a/doc/agile/versions/v0/sprint_25/add_new_stochastic_processes/task_implement_black_karasinski_process.org
+++ b/doc/agile/versions/v0/sprint_25/add_new_stochastic_processes/task_implement_black_karasinski_process.org
@@ -107,7 +107,7 @@ via its "Verifies task" field.
 
 | Scenario | State | Notes |
 |----------+-------+-------|
-| [[id:795B5273-58CF-40BF-9F01-E83CF82F1891][Verify Black-Karasinski IR curve config]] | PENDING | Covers the BK-specific acceptance: engine in combo, four parameter fields with seeded defaults/bounds, save/reopen persistence, live preview via the mapping layer, Vasicek regression. History and eventing steps omitted: both are generic config-entity mechanics, independent of process type. |
+| [[id:795B5273-58CF-40BF-9F01-E83CF82F1891][Verify Black-Karasinski IR curve config]] | FAILED | Covers the BK-specific acceptance: engine in combo, four parameter fields with seeded defaults/bounds, save/reopen persistence, live preview via the mapping layer, Vasicek regression. History and eventing steps omitted: both are generic config-entity mechanics, independent of process type. Closed 2026-09-03 (059ffe11ef): step 6's save persists but the reloaded tree does not show the config; steps 7-9 not executable (tree reopen needs the missing item; IR tree delete broken client-side) — underlying IR/FX client defects captured in story E95A3D20. |
 
 * PRs
 
@@ -115,6 +115,7 @@ via its "Verifies task" field.
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/1980][#1980]] | [ores.synthetic] Wire Black-Karasinski into the system: mapping, seed, editor |
 | [[https://github.com/OreStudio/OreStudio/pull/1932][#1932]] | [ores.analytics.quant] Implement six stochastic IR processes |
+| [[https://github.com/OreStudio/OreStudio/pull/2000][#2000]] | [ores.database,ores.synthetic,ores.qt] Black-Karasinski config test: pool backoff, data-driven parameter labels, editor and tree fixes |
 
 * Review
 


### PR DESCRIPTION
Doc-only bookkeeping: PR #2000 merged via `pr merge`, but no task doc carries the `feature/bk-feature-test-scenario` branch, so the automatic record step was skipped. This adds the #2000 row to task CDB12DB0's PRs table and marks scenario 795B5273 FAILED in the task doc, matching its 059ffe11ef close-out.

No code changes; CI risk is limited to doc checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)