### PR TITLE
[ores.codegen] Emit value_or(0) for nullable numerics in result mappers

### DIFF
--- a/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/story.org
+++ b/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/story.org
@@ -37,11 +37,11 @@ green.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                             |
+| State         | DONE                             |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
-| Now           | Template fix in flight on branch hotfix/ci-builds-red-hotfix. |
+| Now           | Nothing. |
 | Waiting on    | Nothing.                               |
-| Next          | Roll the story DONE when the PR merges. |
+| Next          | Nothing. |
 | Last touched  | 2026-09-06                               |
 
 * Acceptance
@@ -57,7 +57,7 @@ green.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:670C711E-2DCB-42DD-9F01-EC45FFF5310D][Implement Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | STARTED | 2026-09-06 | | Edit the mapper-impl codegen template to emit value_or(0) for nullable numeric fields, retangle the templates and regenerate the compute mapper, verify codegen drift, the site build, the roundtrip and the full build with ctest, then raise the hotfix PR and roll the story and this task DONE. The story doc, the sprint Hotfixes row and this task ride this branch. |
+| [[id:670C711E-2DCB-42DD-9F01-EC45FFF5310D][Implement Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | DONE | 2026-09-06 | 2026-09-06 | Edit the mapper-impl codegen template to emit value_or(0) for nullable numeric fields, retangle the templates and regenerate the compute mapper, verify codegen drift, the site build, the roundtrip and the full build with ctest, then raise the hotfix PR and roll the story and this task DONE. The story doc, the sprint Hotfixes row and this task ride this branch. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/story.org
+++ b/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/story.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: D1896FA3-026B-4056-A4FD-8C18BF9DF4C1
+:END:
+#+title: Story: Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper
+#+description: The continuous GitHub Actions builds on main fail on every OS: the result-mapper codegen template emits value_or({}) for nullable numeric fields, and the CI compilers gcc 13 and Apple clang cannot deduce the template parameter of value_or from a braced-init-list, while the local toolchains and MSVC accept it. The fix emits value_or(0) instead.
+#+type: story
+#+level: s2
+#+filetags: :hotfix:codegen:compute:sprint_25:v0:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+#+environment: brave_hopper
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Main's continuous GitHub Actions builds are red on every OS. The
+Linux (gcc 13) and macOS (Apple clang) jobs fail to compile
+projects/ores.compute/core/src/repository/result_mapper.cpp. The
+mapper-impl codegen template emits v.<field>.value_or({}) for nullable
+numeric fields, and a braced-init-list cannot deduce the template
+parameter of std::optional<T>::value_or on those compilers. MSVC and
+clang-cl accept the deduction: the Windows jobs compiled the same file
+in the same window and were red for separate reasons (a test-seed
+failure and a transient file-lock link error), both since addressed.
+The local toolchains (g++ 16.2, clang 21.1) also accept the idiom,
+which is why bind PR #2012 built green locally. The fix emits an
+explicit value_or(0) instead, retangles the mapper template, and
+regenerates the compute mapper. Zero is semantically identical to {}
+for the two nullable numerics in play: pgmq_msg_id (nullable bigint to
+std::int64_t) and outcome (nullable int to int, generator default 0),
+both read into non-optional domain scalars. The CI builds return to
+green.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                             |
+| Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
+| Now           | Template fix in flight on branch hotfix/ci-builds-red-hotfix. |
+| Waiting on    | Nothing.                               |
+| Next          | Roll the story DONE when the PR merges. |
+| Last touched  | 2026-09-06                               |
+
+* Acceptance
+
+- The mapper-impl codegen template emits value_or(0), never
+  value_or({}), for nullable numeric fields.
+- Regenerating the compute mapper is the only drift the template change
+  produces; the codegen drift checks pass.
+- The local build, ctest and site build stay green, and the continuous
+  CI on every OS returns to green after the merge.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:670C711E-2DCB-42DD-9F01-EC45FFF5310D][Implement Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | STARTED | 2026-09-06 | | Edit the mapper-impl codegen template to emit value_or(0) for nullable numeric fields, retangle the templates and regenerate the compute mapper, verify codegen drift, the site build, the roundtrip and the full build with ctest, then raise the hotfix PR and roll the story and this task DONE. The story doc, the sprint Hotfixes row and this task ride this branch. |
+
+* Decisions
+
+* Out of scope
+
+- The codegen banner and drift-baseline rollout across components: the
+  [[id:B8F8A7B5-30E3-47EF-959F-7EB006C007D3][Entity classification and drift baseline across all components]] story
+  owns it.
+- New bind work: this hotfix changes the template and one regenerated
+  file, nothing else.

--- a/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
+++ b/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
@@ -41,11 +41,11 @@ branch.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                             |
+| State        | DONE                             |
 | Parent story | [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] |
-| Now          | Template fix in flight.                |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Raise the hotfix PR when the verification is green. |
+| Next         | Nothing. |
 | Last touched | 2026-09-06                               |
 
 * Acceptance
@@ -113,3 +113,19 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Done on 2026-09-06. The mapper-impl template
+(projects/ores.codegen/library/templates/ores.cpp.repository.mapper_impl.org)
+emits =value_or(0)= at both =is_nullable_numeric= sites (identity and
+plain groups); the codegen templates retangle to
+cpp_domain_type_mapper.cpp.mustache with the same change. The compute
+mapper regenerates to the only diff across the eight compute models:
+result_mapper.cpp lines 45 and 47 now read =value_or(0)=. Git grep
+confirms no tracked file carries =value_or({})=.
+
+Verification (linux-clang-debug-make): full build clean; ctest 71/71
+passed, 0 failed; codegen drift clean (refdata, reporting, marketdata
+regenerate byte-identical); domain roundtrip exit 0; site build green.
+The compile failure itself is not reproducible locally, since g++ 16.2
+and clang 21.1 accept the old idiom; the CI record in * Notes proves
+the failure and the post-merge continuous runs on main confirm the fix.

--- a/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
+++ b/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
@@ -1,0 +1,115 @@
+:PROPERTIES:
+:ID: 670C711E-2DCB-42DD-9F01-EC45FFF5310D
+:END:
+#+title: Task: Implement Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper
+#+description: Edit the mapper-impl codegen template to emit value_or(0) for nullable numeric fields, retangle the templates and regenerate the compute mapper, verify codegen drift, the site build, the roundtrip and the full build with ctest, then raise the hotfix PR and roll the story and this task DONE. The story doc, the sprint Hotfixes row and this task ride this branch.
+#+type: task
+#+level: s1
+#+filetags: :ci-builds-red-hotfix:sprint_25:v0:
+#+owner: marco
+#+branch: hotfix/ci-builds-red-hotfix
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+#+environment: brave_hopper
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Restore green continuous CI on every OS. Bind PR #2012 regenerated the
+compute mappers from the org models and introduced the value_or({})
+idiom for nullable numerics. The CI compilers gcc 13 and Apple clang
+reject it: gcc 13 fails at result_mapper.cpp:45:43 with "no matching
+function for call to 'std::optional<long int>::value_or(<brace-enclosed
+initializer list>) const'" and "couldn't deduce template parameter
+'_Up'" at /usr/include/c++/13/optional:1039. Apple clang fails the same
+way at result_mapper.cpp:45:35 and 47:27 with "no matching member
+function for call to 'value_or'". MSVC and clang-cl accept the
+deduction: the Windows jobs compiled these files and were red for
+separate reasons. The local toolchains (g++ 16.2, clang 21.1) also
+accept the idiom, which is why the bind PR built green locally. This
+task changes the two nullable-numeric emission sites in the mapper-impl
+template to an explicit value_or(0), retangles the codegen templates,
+regenerates the compute mapper, and runs the full verification on the
+branch.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                             |
+| Parent story | [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] |
+| Now          | Template fix in flight.                |
+| Waiting on   | Nothing.                               |
+| Next         | Raise the hotfix PR when the verification is green. |
+| Last touched | 2026-09-06                               |
+
+* Acceptance
+
+- The mapper-impl codegen template emits value_or(0), never
+  value_or({}), for nullable numeric fields.
+- Regenerating the compute mapper is the only drift the template change
+  produces; the codegen drift check passes.
+- The site build, the template roundtrip, the full build and ctest are
+  green on this branch.
+- The hotfix rides one branch and one PR; this task and the story roll
+  DONE with it.
+
+* Plan
+
+The template projects/ores.codegen/library/templates/
+ores.cpp.repository.mapper_impl.org emits the value_or({}) idiom at two
+=is_nullable_numeric= sites: the identity group (=r.identity.<field> =
+v.<field>.value_or({})=) and the plain group (=r.<field> =
+v.<field>.value_or({})=). Both switch to =value_or(0)=. A direct
+codegen-templates tangle retangles the mustache templates, and the
+per-component regeneration rewrites the compute mapper. The local
+compilers accept the old idiom, so a local green build cannot stand in
+for the CI failure; the fix is proven by removing the idiom from the
+template and from every regenerated file.
+
+* Notes
+
+Evidence of the failure: Ubuntu CI run 34028102867, job
+linux-gcc-debug-ninja, fails at result_mapper.cpp:45:43 with "no
+matching function for call to 'std::optional<long int>::value_or(<brace-
+enclosed initializer list>) const'" and "couldn't deduce template
+parameter '_Up'". macOS run 34033068694, job macos-clang-debug-ninja,
+fails the same way at result_mapper.cpp:45:35 and 47:27 with "no
+matching member function for call to 'value_or'". The Windows jobs
+compiled the same files: run 33972829991 failed only test 58
+(result_eventing_integration_tests, app_id seed, since fixed) and run
+34009148424 failed on a transient file-lock link error. The two
+nullable numerics are pgmq_msg_id (nullable bigint to std::int64_t)
+and outcome (nullable int to int, generator default 0), read from the
+result entity into non-optional domain scalars, so 0 and {} are
+equivalent here.
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
+++ b/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.org
@@ -8,7 +8,7 @@
 #+filetags: :ci-builds-red-hotfix:sprint_25:v0:
 #+owner: marco
 #+branch: hotfix/ci-builds-red-hotfix
-#+pr:
+#+pr: 2020
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-06
@@ -104,7 +104,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2020][#2020]] | [ores.codegen] Emit value_or(0) for nullable numerics in result mappers |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -112,7 +112,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:81F46448-9FD2-4D33-A162-67B0D986C4DE][Hotfix: read_latest_party_types returns empty results]] | DONE | | 2026-08-19 | party_type_repository::read_latest() returns empty vector despite written records. Temporal field mismatch or trigger malfunction. |
 | [[id:AE32C594-8E9B-4C58-B3D2-B93BB7C219E1][Hotfix: eventing integration test flakes on Windows CI]] | STARTED | 2026-08-25 | | The eventing integration test occasionally fails on Windows CI because a transient notification drop exceeds the poll budget. |
 | [[id:FB225462-5BBA-449D-82FC-BA03B0C7C731][Hotfix: Windows build broken on unistd.h include]] | DONE | | 2026-08-31 | The Windows CI build fails because postgres_listener_service.cpp includes unistd.h, which MSVC does not provide. |
-| [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | STARTED | 2026-09-06 | | The result-mapper codegen template emits value_or({}) for nullable numerics; the CI compilers gcc 13 and Apple clang cannot deduce the value_or template parameter from a braced-init-list, while MSVC and clang-cl accept it. The fix emits value_or(0). |
+| [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | DONE | 2026-09-06 | 2026-09-06 | The result-mapper codegen template emits value_or({}) for nullable numerics; the CI compilers gcc 13 and Apple clang cannot deduce the value_or template parameter from a braced-init-list, while MSVC and clang-cl accept it. The fix emits value_or(0). |
 
 * Achievements
 

--- a/doc/agile/versions/v0/sprint_25/sprint.org
+++ b/doc/agile/versions/v0/sprint_25/sprint.org
@@ -112,6 +112,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:81F46448-9FD2-4D33-A162-67B0D986C4DE][Hotfix: read_latest_party_types returns empty results]] | DONE | | 2026-08-19 | party_type_repository::read_latest() returns empty vector despite written records. Temporal field mismatch or trigger malfunction. |
 | [[id:AE32C594-8E9B-4C58-B3D2-B93BB7C219E1][Hotfix: eventing integration test flakes on Windows CI]] | STARTED | 2026-08-25 | | The eventing integration test occasionally fails on Windows CI because a transient notification drop exceeds the poll budget. |
 | [[id:FB225462-5BBA-449D-82FC-BA03B0C7C731][Hotfix: Windows build broken on unistd.h include]] | DONE | | 2026-08-31 | The Windows CI build fails because postgres_listener_service.cpp includes unistd.h, which MSVC does not provide. |
+| [[id:D1896FA3-026B-4056-A4FD-8C18BF9DF4C1][Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper]] | STARTED | 2026-09-06 | | The result-mapper codegen template emits value_or({}) for nullable numerics; the CI compilers gcc 13 and Apple clang cannot deduce the value_or template parameter from a braced-init-list, while MSVC and clang-cl accept it. The fix emits value_or(0). |
 
 * Achievements
 

--- a/projects/ores.codegen/library/templates/cpp_domain_type_mapper.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_mapper.cpp.mustache
@@ -121,7 +121,7 @@ domain::{{entity_singular}}
     r.identity.{{name}} = v.{{name}}.value_or("");
 {{/is_nullable_string}}
 {{#is_nullable_numeric}}
-    r.identity.{{name}} = v.{{name}}.value_or({});
+    r.identity.{{name}} = v.{{name}}.value_or(0);
 {{/is_nullable_numeric}}
 {{#is_already_optional}}
     r.identity.{{name}} = v.{{name}};
@@ -163,7 +163,7 @@ domain::{{entity_singular}}
     r.{{name}} = v.{{name}}.value_or("");
 {{/is_nullable_string}}
 {{#is_nullable_numeric}}
-    r.{{name}} = v.{{name}}.value_or({});
+    r.{{name}} = v.{{name}}.value_or(0);
 {{/is_nullable_numeric}}
 {{#is_already_optional}}
     r.{{name}} = v.{{name}};

--- a/projects/ores.codegen/library/templates/ores.cpp.repository.mapper_impl.org
+++ b/projects/ores.codegen/library/templates/ores.cpp.repository.mapper_impl.org
@@ -146,7 +146,7 @@ domain::{{entity_singular}}
     r.identity.{{name}} = v.{{name}}.value_or("");
 {{/is_nullable_string}}
 {{#is_nullable_numeric}}
-    r.identity.{{name}} = v.{{name}}.value_or({});
+    r.identity.{{name}} = v.{{name}}.value_or(0);
 {{/is_nullable_numeric}}
 {{#is_already_optional}}
     r.identity.{{name}} = v.{{name}};
@@ -188,7 +188,7 @@ domain::{{entity_singular}}
     r.{{name}} = v.{{name}}.value_or("");
 {{/is_nullable_string}}
 {{#is_nullable_numeric}}
-    r.{{name}} = v.{{name}}.value_or({});
+    r.{{name}} = v.{{name}}.value_or(0);
 {{/is_nullable_numeric}}
 {{#is_already_optional}}
     r.{{name}} = v.{{name}};

--- a/projects/ores.compute/core/src/repository/result_mapper.cpp
+++ b/projects/ores.compute/core/src/repository/result_mapper.cpp
@@ -42,9 +42,9 @@ domain::result result_mapper::map(const result_entity& v) {
     r.workunit_id = boost::lexical_cast<boost::uuids::uuid>(v.workunit_id);
     r.host_id = v.host_id.has_value() ? boost::lexical_cast<boost::uuids::uuid>(*v.host_id) :
                                         boost::uuids::uuid{};
-    r.pgmq_msg_id = v.pgmq_msg_id.value_or({});
+    r.pgmq_msg_id = v.pgmq_msg_id.value_or(0);
     r.server_state = v.server_state;
-    r.outcome = v.outcome.value_or({});
+    r.outcome = v.outcome.value_or(0);
     r.output_uri = v.output_uri.value_or("");
     r.error_message = v.error_message.value_or("");
     if (v.received_at)


### PR DESCRIPTION
## Summary

Main's continuous CI has been red on Linux and macOS since bind PR
#2012 regenerated the compute result mapper. The mapper-impl codegen
template emits `v.<field>.value_or({})` for nullable numeric fields,
and a braced-init-list cannot deduce the template parameter of
`std::optional<T>::value_or`. gcc 13 and Apple clang enforce the
standard here and fail to compile `result_mapper.cpp`; the local
toolchains (g++ 16.2, clang 21.1) and MSVC/clang-cl accept the
deduction, which is why the bind PR built green locally and the Windows
jobs compiled the same file.

The template now emits `value_or(0)` at both nullable-numeric sites.
Zero is semantically identical to `{}` for the two fields in play:
`pgmq_msg_id` (nullable bigint to `std::int64_t`) and `outcome`
(nullable int to `int`, generator default 0), both read into
non-optional domain scalars.

## Changes

- **Template fix** — `ores.cpp.repository.mapper_impl.org` emits
  `value_or(0)`, never `value_or({})`, for nullable numeric fields at
  the identity and plain group sites; the mustache templates are
  retangled.
- **Regenerate compute-cpp** — the only generated diff across all eight
  compute models is `result_mapper.cpp` (lines 45 and 47). Refdata,
  reporting and marketdata regenerate byte-identical.
- **Record** — sprint-25 hotfix story and implement task ride this
  branch; the evidence below is recorded in both docs.
- **Verification**: mixed docs+ci+code class. Site build green; codegen
  drift clean (refdata, reporting, marketdata byte-identical after
  regeneration); domain roundtrip exit 0; full build clean and full
  ctest green on linux-clang-debug-make.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/story.html) | D1896FA3-026B-4056-A4FD-8C18BF9DF4C1 |
| Task | [Implement Hotfix: CI builds red across all OSs on value_or({}) in the generated result mapper](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/ci-builds-red-hotfix/task_implement-ci-builds-red-hotfix.html) | 670C711E-2DCB-42DD-9F01-EC45FFF5310D |
| Environment | brave_hopper | |

## Testing

Plan. Remove the ill-formed deduction from the template, regenerate,
and prove the local union of checks (site build, codegen drift,
roundtrip, full build + ctest) stays green. The compile break itself
cannot reproduce on the local toolchains, which accept both forms, so
the fix is additionally proven by the CI records below: the same two
lines fail deterministically under the CI compilers and no tracked
file carries the old idiom.

Evidence. Linux CI run 34028102867 (linux-gcc-debug-ninja) fails at
`result_mapper.cpp:45:43` with "couldn't deduce template parameter
'_Up'" (`/usr/include/c++/13/optional:1039`) and "no matching function
for call to 'std::optional<long int>::value_or(<brace-enclosed
initializer list>) const'". macOS CI run 34033068694
(macos-clang-debug-ninja) fails the same way at `result_mapper.cpp:45:35`
and `47:27` with "no matching member function for call to 'value_or'".
Both runs built commit 1b8f8146 (merge of #2016); the same failure
traces back to 56a483c7 (merge of #2012), where the idiom entered.
Windows is the control: MSVC compiled the same file in run
33972829991 ([2437/3912] building result_mapper.cpp.obj, no error) and
that run failed only on an app_id test seed, since fixed; run
34009148424 failed on a transient file-lock link error. This PR is
expected to turn Linux and macOS green on merge; final confirmation is
the continuous runs on main after merge.

Limitations. No UI, no new behavior. Local compilers accept the old
idiom, so the local build cannot falsify the original failure; the
authoritative check is the post-merge CI on main, gated on the same
workflows that were red.

