### PR TITLE
[iam,sql] Grant iam_service select on refdata for the account_party soft FK

### DIFF
--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/story.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/story.org
@@ -43,6 +43,7 @@ Bring ores.iam to the same proven state as the ores.refdata pilot: every codegen
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:4DDA81C4-4306-4022-A022-75A3A23BE4A0][Bind ores.iam entities to profiles; verify zero-diff regen]] | DONE | 2026-09-05 | 2026-09-05 | Implement profile binding for ores.iam's org-mode entity set (iam and iam-cpp catalogue entries share the same modeling_dir), rebind every matching entity, regenerate, and confirm byte-identical output, following the ores.refdata pilot method exactly. |
+| [[id:4335B0BE-F70C-4C76-9020-4B14B778895B][Grant iam_service select on refdata for the account_party soft FK]] | DONE | 2026-09-05 | 2026-09-05 | The regenerated ores_iam_account_parties_insert_fn runs under the plain invoker idiom, so its soft-FK validation subselect against ores_refdata_parties_tbl executes as the iam service user. The service registry granted iam_service select on ores_assets_ and ores_dq_ only, so the first live tenant provisioning on a fresh DB failed with 'permission denied for table ores_refdata_parties_tbl'. Add ores_refdata_ to iam's Select prefixes in service_registry.org and regenerate iam_service_db_grants_create.sql. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/task_fix-iam-account-party-grant.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/task_fix-iam-account-party-grant.org
@@ -1,0 +1,108 @@
+:PROPERTIES:
+:ID: 4335B0BE-F70C-4C76-9020-4B14B778895B
+:END:
+#+title: Task: Grant iam_service select on refdata for the account_party soft FK
+#+description: The regenerated ores_iam_account_parties_insert_fn runs under the plain invoker idiom, so its soft-FK validation subselect against ores_refdata_parties_tbl executes as the iam service user. The service registry granted iam_service select on ores_assets_ and ores_dq_ only, so the first live tenant provisioning on a fresh DB failed with 'permission denied for table ores_refdata_parties_tbl'. Add ores_refdata_ to iam's Select prefixes in service_registry.org and regenerate iam_service_db_grants_create.sql.
+#+type: task
+#+level: s1
+#+filetags: :entity-classification-drift-iam:sprint_25:v0:
+#+owner: marco
+#+branch: feature/fix-iam-account-party-grant
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-05
+#+updated: 2026-09-05
+#+environment: brave_hopper
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C7AB2C55-5EF6-4DCE-8000-A2BEB3184971][Entity classification and drift baseline: ores.iam]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Bind PR #2014 regenerated the iam junction templates; the account_party
+insert function now runs under the plain invoker idiom, so its soft-FK
+validation subselect against ores_refdata_parties_tbl executes as the
+iam service user. The registry grants covered ores_assets_ and ores_dq_
+only, so first live tenant provisioning on a fresh database failed with
+"permission denied for table ores_refdata_parties_tbl". ctest never
+caught it: the tests run as privileged roles. Express the refdata grant
+for iam_service in the service registry model and regenerate, so the
+generated grants file is lossless again.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:C7AB2C55-5EF6-4DCE-8000-A2BEB3184971][Entity classification and drift baseline: ores.iam]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-05                               |
+
+* Acceptance
+
+- service_registry.org grants iam_service select on ores_refdata_ and
+  regeneration of iam_service_db_grants_create.sql is a no-op (lossless
+  model again).
+- Live tenant provisioning on a fresh database succeeds: the account_party
+  soft-FK validation subselect runs without a permission error.
+- Full build clean; ctest 71/71 green.
+
+* Plan
+
+Extend the per-service cross-domain Select prefixes for iam_service in
+service_registry.org with ores_refdata_ (the model capability the
+investigate-hand-added-service-grants story added), then regenerate
+iam_service_db_grants_create.sql from the model so the grant is
+generator-owned, never hand-added. Prove losslessness: regeneration
+before and after the edit must reproduce the committed file (the diff
+is exactly the one grant line, then a no-op). Verify live with tenant
+provisioning on a fresh database.
+
+* Notes
+
+Found by the post-merge system test of the compute/iam bind PRs: first
+live tenant provisioning on a fresh database failed with "permission
+denied for table ores_refdata_parties_tbl". Same drift class the
+investigate-hand-added-service-grants story closed (regeneration must be
+lossless); this instance was a new cross-domain reference the bind's
+junction regeneration introduced. ctest cannot see it — the tests run as
+privileged roles — so the live test is the only evidence.
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+service_registry.org gains ores_refdata_ in iam_service's Select
+prefixes; iam_service_db_grants_create.sql regenerated — the diff is the
+single grant line. Losslessness proven twice: regeneration was a no-op
+before the edit (baseline) and is a no-op after it (re-verified
+2026-09-05 on the fix branch). Live tenant provisioning on a fresh
+database then succeeded end to end, including the account_party insert
+with its soft-FK validation against ores_refdata_parties_tbl.
+
+Verification: full build clean and ctest 71/71 green on the fix branch
+(linux-clang-debug-make); regeneration no-op (above).

--- a/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/task_fix-iam-account-party-grant.org
+++ b/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/task_fix-iam-account-party-grant.org
@@ -8,7 +8,7 @@
 #+filetags: :entity-classification-drift-iam:sprint_25:v0:
 #+owner: marco
 #+branch: feature/fix-iam-account-party-grant
-#+pr:
+#+pr: 2016
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-05
@@ -86,7 +86,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2016][#2016]] | [iam,sql] Grant iam_service select on refdata for the account_party soft FK |
 
 * Review
 

--- a/projects/modeling/service_registry.org
+++ b/projects/modeling/service_registry.org
@@ -38,6 +38,13 @@
 # no business-unit reference to query this from post-publish.
 - ores_dq_
 
+# The account_party junction's soft-FK validation
+# (ores_iam_account_parties_insert_fn) reads the party row in
+# ores_refdata_parties_tbl under the plain invoker idiom; the legacy
+# SECURITY DEFINER attribute regeneration dropped made this grant
+# load-bearing (see iam_account_party_create.sql).
+- ores_refdata_
+
 ** Execute prefixes
 
 # Security-definer function that reads the system-tenant template image

--- a/projects/modeling/service_registry.org
+++ b/projects/modeling/service_registry.org
@@ -40,9 +40,10 @@
 
 # The account_party junction's soft-FK validation
 # (ores_iam_account_parties_insert_fn) reads the party row in
-# ores_refdata_parties_tbl under the plain invoker idiom; the legacy
-# SECURITY DEFINER attribute regeneration dropped made this grant
-# load-bearing (see iam_account_party_create.sql).
+# ores_refdata_parties_tbl under the plain invoker idiom.
+# Regeneration dropped the function's legacy SECURITY DEFINER
+# attribute, and that made this grant load-bearing
+# (see iam_account_party_create.sql).
 - ores_refdata_
 
 ** Execute prefixes

--- a/projects/ores.sql/create/iam/iam_service_db_grants_create.sql
+++ b/projects/ores.sql/create/iam/iam_service_db_grants_create.sql
@@ -142,6 +142,7 @@ alter default privileges in schema public
 select _ores_grant_dml_fn('ores_iam_', :'iam_service_user');
 select _ores_grant_select_fn('ores_assets_', :'iam_service_user');
 select _ores_grant_select_fn('ores_dq_', :'iam_service_user');
+select _ores_grant_select_fn('ores_refdata_', :'iam_service_user');
 select _ores_grant_execute_fn('ores_assets_get_template_image_', :'iam_service_user');
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bind PR #2014 regenerated the iam junction templates; the account_party insert function now runs under the plain invoker idiom, so its soft-FK validation subselect against ores_refdata_parties_tbl executes as the iam service user. The registry granted iam_service select on ores_assets_ and ores_dq_ only, so the first live tenant provisioning on a fresh database failed with 'permission denied for table ores_refdata_parties_tbl'; ctest never caught it because the tests run as privileged roles. Express the grant in the service registry model, where the investigate-hand-added-service-grants story added the cross-domain capability, and regenerate so the grants file is generator-owned again.

## Changes

- service_registry.org: add ores_refdata_ to the iam_service Select prefixes
- iam_service_db_grants_create.sql regenerated from the model; the diff is the single grant line

## Testing

**Plan.** Model+SQL regen class per the pr-raise rule table: lossless-regeneration proof, full build and the complete ctest suite via compass, codegen drift and roundtrip checks; then live provisioning on a fresh database under the real service-user path (shell-only).

**What was tested.** All green on the fix branch (linux-clang-debug-make):

- service_registry regeneration lossless, proven twice (no-op before and after the edit).
- Full build clean; ctest 71/71 green.
- Codegen drift byte-identical for refdata/reporting/marketdata; roundtrip check exit 0 (informational).
- Live on a fresh database recreated at this commit: has_table_privilege confirms the iam service user now holds select on ores_refdata_parties_tbl, and the tenant-provisioning leg that failed before the fix (account_party soft-FK insert under the real service-user path) completed end to end.

**Limitations.**

- No UI driving: all flows were exercised through ores.shell; the UI-only test gaps are tracked in a separate story per the system-test directive.
- The ctest suite runs as privileged roles and cannot exercise the service-user grant path; the live provisioning run on the fresh database is the evidence for the fix.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Entity classification and drift baseline: ores.iam](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/story.html) | C7AB2C55-5EF6-4DCE-8000-A2BEB3184971 |
| Task | [Grant iam_service select on refdata for the account_party soft FK](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/entity-classification-drift-iam/task_fix-iam-account-party-grant.html) | 4335B0BE-F70C-4C76-9020-4B14B778895B |
| Environment | brave_hopper | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
