### PR TITLE
[doc] Add ORE product knowledge catalogue with asset-class entry page

### DIFF
--- a/doc/knowledge/domain/accumulator.org
+++ b/doc/knowledge/domain/accumulator.org
@@ -39,7 +39,7 @@ knock-out, i.e. the contract terminates early if the underlying price
 exceeds some threshold above strike.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]].
 
 ORE defines the decumulator as follows:
 
@@ -50,7 +50,7 @@ fixed price. A potential knock-out is set below the strike price (and
 below the spot price at inception).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]].
 
 The accumulator investor speculates that the security stays between
 the strike and the knock-out level for the life of the contract.
@@ -79,7 +79,7 @@ of "type 02" meaning that a settlement takes place on specific period
 end dates for all observation dates in that period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]].
 
 =ObservationDates= are the dates on which the underlying is fixed.
 =PricingDates= are optional and define the period end dates. When
@@ -132,7 +132,7 @@ a knock out. On a guaranteed fixing date, Only positive payouts (from
 the buyer/long perspective) are realised.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]].
 
 For type 02 accumulators the =FixingFloor= guarantees a number of
 periods instead of observation dates. When a knock-out happens inside
@@ -156,7 +156,7 @@ Put) is inferred from the sign of the Leverage values in RangeBound,
 which are all required to be the same.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]].
 
 ** Mathematical notes
 
@@ -380,7 +380,7 @@ a fixing floor of one guaranteed period:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]],
 the example FX accumulator and equity decumulator trades.
 
 * See also
@@ -388,6 +388,6 @@ the example FX accumulator and equity decumulator trades.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/accumulator.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/accumulator.tex][accumulator.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/accumulator.org
+++ b/doc/knowledge/domain/accumulator.org
@@ -385,6 +385,9 @@ the example FX accumulator and equity decumulator trades.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/accumulator.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/accumulator.org
+++ b/doc/knowledge/domain/accumulator.org
@@ -1,0 +1,390 @@
+:PROPERTIES:
+:ID: 6B186A8F-B261-40A4-B950-932AB735AE95
+:END:
+#+title: Accumulator
+#+description: A forward purchase of an asset in daily instalments within a price range; ORE's accumulator products.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:accumulator:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+An accumulator is a periodic forward purchase of an underlying asset
+at a fixed strike, with optional knock-out and leverage features. A
+decumulator is its mirror image: a periodic forward sale. ORE offers
+both for FX, equity and commodity underlyings. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An accumulator obliges the investor to buy a fixed amount of an
+underlying on each observation date, at a strike fixed at inception.
+The product can knock out early when the underlying crosses a
+barrier. Leverage can scale the amount bought in ranges of the
+underlying price. A decumulator obliges the investor to sell on each
+observation date. ORE represents both products in a data node per
+asset class.
+
+* Detail
+
+** What it is
+
+ORE defines the accumulator behaviour as follows:
+
+#+begin_quote
+The product settles periodically (e.g. monthly) and allows the
+investor to accumulate a holding in the underlying security over the
+term of the contract. A potential feature of an accumulator is a
+knock-out, i.e. the contract terminates early if the underlying price
+exceeds some threshold above strike.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+
+ORE defines the decumulator as follows:
+
+#+begin_quote
+A decumulator is the reverse of an accumulator -- in this case, the
+investor is required to sell shares periodically at a pre-determined
+fixed price. A potential knock-out is set below the strike price (and
+below the spot price at inception).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+
+The accumulator investor speculates that the security stays between
+the strike and the knock-out level for the life of the contract.
+
+** In plain terms
+
+An accumulator is a series of forwards on one asset. Each fixing date
+the investor buys the asset at a price fixed when the trade starts.
+If the market runs away to the knock-out level, the program ends
+early. In the leveraged form the investor buys more on the days the
+asset trades at or above the strike. A decumulator is the same
+program in reverse: the investor sells on each fixing date.
+
+** How it works in ORE
+
+The data node =FxAccumulatorData= is the trade data container for the
+=FxAccumulator= trade type. =EquityAccumulatorData= and
+=CommodityAccumulatorData= play the same role for the equity and
+commodity trade types. ORE distinguishes two product types by the
+settlement pattern:
+
+#+begin_quote
+Here the FX accumulator is of "type 01" meaning that a settlement
+takes place on each observation date while the equity accumulator is
+of "type 02" meaning that a settlement takes place on specific period
+end dates for all observation dates in that period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+
+=ObservationDates= are the dates on which the underlying is fixed.
+=PricingDates= are optional and define the period end dates. When
+they are present the product is of type 02, and one settlement per
+period replaces one settlement per observation date. =SettlementDates=
+can be given as an explicit list. For type 01 the number of
+settlement dates equals the number of observation dates. For type 02
+it equals the number of pricing dates. Alternatively
+=SettlementLag=, =SettlementCalendar= and =SettlementConvention=
+derive the settlement dates from the observation dates.
+=DailyFixingAmount= applies to type 01 only. When true, the fixing
+amount for a period is the given amount times the number of calendar
+days in the period. =StartDate= starts the first period and is
+mandatory in this case.
+
+=Strike= is the global strike. FX strikes are domestic currency
+(=CCY2=) per unit of foreign currency (=CCY1=). Equity and commodity
+strikes are per share or per unit, in the currency of the underlying.
+Local strikes can be defined per range inside =RangeBounds=, or a
+range strike adjustment can modify the global strike. The logic is as
+follows: a local strike for an interval wins over the global strike;
+otherwise a global strike plus a local adjustment is used; otherwise
+the global strike stands; without either strike an error is thrown.
+For equity accumulators the =StrikeData= node carries the global
+strike and its currency. =FixingAmount= is the unleveraged notional
+accumulated at each fixing date. For FX it is in the foreign
+currency, for equity in shares, for commodity in units. A negative
+amount turns an accumulator into a decumulator and vice versa.
+=Currency= is the payout currency. =OptionData= holds =LongShort= and
+=PayoffType=, which takes the values =Accumulator= and =Decumulator=.
+A long accumulator is equivalent to a short decumulator, except when
+a =FixingFloor= barrier is present.
+
+=RangeBounds= contains one =RangeBound= node per price range, with
+=RangeFrom=, =RangeTo= and =Leverage=. A leverage of 1 applies by
+default to a range without one. All leverage values in one instrument
+must have the same sign. Type 01 accumulators may give a range its
+own strike.
+
+=Barriers= contains =BarrierData= nodes. =Type= can be =UpAndOut=,
+=DownAndOut= or =FixingFloor=. =Style= can be =European=, monitored
+on the observation dates, or =American=, monitored continuously from
+the start date to the first observation date and between observation
+dates. ORE describes the guaranteed fixings as follows:
+
+#+begin_quote
+For type 01 accumulators (no pricing dates are given), the FixingFloor
+guarantees a specific number of fixings to be settled even in case of
+a knock out. On a guaranteed fixing date, Only positive payouts (from
+the buyer/long perspective) are realised.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+
+For type 02 accumulators the =FixingFloor= guarantees a number of
+periods instead of observation dates. When a knock-out happens inside
+a guaranteed period, the remaining fixings of that period settle on
+the knock-out day plus the settlement delay. =StrictComparison=
+chooses the barrier comparison: 0 uses less-or-equal and
+greater-or-equal, 1 uses strict comparisons. For equity accumulators
+each barrier level carries its own =Value= and =Currency= in a
+=LevelData= node. =KnockOutSettlementAtPeriodEnd= and
+=KnockOutFixingAtKOSettlement= tune the knock-out settlement of type
+02 products. =FxIndex= defines the FX conversion for composite
+accumulators, where the strike, barrier and pay currency differ from
+the quote currency of the underlying.
+
+ORE also describes the naked option variant as follows:
+
+#+begin_quote
+If true, the payoff represents that of an option, and only positive
+values are accumulated in the instrument. The option type (Call or
+Put) is inferred from the sign of the Leverage values in RangeBound,
+which are all required to be the same.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=.
+
+** Mathematical notes
+
+ORE states the payout formula from the perspective of the long party,
+for each observation date of an accumulator, as:
+
+Payout = RangeBound(Leverage) x FixingAmount x (fix - Strike).
+
+The holder pays the strike times the fixing amount times the leverage
+and receives, or buys, the same number of units of the underlying at
+the fixing. For a decumulator the formula is:
+
+Payout = RangeBound(Leverage) x FixingAmount x (Strike - fix).
+
+The holder pays the fixing value and receives the strike. In the
+naked option form the payout is the absolute leverage times the
+fixing amount times the positive part of the option payoff. The sign
+of the leverage values fixes the option type: a positive leverage
+with a positive part on rising fixings behaves as a call, a negative
+leverage as a put.
+
+ORE also provides a scripted representation of both product types,
+with the trade types =ScriptedTrade= and the nodes
+=Accumulator01Data= and =Accumulator02Data=. In the scripted form the
+ranges are given as parallel lists: =RangeUpperBounds=,
+=RangeLowerBounds= and =RangeLeverages=. A range without an upper
+bound takes the sentinel value 100000; a range without a lower bound
+takes 0. =KnockOutType= takes the values =UpOut= and =DownOut=.
+=AmericanKO= selects continuous barrier monitoring; otherwise the
+barrier is monitored on the fixing dates only. =GuaranteedFixings=
+is the number of first fixings that settle even after a knock-out.
+The current notional of the trade is the fixing amount times the
+strike.
+
+** What moves its value (static sensitivities)
+
+- The underlying price. It decides which range the fixing falls into,
+  whether the barrier is hit, and the size of each installment.
+- The volatility of the underlying. It drives the probability of a
+  knock-out and of range crossings.
+- The strike, the range boundaries and the knock-out level.
+- The leverage values, which scale the exposure within each range.
+- The interest rates that discount the installment payments.
+
+The payoffs are linear in each fixing. The barrier and the range
+structure add path dependence.
+
+** How the profile ages (dynamic sensitivities)
+
+The fixings settle on their own dates. For type 01 each observation
+date settles alone. For type 02 each observation period settles on
+its period end date. The barrier is observed on the observation dates
+in the European style, and continuously from the start date in the
+American style. A knock-out ends the accumulation, except for the
+guaranteed fixings. The current notional grows with each installment
+until the trade runs off or knocks out.
+
+** Why a customer would want it
+
+An accumulator lets a customer build a position in an asset over
+time, at a price fixed today. The decumulator lets a customer sell a
+position over time in the same way. Banks distribute these products
+to investors who want to accumulate or run down holdings without
+trading each day. In ORE Studio a customer books accumulators and
+decumulators to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an FX accumulator of type 01, with one
+settlement per observation date. The barrier structure adds an
+American up-and-out at 1.5 and a fixing floor of two guaranteed
+fixings:
+
+#+begin_example
+<Trade id="FX_ACCUMULATOR">
+  <TradeType>FxAccumulator</TradeType>
+  <Envelope>
+    ...
+  </Envelope>
+  <FxAccumulatorData>
+    <Currency>USD</Currency>
+    <FixingAmount>1000000</FixingAmount>
+    <Strike>1.1</Strike>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-EUR-USD</Name>
+    </Underlying>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <PayoffType>Accumulator</PayoffType>
+    </OptionData>
+    <StartDate>2016-03-01</StartDate>
+    <ObservationDates>
+      <Dates>
+        <Dates>
+          <Date>2017-03-01</Date>
+          <Date>2020-03-01</Date>
+          <Date>2025-03-01</Date>
+          <Date>2029-03-01</Date>
+        </Dates>
+      </Dates>
+    </ObservationDates>
+    <SettlementDates>
+      <Dates>
+        <Dates>
+          <Date>2017-03-03</Date>
+          <Date>2020-03-03</Date>
+          <Date>2025-03-03</Date>
+          <Date>2029-03-03</Date>
+        </Dates>
+      </Dates>
+    </SettlementDates>
+    <RangeBounds>
+      <RangeBound>
+        <RangeTo>1.14</RangeTo>
+        <Leverage>1</Leverage>
+      </RangeBound>
+      <RangeBound>
+        <RangeFrom>1.14</RangeFrom>
+        <Leverage>1</Leverage>
+      </RangeBound>
+    </RangeBounds>
+    <Barriers>
+      <BarrierData>
+        <Type>UpAndOut</Type>
+        <Style>American</Style>
+        <Levels>
+          <Level>1.5</Level>
+        </Levels>
+      </BarrierData>
+      <BarrierData>
+        <Type>FixingFloor</Type>
+        <Levels>
+          <Level>2</Level>
+        </Levels>
+      </BarrierData>
+    </Barriers>
+  </FxAccumulatorData>
+</Trade>
+#+end_example
+
+The catalogue then shows an equity decumulator of type 02. Its
+observation dates run daily over one year, its settlements take place
+on the pricing dates, and its down-and-out barrier sits at 3500 with
+a fixing floor of one guaranteed period:
+
+#+begin_example
+<Trade id="Equity_Decumulator">
+  <TradeType>EquityAccumulator</TradeType>
+  <Envelope>
+    ...
+  </Envelope>
+  <EquityAccumulatorData>
+    <FixingAmount>30</FixingAmount>
+    <StrikeData>
+      <Value>4000</Value>
+      <Currency>EUR</Currency>
+    </StrikeData>
+    <Underlying>
+      <Type>Equity</Type>
+      <Name>.STOXX50</Name>
+      <IdentifierType>RIC</IdentifierType>
+    </Underlying>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <PayoffType>Decumulator</PayoffType>
+    </OptionData>
+    <StartDate>20190925</StartDate>
+    <ObservationDates>
+      <Rules>
+        <StartDate>20190925</StartDate>
+        <EndDate>20200925</EndDate>
+        <Tenor>1D</Tenor>
+        <Calendar>TARGET</Calendar>
+        <Convention>F</Convention>
+        <TermConvention>F</TermConvention>
+        <Rule>Forward</Rule>
+      </Rules>
+    </ObservationDates>
+    <PricingDates>
+      <Dates>
+        <Dates>
+          <Date>20211025</Date>
+          <Date>20211125</Date>
+          ...
+        </Dates>
+      </Dates>
+    </PricingDates>
+    <SettlementLag>2D</SettlementLag>
+    <SettlementCalendar>TARGET</SettlementCalendar>
+    <SettlementConvention>F</SettlementConvention>
+    <RangeBounds>
+      <RangeBound>
+        <RangeTo>4000</RangeTo>
+        <Leverage>1</Leverage>
+      </RangeBound>
+      <RangeBound>
+        <RangeFrom>4000</RangeFrom>
+        <Leverage>2</Leverage>
+      </RangeBound>
+    </RangeBounds>
+    <Barriers>
+      <BarrierData>
+        <Type>DownAndOut</Type>
+        <LevelData>
+          <Level>
+            <Value>3500</Value>
+            <Currency>EUR</Currency>
+          </Level>
+        </LevelData>
+      </BarrierData>
+      <BarrierData>
+        <Type>FixingFloor</Type>
+        <Levels>
+          <Level>1</Level>
+        </Levels>
+      </BarrierData>
+    </Barriers>
+    <KnockOutSettlementAtPeriodEnd>false<KnockOutSettlementAtPeriodEnd>
+  </EquityAccumulatorData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/accumulator.tex=,
+the example FX accumulator and equity decumulator trades.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/accumulator.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/ascot.org
+++ b/doc/knowledge/domain/ascot.org
@@ -38,7 +38,7 @@ the deal and get the underlying bond in exchange for paying the
 strike.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ascot.tex][ascot.tex]].
 
 The call payout is the convertible price less the strike, floored at
 zero. The put payout is the strike less the convertible price, floored
@@ -46,7 +46,7 @@ at zero. The strike itself is:
 
 =Strike = bondQuantity x (upfrontPayment + assetLeg - redemptionLeg) - fundingLeg=
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ascot.tex][ascot.tex]].
 
 ** In plain terms
 
@@ -148,7 +148,7 @@ bond, funded by a floating reference swap leg:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ascot.tex][ascot.tex]],
 listing =Ascot set up using reference data=. The source closes the
 =AscotData= element without the leading slash; it is normalised here.
 
@@ -159,6 +159,6 @@ listing =Ascot set up using reference data=. The source closes the
 
 - [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/ascot.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ascot.tex][ascot.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/ascot.org
+++ b/doc/knowledge/domain/ascot.org
@@ -1,0 +1,161 @@
+:PROPERTIES:
+:ID: DBC183E7-9AB4-481A-8A27-A70966EE4D48
+:END:
+#+title: Ascot
+#+description: An American-style option to buy back a convertible bond; ORE's Ascot product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:ascot:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An Ascot is an American-style option to buy back a convertible bond.
+ORE models it with the trade type =Ascot=. The container node is
+=AscotData=. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+An Ascot, or a convertible bond option, gives the holder the right to
+sell a convertible bond back for a strike that is set from the terms
+of a reference swap. The option is American and can be cash or
+physically settled. The call form pays the convertible price less the
+strike. The put form pays the strike less the convertible price. The
+strike is a function of the bond quantity, an upfront payment, asset
+and redemption legs, and a funding leg. The bond details are read from
+reference data.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Ascot or a Convertible Bond Option is an American style option to
+buy back a convertible bond. The buyer of a Call Ascot can exercise
+the deal and get the underlying bond in exchange for paying the
+strike.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=.
+
+The call payout is the convertible price less the strike, floored at
+zero. The put payout is the strike less the convertible price, floored
+at zero. The strike itself is:
+
+=Strike = bondQuantity x (upfrontPayment + assetLeg - redemptionLeg) - fundingLeg=
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=.
+
+** In plain terms
+
+An Ascot protects a convertible bond holder. The holder can hand the
+bond back and receive a strike instead. The strike is fixed at trade
+inception from swap terms, not from the market. The structure turns a
+convertible bond into an asset swap with an embedded exit option.
+
+** How it works in ORE
+
+An Ascot is set up using an =AscotData= block. The =AscotData= node
+has three sub-nodes. The =ConvertibleBondData= node describes the
+underlying convertible bond. Its =BondData= carries the =SecurityId=
+and =BondNotional=; the bond details are read from reference data in
+this case. The =OptionData= node carries the option terms. =LongShort=
+takes =Long= or =Short= and multiplies the option price by +1 or -1.
+=OptionType= takes =Call= or =Put=. The =Style= allows American
+exercise only. =Settlement= can be =Cash= or =Physical=. Exactly one
+=ExerciseDate= must be given. =Premiums= is optional. The
+=ReferenceSwapData= node holds a single =LegData= node that describes
+the funding leg of the reference swap. The asset leg is implied from
+the bond data. =Payer= should always be =false=, because the swap is
+entered from the viewpoint of the asset swap buyer.
+
+** Mathematical notes
+
+The call pays =max(0, convertiblePrice - Strike)= at exercise. The put
+pays =max(0, Strike - convertiblePrice)=. The strike bundles the
+conversion economics into a single number: the bond quantity scales an
+upfront payment plus an asset leg less a redemption leg, and the
+funding leg subtracts the cost of carry. The option can be exercised
+at any time until the exercise date because the style is American.
+
+** What moves its value (static sensitivities)
+
+- The convertible bond price. It combines the equity value of the
+  underlying shares with the credit of the issuer.
+- The volatility of the underlying equity. It drives the conversion
+  optionality.
+- The strike structure: the upfront payment and the asset, redemption
+  and funding legs.
+- The interest rates that discount the funding leg.
+- The credit spread of the issuer.
+
+The option is in the money when the convertible price is on the right
+side of the strike. Every input to the convertible price moves the
+Ascot through it.
+
+** How the profile ages (dynamic sensitivities)
+
+The holder can exercise at any time, so the profile follows the
+convertible bond. Early exercise pays off when the convertible price
+is high against the strike. As the bond ages, conversion value, time
+value and credit all decay toward the exercise date. After exercise
+the bond is delivered for the strike, or the difference is settled in
+cash.
+
+** Why a customer would want it
+
+An Ascot lets an investor hold a convertible bond with a known exit
+price. It is the option half of an asset swap on a convertible. A
+customer who owns the bond can buy the Ascot to cap the downside. In
+ORE Studio a customer books Ascots to value them and run sensitivities
+on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long American call Ascot on a convertible
+bond, funded by a floating reference swap leg:
+
+#+begin_example
+<Trade id="Ascot">
+  <TradeType>Ascot</TradeType>
+  <Envelope>...</Envelope>
+  <AscotData>
+    <ConvertibleBondData>
+      <BondData>
+        <SecurityId>ISIN:XY1000000000</SecurityId>
+        <BondNotional>1000000.00</BondNotional>
+      </BondData>
+    </ConvertibleBondData>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <OptionType>Call</OptionType>
+      <Style>American</Style>
+      <Settlement>Physical</Settlement>
+      <ExerciseDates>
+        <ExerciseDate>2029-02-03</ExerciseDate>
+      </ExerciseDates>
+    </OptionData>
+    <ReferenceSwapData>
+      <LegData>
+        <LegType>Floating</LegType>
+        <Payer>false</Payer>
+        ...
+      </LegData>
+    </ReferenceSwapData>
+  </AscotData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ascot.tex=,
+listing =Ascot set up using reference data=. The source closes the
+=AscotData= element without the leading slash; it is normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/ascot.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/ascot.org
+++ b/doc/knowledge/domain/ascot.org
@@ -154,6 +154,9 @@ listing =Ascot set up using reference data=. The source closes the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/autocallable_01.org
+++ b/doc/knowledge/domain/autocallable_01.org
@@ -48,7 +48,7 @@ The catalogue scopes the underlyings as follows:
 The underlying can be an Equity, FX or Commodity underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/autocallable_01.tex][autocallable_01.tex]].
 
 ** In plain terms
 
@@ -86,7 +86,7 @@ The maximum amount, per unit of notional, payable by the option
 holder if a trigger event never occurred
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/autocallable_01.tex][autocallable_01.tex]].
 
 The cap applies when the underlying value is greater than the
 determination level at the last fixing date.
@@ -193,7 +193,7 @@ five annual fixings:
 </Autocallable01Data>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/autocallable_01.tex][autocallable_01.tex]],
 listing =Autocallable Type 01 data=. The settlement dates follow
 their fixing dates by a few days.
 
@@ -202,6 +202,6 @@ their fixing dates by a few days.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/autocallable_01.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/autocallable_01.tex][autocallable_01.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/autocallable_01.org
+++ b/doc/knowledge/domain/autocallable_01.org
@@ -1,0 +1,204 @@
+:PROPERTIES:
+:ID: 6B1D0C78-0CAF-4A1C-BA34-56FB07C4F107
+:END:
+#+title: Autocallable Type 01
+#+description: A structured option that pays accumulated amounts and redeems early below a trigger level; ORE's Autocallable Type 01 product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:autocallable_01:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+An autocallable of type 01 pays the holder a sequence of accumulation
+amounts on fixing dates, and redeems early when the underlying falls
+to a trigger level. ORE prices it on equity, FX and commodity
+underlyings. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+The product is characterised by a notional, a determination level, a
+trigger level, an underlying, fixing dates with matching settlement
+dates, accumulation factors and a cap. On each fixing date the
+holder receives the notional times the accumulation factor when the
+spot is at or below the trigger level. The structure then terminates
+on the settlement date of that fixing. Without a trigger event, the
+holder pays at the last fixing date when the spot is above the
+determination level, capped per unit of notional.
+
+* Detail
+
+** What it is
+
+ORE characterises the autocallable option of type 01 by its data: a
+notional amount, a determination level, a trigger level, the
+reference underlying, a number of fixing dates with matching
+settlement dates, a list of accumulation factors, and a cap. On each
+fixing date, when the underlying spot is at or below the trigger
+level, the option holder receives the notional times the accumulation
+factor for that fixing. The payment falls on the settlement date of
+that fixing, and the structure terminates on this same date.
+
+Without a trigger event on any fixing date, a second branch applies.
+When the underlying spot is above the determination level on the last
+fixing date, the option holder pays an amount to the counterparty.
+The catalogue scopes the underlyings as follows:
+
+#+begin_quote
+The underlying can be an Equity, FX or Commodity underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=.
+
+** In plain terms
+
+An autocallable is a savings-style option on one market. On each
+checking date the market decides the next instalment. When the market
+is at or below the trigger, the holder receives an instalment and the
+product ends. The instalment grows with the fixing dates. When the
+market never falls to the trigger, the holder owes a final capped
+payment at the end, linked to how far the market sits above the
+determination level. The buyer of the structure is short the far
+upside and long the trigger path.
+
+** How it works in ORE
+
+The catalogue shows the trade data container =Autocallable01Data= for
+the =Autocallable_01= trade type. =NotionalAmount= is the notional
+amount of the option. =DeterminationLevel= is the level above which
+the final payment branch fires. For an FX underlying it is the number
+of units of =CCY2= per unit of =CCY1=; for an equity underlying it is
+the equity price in the equity currency. =TriggerLevel= carries the
+same meaning per underlying type, as the level that triggers the
+early redemption. =Underlying= names the option underlying.
+=Position= takes =Long= or =Short=. =PayCcy= is the pay currency of
+the option.
+
+=FixingDates= is the fixing date schedule, given as a =ScheduleData=
+subnode. =SettlementDates= is the settlement date schedule in the
+same form. =AccumulationFactors= is a list of values, one per fixing
+date. =Cap= is the maximum amount, per unit of notional, payable by
+the option holder when no trigger event ever occurred. ORE describes
+its role as follows:
+
+#+begin_quote
+The maximum amount, per unit of notional, payable by the option
+holder if a trigger event never occurred
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=.
+
+The cap applies when the underlying value is greater than the
+determination level at the last fixing date.
+
+** Mathematical notes
+
+ORE states the two payout branches of the product. On the i-th fixing
+date, when a trigger event occurs, the option holder receives:
+
+Payout = NotionalAmount x AccumulationFactor(i).
+
+The structure terminates on the settlement date of that fixing. When
+a trigger event never occurs and the underlying spot at the last
+fixing date is above the determination level, the option holder pays:
+
+Payout = min(Cap, Underlying(fn) - DeterminationLevel).
+
+The payment is capped per unit of notional: the cap multiplies the
+notional of the trade.
+
+** What moves its value (static sensitivities)
+
+- The underlying spot. It decides the trigger branch on each fixing
+  date and the final payment.
+- The volatility of the underlying. It drives the probability of a
+  trigger event.
+- The trigger level and the determination level.
+- The accumulation factors, which set the instalment sizes.
+- The cap, which bounds the final payment.
+- The interest rates that discount the instalments and the final
+  payment.
+
+** How the profile ages (dynamic sensitivities)
+
+The fixing dates are the heartbeat of the product. Each fixing date
+checks the spot against the trigger level. A trigger event pays the
+accumulated amount on the matching settlement date and terminates the
+structure. Without a trigger, the structure runs to the last fixing
+date, where the final payment branch is decided against the
+determination level. The two schedules of dates and the accumulation
+factors shape how the value decays as the structure survives.
+
+** Why a customer would want it
+
+An autocallable pays a coupon-like stream while the market stays
+quiet, and redeems early on a down move. Investors use it when they
+expect the underlying to hold above a level, collecting instalments
+along the way. The final capped payment is the price of that income.
+In ORE Studio a customer books autocallables of type 01 to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long autocallable on EUR-NOK with a notional
+of 12000000 EUR, a determination level of 11.0 and a trigger level of
+9.8. The accumulation factors grow from 0.344 to 1.544 across the
+five annual fixings:
+
+#+begin_example
+<Autocallable01Data>
+  <NotionalAmount>12000000</NotionalAmount>
+  <DeterminationLevel>11.0</DeterminationLevel>
+  <TriggerLevel>9.8</TriggerLevel>
+  <Underlying>
+    <Type>FX</Type>
+    <Name>ECB-EUR-NOK</Name>
+  </Underlying>
+  <Position>Long</Position>
+  <PayCcy>EUR</PayCcy>
+  <FixingDates>
+    <ScheduleData>
+      <Dates>
+        <Dates>
+          <Date>2018-09-27</Date>
+          <Date>2019-09-27</Date>
+          <Date>2020-09-27</Date>
+          <Date>2021-09-29</Date>
+          <Date>2022-09-28</Date>
+        </Dates>
+      </Dates>
+    </ScheduleData>
+  </FixingDates>
+  <SettlementDates>
+    <ScheduleData>
+      <Dates>
+        <Dates>
+          <Date>2018-10-07</Date>
+          <Date>2019-10-09</Date>
+          <Date>2020-10-07</Date>
+          <Date>2021-10-07</Date>
+          <Date>2022-10-07</Date>
+        </Dates>
+      </Dates>
+    </ScheduleData>
+  </SettlementDates>
+  <AccumulationFactors>
+    <Factor>0.344</Factor>
+    <Factor>0.733</Factor>
+    <Factor>0.911</Factor>
+    <Factor>1.123</Factor>
+    <Factor>1.544</Factor>
+  </AccumulationFactors>
+  <Cap>1.0</Cap>
+</Autocallable01Data>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/autocallable_01.tex=,
+listing =Autocallable Type 01 data=. The settlement dates follow
+their fixing dates by a few days.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/autocallable_01.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/autocallable_01.org
+++ b/doc/knowledge/domain/autocallable_01.org
@@ -199,6 +199,9 @@ their fixing dates by a few days.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/autocallable_01.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/balanceguaranteedswap.org
+++ b/doc/knowledge/domain/balanceguaranteedswap.org
@@ -1,0 +1,180 @@
+:PROPERTIES:
+:ID: EE7D0A97-FD6D-46AA-9419-C6F01275F7E2
+:END:
+#+title: Balance Guaranteed Swap
+#+description: An amortising swap that follows the prepayments of a reference security; ORE's BalanceGuaranteedSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:balanceguaranteedswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A balance guaranteed swap amortises with the actual prepayments of a
+reference security. The notional path is not known in advance. ORE
+models it with the trade type =BalanceGuaranteedSwap=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A balance guaranteed swap is similar to an amortising interest rate
+swap. Its notional amortisation matches the actual prepayments of a
+Reference Security. The security can be a tranche, a reference pool
+of assets, or securitised interest backed by a pool of assets. The
+notional amortisations are uncertain. ORE prices the product with an
+auxiliary Flexi Swap as a proxy. The proxy's notional schedule
+assumes a zero CPR. Its lower notional bound assumes a MaxCPR.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Balance Guaranteed Swap is similar to an amortizing interest rate
+swap, but the notional amortization matches actual prepayments of a
+Reference Security which can be either a tranche or a reference pool
+of assets, or securitized interest backed by a pool of assets. The
+BGS differs from an amortizing swap in that the notional
+amortizations are uncertain.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+
+ORE states the pricing approach as follows:
+
+#+begin_quote
+BGS are priced in ORE using an auxiliary Flexi Swap as a proxy. The
+amortization schedule of the Flexi Swap is set up as the notional
+schedule of the BGS assuming a zero CPR (Conditional Prepayment
+Rate). The lower notional bound of the Flexi Swap is constructed
+assuming a MaxCPR (Maximum Conditional Prepayment Rate) which is
+dependent on the Reference Security. The MaxCPR is estimated on the
+basis of the current CPR, historical CPRs and / or expert judgement
+as to provide a (hypothetical) sufficiently realistic hedge for the
+BGS. The option holder in the Flexi Swap is the payer of the
+structured leg (i.e. the leg replicating the payments of the
+reference security) in the BGS.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+
+** In plain terms
+
+The swap balance pays down like a pool of mortgages. When the
+underlying loans prepay faster, the notional falls faster. The path
+is uncertain at trade time. The swap therefore passes the actual
+prepayments of the security into its own schedule. The balance of
+the swap stays aligned with the balance of the security.
+
+** How it works in ORE
+
+The =BalanceGuaranteedSwapData= node is the trade data container for
+the =BalanceGuaranteedSwap= trade type. A BGS must have two legs, one
+fixed and one floating. Each leg typically carries an amortising
+notional. The node also contains a =ReferenceSecurity= sub-node. It
+specifies the Asset Backed Security to which the notional schedule of
+the BGS is linked. Its value is the prefix =ISIN:= followed by an
+ISIN code. The =Tranches= node describes the tranche notionals of the
+security. Each tranche is identified by a =SecurityId= and an
+optional =Description=. Each tranche has a =Seniority= given as a
+positive integer. Lower values mean higher seniority. The most senior
+tranche has seniority 1. The tranche notionals sit in a =Notionals=
+sub-node.
+
+** Mathematical notes
+
+The product needs a prepayment model because its schedule is
+uncertain. CPR is the Conditional Prepayment Rate of the reference
+security. The zero-CPR schedule assumes no prepayment. The MaxCPR
+path assumes the maximum plausible prepayment. ORE prices the BGS as
+a Flexi Swap whose notional can move between these two paths. The
+option holder is the payer of the structured leg. The option value
+covers the prepayment uncertainty of the security.
+
+** What moves its value (static sensitivities)
+
+- The swap rate levels of the fixed and floating legs.
+- The current CPR and the historical CPRs of the security.
+- The MaxCPR estimate for the reference security.
+- The actual prepayment behaviour of the collateral.
+- The discount curve and the spread of the structured leg.
+- The tranche structure and the notional schedules.
+
+Fast prepayment shrinks the notional and the remaining exposure.
+Slow prepayment keeps a larger balance alive for longer.
+
+** How the profile ages (dynamic sensitivities)
+
+Each period the security's actual prepayments set the next notional.
+Realised prepayment replaces the assumption as time passes. Fast
+prepayment amortises the balance down quickly. The remaining swap
+exposure shrinks with it. Slow prepayment leaves a larger balance.
+The optionality between the zero-CPR schedule and the MaxCPR path is
+consumed as prepayments realise.
+
+** Why a customer would want it
+
+A customer that funds or hedges an Asset Backed Security wants the
+swap balance to follow the collateral. A fixed amortisation schedule
+cannot match unknown prepayments. The BGS transfers the prepayment
+uncertainty into the swap. The fixed and floating legs then hedge the
+security's coupon profile. In ORE Studio a customer books balance
+guaranteed swaps to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a balance guaranteed swap on a two-tranche
+security:
+
+#+begin_example
+<BalanceGuaranteedSwapData>
+  <ReferenceSecurity>ISIN:XS0983610930</ReferenceSecurity>
+  <Tranches>
+    <Tranche>
+      <Description>Class A</Description>
+      <SecurityId>ISIN:XS0983610930</SecurityId>
+      <Seniority>1</Seniority>
+      <Notionals>
+      ...
+      </Notionals>
+    </Tranche>
+    <Tranche>
+      <Description>Class B</Description>
+      <SecurityId>ISIN:XS0983610931</SecurityId>
+      <Seniority>2</Seniority>
+      <Notionals>
+      ...
+      </Notionals>
+    </Tranche>
+    <ScheduleData>
+    ...
+    </ScheduleData>
+  </Tranches>
+  <LegData>
+	<LegType>Fixed</LegType>
+	 ...
+  </LegData>
+  <LegData>
+	<LegType>Floating</LegType>
+	 ...
+  </LegData>
+</BalanceGuaranteedSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=,
+listing =Balance Guaranteed Swap data=. The source listing repeats
+the opening tag at its end; the closing tag is normalised here.
+
+The auxiliary product used for pricing is the
+[[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/balanceguaranteedswap.org
+++ b/doc/knowledge/domain/balanceguaranteedswap.org
@@ -173,6 +173,9 @@ The auxiliary product used for pricing is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/balanceguaranteedswap.org
+++ b/doc/knowledge/domain/balanceguaranteedswap.org
@@ -40,7 +40,7 @@ BGS differs from an amortizing swap in that the notional
 amortizations are uncertain.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/balanceguaranteedswap.tex][balanceguaranteedswap.tex]].
 
 ORE states the pricing approach as follows:
 
@@ -58,7 +58,7 @@ structured leg (i.e. the leg replicating the payments of the
 reference security) in the BGS.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/balanceguaranteedswap.tex][balanceguaranteedswap.tex]].
 
 ** In plain terms
 
@@ -164,7 +164,7 @@ security:
 </BalanceGuaranteedSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/balanceguaranteedswap.tex][balanceguaranteedswap.tex]],
 listing =Balance Guaranteed Swap data=. The source listing repeats
 the opening tag at its end; the closing tag is normalised here.
 
@@ -178,6 +178,6 @@ The auxiliary product used for pricing is the
 
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/balanceguaranteedswap.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/balanceguaranteedswap.tex][balanceguaranteedswap.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/basketoption.org
+++ b/doc/knowledge/domain/basketoption.org
@@ -37,7 +37,7 @@ EquityBasketOption / EquityBasketOptionData FxBasketOption /
 FxBasketOptionData CommodityBasketOption / CommodityBasketOptionData
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]].
 
 ORE represents basket options as traditional trades or as scripted
 trades. Each variation has its own payoff script. The catalogue maps
@@ -70,7 +70,7 @@ to represent deterministic option premia to be paid by the option
 holder.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]].
 
 =Currency= is the pay currency. =Notional= is the quantity for
 equity and commodity underlyings, and the foreign amount for an FX
@@ -90,7 +90,7 @@ PayoffType2 can be optionally set to Arithmetic or Geometric and
 defaults to Arithmetic if not given.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]].
 
 The average strike form uses the same observation dates. Its payoff
 type is =AverageStrike=, and it carries no strike: the strike is the
@@ -108,7 +108,7 @@ If CCY1 or the currency of the underlying (for EQ and COMM
 underlyings), this will result in a quanto payoff.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]].
 
 In the scripted representation each variation is a scripted trade
 with its own data node, named after its script, such as
@@ -213,7 +213,7 @@ Euro Stoxx 50, struck at 5000, in its traditional representation:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]],
 the vanilla basket option example trade. The catalogue shows the
 Asian, average strike and lookback variants with the same basket.
 
@@ -222,6 +222,6 @@ Asian, average strike and lookback variants with the same basket.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/basketoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/basketoption.tex][basketoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/basketoption.org
+++ b/doc/knowledge/domain/basketoption.org
@@ -219,6 +219,9 @@ Asian, average strike and lookback variants with the same basket.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/basketoption.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/basketoption.org
+++ b/doc/knowledge/domain/basketoption.org
@@ -1,0 +1,224 @@
+:PROPERTIES:
+:ID: 00DE9B53-9E4F-4FD4-A5E9-BE00B0956710
+:END:
+#+title: Basket Option
+#+description: An option on a basket of underlying assets; ORE's BasketOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:basketoption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A basket option is an option on a weighted basket of assets instead
+of a single asset. ORE offers five variations: vanilla, Asian,
+average strike, lookback call and lookback put. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A basket option pays the option payoff on the value of a basket of
+underlyings. The basket is a weighted sum of equity, FX or commodity
+indices. The vanilla form strikes the basket at expiry. The Asian
+form strikes the average of the basket over its observation dates.
+The average strike form compares the basket at expiry with its own
+time average. The lookback forms compare the basket at expiry with
+its lowest or highest value over the observation dates.
+
+* Detail
+
+** What it is
+
+ORE scopes the product as follows:
+
+#+begin_quote
+The supported underlying types are Equity, Fx or Commodity resulting
+in corresponding trade types and trade data container names
+EquityBasketOption / EquityBasketOptionData FxBasketOption /
+FxBasketOptionData CommodityBasketOption / CommodityBasketOptionData
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+
+ORE represents basket options as traditional trades or as scripted
+trades. Each variation has its own payoff script. The catalogue maps
+them as follows: the vanilla form runs the =VanillaBasketOption=
+script, the Asian form the =AsianBasketOption= script, the average
+strike form the =AverageStrikeBasketOption= script, and the lookback
+forms the =LookbackCallBasketOption= and =LookbackPutBasketOption=
+scripts.
+
+** In plain terms
+
+A basket option is a bet on several assets at once, through one
+option. The assets are combined with weights into one basket value.
+A vanilla basket call pays when the basket is above the strike at
+expiry. The other forms soften the payoff. The Asian form averages
+the basket over time. The average strike form uses the basket's own
+average as the strike. The lookback forms use the best or worst
+basket value over the observation period.
+
+** How it works in ORE
+
+The vanilla form is the plain option on the basket. ORE describes its
+input as follows:
+
+#+begin_quote
+relevant are the long/short flag, the call/put flag, the payoff type
+(must be set to Vanilla to identify the payoff), and the exercise
+date (exactly one date must be given). A Premiums node can be added
+to represent deterministic option premia to be paid by the option
+holder.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+
+=Currency= is the pay currency. =Notional= is the quantity for
+equity and commodity underlyings, and the foreign amount for an FX
+underlying. =Strike= is the strike of the option, expressed as a
+basket price. =Underlyings= lists the basket constituents, each with
+its =Type=, =Name= and =Weight=. =OptionData= carries =LongShort=,
+=OptionType=, =PayoffType=, one =ExerciseDate= and optionally a
+=Premiums= node. =Settlement= is the settlement date; it defaults to
+the exercise date.
+
+The Asian form adds =ObservationDates= on which the basket value is
+observed for the average. Its payoff type is =Asian=. The averaging
+style is selectable:
+
+#+begin_quote
+PayoffType2 can be optionally set to Arithmetic or Geometric and
+defaults to Arithmetic if not given.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+
+The average strike form uses the same observation dates. Its payoff
+type is =AverageStrike=, and it carries no strike: the strike is the
+average basket value itself. The lookback call and put forms observe
+the basket on the observation dates and track its lowest, or
+highest, value there. Their payoff types are =LookbackCall= and
+=LookbackPut=.
+
+All forms share the currency machinery. The =PayCcy= of the scripted
+form defines the payment currency. ORE describes the quanto case as
+follows:
+
+#+begin_quote
+If CCY1 or the currency of the underlying (for EQ and COMM
+underlyings), this will result in a quanto payoff.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=.
+
+In the scripted representation each variation is a scripted trade
+with its own data node, named after its script, such as
+=VanillaBasketOptionData= or =AsianBasketOptionData=. The nodes carry
+=Expiry=, =Settlement=, the =PutCall= and =LongShort= flags,
+=Notional=, =Strike= where the form has one, the index =Underlyings=
+list and the matching =Weights= list, in the same order, and
+=PayCcy=. The observation-based forms add an =ObservationDates=
+schedule.
+
+** Mathematical notes
+
+The basket value on a date is the weighted sum of its constituents:
+
+basketPrice = sum over u of Underlyings[u](date) x Weights[u].
+
+The scripts implement the payoffs on top of it. The vanilla payoff
+is the positive part of the signed distance from the strike, capped
+at zero:
+
+Payoff = max(PutCall x (basketPrice - Strike), 0).
+
+The option value is the long-short signed notional times the payoff,
+settled at expiry. The Asian script averages the basket over the
+observation dates and applies the same payoff against the strike.
+The average strike script compares the basket at expiry with the time
+average of the basket. The lookback call script pays the basket at
+expiry minus its minimum over the observation dates. The lookback
+put script pays the maximum over the observation dates minus the
+basket at expiry. The lookback forms carry their direction in the
+payoff itself, so they take no call-put flag.
+
+** What moves its value (static sensitivities)
+
+- The prices of the basket constituents.
+- The correlation between the constituents. It drives the volatility
+  of the basket: lower correlation diversifies it.
+- The weights, which set the exposure to each constituent.
+- The volatility of each constituent.
+- The strike, for the forms that carry one.
+- The FX rates, when the pay currency differs from the constituent
+  currencies and the payoff is quanto.
+
+** How the profile ages (dynamic sensitivities)
+
+The observation schedule is the heart of the averaging forms. Each
+observation date adds a sample to the Asian average or to the
+lookback running minimum or maximum. The averaging shortens the
+volatility the payoff sees as samples accumulate. At expiry the final
+basket is fixed and the payoff settles on the settlement date.
+
+** Why a customer would want it
+
+A basket option buys exposure to several assets in one trade, with
+one payoff profile. It costs less than a strip of single-asset
+options because the basket is less volatile than its parts. The
+averaging forms further reduce the cost and smooth the payoff. In ORE
+Studio a customer books basket options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a vanilla basket call on the S&P 500 and the
+Euro Stoxx 50, struck at 5000, in its traditional representation:
+
+#+begin_example
+<Trade id="VanillaBasketOption#1">
+  <TradeType>EquityBasketOption</TradeType>
+  <Envelope>
+    <CounterParty>CPTY_A</CounterParty>
+    <NettingSetId>CPTY_A</NettingSetId>
+    <AdditionalFields/>
+  </Envelope>
+  <EquityBasketOptionData>
+    <Currency>USD</Currency>
+    <Notional>1</Notional>
+    <Strike>5000</Strike>
+    <Underlyings>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>RIC:.SPX</Name>
+        <Weight>1.0</Weight>
+      </Underlying>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>RIC:.STOXX50E</Name>
+        <Currency>EUR</Currency>
+        <Weight>1.0</Weight>
+      </Underlying>
+    </Underlyings>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <OptionType>Call</OptionType>
+      <PayoffType>Vanilla</PayoffType>
+      <ExerciseDates>
+        <ExerciseDate>2020-02-15</ExerciseDate>
+      </ExerciseDates>
+      <Premiums> ... </Premiums>
+    </OptionData>
+    <Settlement>2020-02-20</Settlement>
+  </EquityBasketOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/basketoption.tex=,
+the vanilla basket option example trade. The catalogue shows the
+Asian, average strike and lookback variants with the same basket.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/basketoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bestentryoption.org
+++ b/doc/knowledge/domain/bestentryoption.org
@@ -227,6 +227,9 @@ the expiry and settlement both fall on 2021-11-20.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/bestentryoption.tex=. The
   upstream project is

--- a/doc/knowledge/domain/bestentryoption.org
+++ b/doc/knowledge/domain/bestentryoption.org
@@ -41,7 +41,7 @@ specified region on a set of specified `strike observation dates',
 which is determined by a single barrier.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]].
 
 ORE introduces the trade types:
 
@@ -53,7 +53,7 @@ FxBestEntryOptionData, EquityBestEntryOptionData,
 CommodityBestEntryOptionData.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]].
 
 ** In plain terms
 
@@ -88,7 +88,7 @@ option payoff if the underlying index is greater than the strike on
 the expiry date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]].
 
 =TriggerLevel= is the barrier of the product. ORE describes it as
 follows:
@@ -99,7 +99,7 @@ each strike observation date to determine if a Trigger Event has
 occurred.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]].
 
 The trigger level is given as a decimal, a percentage of the index
 level on the strike date. When the observed index level reaches the
@@ -121,7 +121,7 @@ Cap: The maximum value of the payoff (before the notional and
 multiplier are applied).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]].
 
 The cap is given as a decimal percentage. =ExpiryDate= is the date
 when the option expires and the payoff is computed. =SettlementDate=
@@ -220,7 +220,7 @@ improvement:
 </EquityBestEntryOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]],
 listing =Best Entry Option data (Equity Underlying)=. The premium of
 100 USD is paid on 2021-11-22, two days after the strike date, and
 the expiry and settlement both fall on 2021-11-20.
@@ -230,7 +230,7 @@ the expiry and settlement both fall on 2021-11-20.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bestentryoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bestentryoption.tex][bestentryoption.tex]]. The
   upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bestentryoption.org
+++ b/doc/knowledge/domain/bestentryoption.org
@@ -1,0 +1,233 @@
+:PROPERTIES:
+:ID: 18891481-BBFE-4731-A677-DB66400A724C
+:END:
+#+title: Best Entry Option
+#+description: An option whose payoff uses the best observed entry level of the underlying; ORE's Best Entry Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bestentryoption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A best entry option gives a capped participation in the return of an
+index from an entry level, where the entry level can reset to the
+best observed level during a window. ORE prices it on FX, equity and
+commodity underlyings. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+The product is an option on a single underlying. Its payoff depends
+on the best entry of the index into a region on strike observation
+dates, decided by one barrier. When no observation hits the trigger,
+the entry level is the index level on the strike date. When an
+observation hits the trigger, the entry level resets toward the
+lowest observed level, floored by the reset minimum. At expiry the
+final index level is compared with a strike. A final level at or
+above the strike pays a capped participation in the positive return
+from the entry level. A final level below the strike makes the holder
+pay the shortfall.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+The Best Entry Option is an option on a single underlying that has a
+payoff contingent on the `best entry' of the underlying index into a
+specified region on a set of specified `strike observation dates',
+which is determined by a single barrier.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+
+ORE introduces the trade types:
+
+#+begin_quote
+Best Entry Options are defined using one of the trade types
+FxBestEntryOption, EquityBestEntryOption, CommodityBestEntryOption
+depending on the underlying asset class and an associated node
+FxBestEntryOptionData, EquityBestEntryOptionData,
+CommodityBestEntryOptionData.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+
+** In plain terms
+
+A best entry option is a view on one index with a good entry point.
+The entry point is the index level that anchors the payoff. It is set
+on the strike date. If the index dips to the trigger level on a
+strike observation date, the entry point improves to the best level
+seen, but only down to the reset minimum. At expiry the index gets a
+final look. If it stands above the strike, the holder collects the
+capped rise above the improved entry point. If it stands below the
+strike, the holder pays the shortfall. The structure rewards the
+holder when the index ends up, after a dip gave a better entry.
+
+** How it works in ORE
+
+=Underlying= names the underlying. For an FX underlying the currency
+order defines the observed value, so that EUR-USD observes USD per
+EUR and USD-EUR observes EUR per USD. =Currency= is the payment
+currency. =Notional= is the notional amount. =LongShort= takes =Long=
+or =Short= and fixes whether the payoff is computed for the holder or
+the seller.
+
+=StrikeDate= is the date whose index level sets the entry level when
+no trigger event occurs. It must fall before the option expiry date.
+=StrikeObservationDates= is the window that decides the entry level.
+ORE describes it as follows:
+
+#+begin_quote
+StrikeObservationDates: The set of dates on which the underlying
+index level is observed - the lowest of which is used to compute the
+option payoff if the underlying index is greater than the strike on
+the expiry date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+
+=TriggerLevel= is the barrier of the product. ORE describes it as
+follows:
+
+#+begin_quote
+TriggerLevel: The value that is compared to the underlying index on
+each strike observation date to determine if a Trigger Event has
+occurred.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+
+The trigger level is given as a decimal, a percentage of the index
+level on the strike date. When the observed index level reaches the
+trigger level on any observation date, a trigger event occurs and
+the entry level resets. The improved entry level is the maximum of
+the reset minimum value and the lowest observed index level. The
+reset minimum is also a percentage of the strike-date level, and it
+floors how far the entry can improve. Without a trigger event the
+entry level is the strike-date level.
+
+=Strike= is the strike value used to compute the payoff. It is given
+as a decimal, a percentage of the entry level. =Multiplier= is the
+payoff multiplier for the case where the final index level is above
+the strike; it defaults to one. =Cap= is the payoff ceiling. ORE
+describes it as follows:
+
+#+begin_quote
+Cap: The maximum value of the payoff (before the notional and
+multiplier are applied).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=.
+
+The cap is given as a decimal percentage. =ExpiryDate= is the date
+when the option expires and the payoff is computed. =SettlementDate=
+is the date when the payoff is settled, used unadjusted as given and
+on or after the expiry date. =Premium= is the option premium, zero by
+default. =PremiumDate= is the date when the premium is paid.
+
+** Mathematical notes
+
+The payoff compares the final index level with a strike level. The
+strike level is the strike value K times the entry level, where the
+entry level is set per the trigger path above. The strike value is a
+decimal, for example 0.85 for a strike at 85 percent of the entry
+level.
+
+When the final level stands at or above the strike level, the payoff
+is the notional times the multiplier times the capped positive return
+of the index from the entry level. The positive return is floored at
+zero: a final level between the strike level and the entry level
+pays nothing. The cap bounds the participation, for example at 6
+percent.
+
+When the final level stands below the strike level, the payoff is
+negative. The holder pays the notional times the shortfall of the
+final level below the strike level, relative to the entry level.
+
+** What moves its value (static sensitivities)
+
+- The final index level at expiry. It selects the payoff branch and
+  sets its size.
+- The entry level, and with it the strike-date level and the
+  observation path of the index.
+- The volatility of the underlying. It drives the chance of a trigger
+  event and the dispersion of the final level.
+- The trigger level and the reset minimum.
+- The strike value, the cap and the multiplier.
+- The notional.
+- The interest rates that discount the premium and the payoff.
+
+** How the profile ages (dynamic sensitivities)
+
+The strike observation dates form the trigger window. Each one checks
+the index against the trigger level. A trigger event resets the entry
+level toward the best observed level, floored by the reset minimum.
+The entry level then stays fixed. The expiry date compares the final
+level with the strike and computes the payoff, positive or negative.
+The payoff settles on the settlement date, and the premium was paid
+on the premium date.
+
+** Why a customer would want it
+
+A best entry option sells participation in an index from an entry
+point that improves with the market path. The buyer keeps the upside
+of a rise from a good level, capped, and carries the downside of a
+finish below the strike. Banks offer it to clients who expect a
+market to dip and recover, because the dip improves the entry level.
+In ORE Studio a customer books best entry options to value them and
+run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long best entry option on the S&P 500 with a
+notional of 1000000 USD. The strike value is 0.85, the cap 0.06 and
+the multiplier 1. The trigger level of 0.95 sits just below the
+strike-date level, and the reset minimum of 0.85 floors the entry
+improvement:
+
+#+begin_example
+<EquityBestEntryOptionData>
+  <LongShort>Long</LongShort>
+  <Strike>0.85</Strike>
+  <Cap>0.06</Cap>
+  <ResetMinimum>0.85</ResetMinimum>
+  <Notional>1000000</Notional>
+  <Multiplier>1</Multiplier>
+  <TriggerLevel>0.95</TriggerLevel>
+  <SettlementDate>2021-11-20</SettlementDate>
+  <PremiumDate>2021-11-22</PremiumDate>
+  <StrikeDate>2020-12-15</StrikeDate>
+  <Underlying>
+    <Type>Equity</Type>
+    <Name>RIC:.SPX</Name>
+  </Underlying>
+  <StrikeObservationDates>
+    <Dates>
+      <Dates>
+        <Date>2021-03-01</Date>
+        <Date>2021-06-01</Date>
+        <Date>2021-09-01</Date>
+      </Dates>
+    </Dates>
+  </StrikeObservationDates>
+  <Currency>USD</Currency>
+  <Premium>100</Premium>
+  <ExpiryDate>2021-11-20</ExpiryDate>
+</EquityBestEntryOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bestentryoption.tex=,
+listing =Best Entry Option data (Equity Underlying)=. The premium of
+100 USD is paid on 2021-11-22, two days after the strike date, and
+the expiry and settlement both fall on 2021-11-20.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bestentryoption.tex=. The
+  upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bond.org
+++ b/doc/knowledge/domain/bond.org
@@ -1,0 +1,142 @@
+:PROPERTIES:
+:ID: 691B6CE9-930A-4015-942C-A0DD4B04E690
+:END:
+#+title: Bond
+#+description: A bond is a tradable debt instrument paying scheduled interest and principal; ORE's Bond product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bond:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond is a tradable debt instrument. The issuer borrows money from the
+holder and pays scheduled interest and principal in return. ORE's Bond
+product is both a stand-alone trade and a building block for bond
+derivatives. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+A bond is a security that evidences a loan from the holder to the
+issuer. It pays coupons over its life and repays the principal at
+maturity, on a defined schedule and in a defined currency. In ORE a
+=BondData= block describes the trade. A short form references bond
+reference data. A long form inlines the full leg structure. ORE prices
+a bond as plain interest-rate risk unless a credit curve is attached.
+
+* Detail
+
+** What it is
+
+ORE defines the product's scope as follows:
+
+#+begin_quote
+A Bond is set up using a BondData block, and can be both a
+stand-alone instrument with trade type Bond, or a trade component used
+by multiple bond derivative instruments.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=.
+
+** In plain terms
+
+A bond is an IOU that anyone can buy and sell. The borrower, the
+issuer, promises to pay interest on the borrowed amount for a fixed
+period. It repays the amount at the end. Governments and companies
+issue bonds to fund themselves. Investors hold them for income, for
+safety, or to trade them.
+
+** How a bond is specified in ORE
+
+The short form names the bond and the position only:
+
+- =SecurityId=. The identifier of the bond, typically its ISIN with
+  the =ISIN:= prefix. The bond details are read from reference data.
+- =BondNotional=. The size of the position in the bond's currency.
+- =CreditRisk=. Whether the product carries credit sensitivities.
+
+The long form inlines the issuer, the credit curve, the security, the
+reference curve, settlement details, and a full =LegData= block for the
+coupon leg. The leg data selects the coupon structure. It can be fixed,
+floating, zero-coupon, or amortising.
+
+** Credit risk and product class
+
+ORE's own words on the credit flag:
+
+#+begin_quote
+If set to false, the product class will not be set to Credit, and there
+will be no credit sensitivities.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=.
+
+A bond whose reference data carries no =CreditCurveId= shows no credit
+sensitivities even with the flag on. This is typical for highly rated
+government bonds. A bond whose reference data sets a =CreditCurveId= is
+an IR/CR product. ORE prices it with credit sensitivities.
+
+** Mathematical notes
+
+The price of a bond is the present value of its remaining coupons and
+principal, discounted at the yield. Fixed coupons make the price move
+inversely with rates. Floating coupons reset and damp that move.
+Duration measures the price sensitivity to a yield shift. It falls as
+maturity approaches.
+
+** What moves its value (static sensitivities)
+
+The risk factors differ by product class:
+
+- Plain IR class. The discount curve in the bond's currency moves the
+  value. It acts through the reference curve and any credit spread
+  embedded in the price.
+- IR/CR class. The credit spread of the issuer moves the value as well.
+  It gives a CS01-type sensitivity to the credit curve.
+- Deal parameters. Coupon level, maturity, notional, and day-count
+  conventions scale or shape every sensitivity.
+
+** How the profile ages (dynamic sensitivities)
+
+A fixed-rate bond converges to par as maturity approaches. Fewer and
+fewer coupons remain. Its duration declines along the way. A
+floating-rate bond stays near par through each reset, because the next
+coupon tracks the market. Around call or redemption features the price
+behaviour changes as the option dates approach.
+
+** Why a customer would want it
+
+Governments and companies issue bonds to borrow. Investors buy them for
+income, for capital preservation, or for trading. A bank books bond
+positions to manage funding, collateral, and credit exposure. In ORE
+Studio a customer imports bond trades, prices them, and runs credit
+and rate sensitivities on the ORE engine.
+
+** Example
+
+ORE's own catalogue shows the short form with reference data:
+
+#+begin_example
+<BondData>
+  <SecurityId>ISIN:XS0982710740</SecurityId>
+  <BondNotional>100000000.0</BondNotional>
+  <CreditRisk>true</CreditRisk>
+</BondData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=,
+listing =BondData= (reference-data form).
+
+A full fixed-coupon bond trade sits in the ORE trade corpus at
+=assets/test_data/golden_dataset/Products/Example_Trades/Cash_Bonds.xml=.
+Native ORE example portfolios with bonds sit under
+=external/ore/examples/CreditRisk/Input/CreditPortfolioModel/portfolio.xml=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Bond_(finance)][Wikipedia: Bond (finance)]]. This note follows its general definition.
+- [[https://en.wikipedia.org/wiki/International_Securities_Identification_Number][Wikipedia: ISIN]]. This covers the identifier convention that
+  =SecurityId= uses.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bond.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bond.org
+++ b/doc/knowledge/domain/bond.org
@@ -134,6 +134,9 @@ Native ORE example portfolios with bonds sit under
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Bond_(finance)][Wikipedia: Bond (finance)]]. This note follows its general definition.
 - [[https://en.wikipedia.org/wiki/International_Securities_Identification_Number][Wikipedia: ISIN]]. This covers the identifier convention that
   =SecurityId= uses.

--- a/doc/knowledge/domain/bond.org
+++ b/doc/knowledge/domain/bond.org
@@ -36,7 +36,7 @@ stand-alone instrument with trade type Bond, or a trade component used
 by multiple bond derivative instruments.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bond.tex][bond.tex]].
 
 ** In plain terms
 
@@ -69,7 +69,7 @@ If set to false, the product class will not be set to Credit, and there
 will be no credit sensitivities.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bond.tex][bond.tex]].
 
 A bond whose reference data carries no =CreditCurveId= shows no credit
 sensitivities even with the flag on. This is typical for highly rated
@@ -124,7 +124,7 @@ ORE's own catalogue shows the short form with reference data:
 </BondData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bond.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bond.tex][bond.tex]],
 listing =BondData= (reference-data form).
 
 A full fixed-coupon bond trade sits in the ORE trade corpus at
@@ -140,6 +140,6 @@ Native ORE example portfolios with bonds sit under
 - [[https://en.wikipedia.org/wiki/Bond_(finance)][Wikipedia: Bond (finance)]]. This note follows its general definition.
 - [[https://en.wikipedia.org/wiki/International_Securities_Identification_Number][Wikipedia: ISIN]]. This covers the identifier convention that
   =SecurityId= uses.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bond.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bond.tex][bond.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondforward_refdata.org
+++ b/doc/knowledge/domain/bondforward_refdata.org
@@ -39,7 +39,7 @@ bond at a future point in time (the ForwardMaturityDate) at an agreed
 price (the settlement Amount).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondForward_refdata.tex][bondForward_refdata.tex]].
 
 ORE describes the T-Lock and J-Lock forms as follows:
 
@@ -51,7 +51,7 @@ rather then a settlement amount. The cash settlement amount is given
 by (bond yield at maturity - lock rate) x DV01 in this case.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondForward_refdata.tex][bondForward_refdata.tex]].
 
 ** In plain terms
 
@@ -153,7 +153,7 @@ premium, on a bond from reference data:
 </ForwardBondData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondForward_refdata.tex][bondForward_refdata.tex]],
 listing =Forward Bond Data=. The source spells the settlement value
 =Physcial= and closes the =BondData= element without the leading
 slash; both are normalised here.
@@ -165,7 +165,7 @@ slash; both are normalised here.
 
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondForward_refdata.tex][bondForward_refdata.tex]].
   The upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondforward_refdata.org
+++ b/doc/knowledge/domain/bondforward_refdata.org
@@ -160,6 +160,9 @@ slash; both are normalised here.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondforward_refdata.org
+++ b/doc/knowledge/domain/bondforward_refdata.org
@@ -1,0 +1,168 @@
+:PROPERTIES:
+:ID: C00D82F7-942F-4270-AB9F-D0C31F0881A9
+:END:
+#+title: Bond Forward (Reference Data)
+#+description: A forward contract on a bond with the underlying set by reference data; ORE's ForwardBond product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondforward_refdata:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond forward is a contract to buy or sell a bond at a future date
+at an agreed price. ORE's catalogue documents the product twice: once
+with the full bond data in the trade, and once with the underlying
+bond taken from reference data. This note records the reference-data
+form, as ORE documents it in its product catalogue. The container node
+is =ForwardBondData=.
+
+* Summary
+
+A forward bond, or bond forward, is an agreement to buy or sell an
+underlying bond at a future point in time at an agreed settlement
+amount. The direction comes from =LongInForward=. The underlying bond
+is named by its =SecurityId= and fetched from reference data. The
+T-Lock and J-Lock forms restrict the underlying to US Treasury and
+Japanese Government bonds, and can be specified by a lock-in yield
+instead of an amount. The trade type is =ForwardBond=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Forward Bond (or Bond Forward) is a contract that establishes an
+agreement to buy or sell (determined by LongInForward) an underlying
+bond at a future point in time (the ForwardMaturityDate) at an agreed
+price (the settlement Amount).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+
+ORE describes the T-Lock and J-Lock forms as follows:
+
+#+begin_quote
+A T-Lock is a Forward Bond with a US Treasury Bond as underlying,
+whereas a J-Lock is a Forward Bond with a Japanese Government Bond as
+underlying. T-Locks can be specified in terms of a lock-in yield
+rather then a settlement amount. The cash settlement amount is given
+by (bond yield at maturity - lock rate) x DV01 in this case.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+
+** In plain terms
+
+A bond forward locks the price of a bond today for delivery later. The
+buyer pays the agreed amount at maturity and receives the bond, or the
+cash difference. The T-Lock is the same trade on a Treasury bond, with
+the price expressed as a yield. It lets a mortgage desk lock the
+yield it will pay on a future delivery.
+
+** How it works in ORE
+
+A Forward Bond is set up using a =ForwardBondData= block and the trade
+type is =ForwardBond=. The block has four parts. The =BondData= block
+specifies the underlying bond by =SecurityId= and =BondNotional=. The
+=SecurityId= is typically the ISIN of the underlying bond with the
+=ISIN:= prefix. The optional =CreditRisk= flag decides whether credit
+risk shows on the product. When it is =false=, the product class is
+=RatesFX= instead of =Credit= and there are no credit sensitivities.
+The flag has no effect when the bond reference carries no
+=CreditCurveId=, which is typical for highly rated government bonds.
+The =SettlementData= block holds the settlement terms.
+=ForwardMaturityDate= is the maturity of the forward contract.
+=ForwardSettlementDate= is optional and names the settlement or cash
+payment date. =Settlement= takes =Cash= or =Physical= and defaults to
+physical, except that a trade defined by a =LockRate= defaults to
+cash. =Amount= is the settlement amount, or strike, transferred at
+maturity in return for the bond or its dirty price. It moves from the
+long party to the short party and cannot be negative. Exactly one of
+=Amount= and =LockRate= must be given. =LockRate= sets the payoff as
+=(yield at forward maturity - LockRate) x DV01= for a long position;
+it is expressed in decimal form. =dv01= can override the DV01 derived
+from the bond price. =LockRateDayCounter= is optional and defaults to
+=A360=. =SettlementDirty= decides whether the amount reflects a clean
+or dirty price; the dirty amount is always paid at maturity, and
+accruals are added internally when the flag is false. The =PremiumData=
+block is optional and holds a premium =Date= and =Amount=. The
+=LongInForward= flag decides whether the contract is long or short.
+
+** Mathematical notes
+
+A physically settled forward pays the agreed amount at maturity and
+receives the bond. A cash-settled forward pays the difference between
+the dirty bond price and the amount. The T-Lock variant pays the
+difference between the bond yield at maturity and the lock rate,
+scaled by the DV01 of the bond. The DV01 converts the yield
+difference into a price difference.
+
+** What moves its value (static sensitivities)
+
+- The price and yield of the underlying bond.
+- The forward date and the settlement amount or lock rate.
+- The interest rates that finance the position to maturity.
+- The credit of the issuer, unless the trade opts out of credit risk.
+
+The trade is a linear claim on the underlying bond, so its value
+moves almost one for one with the bond price. The T-Lock form is
+sensitive to the yield curve through both the bond yield and the
+DV01.
+
+** How the profile ages (dynamic sensitivities)
+
+A bond forward has no coupon flows during its life. Only the premium,
+if any, changes hands before maturity. The value converges to the
+difference between the bond price and the agreed amount as maturity
+approaches. At maturity the trade settles physically or in cash.
+
+** Why a customer would want it
+
+A bond forward locks a purchase or sale price without funding the bond
+today. It suits a customer who must deliver a bond at a known future
+date, or who wants a leveraged view on a bond. The T-Lock form locks a
+yield, which is how mortgage pipelines hedge. In ORE Studio a customer
+books forward bonds to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a long, physically settled forward bond with a
+premium, on a bond from reference data:
+
+#+begin_example
+<ForwardBondData>
+  <BondData>
+    <SecurityId>ISIN:XS1234567890</SecurityId>
+    <BondNotional>100000</BondNotional>
+  </BondData>
+  <SettlementData>
+    <ForwardMaturityDate>20160808</ForwardMaturityDate>
+    <Settlement>Physical</Settlement>
+    <ForwardSettlementDate>20160810</ForwardSettlementDate>
+    <Amount>1000000.00</Amount>
+    <SettlementDirty>true</SettlementDirty>
+  </SettlementData>
+  <PremiumData>
+    <Amount>1000.00</Amount>
+    <Date>20160808</Date>
+  </PremiumData>
+  <LongInForward>true</LongInForward>
+</ForwardBondData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondForward_refdata.tex=,
+listing =Forward Bond Data=. The source spells the settlement value
+=Physcial= and closes the =BondData= element without the leading
+slash; both are normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondForward_refdata.tex=.
+  The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondfuture.org
+++ b/doc/knowledge/domain/bondfuture.org
@@ -41,7 +41,7 @@ factor that is specific to the CTD bond and which compensates for the
 different yields of the bonds in the underlying basket.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondfuture.tex][bondfuture.tex]].
 
 ORE describes the dual role of the product as follows:
 
@@ -51,7 +51,7 @@ BondFuture) or as a trade component (BondFutureData) used within the
 TotalReturnSwap (Generic TRS) trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondfuture.tex][bondfuture.tex]].
 
 ** In plain terms
 
@@ -131,7 +131,7 @@ note contract:
 </BondFutureData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondfuture.tex][bondfuture.tex]],
 listing =BondFutureData=. The example contract =TYU25= carries the
 =DeliveryBasket=, the expiry dates and the =DeliverableGrade= in its
 =BondFutureReferenceData= block; that block is not part of the trade
@@ -144,6 +144,6 @@ representation.
 
 - [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondfuture.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondfuture.tex][bondfuture.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondfuture.org
+++ b/doc/knowledge/domain/bondfuture.org
@@ -139,6 +139,9 @@ representation.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondfuture.org
+++ b/doc/knowledge/domain/bondfuture.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: B50027E5-44CD-49FA-B4DF-1177E321F156
+:END:
+#+title: Bond Future
+#+description: A contract to buy or sell an underlying bond at expiry at an agreed price; ORE's BondFuture product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondfuture:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond future is an exchange-style contract to buy or sell a bond at
+expiry, with the deliverable bond chosen from a basket. ORE models it
+with the trade type =BondFuture=. The container node is
+=BondFutureData=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A bond future is a contract that establishes an agreement to buy or
+sell an underlying bond at a future point in time at an agreed price.
+The contract seller chooses the deliverable bond from a list of
+eligible securities. That bond is called the cheapest to deliver, or
+CTD. The trade names a contract; the delivery basket and the expiry
+rules live in the =BondFutureReferenceData= for that contract.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Bond Future is a contract that establishes an agreement to buy or
+sell an underlying bond at a future point in time (expiry) at an
+agreed price (strike amount). The underlying bond can be selected by
+the contract seller from a list of eligible securities and is called
+"cheapest to deliver" (CTD). The bond is exchanged with a cash payment
+determined as the future settlement price multiplied by a conversion
+factor that is specific to the CTD bond and which compensates for the
+different yields of the bonds in the underlying basket.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=.
+
+ORE describes the dual role of the product as follows:
+
+#+begin_quote
+A BondFuture can be used both as a stand alone trade (TradeType:
+BondFuture) or as a trade component (BondFutureData) used within the
+TotalReturnSwap (Generic TRS) trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=.
+
+** In plain terms
+
+A bond future is a bet on the price of a bond at a fixed date. One
+bond in a basket is delivered, not a named bond. The seller picks the
+bond that is cheapest to deliver, so the future trades against that
+bond. The conversion factor makes the basket bonds comparable.
+
+** How it works in ORE
+
+The =BondFutureData= block holds the trade terms. =ContractName=
+selects both the bond future reference datum and the security specific
+spread used for pricing. =ContractNotional= is the notional of the
+position in the currency of the bond. =LongShort= takes =Long=, =L=,
+=Short= or =S=. The corresponding reference data, which is not part of
+the trade representation, sits in the =BondFutureReferenceData= block.
+=Currency= names the currency of the future. =DeliveryBasket= lists
+the eligible security identifiers, typically ISINs with the =ISIN:=
+prefix. =Settlement= defaults to =Physical=. =DirtyQuotation= decides
+whether the market quote of the future price is dirty or clean, and
+defaults to clean. The last trading and last delivery dates can be
+given explicitly as =LastTradingDate= and =LastDeliveryDate=. They can
+also be derived from =ContractMonth=, =RootDate=, =ExpiryBasis=,
+=SettlementBasis=, =ExpiryLag= and =SettlementLag=. The conversion
+factor can come from market data or be deduced internally. In the
+latter case =DeliverableGrade= restricts the deliverable underlyings,
+with values such as =ZN= for the CME and =TY= for Bloomberg. The
+derivation rules follow the CME Group primer. The last delivery day is
+the last business day of the delivery month. The last trading day is
+the seventh business day preceding it.
+
+** Mathematical notes
+
+Let =sp= be the quoted future settlement price, =ai= the accrued
+interest, =cf= the bond specific conversion factor and =bp= the bond
+price. The short party receives =(sp x cf) + ai= and pays the cost of
+purchasing a bond, =bp + ai=. The cheapest to deliver is the bond for
+which =bp - (sp x cf)= is least. The decision takes place at future
+expiry.
+
+** What moves its value (static sensitivities)
+
+- The price of the deliverable bonds in the basket.
+- The yield curve, which sets the forward prices of the basket.
+- The conversion factors of the basket bonds.
+- The choice of the cheapest to deliver.
+
+The future tracks the CTD bond. When yields move, the CTD can switch,
+and the future then tracks a different bond.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade names a contract with a fixed expiry. As expiry approaches,
+the value converges to the CTD bond price, and the delivery decision
+approaches. At expiry the seller delivers the cheapest bond and the
+buyer pays the settlement price times the conversion factor. Until
+then the future is a linear claim on the CTD with no cash flows.
+
+** Why a customer would want it
+
+A bond future is a liquid, leveraged way to take a position on
+government bond prices. It hedges a bond portfolio without buying the
+bonds. Because delivery is a basket, the future needs no single-bond
+liquidity. In ORE Studio a customer books bond futures to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a bond future trade on a 10-year US Treasury
+note contract:
+
+#+begin_example
+<BondFutureData>
+  <ContractName>with_ref</ContractName>
+  <ContractNotional>1000000</ContractNotional>
+  <LongShort>L</LongShort>
+</BondFutureData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondfuture.tex=,
+listing =BondFutureData=. The example contract =TYU25= carries the
+=DeliveryBasket=, the expiry dates and the =DeliverableGrade= in its
+=BondFutureReferenceData= block; that block is not part of the trade
+representation.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondfuture.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondoption.org
+++ b/doc/knowledge/domain/bondoption.org
@@ -1,0 +1,161 @@
+:PROPERTIES:
+:ID: 52C1431E-517D-40EC-AE9F-838F040A4103
+:END:
+#+title: Bond Option
+#+description: A right to buy or sell a given bond at a fixed price; ORE's BondOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond option gives the buyer the right to buy or sell a bond at a
+fixed price. The option is European, and the underlying bond sits in
+the trade. ORE models it with the trade type =BondOption=. The
+container node is =BondOptionData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A bond option provides the buyer with the right, but not the
+obligation, to buy or sell a given bond at a fixed price either at or
+before a specific date. Options are written on government bonds and
+are traded on an OTC basis. Only vanilla bond options are supported,
+and the exercise style must be European. The =BondOptionData= node
+holds one =OptionData= sub-node plus the strike, the redemption ratio,
+the price type and the default behaviour, together with the underlying
+bond.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A bond option provides the buyer with the right, but not the
+obligation, to buy or sell a given bond at a fixed price either at or
+before a specific date. Options are written on government bonds and
+are traded on an OTC basis.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=.
+
+ORE describes the trade node as follows:
+
+#+begin_quote
+The BondOptionData node is the trade data container for the option
+part of a bond option trade type. Vanilla bond options are supported,
+the exercise style must be European. The BondOptionData node includes
+one and only one OptionData trade component sub-node plus elements
+specific to the bond option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=.
+
+** In plain terms
+
+A bond option is a vanilla option on a government bond. The buyer of a
+call can buy the bond at the strike. The buyer of a put can sell it.
+The strike can be a clean or a dirty price, which decides how accrued
+interest enters the payoff.
+
+** How it works in ORE
+
+The =BondOptionData= node is the trade data container for the option
+part of the =BondOption= trade type. It has one =OptionData= sub-node
+plus elements specific to the bond option. The =OptionData= sub-node
+carries the option terms. The =StrikeData= node holds the strike and
+supports =StrikePrice= and =StrikeYield=. =Redemption= is the
+redemption ratio in percent. =PriceType= decides which strike is used
+for pricing. With =Dirty=, the strike price is used as given. With
+=Clean=, the strike price is set equal to the strike value plus the
+accrued interest at the expiration date of the option. =KnocksOut=
+decides the default behaviour. When it is =true=, the option knocks
+out if the underlying defaults before option expiry. When it is
+=false=, the option is written on the recovery value in case of a
+default. The =BondData= block describes the underlying bond and holds
+the =VolatilityCurveId=, the yield volatility curve used for the
+valuation. This product carries the full bond description in the
+trade; ORE also documents a form that takes the bond from reference
+data.
+
+** Mathematical notes
+
+The option payoff is the bond value less the strike, floored at zero,
+or the strike less the bond value. The exercise style is European, so
+the option can be exercised at expiry only. The strike enters as a
+dirty price when =PriceType= is =Dirty=, and as a clean price plus
+accruals when it is =Clean=. The value comes from a yield volatility
+model of the underlying bond.
+
+** What moves its value (static sensitivities)
+
+- The price and yield of the underlying bond.
+- The yield volatility curve named by =VolatilityCurveId=.
+- The strike and the redemption ratio.
+- The interest rates that discount the payoff.
+- The credit of the issuer, through the default behaviour.
+
+The option is a claim on a bond, so bond yields, volatility and
+credit all move its value. Near the strike it is most sensitive to the
+bond price.
+
+** How the profile ages (dynamic sensitivities)
+
+The option is European and ages like a vanilla option. Time value
+decays toward expiry. The default behaviour decides the outcome if
+the issuer fails before expiry: the option either dies or falls back
+to the recovery value. At expiry the buyer exercises when the bond
+value is on the right side of the strike.
+
+** Why a customer would want it
+
+A bond option gives cheap, leveraged exposure to a government bond
+without buying it. It hedges a bond position or a pipeline of future
+bond purchases. In ORE Studio a customer books bond options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a European bond option on a bond with a strike
+in EUR and a dirty price convention:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>BondOption</TradeType>
+  <Envelope>
+      ...
+  </Envelope>
+  <BondOptionData>
+    <OptionData>
+        ...
+    </OptionData>
+    <StrikeData>
+      <StrikePrice>
+        <Value>11809123.56</Value>
+        <Currency>EUR</Currency>
+      </StrikePrice>
+    </StrikeData>
+    <Redemption>100.00</Redemption>
+    <PriceType>Dirty</PriceType>
+    <KnocksOut>false</KnocksOut>
+    <BondData>
+       <VolatilityCurveId>YieldVols-EUR</VolatilityCurveId>
+        ...
+    </BondData>
+  </BondOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=,
+listing =Bond Option data=. The source closes the =BondData= element
+without the leading slash; it is normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondoption.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondoption.org
+++ b/doc/knowledge/domain/bondoption.org
@@ -39,7 +39,7 @@ before a specific date. Options are written on government bonds and
 are traded on an OTC basis.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption.tex][bondoption.tex]].
 
 ORE describes the trade node as follows:
 
@@ -51,7 +51,7 @@ one and only one OptionData trade component sub-node plus elements
 specific to the bond option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption.tex][bondoption.tex]].
 
 ** In plain terms
 
@@ -148,7 +148,7 @@ in EUR and a dirty price convention:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption.tex][bondoption.tex]],
 listing =Bond Option data=. The source closes the =BondData= element
 without the leading slash; it is normalised here.
 
@@ -159,6 +159,6 @@ without the leading slash; it is normalised here.
 
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondoption.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption.tex][bondoption.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondoption.org
+++ b/doc/knowledge/domain/bondoption.org
@@ -154,6 +154,9 @@ without the leading slash; it is normalised here.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondoption_refdata.org
+++ b/doc/knowledge/domain/bondoption_refdata.org
@@ -41,7 +41,7 @@ one and only one OptionData trade component sub-node plus elements
 specific to the bond option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption_refdata.tex][bondoption_refdata.tex]].
 
 ORE adds a restriction on the bond form:
 
@@ -49,7 +49,7 @@ ORE adds a restriction on the bond form:
 Note that only par redemption vanilla bonds are supported.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption_refdata.tex][bondoption_refdata.tex]].
 
 ** In plain terms
 
@@ -152,7 +152,7 @@ reference data, with the strike per unit notional:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption_refdata.tex][bondoption_refdata.tex]],
 listing =Bond Option data using bond reference data=. The source
 closes the =BondData= element without the leading slash; it is
 normalised here.
@@ -164,6 +164,6 @@ normalised here.
 
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondoption_refdata.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondoption_refdata.tex][bondoption_refdata.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondoption_refdata.org
+++ b/doc/knowledge/domain/bondoption_refdata.org
@@ -1,0 +1,166 @@
+:PROPERTIES:
+:ID: 0E145E20-C296-4D0F-B26C-2CC5EAA22F3B
+:END:
+#+title: Bond Option (Reference Data)
+#+description: A bond option with the underlying bond set by reference data; ORE's BondOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondoption_refdata:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond option gives the buyer the right to buy or sell a bond at a
+fixed price. ORE's catalogue documents the product twice: once with
+the full bond data in the trade, and once with the underlying bond
+taken from reference data. This note records the reference-data form,
+as ORE documents it in its product catalogue. The container node is
+=BondOptionData=.
+
+* Summary
+
+A bond option provides the buyer with the right, but not the
+obligation, to buy or sell a given bond at a fixed price either at or
+before a specific date. Only vanilla bond options are supported, the
+exercise style must be European, and only par redemption vanilla
+bonds are supported. The underlying bond is named by its =SecurityId=
+and fetched from reference data. The payoff is the dirty bond value
+less the strike, with the strike interpreted as clean or dirty by
+=PriceType=.
+
+* Detail
+
+** What it is
+
+ORE describes the trade node as follows:
+
+#+begin_quote
+The BondOptionData node is the trade data container for the option
+part of a bond option trade type. Vanilla bond options are supported,
+the exercise style must be European. The BondOptionData node includes
+one and only one OptionData trade component sub-node plus elements
+specific to the bond option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=.
+
+ORE adds a restriction on the bond form:
+
+#+begin_quote
+Note that only par redemption vanilla bonds are supported.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=.
+
+** In plain terms
+
+A bond option is a vanilla option on a bond that the trade finds in
+reference data. The buyer names the bond by its identifier, not by a
+full description. The option is European and the bond must be a plain
+par bond. The strike can quote a clean or a dirty price.
+
+** How it works in ORE
+
+The =BondOptionData= node holds one =OptionData= sub-node plus the
+strike, the price type, the default behaviour and the underlying
+bond. =LongShort= takes =Long= or =Short=. =OptionType= takes =Call=
+or =Put=. A call holder has the right to buy the underlying bond at
+the strike. A put holder has the right to sell it. The =Style= is
+=European= only. =Settlement= can be =Cash= or =Physical= but is
+currently ignored. Exactly one =ExerciseDate= must be given.
+=Premiums= is optional. The =StrikeData= node represents the strike
+price or strike yield. With =StrikePrice=, the =Value= field is
+expressed per unit notional: a strike of 101 percent of the bond
+notional is expressed as 1.01. With =StrikeYield=, the =Yield= is
+quoted in decimal form. =PriceType= is mandatory for =StrikePrice= and
+has no impact for =StrikeYield=. =KnocksOut= decides the default
+behaviour. When =true=, the option knocks out if the underlying
+defaults before option expiry. When =false=, the option is written on
+the recovery value. The =BondData= block names the bond: =SecurityId=
+is typically the ISIN with the =ISIN:= prefix, =BondNotional= is the
+notional in the currency of the bond, and the optional =CreditRisk=
+flag decides whether credit risk shows on the product.
+
+** Mathematical notes
+
+The payoff for a bond option is =max(B - X, 0)=, where =B= is always
+the dirty NPV of the underlying bond on the exercise settlement date.
+With =PriceType= =Clean=, =X= is =(Strike + Underlying Bond Accruals) x
+BondNotional=. With =PriceType= =Dirty=, =X= is =Strike x
+BondNotional=. When =StrikeData= uses =StrikeYield=, =PriceType= is
+omitted because it is not relevant in the yield case.
+
+** What moves its value (static sensitivities)
+
+- The price and yield of the underlying bond.
+- The yield volatility of the bond.
+- The strike, quoted as price or yield.
+- The interest rates that discount the payoff.
+- The credit of the issuer, through the default behaviour.
+
+The bond is fetched from reference data, so the valuation depends on
+the reference data of the issuer and the bond.
+
+** How the profile ages (dynamic sensitivities)
+
+The option is European and ages like a vanilla option. Time value
+decays toward expiry. If the issuer fails before expiry, the option
+either knocks out or falls back to the recovery value, as =KnocksOut=
+decides. At expiry the payoff is the dirty bond value less the strike,
+floored at zero.
+
+** Why a customer would want it
+
+A bond option gives cheap, leveraged exposure to a government bond
+without buying it. The reference-data form keeps the trade small,
+because the bond description lives once in the reference data. In ORE
+Studio a customer books bond options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European call bond option on a bond from
+reference data, with the strike per unit notional:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>BondOption</TradeType>
+  <Envelope>
+      ...
+  </Envelope>
+  <BondOptionData>
+    <OptionData>
+     <LongShort>Long</LongShort>
+     <OptionType>Call</OptionType>
+     <Style>European</Style>
+     <ExerciseDates>
+      <ExerciseDate>20210203</ExerciseDate>
+     </ExerciseDates>
+        ...
+    </OptionData>
+    <StrikeData>
+      <StrikePrice>
+        <Value>1.23</Value>
+      </StrikePrice>
+    </StrikeData>
+    <PriceType>Dirty</PriceType>
+    <KnocksOut>false</KnocksOut>
+    <BondData>
+       <SecurityId>ISIN:XS1234567890</SecurityId>
+       <BondNotional>100000</BondNotional>
+    </BondData>
+  </BondOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondoption_refdata.tex=,
+listing =Bond Option data using bond reference data=. The source
+closes the =BondData= element without the leading slash; it is
+normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondoption_refdata.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondoption_refdata.org
+++ b/doc/knowledge/domain/bondoption_refdata.org
@@ -159,6 +159,9 @@ normalised here.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondposition.org
+++ b/doc/knowledge/domain/bondposition.org
@@ -1,0 +1,140 @@
+:PROPERTIES:
+:ID: 531499CE-C843-4178-8F89-CA901B1BA9AE
+:END:
+#+title: Bond Position
+#+description: A position in a weighted basket of underlying bonds; ORE's BondPosition product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondposition:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond position holds a weighted basket of underlying bonds. ORE
+models it with the trade type =BondPosition=. The container node is
+=BondBasketData=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A bond position represents a position in a weighted basket of
+underlying bonds. It can be a stand-alone trade type or a trade
+component inside a total return swap. The basket can be built in the
+trade or fetched from reference data by an identifier. Only underlying
+descriptions of type =Bond= are allowed.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A bond position represents a position in a weighted basket of
+underlying bonds.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=.
+
+ORE describes the dual role as follows:
+
+#+begin_quote
+A bond position can be used both as a stand alone trade type
+(TradeType: BondPosition) or as a trade component (BondBasketData)
+used within the TotalReturnSwap (Generic TRS) trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=.
+
+** In plain terms
+
+A bond position is a list of bonds with weights. It lets a trade hold
+several bonds as one position. The same block also builds the asset
+side of a total return swap on a bond basket.
+
+** How it works in ORE
+
+The position is set up using a =BondBasketData= block. =Quantity= is
+the number of units of the weighted basket held. =Identifier= is
+optional: the underlying data can be retrieved from reference data
+through it, when it is not given in the trade itself. =Underlying= is
+optional for the same reason: when the basket lives in reference data,
+the underlying data is populated from there. Each =Underlying= block
+carries a =Type=, a =Name=, an =IdentifierType=, a =Weight= and an
+optional =BidAskAdjustment=. Only underlyings of type =Bond= are
+allowed.
+
+** Mathematical notes
+
+The weighted basket price is:
+
+=Basket-Price = Quantity x sum_i Weight_i x B_i x FX_i=
+
+where =B_i= is the price of the i-th bond in the basket. =FX_i= is the
+FX spot converting from the currency of the i-th bond to the return
+currency when the position sits in a total return swap, and to the
+currency of the first bond in the basket otherwise.
+
+** What moves its value (static sensitivities)
+
+- The price of each bond in the basket.
+- The weights of the basket and the quantity.
+- The FX rates into the return currency.
+- The credit of each issuer.
+
+The position is a linear claim on the basket, so each bond price moves
+the value by its weight.
+
+** How the profile ages (dynamic sensitivities)
+
+A bond position is a static holding with no cash flows of its own. Its
+value tracks the bonds as they age toward maturity. As a trade
+component inside a total return swap, it provides the asset leg whose
+total return is swapped against funding.
+
+** Why a customer would want it
+
+A bond position bundles several bonds into one tradable unit. It is
+the natural asset leg of a bond total return swap, where the return of
+the basket is paid out. In ORE Studio a customer books bond positions
+to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a basket of two US bonds, half each, with small
+bid-ask adjustments:
+
+#+begin_example
+<Trade id="BondPosition">
+  <TradeType>BondPosition</TradeType>
+  <Envelope>...</Envelope>
+  <BondBasketData>
+    <Quantity>1000</Quantity>
+    <Identifier>ISIN:GB00B4KT9Q30</Identifier>
+    <Underlying>
+      <Type>Bond</Type>
+      <Name>US69007TAB08</Name>
+      <IdentifierType>ISIN</IdentifierType>
+      <Weight>0.5</Weight>
+      <BidAskAdjustment>-0.0025</BidAskAdjustment>
+    </Underlying>
+    <Underlying>
+      <Type>Bond</Type>
+      <Name>US750236AW16</Name>
+      <IdentifierType>ISIN</IdentifierType>
+      <Weight>0.5</Weight>
+      <BidAskAdjustment>-0.005</BidAskAdjustment>
+    </Underlying>
+  </BondBasketData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=,
+listing =Bond position data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondposition.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondposition.org
+++ b/doc/knowledge/domain/bondposition.org
@@ -133,6 +133,9 @@ listing =Bond position data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondposition.org
+++ b/doc/knowledge/domain/bondposition.org
@@ -33,7 +33,7 @@ A bond position represents a position in a weighted basket of
 underlying bonds.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondposition.tex][bondposition.tex]].
 
 ORE describes the dual role as follows:
 
@@ -43,7 +43,7 @@ A bond position can be used both as a stand alone trade type
 used within the TotalReturnSwap (Generic TRS) trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondposition.tex][bondposition.tex]].
 
 ** In plain terms
 
@@ -128,7 +128,7 @@ bid-ask adjustments:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondposition.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondposition.tex][bondposition.tex]],
 listing =Bond position data=.
 
 * See also
@@ -138,6 +138,6 @@ listing =Bond position data=.
 
 - [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondposition.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondposition.tex][bondposition.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondrepo.org
+++ b/doc/knowledge/domain/bondrepo.org
@@ -150,6 +150,9 @@ listing =Bond Repo Data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Repurchase_agreement][Wikipedia: Repurchase agreement]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondrepo.org
+++ b/doc/knowledge/domain/bondrepo.org
@@ -1,0 +1,157 @@
+:PROPERTIES:
+:ID: C96BBC70-71C1-442A-97FF-CCD596C193DB
+:END:
+#+title: Bond Repo
+#+description: A cash borrowing with a bond posted as collateral; ORE's BondRepo product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondrepo:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond repo is a secured cash borrowing: a bond is posted as
+collateral for cash. ORE models it with the trade type =BondRepo=. The
+container node is =BondRepoData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+In a bond repo transaction one party receives a cash amount from
+another party for a specified period. At maturity the borrower pays
+back the cash amount plus accrued interest. A bond is delivered as
+collateral for the duration of the trade. The interest paid is lower
+than for an uncollateralised borrowing. The =BondRepoData= block
+contains a =BondData= node for the collateral and a =RepoData= node
+for the cash leg.
+
+* Detail
+
+** What it is
+
+ORE defines the transaction as follows:
+
+#+begin_quote
+In a bond repo transaction one party A receives a cash amount from a
+party B for a specified period. At the maturity of the trade party A
+pays back the cash amount plus accrued interest to party B.
+Intermediate interest payments are also possible. Party A delivers a
+bond to party B as a collateral for the received cash amount for the
+duration of the trade. In exchange the interest to be paid by party A
+will be lower than for an uncollateralised borrowing transaction.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondrepo.tex=.
+
+** In plain terms
+
+A repo is a short-term loan against a bond. The borrower hands over
+the bond and gets cash. At the end the borrower repays the cash with
+interest and gets the bond back. The bond makes the loan cheap and
+safe.
+
+** How it works in ORE
+
+A bond repo trade is set up using the trade type =BondRepo= and a
+=BondRepoData= block. The block contains two nodes. The =BondData=
+node specifies the underlying bond and its quantity. =SecurityId= is
+the identifier of the underlying security, usually of the form
+=ISIN::XY012345679=. =BondNotional= is the effective notional used as
+collateral, so it should include hair cuts. Usually the number =Bond
+Notional x Bond Dirty Price x (1 - Haircut)= corresponds to the
+nominal on the cash leg at trade inception. The optional =CreditRisk=
+flag decides whether credit risk shows on the product. The details of
+the underlying bond are read from the reference data in this case,
+but it is also possible to inline the details in the trade. The
+=RepoData= node contains exactly one =LegData= sub-node that describes
+the payments on the cash leg of the repo. The =Payer= leg determines
+whether interest is paid, a regular repo, or received, a reversed
+repo.
+
+** Mathematical notes
+
+The cash leg is a fixed or floating interest leg over the repo period.
+The collateral leg delivers the bond and returns it at maturity. The
+economics of the trade are the difference between the interest on the
+cash and the value of holding the collateral. A haircut makes the
+collateral value exceed the cash, which protects the lender.
+
+** What moves its value (static sensitivities)
+
+- The repo rate on the cash leg.
+- The price of the collateral bond and its credit.
+- The haircut and the notional of the collateral.
+- The funding rates of the two parties.
+
+The trade is a pair of opposite cash flows, so its value is driven by
+the spread between the repo rate and the funding of the bond.
+
+** How the profile ages (dynamic sensitivities)
+
+The repo runs over a fixed period. Interest accrues on the cash leg,
+with intermediate payments possible. The bond stays with the lender as
+collateral. At maturity the borrower repays the cash plus interest and
+the bond returns. Until then the value tracks the difference between
+the two legs.
+
+** Why a customer would want it
+
+A repo funds a bond position cheaply, or lends cash against safe
+collateral. It is the standard tool of the money market for secured
+funding. In ORE Studio a customer books bond repos to value them and
+run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a three-month USD repo: the borrower posts a US
+Treasury and pays a fixed rate of 1.78 percent on the cash:
+
+#+begin_example
+<BondRepoData>
+  <BondData>
+    <SecurityId>ISIN:US912828X703</SecurityId>
+    <BondNotional>27807597.777444</BondNotional>
+  </BondData>
+  <RepoData>
+    <LegData>
+      <LegType>Fixed</LegType>
+      <Payer>true</Payer>
+      <Currency>USD</Currency>
+      <Notionals>
+        <Notional>28371510.00</Notional>
+      </Notionals>
+      <ScheduleData>
+        <Rules>
+          <StartDate>2020-01-06</StartDate>
+          <EndDate>2020-04-07</EndDate>
+          <Tenor>1Y</Tenor>
+          <Calendar>US</Calendar>
+          <Convention>MF</Convention>
+          <TermConvention>MF</TermConvention>
+          <Rule>Forward</Rule>
+          <EndOfMonth/>
+          <FirstDate/>
+          <LastDate/>
+        </Rules>
+      </ScheduleData>
+      <DayCounter>A360</DayCounter>
+      <PaymentConvention>F</PaymentConvention>
+      <FixedLegData>
+        <Rates>
+          <Rate>0.0178</Rate>
+        </Rates>
+      </FixedLegData>
+    </LegData>
+  </RepoData>
+</BondRepoData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondrepo.tex=,
+listing =Bond Repo Data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Repurchase_agreement][Wikipedia: Repurchase agreement]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondrepo.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondrepo.org
+++ b/doc/knowledge/domain/bondrepo.org
@@ -40,7 +40,7 @@ duration of the trade. In exchange the interest to be paid by party A
 will be lower than for an uncollateralised borrowing transaction.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondrepo.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondrepo.tex][bondrepo.tex]].
 
 ** In plain terms
 
@@ -145,7 +145,7 @@ Treasury and pays a fixed rate of 1.78 percent on the cash:
 </BondRepoData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondrepo.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondrepo.tex][bondrepo.tex]],
 listing =Bond Repo Data=.
 
 * See also
@@ -155,6 +155,6 @@ listing =Bond Repo Data=.
 
 - [[https://en.wikipedia.org/wiki/Repurchase_agreement][Wikipedia: Repurchase agreement]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondrepo.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondrepo.tex][bondrepo.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondtotalreturnswap.org
+++ b/doc/knowledge/domain/bondtotalreturnswap.org
@@ -192,6 +192,9 @@ listing =Bond Total Return Swap Data with indexed funding leg=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/bondtotalreturnswap.org
+++ b/doc/knowledge/domain/bondtotalreturnswap.org
@@ -1,0 +1,199 @@
+:PROPERTIES:
+:ID: 0727A454-AB7F-4202-A3A8-A4A183683566
+:END:
+#+title: Bond Total Return Swap
+#+description: A swap paying the total return of a bond against a funding leg; ORE's BondTRS product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:bondtotalreturnswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A bond total return swap pays the total return of a bond against a
+funding leg. ORE models it with the trade type =BondTRS=. The
+container node is =BondTRSData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A total return swap is a derivative contract in which one
+counterparty pays out the total returns of an underlying asset and
+receives a regular fixed or floating cash flow from the other
+counterparty. The total return of a bond covers its coupons,
+redemptions and amortisations, and the changes in its clean value
+along the schedule. The =BondTRSData= block has three sub-blocks:
+=BondData= for the underlying, =TotalReturnData= for the return leg,
+and =FundingData= for the funding leg.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A total return swap is a derivative contract in which one
+counterparty (short) pays out the total returns of an underlying asset
+and receives a regular fixed or floating cash flow from the other
+counterparty (long). Here we describe total return swaps with an
+underlying bond. The total return of the bond is comprised of
+#+end_quote
+
+#+begin_quote
+coupon, redemption and amortization payments of the bond, including
+recovery payments in case of default
+compensation payments that reflect changes of the clean bond value
+along the TRS schedule.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=.
+
+ORE describes the setup as follows:
+
+A vanilla Bond Total Return Swap (Trade type: BondTRS) is set up
+using a =BondTRSData= block, which the catalogue shows in a listing.
+The block is split into three sub-blocks. ORE describes them as
+follows:
+
+#+begin_quote
+The block is comprised of three sub-blocks, which are BondData,
+TotalReturnData and FundingData.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=.
+
+** In plain terms
+
+A bond total return swap converts the return of a bond into a cash
+flow. One side pays the coupons and the price moves of the bond. The
+other side pays a funding rate on a notional. The bond owner keeps
+the bond but passes its economics to the other side.
+
+** How it works in ORE
+
+The =BondData= block specifies the underlying bond, usually by
+=SecurityId= and =BondNotional=, relying on reference data. One bond
+always corresponds to a face value of one unit of bond currency. The
+=SecurityId= is typically the ISIN with the =ISIN:= prefix.
+Convertible bonds are not supported as underlyings for =BondTRS=; the
+=TotalReturnSwap= trade type should be used for them. The optional
+=CreditRisk= flag decides whether credit risk shows on the product.
+The =TotalReturnData= block specifies the return leg. =Payer= decides
+whether the total return leg is paid. =InitialPrice= is optional and
+holds a contractually given bond price for the first date of the total
+return schedule, in percent. =PriceType= decides whether the payments
+are based on dirty or clean prices. =ObservationLag=,
+=ObservationConvention= and =ObservationCalendar= derive the valuation
+dates from the =ScheduleData= reference schedule. =PaymentLag=,
+=PaymentConvention= and =PaymentCalendar= derive the payment dates,
+which can also be given explicitly in a =PaymentDates= node.
+=FXTerms= is mandatory when the bond currency differs from the return
+currency, which is always assumed to equal the funding leg currency.
+This kind of trade is also known as a composite TRS. =FXIndex= names
+the FX index for the conversion. =ApplyFXIndexFixingDays= decides
+whether the FX fixing date moves back by the usual number of fixing
+days. =PayBondCashFlowsImmediately= decides whether bond cash flows
+are paid when they occur, or together with the next return payment.
+The =FundingData= block specifies the funding leg, which can be of any
+leg type. It contains exactly one =Leg=, and its currency defines the
+currency in which the return is paid. The funding notional can follow
+the return leg through =Indexings= with =FromAssetLeg= set to =true=;
+the notionals node is not required in that case.
+
+** Mathematical notes
+
+The total return leg pays the coupons, redemptions and amortisations
+of the bond plus the change in its clean value along the schedule. The
+funding leg pays a fixed or floating rate on the notional. The two
+legs net against each other on the payment dates. The return currency
+is the funding currency; a composite TRS converts the bond economics
+through an FX index when the currencies differ.
+
+** What moves its value (static sensitivities)
+
+- The price of the underlying bond.
+- The interest rates of the funding leg.
+- The FX rate between the bond currency and the funding currency.
+- The credit of the issuer, through the bond price and the recovery
+  payments.
+
+The swap passes the full economics of the bond to the receiver, so the
+bond price dominates the value. The funding leg offsets the carry.
+
+** How the profile ages (dynamic sensitivities)
+
+The return leg marks to the bond on each date of the schedule. The
+receiver gets the coupons and the price moves as they happen, or at
+the next payment date. The funding leg accrues against it. At each
+payment date the difference between the two legs settles, and the
+trade resets for the next period.
+
+** Why a customer would want it
+
+A bond total return swap gives the return of a bond without funding
+the purchase. It suits a customer who wants bond exposure with
+leverage, or who must warehouse bonds off balance sheet. In ORE Studio
+a customer books bond total return swaps to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a composite bond TRS: a New Zealand bond pays
+its return in USD against a floating USD funding leg:
+
+#+begin_example
+<BondTRSData>
+  <BondData>
+    <SecurityId>ISIN:NZIIBDT005C5</SecurityId>
+    <BondNotional>100000</BondNotional>
+  </BondData>
+  <TotalReturnData>
+    <Payer>false</Payer>
+    <InitialPrice>102.0</InitialPrice>
+    <PriceType>Clean</PriceType>
+    <ObservationLag>0D</ObservationLag>
+    <ObservationConvention>P</ObservationConvention>
+    <ObservationCalendar>USD</ObservationCalendar>
+    <PaymentLag>2D</PaymentLag>
+    <PaymentConvention>F</PaymentConvention>
+    <PaymentCalendar>TARGET</PaymentCalendar>
+    <!-- <PaymentDates> -->
+    <!--   <PaymentDate> ... </PaymentDate> -->
+    <!--   <PaymentDate> ... </PaymentDate> -->
+    <!-- </PaymentDates> -->
+    <FXTerms>
+      <FXIndex>FX-TR20H-NZD-USD</FXIndex>
+    </FXTerms>
+    <ScheduleData>
+    ...
+    </ScheduleData>
+    <PayBondCashFlowsImmediately>false</PayBondCashFlowsImmediately>
+  </TotalReturnData>
+  <FundingData>
+    <LegData>
+      <Payer>true</Payer>
+      <LegType>Floating</LegType>
+      <Currency>USD</Currency>
+      ...
+      <!-- Notionals node is not required, set to 1 internally -->
+      ...
+      <Indexings>
+      <!-- derive the indexing information (bond price, FX) from the total return leg -->
+      <FromAssetLeg>true</FromAssetLeg>
+      </Indexings>
+      ...
+    </LegData>
+  </FundingData>
+</BondTRSData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=,
+listing =Bond Total Return Swap Data with indexed funding leg=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/bondtotalreturnswap.org
+++ b/doc/knowledge/domain/bondtotalreturnswap.org
@@ -46,7 +46,7 @@ compensation payments that reflect changes of the clean bond value
 along the TRS schedule.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondTotalReturnSwap.tex][bondTotalReturnSwap.tex]].
 
 ORE describes the setup as follows:
 
@@ -60,7 +60,7 @@ The block is comprised of three sub-blocks, which are BondData,
 TotalReturnData and FundingData.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondTotalReturnSwap.tex][bondTotalReturnSwap.tex]].
 
 ** In plain terms
 
@@ -187,7 +187,7 @@ its return in USD against a floating USD funding leg:
 </BondTRSData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondTotalReturnSwap.tex][bondTotalReturnSwap.tex]],
 listing =Bond Total Return Swap Data with indexed funding leg=.
 
 * See also
@@ -197,6 +197,6 @@ listing =Bond Total Return Swap Data with indexed funding leg=.
 
 - [[https://en.wikipedia.org/wiki/Total_return_swap][Wikipedia: Total return swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/bondTotalReturnSwap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/bondTotalReturnSwap.tex][bondTotalReturnSwap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/callablebond.org
+++ b/doc/knowledge/domain/callablebond.org
@@ -1,0 +1,137 @@
+:PROPERTIES:
+:ID: 4E78B88B-432F-445D-9FEA-9DBE80718DBF
+:END:
+#+title: Callable Bond
+#+description: A bond with issuer call and investor put rights; ORE's CallableBond product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:callablebond:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A callable bond is a bond with issuer call and investor put rights.
+ORE models it with the trade type =CallableBond=. The container node
+is =CallableBondData=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A callable bond is a bond with issuer call and investor put rights.
+The call style is typically American, the put style Bermudan, but any
+combination of styles is supported. The trade names the bond from
+reference data. The reference data carries the vanilla bond terms
+plus the optional =CallData= and =PutData= schedules that describe the
+rights.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A callable bond is a bond with issuer call and / or investor put
+rights. Typically, the call style is American while the put is
+Bermudan, but we support any combination of styles.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callablebond.tex=.
+
+** In plain terms
+
+A callable bond carries extra rights on top of the vanilla bond. The
+issuer can call the bond back at set prices on set dates. The investor
+can put it back to the issuer. The rights make the bond cheaper for
+the issuer and compensate the investor with a higher coupon.
+
+** How it works in ORE
+
+The =CallableBondData= block names the bond and its quantity.
+=SecurityId= is typically the ISIN with the =ISIN:= prefix.
+=BondNotional= is the notional in the currency of the bond. The
+optional =CreditRisk= flag decides whether credit risk shows on the
+product. The bond terms of the trade are set up in reference data. The
+reference datum carries the =BondData= with the vanilla part of the
+bond, plus the optional =CallData= and =PutData= with the call and put
+terms. Without them there are no calls or puts. =Styles= holds the
+exercise styles, =American= or =Bermudan=. Bermudan also defines
+European exercises, namely as a Bermudan exercise with a single
+exercise date. =ScheduleData= holds a schedule of exercise dates for
+Bermudan exercises, or start and end dates for American exercises.
+=Prices= holds exercise prices in relative terms: a price of 1.02
+means the amount paid on exercise is 1.02 times the current notional
+of the bond, plus accrued interest when the price type is clean.
+=PriceType= gives the flavour of the exercise prices, =Clean= or
+=Dirty=. =IncludeAccrual= decides whether accruals have to be paid on
+exercise, independently of the quoting style. Lists in the sub-nodes
+can be explicit lists or use the =startDate= attribute. An explicit
+value list can be shorter than the list of dates; the last value then
+applies to the remaining dates.
+
+** Mathematical notes
+
+The callable bond splits into a vanilla bond and an embedded option
+position. The issuer call is a short option from the investor's view;
+the investor put is a long option. The exercise prices are quoted in
+relative terms and converted by the current notional. The value is the
+vanilla bond value adjusted for the call and put rights, with American
+and Bermudan exercise valued accordingly.
+
+** What moves its value (static sensitivities)
+
+- The yield curve, which prices the vanilla bond and the embedded
+  options.
+- The credit of the issuer.
+- The volatility of the yield curve; it raises the value of the
+  rights.
+- The exercise prices and the call and put schedules.
+
+The bond is a vanilla bond plus optionality, so rates, credit and
+volatility all move its value. The issuer credit affects both the
+bond floor and the probability of the call.
+
+** How the profile ages (dynamic sensitivities)
+
+The call and put rights run on their schedules. An American call can
+be exercised at any time in its window. Bermudan calls and puts can be
+exercised on their dates. As the bond approaches a call date, the
+issuer compares the call price with the market value. After the call
+periods pass, the bond ages as a vanilla bond to maturity.
+
+** Why a customer would want it
+
+Issuers sell callable bonds to lower their funding cost. Investors buy
+them for the higher coupon and the put protection. The structure is
+common in corporate and agency markets. In ORE Studio a customer books
+callable bonds to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a callable bond trade whose terms are set up in
+reference data:
+
+#+begin_example
+<Trade id="CallableBond">
+  <TradeType>CallableBond</TradeType>
+  <Envelope>...</Envelope>
+  <CallableBondData>
+    <BondData>
+      <SecurityId>ISIN:XS0123456789</SecurityId>
+      <BondNotional>1000000.00</BondNotional>
+    </BondData>
+  </CallableBondData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callablebond.tex=,
+listing =Callable bond set up using reference data=. The source
+describes a Bermudan issuer call on three dates at a clean price of
+100, 100, 102, with accruals paid on exercise, in its =CallData=
+example; the corresponding =Price= values are 1.00, 1.00 and 1.02.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Callable_bond][Wikipedia: Callable bond]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/callablebond.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/callablebond.org
+++ b/doc/knowledge/domain/callablebond.org
@@ -35,7 +35,7 @@ rights. Typically, the call style is American while the put is
 Bermudan, but we support any combination of styles.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callablebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callablebond.tex][callablebond.tex]].
 
 ** In plain terms
 
@@ -123,7 +123,7 @@ reference data:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callablebond.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callablebond.tex][callablebond.tex]],
 listing =Callable bond set up using reference data=. The source
 describes a Bermudan issuer call on three dates at a clean price of
 100, 100, 102, with accruals paid on exercise, in its =CallData=
@@ -135,6 +135,6 @@ example; the corresponding =Price= values are 1.00, 1.00 and 1.02.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Callable_bond][Wikipedia: Callable bond]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/callablebond.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callablebond.tex][callablebond.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/callablebond.org
+++ b/doc/knowledge/domain/callablebond.org
@@ -131,6 +131,9 @@ example; the corresponding =Price= values are 1.00, 1.00 and 1.02.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Callable_bond][Wikipedia: Callable bond]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/callablebond.tex=. The

--- a/doc/knowledge/domain/callableswap.org
+++ b/doc/knowledge/domain/callableswap.org
@@ -148,6 +148,9 @@ The embedded right is a physically settled swaption, see the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/callableswap.org
+++ b/doc/knowledge/domain/callableswap.org
@@ -1,0 +1,155 @@
+:PROPERTIES:
+:ID: 0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE
+:END:
+#+title: Callable Swap
+#+description: A swap one party can cancel on set dates; ORE's CallableSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:callableswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A callable swap lets one party terminate the swap on specific dates.
+The right is a physically settled swaption embedded in the swap. ORE
+models it with the trade type =CallableSwap=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A callable swap can be terminated by one of the parties on specific
+dates. The product decomposes into a swap and a physically settled
+swaption. The swaption represents the call right. The underlying swap
+must be fixed versus float. Its notional, rates, and spreads may vary
+during its lifetime.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Callable Swap can be terminated by one of the parties on specific
+dates and thus can be decomposed into a swap and a physically settled
+swaption, the latter representing the call right. The underlying swap
+must be fixed versus float and may have varying notional, rates, and
+spreads during its lifetime.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callableswap.tex=.
+
+The =CallableSwapData= node is the trade data container for the
+=CallableSwap= trade type. A callable swap is a swap that can be
+cancelled at predefined dates by one of the counterparties.
+
+** In plain terms
+
+A callable swap is a normal swap with a kill switch. One party holds
+the switch. That party can end the swap on the call dates. If the
+right is never used, the swap runs to maturity like any other. The
+party holding the right pays for it through the terms of the trade.
+
+** How it works in ORE
+
+A callable swap must have at least one leg. Multiple legs are
+allowed. The leg types can be =Floating=, =Fixed=, or =Cashflow=.
+Cross-currency underlyings are supported. The =OptionData= node
+describes the exercise dates. Its =LongShort= flag names the party
+holding the call right. The settlement must always be =Physical=.
+Leg directions follow the =Payer= flag, as for a swap, from the
+perspective of the party to the trade. This differs from a swaption,
+where leg directions follow the party that is long. If exercise
+triggers an exchange of notionals in a cross-currency callable swap,
+the exchange is captured as two exercise fees in the respective
+currencies. Unless =MidCouponExercise= is true, at least one full
+coupon period must follow the exercise date for a European callable
+swap. The same holds after the last exercise date for Bermudan and
+American callable swaps. An exercised callable swap is marked via the
+=ExerciseData= node within =OptionData=.
+
+** Mathematical notes
+
+A callable swap is a swap plus an embedded option. The option is a
+physically settled swaption on the remaining swap. The party holding
+the call right terminates when the swap has become unfavourable to
+receive. ORE values the callable swap with the same machinery as a
+swaption. The exercise dates drive the optionality. Between the
+dates, the swap legs accrue and pay as usual.
+
+** What moves its value (static sensitivities)
+
+- The swap rate levels that set the value of the fixed and floating
+  legs.
+- The volatility of the swap rates, through the embedded option.
+- The exercise dates and the notice conventions.
+- The discount curve.
+- The terms of the legs, including notional amortisation.
+
+The fixed payer benefits when rates fall and the swap runs. The party
+holding the call right benefits when terminating removes an
+unfavourable swap.
+
+** How the profile ages (dynamic sensitivities)
+
+The swap runs coupon by coupon between call dates. On each call date
+the holder decides to terminate or to continue. A date that passes
+without exercise consumes that right. After termination no further
+payments occur. If no call date is used, the swap runs to maturity
+and ages like a plain vanilla swap.
+
+** Why a customer would want it
+
+A customer that may want to exit a swap buys the right to do so. The
+right allows a refinancing when rates move in the customer's favour.
+A bank structures the product for customers with uncertain swap
+needs. In ORE Studio a customer books callable swaps to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a callable swap with a Bermudan call right on
+annual dates from 2031 to 2033:
+
+#+begin_example
+<CallableSwapData>
+    <OptionData>
+      <LongShort>Short</LongShort>
+      <Style>Bermudan</Style>
+      <Settlement>Physical</Settlement>
+      <MidCouponExercise>true</MidCouponExercise>
+      <ExerciseDates>
+        <ExerciseDate>2031-10-01</ExerciseDate>
+        <ExerciseDate>2032-10-01</ExerciseDate>
+        <ExerciseDate>2033-10-01</ExerciseDate>
+      </ExerciseDates>
+      ...
+    </OptionData>
+  <LegData>
+    <LegType>Fixed</LegType>
+    <Payer>false</Payer>
+    <Currency>USD</Currency>
+    ...
+  </LegData>
+  <LegData>
+    <LegType>Floating</LegType>
+    <Payer>true</Payer>
+    <Currency>USD</Currency>
+    ...
+  </LegData>
+</CallableSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callableswap.tex=,
+listing =Callable Swap data=. The source listing repeats the opening
+tag of =MidCouponExercise=; the closing tag is normalised here.
+
+The embedded right is a physically settled swaption, see the
+[[id:FCC37EB3-D654-4333-B110-3BF4AFA3A237][Swaption]] note.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/callableswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/callableswap.org
+++ b/doc/knowledge/domain/callableswap.org
@@ -36,7 +36,7 @@ must be fixed versus float and may have varying notional, rates, and
 spreads during its lifetime.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callableswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callableswap.tex][callableswap.tex]].
 
 The =CallableSwapData= node is the trade data container for the
 =CallableSwap= trade type. A callable swap is a swap that can be
@@ -139,7 +139,7 @@ annual dates from 2031 to 2033:
 </CallableSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/callableswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callableswap.tex][callableswap.tex]],
 listing =Callable Swap data=. The source listing repeats the opening
 tag of =MidCouponExercise=; the closing tag is normalised here.
 
@@ -153,6 +153,6 @@ The embedded right is a physically settled swaption, see the
 
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/callableswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/callableswap.tex][callableswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/capfloor.org
+++ b/doc/knowledge/domain/capfloor.org
@@ -157,6 +157,9 @@ listing =Cap/Floor data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_cap_and_floor][Wikipedia: Interest rate cap and floor]]. This note follows its
   general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/capfloor.org
+++ b/doc/knowledge/domain/capfloor.org
@@ -38,7 +38,7 @@ the cap or floor rate is the strike price, and each floating rate
 reset date is an option expiry date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/capfloor.tex][capfloor.tex]].
 
 ORE states the collar composition as follows:
 
@@ -47,7 +47,7 @@ A collar is the combination of a series of long caplets and short
 floorlets for a long position in the collar.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/capfloor.tex][capfloor.tex]].
 
 ORE also supports the standalone form:
 
@@ -56,7 +56,7 @@ Standalone caps and floors with a single payoff on an IBOR or CMS
 index are also supported.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/capfloor.tex][capfloor.tex]].
 
 ** In plain terms
 
@@ -152,7 +152,7 @@ cap rate and an upfront premium:
 </CapFloorData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/capfloor.tex][capfloor.tex]],
 listing =Cap/Floor data=.
 
 * See also
@@ -162,6 +162,6 @@ listing =Cap/Floor data=.
 
 - [[https://en.wikipedia.org/wiki/Interest_rate_cap_and_floor][Wikipedia: Interest rate cap and floor]]. This note follows its
   general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/capfloor.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/capfloor.tex][capfloor.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/capfloor.org
+++ b/doc/knowledge/domain/capfloor.org
@@ -1,0 +1,164 @@
+:PROPERTIES:
+:ID: 3DCC5F43-9728-4E67-8720-AE307E780CBF
+:END:
+#+title: Cap/Floor
+#+description: A strip of interest rate caplets or floorlets bounding a floating leg; ORE's CapFloor product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:capfloor:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A cap, floor, or collar bounds the floating coupons of an interest
+rate leg. The product is a series of European options on the rate
+fixings. ORE models it with the trade type =CapFloor=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A single floating swap leg benchmarked to IBOR or CMS indices may
+carry a cap, a floor, or a collar. The cap or floor rate is the
+strike. Each floating rate reset date is an option expiry date. The
+result is a series of European caplets or floorlets. A collar is the
+combination of a long cap and a short floor for a long position.
+Standalone caps and floors with a single payoff are also supported.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A single floating swap leg with interest payments benchmarked to IBOR
+or CMS indices, may have a cap, floor, or collar. This creates a
+series of European interest rate options (caplets or floorlets) where
+the cap or floor rate is the strike price, and each floating rate
+reset date is an option expiry date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+
+ORE states the collar composition as follows:
+
+#+begin_quote
+A collar is the combination of a series of long caplets and short
+floorlets for a long position in the collar.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+
+ORE also supports the standalone form:
+
+#+begin_quote
+Standalone caps and floors with a single payoff on an IBOR or CMS
+index are also supported.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=.
+
+** In plain terms
+
+A floating coupon pays whatever the index fixes. A cap sets a ceiling
+on that payment. A floor sets a floor beneath it. A collar does both.
+The option buyer pays a premium. If the fixing is above the cap rate,
+the caplet pays the difference. If the fixing is below the floor
+rate, the floorlet pays the difference.
+
+** How it works in ORE
+
+The =CapFloorData= node is the trade data container for the
+=CapFloor= trade type. It carries a =LongShort= sub-node for the
+position. One =LegData= sub-node sets the leg type. The type can be
+=Floating= for IBOR and OIS indices, =CMS=, =CMSSpread=,
+=DurationAdjustedCMS=, =CPI=, or =YY=. The =Caps= or =Floors=
+elements, or both, sit outside the leg node. With both, the
+instrument is a collar and =Caps= must come above =Floors=. ORE notes
+that the =Payer= flag is ignored for this instrument. The optional
+=PaymentDates= node in the leg serves only OIS and IBOR indices.
+
+** Mathematical notes
+
+ORE states the caplet payoff on an IBOR floating leg coupon period as
+follows:
+
+Caplet payoff = N x max(0, L - K) x δ
+
+N is the notional. L is the IBOR index fixing for the period. K is
+the cap rate, the strike. δ is the day-count fraction for the coupon
+period. The floorlet payoff is the mirror image:
+
+Floorlet payoff = N x max(0, K - L) x δ
+
+For a caplet or floorlet on a CMS index, L is replaced by the CMS
+rate of the relevant tenor. The standalone form pays:
+
+Payoff = N x max(0, ω x (L - K))
+
+ω is 1 for a cap and -1 for a floor.
+
+** What moves its value (static sensitivities)
+
+- The level of the reference index against the strike.
+- The cap or floor rate itself.
+- The volatility of the index fixings.
+- The reset frequency and the day-count convention.
+- The discount curve.
+
+The cap pays when the fixing exceeds the strike. The floor pays when
+the fixing falls below it. Near the strike, each caplet or floorlet
+shows its strongest gamma and vega.
+
+** How the profile ages (dynamic sensitivities)
+
+Caplets and floorlets settle one per period. Each reset date is the
+expiry date of that period's option. Once a fixing settles, that
+option is decided and gone. The remaining value is the strip of
+options not yet decided. As each period passes, the number of live
+options falls by one.
+
+** Why a customer would want it
+
+A borrower with floating debt buys a cap to bound the funding cost.
+An investor holding floating notes buys a floor to protect income. A
+collar sells one side to pay for the other. In ORE Studio a customer
+books caps and floors to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a long cap on a floating leg with a 5 percent
+cap rate and an upfront premium:
+
+#+begin_example
+<CapFloorData>
+  <LongShort>Long</LongShort>
+  <LegData>
+    <Payer>false</Payer>
+    <LegType>Floating</LegType>
+     ...
+  </LegData>
+  <Caps>
+    <Cap>0.05</Cap>
+  </Caps>
+  <Premiums>
+    <Premium>
+      <Amount>1000</Amount>
+      <Currency>EUR</Currency>
+      <PayDate>2021-01-27</PayDate>
+    </Premium>
+  </Premiums>
+</CapFloorData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/capfloor.tex=,
+listing =Cap/Floor data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_cap_and_floor][Wikipedia: Interest rate cap and floor]]. This note follows its
+  general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/capfloor.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cashposition.org
+++ b/doc/knowledge/domain/cashposition.org
@@ -101,6 +101,9 @@ listing =Cash Position data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/cashposition.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cashposition.org
+++ b/doc/knowledge/domain/cashposition.org
@@ -1,0 +1,106 @@
+:PROPERTIES:
+:ID: 940CB31A-BD50-45D6-98AC-4B0D53973825
+:END:
+#+title: Cash Position
+#+description: An amount of cash in a currency; ORE's CashPosition product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:cashposition:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A cash position holds an amount of cash in a currency. ORE models it
+with the trade type =CashPosition=. The container node is
+=CashPositionData=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A cash position is the trade representation of an amount of cash in a
+currency. It can be a stand-alone trade type or a trade component
+inside a total return swap. The node carries two elements: the
+=Currency= and the =Amount=.
+
+* Detail
+
+** What it is
+
+ORE defines the trade node as follows:
+
+#+begin_quote
+The CashPositionData node is the trade data container for the
+CashPosition trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=.
+
+ORE describes the dual role as follows:
+
+#+begin_quote
+A cash position can be used both as a stand alone trade type
+(TradeType: CashPosition) or as a trade component within the
+TotalReturnSwap (Generic TRS) trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=.
+
+** In plain terms
+
+A cash position is the smallest trade there is: a currency and an
+amount. It books the cash side of a transaction. The amount can be
+positive or negative, so it also books a debt.
+
+** How it works in ORE
+
+The =CashPositionData= node is the trade data container for the
+=CashPosition= trade type. =Currency= is the currency of the cash
+position. =Amount= is the amount of the cash position and can be any
+real number. A negative amount represents a cash debt.
+
+** Mathematical notes
+
+The value of a cash position is its amount in its currency. There is
+no payoff formula and no schedule. The position carries no market
+risk factors of its own.
+
+** What moves its value (static sensitivities)
+
+- The amount itself.
+- Nothing else: cash in its own currency has no market risk factors.
+
+When the position must be valued in another currency, the FX rate into
+that currency applies.
+
+** How the profile ages (dynamic sensitivities)
+
+A cash position has no schedule and no maturity. Its value does not
+change with time. It is the fixed reference against which the other
+legs of a structure are measured.
+
+** Why a customer would want it
+
+A cash position books the funding or return side of a trade. As a
+stand-alone trade it records a cash balance. As a component of a total
+return swap it represents the cash leg against the asset leg. In ORE
+Studio a customer books cash positions to complete the cash flows of a
+structure.
+
+** Example
+
+ORE's catalogue shows one million euro of cash:
+
+#+begin_example
+<CashPositionData>
+    <Currency>EUR</Currency>
+    <Amount>1000000</Amount>
+</CashPositionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=,
+listing =Cash Position data=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/cashposition.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cashposition.org
+++ b/doc/knowledge/domain/cashposition.org
@@ -32,7 +32,7 @@ The CashPositionData node is the trade data container for the
 CashPosition trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cashposition.tex][cashposition.tex]].
 
 ORE describes the dual role as follows:
 
@@ -42,7 +42,7 @@ A cash position can be used both as a stand alone trade type
 TotalReturnSwap (Generic TRS) trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cashposition.tex][cashposition.tex]].
 
 ** In plain terms
 
@@ -96,7 +96,7 @@ ORE's catalogue shows one million euro of cash:
 </CashPositionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cashposition.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cashposition.tex][cashposition.tex]],
 listing =Cash Position data=.
 
 * See also
@@ -104,6 +104,6 @@ listing =Cash Position data=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/cashposition.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cashposition.tex][cashposition.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cbodata.org
+++ b/doc/knowledge/domain/cbodata.org
@@ -39,7 +39,7 @@ and do need not coincide. We assume that hazard rate data is available
 and provided externally.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 ORE describes the cashflow structure as follows:
 
@@ -49,7 +49,7 @@ Interest and Notional repayments are directed in an order of priority
 first to the note holder.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 ORE describes the role of the equity piece as follows:
 
@@ -58,7 +58,7 @@ Class N notes or equity receive the excess pool coupon available
 after other items in the interest waterfall are discharged.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 ** In plain terms
 
@@ -80,7 +80,7 @@ in a static CBO reference datum or a long version, where the CBO
 structure is specified explicitly.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 The main building block is the =CBOData= node. It requires two
 components: =CBOInvestment= and =CBOStructure=. In the short version
@@ -119,7 +119,7 @@ EquityKicker: Fraction x of the residual payment, that will be split
 among the senior fee receiver (x) and the equity piece (1-x).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 The fees themselves follow the same pattern. ORE describes them as
 follows:
@@ -129,13 +129,13 @@ The fee, expressed as rate, paid before all other obligations, top of
 the waterfall.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 #+begin_quote
 The fee, expressed as rate, paid after all other obligations.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 ** Mathematical notes
 
@@ -168,7 +168,7 @@ Notional repayments after expenses go to redemption of the senior
 notes and finally to the equity note holder.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 The pool of the deal behaves differently inside and outside the
 reinvestment period. ORE notes a model limit as follows:
@@ -178,7 +178,7 @@ Currently the model cannot handle underlying bonds with full
 amortisation within the reinvestment period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]].
 
 ** What moves its value (static sensitivities)
 
@@ -250,7 +250,7 @@ percent and an equity kicker of 0.25:
 </CBOData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]],
 listing =CBO Data=. The source elides the contents of the three
 sub-nodes with dots; they are reproduced verbatim.
 
@@ -261,6 +261,6 @@ sub-nodes with dots; they are reproduced verbatim.
 
 - [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows its
   general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/cbodata.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cbodata.tex][cbodata.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cbodata.org
+++ b/doc/knowledge/domain/cbodata.org
@@ -1,0 +1,263 @@
+:PROPERTIES:
+:ID: F8341BB7-33FE-4441-8C2D-56B8DDDCA91C
+:END:
+#+title: Collateral Bond Obligation
+#+description: A tranched securitisation of a portfolio of corporate bonds or loans; ORE's CBO product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:cbodata:
+#+created: 2026-09-06
+#+updated: 2026-09-07
+
+A collateral bond obligation is a tranched securitisation of a
+portfolio of corporate bonds or loans. ORE models it with the trade
+type =CBO=. The container node is =CBOData=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A collateral bond obligation, also called a cashflow CDO, is a
+structured deal backed by a portfolio of corporate bonds or loans.
+The portfolio pays its coupons and capital into a waterfall. The
+waterfall pays the notes of the deal in an order of priority. Senior
+notes are paid first; the equity note receives what is left. The deal
+can be set up in a short version, referencing the structure in a
+static reference datum, or in a long version, where the structure is
+given explicitly.
+
+* Detail
+
+** What it is
+
+ORE describes the underlying portfolio as follows:
+
+#+begin_quote
+The underlying assets consist of a portfolio of corporate bonds or
+loans with either amortising or bullet structures. The portfolio can
+contain fixed or floating rate obligations. Maturities cover a range
+and do need not coincide. We assume that hazard rate data is available
+and provided externally.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+ORE describes the cashflow structure as follows:
+
+#+begin_quote
+The deal is assumed to be structured as a cashflow securitisation.
+Interest and Notional repayments are directed in an order of priority
+first to the note holder.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+ORE describes the role of the equity piece as follows:
+
+#+begin_quote
+Class N notes or equity receive the excess pool coupon available
+after other items in the interest waterfall are discharged.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+** In plain terms
+
+A CBO repackages a pool of corporate bonds into notes with different
+risk. The pool pays its coupons and its capital into a waterfall. The
+waterfall pays the notes in a fixed order of priority. Senior notes
+are paid first. The equity note gets what is left after every other
+item is discharged. Early losses fall on the equity and the junior
+notes first.
+
+** How it works in ORE
+
+ORE defines the two setup forms as follows:
+
+#+begin_quote
+A Cashflow CDO or Collateral Bond Obligation CBO (trade type CBO) can
+be set up in a short version referencing the underlying CBO structure
+in a static CBO reference datum or a long version, where the CBO
+structure is specified explicitly.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+The main building block is the =CBOData= node. It requires two
+components: =CBOInvestment= and =CBOStructure=. In the short version
+the =CBOInvestment= component alone specifies the deal; the
+=CBOStructure= component can be omitted.
+
+The =CBOInvestment= component carries three elements. =TrancheName=
+names the tranche whose results are shown in the report files; the
+name must match one of the names in =CBOTranches=. =Notional= is the
+amount invested in that tranche; it scales the NPV of the generic
+tranche. =StructureId= is the key used when the structure is read
+from reference data.
+
+The =CBOStructure= component carries the general structure. Its
+elements follow:
+
+- =DayCounter= and =PaymentConvention= apply to the tranches.
+- =Currency= defines the currency of the trade.
+- =ReinvestmentEndDate= ends the reinvestment period.
+- =SeniorFee= is a rate paid before all other obligations, at the top
+  of the waterfall.
+- =FeeDayCounter= is the day count convention for the fees.
+- =SubordinatedFee= is a rate paid after all other obligations.
+- =EquityKicker= splits the residual between the senior fee receiver
+  and the equity piece.
+- =BondBasketData= holds the specifications of the underlying bond
+  basket.
+- =CBOTranches= holds the instrument data for the tranches of the
+  deal.
+- =ScheduleData= holds the schedule of the trade.
+
+ORE defines the equity kicker as follows:
+
+#+begin_quote
+EquityKicker: Fraction x of the residual payment, that will be split
+among the senior fee receiver (x) and the equity piece (1-x).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+The fees themselves follow the same pattern. ORE describes them as
+follows:
+
+#+begin_quote
+The fee, expressed as rate, paid before all other obligations, top of
+the waterfall.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+#+begin_quote
+The fee, expressed as rate, paid after all other obligations.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+** Mathematical notes
+
+The deal has =n= tranches, one for each note. Each tranche is defined
+by an attachment point and a detachment point. The tranches absorb the
+losses of the pool in order of seniority, from the equity note up to
+the senior note.
+
+The waterfall is the pricing core of the deal. The interest waterfall
+pays taxes, trustee and administration fees up to their caps, hedge
+payments, the liquidity facility and the servicing fees. It then pays
+the note coupons in seniority order. Senior notes are redeemed early
+when the over-collateralisation or interest coverage tests fail.
+Interest flows down the deflection tests to the subordinated items,
+then to the equity note up to an IRR hurdle. A management incentive
+fee is paid before the final excess reaches the equity note.
+
+The principal waterfall works on capital. It first pays the unpaid
+interest items, then redeems the notes in seniority order. During the
+reinvestment period it buys additional securities instead of
+redeeming notes.
+
+ORE summarises the two waterfalls as follows:
+
+#+begin_quote
+In summary, Interest after tax and expenses goes first to the Senior
+note holders and then on down the order of priority and finally to
+the equity noteholder after ensuring that any tests are satisfied.
+Notional repayments after expenses go to redemption of the senior
+notes and finally to the equity note holder.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+The pool of the deal behaves differently inside and outside the
+reinvestment period. ORE notes a model limit as follows:
+
+#+begin_quote
+Currently the model cannot handle underlying bonds with full
+amortisation within the reinvestment period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=.
+
+** What moves its value (static sensitivities)
+
+- The credit of the pool issuers. The hazard rates come from outside
+  the trade; defaults and recoveries feed the waterfalls.
+- The level of interest rates, for floating rate coupons and for
+  discounting.
+- The value of the underlying bonds, through their coupons and
+  redemptions.
+- The structure of the deal: the fees, the equity kicker and the
+  over-collateralisation and interest coverage tests.
+- The seniority of the tranche the trade holds.
+
+The value of a booked tranche is its share of the waterfall. The
+senior notes feel the pool only when the losses reach their
+attachment point. The equity note feels every loss first.
+
+** How the profile ages (dynamic sensitivities)
+
+The pool pays its coupons and amortisations into the waterfall on the
+payment dates. Until the reinvestment end date, principal proceeds
+buy more assets instead of redeeming notes. After that date the
+proceeds redeem the notes in seniority order. Failed coverage tests
+can force senior redemptions at any time. As the pool ages and
+defaults, the remaining value flows down the order of priority to the
+equity note last.
+
+** Why a customer would want it
+
+A CBO turns a credit portfolio into tradeable notes of different
+seniority. A customer buys senior notes for low-risk yield, or equity
+notes for leveraged credit exposure. An originator uses the structure
+to fund a portfolio off balance sheet. In ORE Studio a customer books
+CBOs to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long-version CBO on a EUR structure. The
+trade invests 4 million in a junior note of the =Constellation=
+structure, with a senior fee of 1 percent, a subordinated fee of 2
+percent and an equity kicker of 0.25:
+
+#+begin_example
+<CBOData>
+  <CBOInvestment>
+    <TrancheName>JuniorNote</TrancheName>
+    <Notional>4000000.00</Notional>
+    <StructureId>Constellation</StructureId>
+  </CBOInvestment>
+  <CBOStructure>
+    <DayCounter>ACT/ACT</DayCounter>
+    <PaymentConvention>F</PaymentConvention>
+    <Currency>EUR</Currency>
+    <ReinvestmentEndDate>2019-12-31</ReinvestmentEndDate>
+    <SeniorFee>0.01</SeniorFee>
+    <FeeDayCounter>A365</FeeDayCounter>
+    <SubordinatedFee>0.02</SubordinatedFee>
+    <EquityKicker>0.25</EquityKicker>
+    <BondBasketData>
+      ...
+    </BondBasketData>
+    <CBOTranches>
+      ...
+    </CBOTranches>
+    <ScheduleData>
+      ...
+    </ScheduleData>
+  </CBOStructure>
+</CBOData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cbodata.tex=,
+listing =CBO Data=. The source elides the contents of the three
+sub-nodes with dots; they are reproduced verbatim.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows its
+  general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/cbodata.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cbodata.org
+++ b/doc/knowledge/domain/cbodata.org
@@ -256,6 +256,9 @@ sub-nodes with dots; they are reproduced verbatim.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows its
   general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityapo.org
+++ b/doc/knowledge/domain/commodityapo.org
@@ -1,0 +1,150 @@
+:PROPERTIES:
+:ID: D16393FC-784B-4BCB-90B9-7010894CD2D2
+:END:
+#+title: Commodity Average Price Option
+#+description: An Asian option on daily commodity price fixings; ORE's CommodityAveragePriceOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityapo:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity average price option is the Asian option of the commodity
+family. Its payoff depends on the average of daily fixings, not on one
+price. ORE models it with the trade type =CommodityAveragePriceOption=.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+The commodity APO is an Asian option. Its underlying is a single-period
+commodity swap that observes daily price fixings. A call receives the
+floating average and pays the fixed strike. A put pays the floating
+average and receives the fixed strike. Exercise happens at the end of
+the calculation period. A barrier, if present, conditions the payoff.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+The (Arithmetic) Average Price Option (APO) is an Asian option with a
+single-period Commodity Swap as an underlying which observes daily
+price fixings in the calculation period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityapo.tex=.
+
+** In plain terms
+
+A commodity APO is a bet on an average. The daily commodity prices over
+a period decide the payoff. One side pays a fixed price. The other side
+pays what the average turns out to be. The average smooths the swings
+of a single day.
+
+** How it works in ORE
+
+The =CommodityAveragePriceOptionData= node carries =OptionData=, an
+optional =BarrierData=, the commodity =Name=, the =StrikeData=, the
+=Quantity=, and the period dates. Exercise happens at the calculation
+period end, typically on the last floating price fixing date. This
+contrasts with the [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]], whose expiry comes before
+the underlying swap starts. In a call option, the owner has the right
+to receive average floating prices and to pay fixed prices. In a put
+option it is the other way around. APOs can occur in combinations,
+such as series of puts and calls at different strikes, and over a
+series of consecutive calculation periods.
+
+** Mathematical notes
+
+The floating average is the arithmetic mean of the daily fixings over
+the period. The call payoff is the difference between that average and
+the strike, when positive. The average reduces the volatility of the
+payoff relative to a single-fixing option. The value prices off the
+commodity forward curve at each observation date and the volatility of
+the average.
+
+** What moves its value (static sensitivities)
+
+- The commodity forward curve at each observation date. It drives the
+  expected average.
+- The volatility of the daily fixings. It sets the value of the
+  average optionality.
+- The strike and the quantity.
+- The barrier level and style, when present.
+- The discount curve of the settlement currency.
+
+A call gains when the average rises above the strike. A put gains when
+the average falls below it.
+
+** How the profile ages (dynamic sensitivities)
+
+Each daily fixing turns part of the average from unknown to known. The
+remaining fixings keep their market exposure. The averaging window
+closes as the period end approaches. At the last fixing date the
+average is known and the option settles. After settlement the trade
+stops.
+
+** Why a customer would want it
+
+A consumer who buys commodities month by month wants protection on the
+period average, not on one date. An airline, a refiner, or a utility
+has exactly this exposure. The average makes the hedge cheaper than a
+series of single-date options. In ORE Studio a customer books commodity
+APOs to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a short call with an up-and-in barrier:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>CommodityAveragePriceOption</TradeType>
+  <Envelope>
+    ...
+  </Envelope>
+  <CommodityAveragePriceOptionData>
+    <OptionData>
+      <LongShort>Short</LongShort>
+      <OptionType>Call</OptionType>
+      <Style>European</Style>
+      <ExerciseDates>
+        <ExerciseDate>2020-01-31</ExerciseDate>
+      </ExerciseDates>
+    </OptionData>
+    <BarrierData>
+      <Type>UpAndIn</Type>
+      <Style>American</Style>
+      <LevelData>
+        <Level>
+          <Value>80</Value>
+        </Level>
+      </LevelData>
+    </BarrierData>
+    <Name>NYMEX:CL</Name>
+    <Currency>USD</Currency>
+    <Quantity>6000</Quantity>
+    <StrikeData>
+      <StrikePrice>
+        <Value>80</Value>
+        <Currency>USD</Currency>
+      </StrikePrice>
+    </StrikeData>
+    <PriceType>FutureSettlement</PriceType>
+    <StartDate>2022-01-01</StartDate>
+    <EndDate>2023-01-31</EndDate>
+  </CommodityAveragePriceOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityapo.tex=,
+listing =Commodity Average Price Option= (optional elements omitted).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityapo.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityapo.org
+++ b/doc/knowledge/domain/commodityapo.org
@@ -35,7 +35,7 @@ single-period Commodity Swap as an underlying which observes daily
 price fixings in the calculation period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityapo.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityapo.tex][commodityapo.tex]].
 
 ** In plain terms
 
@@ -139,7 +139,7 @@ ORE's catalogue shows a short call with an up-and-in barrier:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityapo.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityapo.tex][commodityapo.tex]],
 listing =Commodity Average Price Option= (optional elements omitted).
 
 * See also
@@ -148,6 +148,6 @@ listing =Commodity Average Price Option= (optional elements omitted).
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityapo.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityapo.tex][commodityapo.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityapo.org
+++ b/doc/knowledge/domain/commodityapo.org
@@ -144,6 +144,9 @@ listing =Commodity Average Price Option= (optional elements omitted).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/commodityapo.tex=. The

--- a/doc/knowledge/domain/commodityforward.org
+++ b/doc/knowledge/domain/commodityforward.org
@@ -37,7 +37,7 @@ predetermined price (the strike), at the end of the contract. A
 commodity forward does not involve any upfront payment.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityforward.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityforward.tex][commodityforward.tex]].
 
 ** In plain terms
 
@@ -111,7 +111,7 @@ future:
 </CommodityForwardData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityforward.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityforward.tex][commodityforward.tex]],
 listing =CommodityForwardData= for a forward on the LME Aluminium 3M
 future (optional elements omitted).
 
@@ -125,6 +125,6 @@ The family siblings are the [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity
 
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityforward.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityforward.tex][commodityforward.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityforward.org
+++ b/doc/knowledge/domain/commodityforward.org
@@ -1,0 +1,127 @@
+:PROPERTIES:
+:ID: 992F5349-6D73-4780-855C-532B63073191
+:END:
+#+title: Commodity Forward
+#+description: An agreement to buy or sell a commodity at a set price later; ORE's CommodityForward product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityforward:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity forward is the linear building block of commodity
+derivatives. Two parties fix today the price of a future commodity
+exchange. ORE models it with the trade type =CommodityForward=. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A commodity forward is an agreement to buy or sell a set amount of a
+commodity at a predetermined price on a future date. No money changes
+hands at trade time. The trade data names the position, the maturity,
+the commodity, the strike, and the quantity. A forward can reference a
+commodity price or a commodity future. Settlement can be physical. The
+value moves with the commodity forward curve.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Commodity Forward contract is an agreement between two
+counterparties to buy/sell a set amount of a commodity, at a
+predetermined price (the strike), at the end of the contract. A
+commodity forward does not involve any upfront payment.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityforward.tex=.
+
+** In plain terms
+
+A commodity forward is a handshake on a future price. A producer and a
+buyer agree today on the price of a commodity for a later delivery.
+Neither side pays now. At maturity they exchange the commodity and the
+agreed price.
+
+** How it works in ORE
+
+The =CommodityForwardData= node is the trade data container. It names
+the =Position=, long or short, and the =Maturity=. The =Name= selects
+the commodity, such as =NYMEX:CL= for crude oil. The =Strike= and
+=Quantity= set the deal. The =IsFuturePrice= flag says whether the
+reference price is a future price. A forward on a future names the
+future contract and its expiry. =PhysicallySettled= selects physical
+delivery over cash settlement.
+
+** Mathematical notes
+
+A long forward gains when the commodity price rises above the strike.
+The value is the present value of the difference between the forward
+price and the strike, times the quantity. A forward priced on a future
+tracks the future contract, with its own expiry and roll. The trade is
+linear, with no optionality.
+
+** What moves its value (static sensitivities)
+
+- The commodity forward curve at the maturity point. It is the
+  dominant driver.
+- The reference future, when used. Its expiry and settlement drive the
+  price.
+- The discount rate of the trade currency.
+- The strike and the quantity. They scale the exposure.
+- The FX rate, when the commodity currency differs from the trade
+  currency.
+
+A long position gains when the commodity strengthens. A short gains
+when it weakens.
+
+** How the profile ages (dynamic sensitivities)
+
+Between trade date and maturity the value moves with the commodity
+market. The exposure narrows to the remaining time. Near maturity the
+price converges to the settlement price. At maturity the trade settles
+in cash or in the commodity and stops.
+
+** Why a customer would want it
+
+A producer locks the price of a future harvest or output. A consumer
+locks the cost of a future input. A trader takes a view on the
+commodity without storing it. In ORE Studio a customer books commodity
+forwards to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a forward on the LME aluminium three-month
+future:
+
+#+begin_example
+<CommodityForwardData>
+  <Position>Long</Position>
+  <Maturity>2029-08-16</Maturity>
+  <Name>XLME:AH</Name>
+  <Currency>USD</Currency>
+  <Strike>2160</Strike>
+  <Quantity>1000</Quantity>
+  <IsFuturePrice>true</IsFuturePrice>
+  <FutureExpiryDate>2021-11-16</FutureExpiryDate>
+  <PhysicallySettled>true</PhysicallySettled>
+</CommodityForwardData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityforward.tex=,
+listing =CommodityForwardData= for a forward on the LME Aluminium 3M
+future (optional elements omitted).
+
+The family siblings are the [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]] and the
+[[id:EC6DB3A0-4B34-4CD2-A3B7-ED004F3FA1B8][Commodity Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityforward.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityforward.org
+++ b/doc/knowledge/domain/commodityforward.org
@@ -120,6 +120,9 @@ The family siblings are the [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityoption.org
+++ b/doc/knowledge/domain/commodityoption.org
@@ -127,6 +127,9 @@ listing =Commodity Option data= (closing tags normalised).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityoption.org
+++ b/doc/knowledge/domain/commodityoption.org
@@ -1,0 +1,134 @@
+:PROPERTIES:
+:ID: EC6DB3A0-4B34-4CD2-A3B7-ED004F3FA1B8
+:END:
+#+title: Commodity Option
+#+description: A European or American option on a commodity; ORE's CommodityOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity option is the vanilla option of the commodity family. The
+buyer gains the right to trade a commodity at a set price. ORE models
+it with the trade type =CommodityOption=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A commodity option gives the buyer the right, not the obligation, to
+buy or sell a set amount of a commodity at a predetermined price at
+the end of the contract. The buyer pays a premium for this right. The
+exercise style can be European or American. Settlement is cash or
+physical delivery. The trade data carries one =OptionData= node plus
+commodity-specific elements.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A European Commodity Option gives the buyer the right, but not the
+obligation, to buy a set amount of a commodity, at a predetermined
+price (the strike), at the end of the contract. For this right the
+buyer pays a premium to the seller.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoption.tex=.
+
+ORE states that vanilla commodity options are supported. The exercise
+style may be European or American. Settlement can be cash or physical
+delivery.
+
+** In plain terms
+
+A commodity option is a ticket to a future price. The buyer pays a
+premium today. If the commodity moves in the buyer's favour, the
+option is used. If not, it expires and only the premium is lost.
+
+** How it works in ORE
+
+The =CommodityOptionData= node includes exactly one =OptionData= node
+and the commodity-specific elements. The =OptionData= names the
+direction, the option type, the exercise style, the settlement, and
+the exercise dates. The =Name= selects the commodity, such as
+=NYMEX:CL= for crude oil. The =StrikeData= and =Quantity= set the
+deal. The option can reference a future price with its own expiry.
+
+** Mathematical notes
+
+A call gains when the commodity price at expiry exceeds the strike. A
+put gains when it falls below. The value prices off the commodity
+forward curve and the volatility surface. An American option adds the
+value of early exercise. The trade is the classic optionality of the
+family, in the [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]]'s terms.
+
+** What moves its value (static sensitivities)
+
+- The commodity forward curve at the expiry point. It sets the
+  moneyness.
+- The commodity volatility surface. It drives the time value.
+- The strike and the quantity.
+- The discount curve of the settlement currency.
+- The exercise style and the settlement mode.
+
+A call gains when the commodity strengthens. A put gains when it
+weakens. Volatility raises the value of both.
+
+** How the profile ages (dynamic sensitivities)
+
+The option loses time value as expiry approaches. The moneyness
+decides its fate at the end. An American option can be exercised early
+when that pays. At expiry a European option settles or expires. After
+settlement the trade stops.
+
+** Why a customer would want it
+
+A consumer buys calls to cap purchase prices. A producer buys puts to
+floor sales prices. Both keep the upside of the market. A dealer
+quotes options to earn premium. In ORE Studio a customer books
+commodity options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a short European put on crude oil:
+
+#+begin_example
+<CommodityOptionData>
+  <OptionData>
+    <LongShort>Short</LongShort>
+    <OptionType>Put</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <PayOffAtExpiry>false</PayOffAtExpiry>
+    <ExerciseDates>
+      <ExerciseDate>2029-04-28</ExerciseDate>
+    </ExerciseDates>
+  </OptionData>
+  <Name>NYMEX:CL</Name>
+  <Currency>USD</Currency>
+  <StrikeData>
+    <StrikePrice>
+      <Value>100</Value>
+      <Currency>USD</Currency>
+    </StrikePrice>
+  </StrikeData>
+  <Quantity>500000</Quantity>
+  <IsFuturePrice>true</IsFuturePrice>
+  <FutureExpiryDate>2029-04-28</FutureExpiryDate>
+</CommodityOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoption.tex=,
+listing =Commodity Option data= (closing tags normalised).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityoption.org
+++ b/doc/knowledge/domain/commodityoption.org
@@ -36,7 +36,7 @@ price (the strike), at the end of the contract. For this right the
 buyer pays a premium to the seller.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityoption.tex][commodityoption.tex]].
 
 ORE states that vanilla commodity options are supported. The exercise
 style may be European or American. Settlement can be cash or physical
@@ -122,7 +122,7 @@ ORE's catalogue shows a short European put on crude oil:
 </CommodityOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityoption.tex][commodityoption.tex]],
 listing =Commodity Option data= (closing tags normalised).
 
 * See also
@@ -132,6 +132,6 @@ listing =Commodity Option data= (closing tags normalised).
 
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityoption.tex][commodityoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityoptionstrip.org
+++ b/doc/knowledge/domain/commodityoptionstrip.org
@@ -1,0 +1,161 @@
+:PROPERTIES:
+:ID: 48305B53-26C5-474D-8AA2-0DC425F96E3B
+:END:
+#+title: Commodity Option Strip
+#+description: A strip of commodity APOs or European options over periods; ORE's CommodityOptionStrip product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityoptionstrip:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity option strip is a series of commodity options over the
+calculation periods of a swap. ORE models it with the trade type
+=CommodityOptionStrip=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A commodity option strip is a series of options, one per calculation
+period. Each period's option is an APO or a European commodity option,
+set by =IsAveraged=. The strip names its calls and puts separately,
+with strikes, barriers, premiums, style, settlement, and digital
+flags. The product covers averaging and non-averaging variants in one
+structure.
+
+* Detail
+
+** What it is
+
+ORE groups both forms under one node. The node can represent a strip
+of commodity average price options, or a strip of European commodity
+options, one per calculation period. The trade type
+=CommodityOptionStrip= selects the form.
+
+** In plain terms
+
+A commodity option strip is a strip of tickets, one for each period of
+a swap. Each ticket is an option on that period's commodity price. The
+buyer can hedge a stream of purchases, period by period, with a strip
+of options instead of one contract.
+
+** How it works in ORE
+
+The =CommodityOptionStripData= node starts with a =LegData= node of
+type =CommodityFloating=. It names the commodity and the calculation
+periods. The =IsAveraged= flag in its =CommodityFloatingLegData=
+chooses the option type. With =IsAveraged= false, a strip of European
+commodity options is created, one put or call per calculation period.
+The exercise date is the pricing date of the period. With =IsAveraged=
+true, a strip of commodity average price options is created. The
+exercise date is the period end date.
+
+Each calculation period may contain a put and a call, bought or sold.
+The =Calls= and =Puts= nodes set the type, the direction, and the
+strike. Inside =Calls= sit =LongShorts=, =Strikes=, and an optional
+=BarrierData=. =Puts= mirrors it. =LongShorts= and =Strikes= hold one
+entry, shared by all periods, or one entry per period. If =Calls= is
+omitted, the strip has no calls. At least one of =Calls= or =Puts= is
+needed for a valid strip. Calls and puts can carry different barrier
+terms. All calls share the same terms, and all puts share theirs.
+
+The =Style= node sets the exercise style, European or American.
+European is the default. A strip of APOs assumes European and issues a
+warning otherwise. =Settlement= sets cash or physical delivery, with
+cash the default. A strip of APOs assumes cash and issues a warning
+otherwise. =Premiums= adds premium amounts, received or paid.
+=IsDigital= true turns the strip into commodity digitals. =PayoffPerUnit=
+then sets the payoff per commodity unit.
+
+** Mathematical notes
+
+The strip value is the sum of its period option values. Each
+non-averaging option prices on one fixing. Each averaging option
+prices on the period average. Period structure, strikes, and barriers
+enter the value independently, period by period.
+
+** What moves its value (static sensitivities)
+
+- The commodity forward curve at each period's fixing dates.
+- The volatility surface at each period.
+- The strikes, premiums, and barriers of the individual options.
+- The settlement mode and the digital payoff, when selected.
+- The discount curve of the settlement currency.
+
+Each option follows its own direction. A strip of calls gains when
+commodity prices rise across the periods. A strip of puts gains when
+they fall.
+
+** How the profile ages (dynamic sensitivities)
+
+Each period's option settles as its calculation period completes. The
+settled options drop out of the strip. The remaining periods keep
+their exposure. Near the end only the last period option is left. At
+the last period end the strip completes.
+
+** Why a customer would want it
+
+A customer with a rolling commodity exposure can hedge each period
+with its own option. Averaging periods suit buyers of physical
+commodity priced off averages. Non-averaging periods suit single-point
+fixings. The strip books the whole stream in one trade. In ORE Studio
+a customer books commodity option strips to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a strip with a short call and a long put:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>CommodityOptionStrip</TradeType>
+  <Envelope>
+    ...
+  </Envelope>
+  <CommodityOptionStripData>
+    <LegData>
+      <LegType>CommodityFloating</LegType>
+      ...
+    </LegData>
+    <Calls>
+      <LongShorts>
+        <LongShort>Short</LongShort>
+      </LongShorts>
+      <Strikes>
+        <Strike>5.3</Strike>
+      </Strikes>
+      <BarrierData>
+        <Type>UpAndIn</Type>
+        <Style>American</Style>
+        <LevelData>
+          <Level>
+            <Value>70.0</Value>
+          </Level>
+        </LevelData>
+      </BarrierData>
+    </Calls>
+    <Puts>
+      <LongShorts>
+        <LongShort>Long</LongShort>
+      </LongShorts>
+      <Strikes>
+        <Strike>8.17</Strike>
+      </Strikes>
+    </Puts>
+    <Premiums> ... </Premiums>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+  </CommodityOptionStripData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoptionstrip.tex=,
+listing =Commodity Option Strip= (optional elements omitted).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Exotic_option][Wikipedia: Exotic option]]. This places the product in the exotic
+  options family.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityoptionstrip.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityoptionstrip.org
+++ b/doc/knowledge/domain/commodityoptionstrip.org
@@ -154,6 +154,9 @@ listing =Commodity Option Strip= (optional elements omitted).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Exotic_option][Wikipedia: Exotic option]]. This places the product in the exotic
   options family.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityoptionstrip.org
+++ b/doc/knowledge/domain/commodityoptionstrip.org
@@ -149,7 +149,7 @@ ORE's catalogue shows a strip with a short call and a long put:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityoptionstrip.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityoptionstrip.tex][commodityoptionstrip.tex]],
 listing =Commodity Option Strip= (optional elements omitted).
 
 * See also
@@ -159,6 +159,6 @@ listing =Commodity Option Strip= (optional elements omitted).
 
 - [[https://en.wikipedia.org/wiki/Exotic_option][Wikipedia: Exotic option]]. This places the product in the exotic
   options family.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityoptionstrip.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityoptionstrip.tex][commodityoptionstrip.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityposition.org
+++ b/doc/knowledge/domain/commodityposition.org
@@ -128,7 +128,7 @@ ORE's catalogue shows a basket of two commodities:
 </CommodityPositionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityposition.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityposition.tex][commodityposition.tex]],
 listing =Commodity Position= (optional elements omitted).
 
 * See also
@@ -138,6 +138,6 @@ listing =Commodity Position= (optional elements omitted).
 
 - [[https://en.wikipedia.org/wiki/Commodity_market][Wikipedia: Commodity market]]. This places the product in the
   commodity markets.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityposition.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityposition.tex][commodityposition.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityposition.org
+++ b/doc/knowledge/domain/commodityposition.org
@@ -133,6 +133,9 @@ listing =Commodity Position= (optional elements omitted).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Commodity_market][Wikipedia: Commodity market]]. This places the product in the
   commodity markets.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityposition.org
+++ b/doc/knowledge/domain/commodityposition.org
@@ -1,0 +1,140 @@
+:PROPERTIES:
+:ID: 8B992141-85D3-4480-ABAF-9E2BD1BEB01B
+:END:
+#+title: Commodity Position
+#+description: A position in a commodity or weighted commodity basket; ORE's CommodityPosition product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityposition:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity position is the direct holding view of the commodity
+family. It prices a position in one commodity or in a weighted basket.
+ORE models it with the trade type =CommodityPosition=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A commodity position represents a position in a single commodity or in
+a weighted basket of underlying commodities. It can be a standalone
+trade or a component of a total return swap. The position values a
+quantity times the commodity price, or the basket weighted sum of its
+prices. The pricing reference is a spot or future settlement price.
+
+* Detail
+
+** What it is
+
+ORE states that a commodity position represents a position in a single
+commodity, with a single =Underlying= node, or in a weighted basket of
+underlying commodities, with multiple =Underlying= nodes. The node can
+be a standalone trade type, =CommodityPosition=, or a trade component,
+=CommodityPositionData=, inside the TotalReturnSwap trade type.
+
+** In plain terms
+
+A commodity position is the commodity itself in portfolio form. One
+trade holds a quantity of a commodity. The price follows the market
+each day. A basket trade holds several commodities with weights, like
+one index holding.
+
+** How it works in ORE
+
+The =CommodityPositionData= node carries the =Quantity= and the
+underlyings. Each =Underlying= node names a commodity, such as
+=NYMEX:CL= or =ICE:B=. A single commodity uses one node. A weighted
+basket uses several, each with a =Weight=. The =PriceType= selects
+the pricing reference. With =FutureSettlement=, the position refers by
+default to today's prompt (lead) future. =FutureMonthOffset=,
+=DeliveryRollDays=, and =DeliveryRollCalendar= refine which future
+contract prices the position.
+
+ORE notes that a generic TRS does not support rolling of the future
+contracts. Today's prompt future can differ from the prompt future at
+inception. If the initial basket price is not set, the position uses
+the price of today's prompt future at trade inception. The TRS ignores
+the roll yield caused by rolling from one prompt future to the next.
+
+** Mathematical notes
+
+A single position value is the quantity times the commodity price. A
+basket position value is the quantity times the weighted sum of the
+underlying prices:
+
+V = Q x (Sum over i of Weight_i x S_i x FX_i)
+
+The weights set the basket's exposure to each commodity. Each S_i is
+the i-th commodity prompt future or spot price. Each FX_i converts
+from the i-th commodity currency to the first commodity currency. The
+first commodity currency is the currency of the basket NPV.
+
+** What moves its value (static sensitivities)
+
+- The commodity price of each underlying. It drives the value.
+- The FX rate of each underlying's currency to the first commodity
+  currency.
+- The basket weights. They set the share of each commodity.
+- The quantity.
+- The pricing reference, spot or future settlement.
+
+The value moves with the weighted commodity prices. A long position
+gains when the basket rises. A short position gains when it falls.
+
+** How the profile ages (dynamic sensitivities)
+
+The pricing reference decides how the position follows the market. A
+spot reference tracks the spot day by day. A future settlement
+reference follows today's prompt future. The prompt future changes as
+near contracts expire, and a TRS does not accrue the roll yield. The
+position has no maturity of its own. It continues until the trade is
+closed.
+
+** Why a customer would want it
+
+A customer who holds physical commodity wants its value on the books.
+A hedge fund wants an index-like commodity exposure in one trade. A
+bank prices a client's commodity basket position in its portfolio.
+Inside a total return swap, the position pays the swap's return
+leg. In ORE Studio a customer books commodity positions to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a basket of two commodities:
+
+#+begin_example
+<CommodityPositionData>
+  <Quantity>1000</Quantity>
+  <Underlying>
+    <Type>Commodity</Type>
+    <Name>NYMEX:CL</Name>
+    <Weight>0.5</Weight>
+    <PriceType>FutureSettlement</PriceType>
+    <FutureMonthOffset>0</FutureMonthOffset>
+    <DeliveryRollDays>0</DeliveryRollDays>
+    <DeliveryRollCalendar>TARGET</DeliveryRollCalendar>
+  </Underlying>
+  <Underlying>
+    <Type>Commodity</Type>
+    <Name>ICE:B</Name>
+    <Weight>0.5</Weight>
+    <PriceType>FutureSettlement</PriceType>
+    <FutureMonthOffset>0</FutureMonthOffset>
+    <DeliveryRollDays>0</DeliveryRollDays>
+    <DeliveryRollCalendar>TARGET</DeliveryRollCalendar>
+  </Underlying>
+</CommodityPositionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityposition.tex=,
+listing =Commodity Position= (optional elements omitted).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Commodity_market][Wikipedia: Commodity market]]. This places the product in the
+  commodity markets.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityposition.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityswap.org
+++ b/doc/knowledge/domain/commodityswap.org
@@ -1,0 +1,145 @@
+:PROPERTIES:
+:ID: 0C0FDF39-B4D4-4794-83AD-076B4681830B
+:END:
+#+title: Commodity Swap
+#+description: Floating commodity prices against a fixed price; ORE's CommoditySwap and basis swap forms.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity swap exchanges a series of floating commodity prices
+against a fixed price. ORE models it with the trade type
+=CommoditySwap=, including the basis swap form. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A commodity swap exchanges floating commodity prices against a fixed
+known price, with cash settlement at the end of the swap or monthly.
+Each period pays the average of the differences between the fixings
+and the strike. A commodity basis swap exchanges the spread between
+two floating prices against a fixed spread. The fixings can be
+commodity spot prices or prompt future prices. The trade data uses
+swap legs of commodity fixed and floating type.
+
+* Detail
+
+** What it is
+
+ORE defines the plain form as follows:
+
+#+begin_quote
+A Commodity Swap involves the exchange of floating commodity prices
+against a fixed known commodity price, with cash settlement either at
+the end of the swap or on a monthly basis.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=.
+
+ORE defines the basis form as follows:
+
+#+begin_quote
+A Commodity Basis Swap involves the exchange of the spread between
+floating commodity prices against a fixed known spread K, with cash
+settlement either at the end of the swap or on a monthly basis.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=.
+
+** In plain terms
+
+A commodity swap is a series of commodity forwards in one contract.
+One side pays an average of market prices over each period. The other
+side pays a fixed price. The exposure is to the price level, settled
+in cash without moving the commodity.
+
+** How it works in ORE
+
+The trade uses =SwapData= with =CommodityFixed= and
+=CommodityFloating= legs. A long position computes the average of the
+difference between the variable fixing and the fixed strike at each
+fixing date. The fixing can be a spot price, possibly the average of
+the high and low values of the day in a given source. It can also be
+the price of the prompt future, the earliest futures expiry after the
+fixing date. The final payoff of a period is the arithmetic average of
+the period contributions, settled in cash with a delay after the
+period, or rolled up into one payment after the swap end.
+
+ORE also supports netting of the floating legs. With
+=RoundNettedFloatingLegs= on, all floating leg cash flows with the
+same payment date are netted into one cash flow. =NettingPrecision=
+sets the rounding of the netted average fixing.
+
+** Mathematical notes
+
+Each pricing date contributes the fixing minus the strike, per unit.
+The period payoff is the arithmetic average of the contributions. The
+swap value is the sum of the period payoffs, discounted. A long
+position gains when the average price rises above the strike.
+
+** What moves its value (static sensitivities)
+
+- The commodity price curve at each fixing date. It drives the
+  expected fixings.
+- The spread of the two references, for a basis swap.
+- The discount curve of the settlement currency.
+- The strike and the quantity per period.
+- The averaging conventions, the fixing source, and the payment lag.
+
+A long fixed-price payer gains when commodity prices fall below the
+strike. The floating receiver gains when they rise.
+
+** How the profile ages (dynamic sensitivities)
+
+Each fixing turns one unknown contribution into a known one. The
+remaining periods keep their exposure to the forward curve. Near the
+end of the swap the outstanding fixings narrow to the last period.
+At maturity the final average settles and the swap stops.
+
+** Why a customer would want it
+
+A consumer with a stream of commodity purchases swaps floating prices
+to fixed and removes budget risk. A producer swaps fixed to floating
+to keep market exposure. The product hedges a price series, not one
+delivery. In ORE Studio a customer books commodity swaps to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows the trade with its two legs:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>CommoditySwap</TradeType>
+  <Envelope>
+  </Envelope>
+  <SwapData>
+    <LegData>
+      <LegType>CommodityFixed</LegType>
+      ...
+    </LegData>
+    <LegData>
+      <LegType>CommodityFloating</LegType>
+      ...
+    </LegData>
+    <RoundNettedFloatingLegs>true</RoundNettedFloatingLegs>
+    <NettingPrecision>2</NettingPrecision>
+  </SwapData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=,
+listing =Commodity Swap= (leg detail abbreviated).
+
+The [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]] is the single-period form of the same
+exposure. The [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] options its start.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Commodity_derivative][Wikipedia: Commodity derivative]]. This places the product in the
+  commodity derivatives family.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityswap.org
+++ b/doc/knowledge/domain/commodityswap.org
@@ -36,7 +36,7 @@ against a fixed known commodity price, with cash settlement either at
 the end of the swap or on a monthly basis.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswap.tex][commodityswap.tex]].
 
 ORE defines the basis form as follows:
 
@@ -46,7 +46,7 @@ floating commodity prices against a fixed known spread K, with cash
 settlement either at the end of the swap or on a monthly basis.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswap.tex][commodityswap.tex]].
 
 ** In plain terms
 
@@ -130,7 +130,7 @@ ORE's catalogue shows the trade with its two legs:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswap.tex][commodityswap.tex]],
 listing =Commodity Swap= (leg detail abbreviated).
 
 The [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]] is the single-period form of the same
@@ -143,6 +143,6 @@ exposure. The [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] op
 
 - [[https://en.wikipedia.org/wiki/Commodity_derivative][Wikipedia: Commodity derivative]]. This places the product in the
   commodity derivatives family.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswap.tex][commodityswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityswap.org
+++ b/doc/knowledge/domain/commodityswap.org
@@ -138,6 +138,9 @@ exposure. The [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] op
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Commodity_derivative][Wikipedia: Commodity derivative]]. This places the product in the
   commodity derivatives family.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/commodityswaption.org
+++ b/doc/knowledge/domain/commodityswaption.org
@@ -140,6 +140,9 @@ period end rather than before the underlying starts.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This covers the general swaption concept.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/commodityswaption.tex=. The

--- a/doc/knowledge/domain/commodityswaption.org
+++ b/doc/knowledge/domain/commodityswaption.org
@@ -35,7 +35,7 @@ Commodity Swap consisting of a sequence of calculation periods. The
 exercise decision is made once before the Swap starts.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswaption.tex][commodityswaption.tex]].
 
 ORE states the exercise directions as follows:
 
@@ -46,7 +46,7 @@ Swaption, the holder of the option has the right to receive the fixed
 prices and to pay the floating prices.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswaption.tex][commodityswaption.tex]].
 
 ** In plain terms
 
@@ -131,7 +131,7 @@ ORE's catalogue shows a long European swaption:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswaption.tex][commodityswaption.tex]],
 listing =Commodity swaption= (leg detail abbreviated).
 
 The underlying is a [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]]. The
@@ -144,6 +144,6 @@ period end rather than before the underlying starts.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This covers the general swaption concept.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityswaption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityswaption.tex][commodityswaption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityswaption.org
+++ b/doc/knowledge/domain/commodityswaption.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: 8FAE9780-9737-49DB-87E7-D678F3AEBD69
+:END:
+#+title: Commodity Swaption
+#+description: A European option on a forward-starting commodity swap; ORE's CommoditySwaption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityswaption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity swaption is an option on a commodity swap that starts in
+the future. ORE models it with the trade type =CommoditySwaption=.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+A commodity swaption is a European option on a forward-starting
+commodity swap. The underlying swap consists of a sequence of
+calculation periods. The exercise decision is made once, before the
+swap starts. A payer swaption has the right to pay the fixed prices
+and receive the floating prices. A receiver swaption has the
+opposite rights. Settlement is cash or physical.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Commodity Swaption is a European option on a forward starting
+Commodity Swap consisting of a sequence of calculation periods. The
+exercise decision is made once before the Swap starts.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=.
+
+ORE states the exercise directions as follows:
+
+#+begin_quote
+In a Payer Swaption, the holder of the option has the right to pay the
+fixed prices and to receive the floating prices. In a Receiver
+Swaption, the holder of the option has the right to receive the fixed
+prices and to pay the floating prices.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=.
+
+** In plain terms
+
+A commodity swaption is an option on a future price agreement. The
+buyer pays a premium for the right to enter a commodity swap later.
+If commodity prices move in the right direction, the option is
+exercised. Otherwise it expires.
+
+** How it works in ORE
+
+The =CommoditySwaptionData= node carries an =OptionData= node. The
+=LongShort= flag sets the direction from the point of view of the long
+party. The payer and receiver legs of the underlying swap always use
+the perspective of the party that is long. Only the European exercise
+style is supported. The =Settlement= flag selects cash or physical
+delivery. Optional =NoticePeriod=, =NoticeCalendar=, and
+=NoticeConvention= terms move the notice date relative to the exercise
+date. An =ExerciseFees= node holds the exercise fees, if any.
+
+** Mathematical notes
+
+The underlying is a forward-starting commodity swap. Its value at the
+exercise date decides the option. The option prices off the commodity
+volatility surface and the forward curve at the swap start. After
+exercise the position ages like the commodity swap it started.
+
+** What moves its value (static sensitivities)
+
+- The commodity volatility surface. It drives the option value.
+- The commodity forward curve at the swap start. It sets the moneyness
+  of the option.
+- The strike swap rate and the leg conventions.
+- The discount curve of the settlement currency.
+- The settlement mode, cash or physical.
+
+A payer swaption gains when prices rise above the strike. A receiver
+gains when they fall. Volatility raises the value of both sides.
+
+** How the profile ages (dynamic sensitivities)
+
+The option loses time value as the exercise date approaches. The
+exercise decision is made once before the underlying swap starts. At
+exercise the trade becomes the underlying swap and ages with it.
+Without exercise it expires worthless.
+
+** Why a customer would want it
+
+A consumer buys a payer swaption to cap the price of future commodity
+purchases. A producer buys a receiver swaption to protect its sales
+price. A dealer sells swaptions to earn premium. In ORE Studio a
+customer books commodity swaptions to value them and run sensitivities
+on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European swaption:
+
+#+begin_example
+<Trade id="...">
+  <TradeType>CommoditySwaption</TradeType>
+  <Envelope>
+    ...
+  </Envelope>
+  <CommoditySwaptionData>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <Style>European</Style>
+      <Settlement>Cash</Settlement>
+      <ExerciseDates>
+        <ExerciseDate>2023-01-05</ExerciseDate>
+      </ExerciseDates>
+    </OptionData>
+    <LegData>
+      <LegType>CommodityFixed</LegType>
+      ...
+    </LegData>
+    <LegData>
+      <LegType>CommodityFloating</LegType>
+      ...
+    </LegData>
+  </CommoditySwaptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityswaption.tex=,
+listing =Commodity swaption= (leg detail abbreviated).
+
+The underlying is a [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]]. The
+[[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]] differs in its exercise timing, at the
+period end rather than before the underlying starts.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This covers the general swaption concept.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityswaption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityvarianceswap.org
+++ b/doc/knowledge/domain/commodityvarianceswap.org
@@ -96,6 +96,9 @@ variance swap section of the catalogue for the node layout.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/commodityvarianceswap.tex=.

--- a/doc/knowledge/domain/commodityvarianceswap.org
+++ b/doc/knowledge/domain/commodityvarianceswap.org
@@ -1,0 +1,102 @@
+:PROPERTIES:
+:ID: 1989F85A-42F8-4894-8982-AC34D19B0351
+:END:
+#+title: Commodity Variance Swap
+#+description: A swap on commodity volatility or variance; ORE's CommodityVarianceSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:commodityvarianceswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A commodity variance swap trades volatility directly. Its payoff
+depends on how much a commodity price moves, not on where it ends. ORE
+models it with the trade type =CommodityVarianceSwap=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A commodity variance or volatility swap has a payoff that depends on
+the volatility or variance of an underlying commodity instrument. The
+structure mirrors the equity variance swap, with a commodity
+underlying. Two counterparties exchange the realised variance against
+a fixed strike. One notional leg scales the payoff. No money changes
+hands at trade time.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Commodity Variance or Volatility Swap has a payoff that depends on
+the volatility/variance of an underlying commodity instrument.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityvarianceswap.tex=.
+
+** In plain terms
+
+A commodity variance swap is a bet on movement, not direction. One
+side pays the realised variance of a commodity price over the life of
+the swap. The other side pays a fixed variance agreed at trade time.
+If the commodity moves more than expected, the variance buyer gains.
+
+** How it works in ORE
+
+ORE states that the structure of the input is the same as that of the
+Equity Variance Swap. Only the underlying type changes, to a
+commodity instrument. The trade data carries the variance swap
+conventions, the observation period, and the commodity underlying.
+
+** Mathematical notes
+
+The payoff is the difference between the realised variance and the
+variance strike, scaled by a notional that converts variance into
+money. The realised variance sums the squared daily returns over the
+observation period. A volatility swap variant exchanges the realised
+volatility instead.
+
+** What moves its value (static sensitivities)
+
+- The implied volatility of the commodity. It prices the variance
+  strike.
+- The realised path of daily commodity returns. It settles the payoff.
+- The variance notional. It scales the exposure.
+- The observation schedule and the annualisation convention.
+- The discount curve of the settlement currency.
+
+A long variance position gains when realised movement exceeds the
+strike. It gains from jumps in either direction. Direction of the
+commodity price itself does not drive the payoff.
+
+** How the profile ages (dynamic sensitivities)
+
+Each day adds one return to the realised variance. Early in life the
+realised part is small and the trade trades like a forward on implied
+variance. Late in life the realised variance dominates and the payoff
+locks in. At maturity the final variance settles and the swap stops.
+
+** Why a customer would want it
+
+A producer of a commodity is long the price but hedges its
+volatility. A trader takes a view that commodity volatility is cheap
+or rich. Variance swaps isolate that view from direction. In ORE
+Studio a customer books commodity variance swaps to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue does not show a worked commodity variance swap
+listing. The trade data follows the Equity Variance Swap structure,
+with the underlying type set to a commodity instrument. See the equity
+variance swap section of the catalogue for the node layout.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/commodityvarianceswap.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/commodityvarianceswap.org
+++ b/doc/knowledge/domain/commodityvarianceswap.org
@@ -35,7 +35,7 @@ A Commodity Variance or Volatility Swap has a payoff that depends on
 the volatility/variance of an underlying commodity instrument.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/commodityvarianceswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityvarianceswap.tex][commodityvarianceswap.tex]].
 
 ** In plain terms
 
@@ -100,6 +100,6 @@ variance swap section of the catalogue for the node layout.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/commodityvarianceswap.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/commodityvarianceswap.tex][commodityvarianceswap.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/compositetrade.org
+++ b/doc/knowledge/domain/compositetrade.org
@@ -34,7 +34,7 @@ component subtrades. As such it inherits the characteristics of the
 trades defined within it.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/compositetrade.tex][compositetrade.tex]].
 
 ORE gives an example of a composite as follows:
 
@@ -43,7 +43,7 @@ Examples of Composite Trades include combinations of vanilla options
 like straddles.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/compositetrade.tex][compositetrade.tex]].
 
 ORE defines the container node as follows:
 
@@ -52,7 +52,7 @@ The CompositeTradeData node is the trade data container for the
 CompositeTrade trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/compositetrade.tex][compositetrade.tex]].
 
 ** In plain terms
 
@@ -144,7 +144,7 @@ sum notional:
 </CompositeTradeData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/compositetrade.tex][compositetrade.tex]],
 listing =Composite trade data=. The catalogue also shows the
 portfolio basket form, in which =PortfolioBasket= is =true= and a
 =BasketName= and =IndexQuantity= are given.
@@ -154,6 +154,6 @@ portfolio basket form, in which =PortfolioBasket= is =true= and a
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/compositetrade.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/compositetrade.tex][compositetrade.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/compositetrade.org
+++ b/doc/knowledge/domain/compositetrade.org
@@ -151,6 +151,9 @@ portfolio basket form, in which =PortfolioBasket= is =true= and a
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/compositetrade.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/compositetrade.org
+++ b/doc/knowledge/domain/compositetrade.org
@@ -1,0 +1,156 @@
+:PROPERTIES:
+:ID: 2D1B9342-FC33-49DF-8F23-5B2248968156
+:END:
+#+title: Composite Trade
+#+description: A hybrid position bundling multiple component trades; ORE's CompositeTrade product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:compositetrade:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A composite trade is a hybrid position made of several component
+trades. ORE models it with the trade type =CompositeTrade=. The
+container node is =CompositeTradeData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A composite trade bundles several component trades into one position.
+It inherits the characteristics of the trades defined within it. The
+node carries a currency for the results, a method to calculate the
+trade notional from the components, and the list of components. A
+portfolio basket form names a basket from reference data instead.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A composite trade is a hybrid position consisting of multiple
+component subtrades. As such it inherits the characteristics of the
+trades defined within it.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+
+ORE gives an example of a composite as follows:
+
+#+begin_quote
+Examples of Composite Trades include combinations of vanilla options
+like straddles.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+
+ORE defines the container node as follows:
+
+#+begin_quote
+The CompositeTradeData node is the trade data container for the
+CompositeTrade trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=.
+
+** In plain terms
+
+A composite trade is a wrapper around other trades. The wrapper makes
+several trades report as one position in one currency. The
+components keep their own payoff behaviour. A straddle is the classic
+example: one call and one put on the same underlying, booked as a
+single composite trade.
+
+** How it works in ORE
+
+=Currency= defines the currency in which the NPV of the composite
+trade is represented. =NotionalCalculation= is optional and defines
+how the notional of the composite is calculated:
+
+- =Sum=: the sum of the notionals of the constituent trades. This is
+  the default when the field is omitted.
+- =Mean= or =Average=: the mean of the notionals.
+- =First=: the notional of the first constituent trade.
+- =Last=: the notional of the last constituent trade.
+- =Min=: the minimum of the notionals.
+- =Max=: the maximum of the notionals.
+- =Override=: the notional is read directly from the override field.
+
+=NotionalOverride= is optional; when given, it overrides any
+calculation method. =Components= is the portfolio of trades that make
+up the composite. The components are valid trade XMLs of the kind
+that could otherwise be entered into the portfolio, with the
+exception that they can have empty ids.
+
+The node also has a portfolio basket form. =PortfolioBasket= is
+optional and indicates whether the components represent a portfolio
+basket. =BasketName= is the portfolio id. When =PortfolioBasket= is =true=,
+a =BasketName= must be given, and the basket is looked up in the
+reference data. =IndexQuantity= is the number of shares of the
+index.
+
+** Mathematical notes
+
+The composite trade has no payoff of its own. Its value is the value
+of the component trades, valued with their own engines and models.
+The composite aggregates their notionals with the chosen method. Its
+NPV is reported in =Currency=, whatever the currencies of the
+components.
+
+** What moves its value (static sensitivities)
+
+- The risk factors of each component trade. The composite inherits
+  them all.
+- The currency conversion into the reporting currency.
+- The notional aggregation method, which scales the reported
+  quantities.
+
+There is no single dominant risk factor. The profile is the sum of
+the profiles of the components.
+
+** How the profile ages (dynamic sensitivities)
+
+A composite trade has no schedule of its own. Each component ages on
+its own schedule and matures on its own dates. The composite simply
+holds the components until they all run off.
+
+** Why a customer would want it
+
+A composite trade books a strategy as one position. It reports one
+NPV, one notional and one set of results in one currency. A customer
+who trades straddles, or any basket of small trades with a common
+theme, books them as a composite. In ORE Studio a customer books
+composite trades to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a composite with two component trades and a
+sum notional:
+
+#+begin_example
+<CompositeTradeData>
+  <Currency>USD</Currency>
+  <NotionalCalculation>Sum</NotionalCalculation>
+  <Components>
+    <SubTrade id="">
+      <!-- A valid trade xml -->
+    </SubTrade>
+    <SubTrade id="">
+      <!-- A valid trade xml -->
+    </SubTrade>
+  </Components>
+</CompositeTradeData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/compositetrade.tex=,
+listing =Composite trade data=. The catalogue also shows the
+portfolio basket form, in which =PortfolioBasket= is =true= and a
+=BasketName= and =IndexQuantity= are given.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/compositetrade.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/convertiblebond.org
+++ b/doc/knowledge/domain/convertiblebond.org
@@ -39,7 +39,7 @@ is also possible that the shares are from a different issuer
 from the bond currency in both cases (cross-currency convertibles).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]].
 
 ORE describes the call and put rights as follows:
 
@@ -49,7 +49,7 @@ style) and / or puttable by the investor (typically in Bermudan
 style).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]].
 
 ORE describes forced conversion as follows:
 
@@ -59,7 +59,7 @@ the bond into shares instead of accepting the payment from the issuer
 call ("forced conversion").
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]].
 
 ORE describes the detachable form as follows:
 
@@ -71,7 +71,7 @@ the bond floor npv, where the bond floor denotes the underlying
 vanilla bond stripped of any optionality.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]].
 
 ** In plain terms
 
@@ -101,7 +101,7 @@ still be used to overwrite the information partially, if this seems
 appropriate.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]].
 
 In the explicit form, the block carries five sub-blocks. =BondData=
 holds the vanilla part of the bond. =CallData= and =PutData= hold the
@@ -212,7 +212,7 @@ reference data:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]],
 listing =Convertible bond set up using reference data=. The source
 also shows the explicit form, in which =BondData=, =CallData=,
 =PutData=, =ConversionData= and =DividendProtectionData= are given
@@ -225,6 +225,6 @@ with their details and =Detachable= is set to =false=.
 
 - [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/convertiblebond.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/convertiblebond.tex][convertiblebond.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/convertiblebond.org
+++ b/doc/knowledge/domain/convertiblebond.org
@@ -220,6 +220,9 @@ with their details and =Detachable= is set to =false=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/convertiblebond.org
+++ b/doc/knowledge/domain/convertiblebond.org
@@ -1,0 +1,227 @@
+:PROPERTIES:
+:ID: F5D8E0C4-EC67-4210-AF1C-B664246810C9
+:END:
+#+title: Convertible Bond
+#+description: A bond that converts into a prespecified number of shares; ORE's ConvertibleBond product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:convertiblebond:
+#+created: 2026-09-06
+#+updated: 2026-09-07
+
+A convertible bond is a bond that can be converted into a
+prespecified number of shares. ORE models it with the trade type
+=ConvertibleBond=. The container node is =ConvertibleBondData=. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A convertible bond pays like a bond and can be converted into a fixed
+number of shares of an issuer. The shares are usually from the bond
+issuer, but they can come from a different issuer; such a structure
+is an exchangeable. The bond can be callable by the issuer and
+puttable by the investor. Its value splits into the bond floor plus
+the embedded optionality. The number of shares on conversion is the
+bond notional divided by the conversion ratio.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A convertible bond is a bond, that can be converted to a prespecified
+number of shares. The shares are usually from the bond issuer, but it
+is also possible that the shares are from a different issuer
+(exchangeables). In addition, the share currency can be different
+from the bond currency in both cases (cross-currency convertibles).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+
+ORE describes the call and put rights as follows:
+
+#+begin_quote
+The bond might be callable by the issuer (typically in American
+style) and / or puttable by the investor (typically in Bermudan
+style).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+
+ORE describes forced conversion as follows:
+
+#+begin_quote
+If a soft call is exercised, the investor has the right to convert
+the bond into shares instead of accepting the payment from the issuer
+call ("forced conversion").
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+
+ORE describes the detachable form as follows:
+
+#+begin_quote
+For a detachable or stripped convertible bond the optionality can be
+traded separately from the bond. We set the NPV for a detachable
+convertible bond to the difference of the convertible bond npv and
+the bond floor npv, where the bond floor denotes the underlying
+vanilla bond stripped of any optionality.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+
+** In plain terms
+
+A convertible bond is a bond with a stock option attached. The
+investor receives coupons and the return of principal, exactly like a
+bond. The investor can also hand the bond back and receive shares
+instead. The conversion right is worth more when the share price
+rises. The bond pays a lower coupon than a plain bond of the same
+issuer because of that right.
+
+** How it works in ORE
+
+The trade type is =ConvertibleBond=. The =ConvertibleBondData= block
+names the bond and its quantity. =SecurityId= is typically the ISIN
+of the underlying bond with the =ISIN:= prefix. =BondNotional= is the
+notional of the underlying bond in its currency. The optional
+=CreditRisk= flag decides whether credit risk shows on the product.
+
+The bond terms can come from reference data, or be given explicitly
+in the trade. ORE states the relationship between the two:
+
+#+begin_quote
+All fields that are not given in the trade XML are filled up with the
+information from the reference data if available in the reference
+data. In other words, if reference data is given, the trade xml can
+still be used to overwrite the information partially, if this seems
+appropriate.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=.
+
+In the explicit form, the block carries five sub-blocks. =BondData=
+holds the vanilla part of the bond. =CallData= and =PutData= hold the
+call and put terms; when they are not given, no calls or puts are
+present. =ConversionData= holds the conversion terms and must always
+be given, even when no conversion rights are present; an empty
+conversion date list expresses that case. =DividendProtectionData=
+holds the dividend protection terms. =Detachable= is a flag, false by
+default; when it is =true=, the trade represents the embedded
+optionality only, that is the difference between the full convertible
+bond and the bond floor.
+
+The call and put data are lists of exercise rights. =Styles= holds
+the exercise styles, =American= or =Bermudan=. Bermudan also defines
+European exercises, namely as a Bermudan exercise with a single
+exercise date. =ScheduleData= holds a schedule of exercise dates for
+Bermudan exercises, or start and end dates for American exercises.
+=Prices= holds exercise prices in relative terms: a price of 1.02
+means the amount paid on exercise is 1.02 times the current notional
+of the bond, plus accrued interest when the price type is clean.
+=PriceType= gives the flavour in which the prices are quoted. Lists
+in the sub-nodes can be explicit lists or use the =startDate=
+attribute. An explicit value list can be shorter than the list of
+dates; the last value then applies to the remaining dates.
+
+The trade type supports perpetual schedules. Omitting the =EndDate=
+in a schedule makes the schedule perpetual. Only rule based schedules
+can be perpetual. This applies to the bond leg, the call and put
+data, the conversion data, the conversion resets and the dividend
+protection schedule.
+
+** Mathematical notes
+
+The conversion ratio is the number of shares received for one bond,
+that is for the bond face value. The conversion value, also called
+the parity, is the ratio times the share price. The number of shares
+delivered on conversion is the bond notional divided by the
+conversion ratio; the ratio lives in the underlying bond reference
+data.
+
+The bond reference data in ORE is typically set up with a face value
+of one, even when the market quotes the bond at 100 or 100,000. The
+value of a convertible bond splits into the bond floor and the
+embedded optionality. The floor is the vanilla bond stripped of any
+optionality. The optionality is a conversion right, long for the
+investor, an issuer call, short for the investor, and an investor
+put, long for the investor.
+
+A hard issuer call pays the call price times the current notional,
+plus the accruals when they are due. A call price of 1.00 is a call
+at par; 1.02 is a call at 102 percent. A soft call can only be
+exercised when the share price on the exercise date is above the
+conversion price times a trigger. The issuer call always leaves the
+investor the choice to convert instead, which is the forced
+conversion.
+
+** What moves its value (static sensitivities)
+
+- The share price of the underlying equity, through the conversion
+  right.
+- The volatility of the equity.
+- The interest rates, which price the bond floor and discount the
+  cash flows.
+- The credit of the issuer and the recovery value on default.
+- The FX rate, for cross-currency convertibles.
+- The terms of the deal: the conversion ratio, the call and put
+  schedules, the triggers and the dividend protection.
+
+The value moves like a bond at low share prices and like the equity
+at high share prices. Between the two, the conversion right, the call
+rights and the credit of the issuer all compete.
+
+** How the profile ages (dynamic sensitivities)
+
+As the share price moves, the investor compares the conversion value
+with the bond floor. When a soft call is in the money, the issuer can
+force a conversion and end the bond. The conversion ratio can change
+over time through dividend protection and reset features. When a
+dividend is paid, the protection can adjust the ratio to compensate
+the investor. Near maturity the investor decides between redemption
+and conversion. On a default of the issuer, the claim is bounded by
+the recovery of the bond and the conversion value.
+
+** Why a customer would want it
+
+A convertible bond is hybrid financing. The issuer pays a lower
+coupon than on a plain bond, because the conversion right is
+valuable. The investor keeps the downside protection of a bond and
+gains the upside of the equity. In ORE Studio a customer books
+convertible bonds to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a convertible bond whose terms are set up in
+reference data:
+
+#+begin_example
+<Trade id="ConvertibleBond">
+  <TradeType>ConvertibleBond</TradeType>
+  <Envelope>...</Envelope>
+  <ConvertibleBondData>
+    <BondData>
+      <SecurityId>ISIN:XS0451905367</SecurityId>
+      <BondNotional>1000000.00</BondNotional>
+    </BondData>
+  </ConvertibleBondData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/convertiblebond.tex=,
+listing =Convertible bond set up using reference data=. The source
+also shows the explicit form, in which =BondData=, =CallData=,
+=PutData=, =ConversionData= and =DividendProtectionData= are given
+with their details and =Detachable= is set to =false=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Convertible_bond][Wikipedia: Convertible bond]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/convertiblebond.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cpiswap.org
+++ b/doc/knowledge/domain/cpiswap.org
@@ -1,0 +1,159 @@
+:PROPERTIES:
+:ID: 13D3230A-D5C2-46DA-92E6-1DB128B8392A
+:END:
+#+title: CPI Swap
+#+description: An inflation swap whose CPI-linked leg pays a real rate scaled by index changes.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:cpiswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A CPI swap exchanges the change in a consumer price index against a
+rate. ORE models it with the =InflationSwap= trade type, or as a
+=Swap= with a CPI leg. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A CPI swap is the standard inflation derivative. One leg pays a real
+coupon, set at inception, scaled by the change of a consumer price
+index. The other leg pays a floating or fixed nominal rate. The
+inflation leg converts a contractual real rate into a nominal payment
+with the index ratio of two fixings. At maturity the inflation leg may
+also pay the index appreciation on the notional. The product protects a
+holder against realised inflation, which is the rise of the index over
+the life of the trade.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A CPI swap is an inflation swap where one of the legs has a floating
+rate with coupon payments linked to a supported inflation index.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+
+** In plain terms
+
+Two parties swap inflation for a fixed or floating rate. One pays a
+real rate, agreed at trade time. The payment grows with the consumer
+price index, so the payer is protected if prices rise faster than the
+rate. The other side receives the real rate and carries the inflation
+risk.
+
+** How it works in ORE
+
+ORE states the input form as follows:
+
+#+begin_quote
+A CPI inflation swap can be set up using the InflationSwap trade type,
+with one leg of type CPI.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+The remaining legs can be of any leg type, per the catalogue.
+
+The same structure works with the =Swap= trade type and a CPI leg.
+The CPI leg carries a =CPILegData= block. It names the inflation
+index, the observation lag, and the interpolation method. The coupons
+start from the index fixing before the issue date. They adjust to the
+fixing at each coupon reset date. ORE supports cross-currency
+inflation swaps, because the currencies of the legs do not need to be
+the same.
+
+** Mathematical notes
+
+ORE's words on the coupon:
+
+#+begin_quote
+Coupons on the inflation leg are calculated starting by the contractual
+real coupon rate and adjusting it to a nominal rate using the change
+from the relevant inflation index fixing before issue date to the index
+fixing at coupon reset date, taking into account observation lag, and
+if necessary, interpolation between inflation index fixings.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+
+A coupon at time Ti equals the product of the notional N, the real
+rate r, the index ratio I(Ti)/I(T0), and the day count fraction of the
+accrual period. The index ratio is the only inflation term. The
+maturity flow, when exchanged, is N times I(T)/I(T0) on the inflation
+leg against the notional on the other leg. CPI coupons and maturity
+flows can be capped or floored.
+
+** What moves its value (static sensitivities)
+
+- The discount curve of the payment currency. All legs are sensitive
+  to it.
+- The inflation index curve. It projects the index fixings that drive
+  the index ratio.
+- The real rate. It fixes the contractual coupon level.
+- The cap or floor, when present. It adds an inflation-volatility
+  sensitivity.
+
+A long-inflation leg gains value when expected inflation rises. The
+index ratio scales every remaining payment, so the exposure grows with
+the ratio level.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade starts from the index level at issue. Each printed fixing
+locks a piece of the index path. The remaining coupons depend on fewer
+and fewer future fixings. The maturity flow, when present, keeps the
+long-dated index exposure until the end. The trade ends with the index
+level at maturity. Only the last coupon and the flow remain uncertain
+in the final period.
+
+** Why a customer would want it
+
+A pension fund with inflation-linked liabilities buys CPI swaps to
+match them. An investor receives real rates to protect purchasing
+power. An issuer of inflation-linked debt swaps the index exposure back
+to nominal. In ORE Studio a customer books CPI swaps to value them and
+run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows the structure with the =InflationSwap= trade
+type. The floating leg is abbreviated.
+
+#+begin_example
+<InflationSwapData>
+  <LegData>
+    <LegType>Floating</LegType>
+    <Payer>true</Payer>
+    ...
+  </LegData>
+  <LegData>
+    <LegType>CPI</LegType>
+    <Payer>false</Payer>
+    ...
+    <CPILegData>
+      ...
+    </CPILegData>
+  </LegData>
+</InflationSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=,
+listing =CPI Swap Data= (using InflationSwap trade type).
+
+The sibling [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] pays the annual index
+change instead of a real rate. The [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]] note covers the leg
+mechanics both products share.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Inflation_swap][Wikipedia: Inflation swap]]. This note follows its general
+  definition.
+- [[https://en.wikipedia.org/wiki/Consumer_price_index][Wikipedia: Consumer price index]]. This covers the typical
+  reference index.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/cpiswap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/cpiswap.org
+++ b/doc/knowledge/domain/cpiswap.org
@@ -150,6 +150,9 @@ mechanics both products share.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Inflation_swap][Wikipedia: Inflation swap]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Consumer_price_index][Wikipedia: Consumer price index]]. This covers the typical

--- a/doc/knowledge/domain/cpiswap.org
+++ b/doc/knowledge/domain/cpiswap.org
@@ -36,7 +36,7 @@ A CPI swap is an inflation swap where one of the legs has a floating
 rate with coupon payments linked to a supported inflation index.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cpiswap.tex][cpiswap.tex]].
 
 ** In plain terms
 
@@ -55,7 +55,7 @@ A CPI inflation swap can be set up using the InflationSwap trade type,
 with one leg of type CPI.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cpiswap.tex][cpiswap.tex]].
 The remaining legs can be of any leg type, per the catalogue.
 
 The same structure works with the =Swap= trade type and a CPI leg.
@@ -78,7 +78,7 @@ fixing at coupon reset date, taking into account observation lag, and
 if necessary, interpolation between inflation index fixings.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cpiswap.tex][cpiswap.tex]].
 
 A coupon at time Ti equals the product of the notional N, the real
 rate r, the index ratio I(Ti)/I(T0), and the day count fraction of the
@@ -141,7 +141,7 @@ type. The floating leg is abbreviated.
 </InflationSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/cpiswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cpiswap.tex][cpiswap.tex]],
 listing =CPI Swap Data= (using InflationSwap trade type).
 
 The sibling [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] pays the annual index
@@ -157,6 +157,6 @@ mechanics both products share.
   definition.
 - [[https://en.wikipedia.org/wiki/Consumer_price_index][Wikipedia: Consumer price index]]. This covers the typical
   reference index.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/cpiswap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/cpiswap.tex][cpiswap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/creditdefaultswap.org
+++ b/doc/knowledge/domain/creditdefaultswap.org
@@ -140,6 +140,9 @@ The family siblings are the [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Cre
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Credit_default_swap][Wikipedia: Credit default swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/creditdefaultswap.org
+++ b/doc/knowledge/domain/creditdefaultswap.org
@@ -1,0 +1,147 @@
+:PROPERTIES:
+:ID: 1A201C57-AC68-4D0F-94A8-E33490D65EA3
+:END:
+#+title: Credit Default Swap
+#+description: A CDS trades protection on a reference entity's default; ORE's CreditDefaultSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:creditdefaultswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A credit default swap trades the default risk of a reference entity.
+The buyer pays a premium and receives compensation if the entity
+defaults. ORE models it with the trade type =CreditDefaultSwap=, with
+single-name and quanto forms. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+A credit default swap (CDS) is a bilateral contract on the credit of a
+reference entity. The protection buyer pays a running premium. In
+return, the seller compensates the buyer if the entity defaults or
+experiences a credit event. The payment is tied to a financial
+instrument issued by the entity. The premium leg is a fixed leg; its
+direction marks the trade as bought or sold protection. A fixed
+recovery CDS sets the recovery rate in the contract. The product is
+the atomic building block of the credit family in this set.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A CDS is a credit derivative between two counterparties. The buyer of
+a CDS makes premium payments to the CDS seller. In return, the seller
+agrees that in the event that an underlying reference entity defaults
+or experiences a credit event, seller will compensate the buyer, in
+relation to a financial instrument issued by the reference entity.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditdefaultswap.tex=.
+
+** In plain terms
+
+A CDS works like insurance on a loan or a bond. The buyer pays a
+regular premium, like an insurance policy. If the borrower defaults,
+the seller pays the loss. The buyer keeps credit protection without
+holding the underlying instrument.
+
+** How it works in ORE
+
+The trade uses a =CreditDefaultSwapData= block. It must name the
+credit curve with a =CreditCurveId=, or carry a =ReferenceInformation=
+node instead. That node names the reference entity, the tier, the
+currency, and the documentation clause. The =LegData= sub-node is a
+fixed leg and holds the recurring premium. Payer true means the trade
+buys protection. Payer false means it sells protection.
+
+The trade data also controls the default mechanics. =ProtectionStart=
+is the first date on which a credit event triggers the contract. For
+standard CDS it is the trade date. =SettlesAccrual= decides whether the
+accrued premium is due at default. =ProtectionPaymentTime= sets when
+protection and accrual pay, at default, at period end, or at maturity.
+An =UpfrontFee= and =UpfrontDate= express an off-par premium as a
+decimal share of the notional. A =FixedRecoveryRate= turns the trade
+into a fixed recovery CDS.
+
+The quanto form is a CDS whose denomination and settlement currencies
+differ. The catalogue example has a notional of 50 million BRL and
+pays a 6 percent premium. The premium converts to USD with an FX
+fixing two days before settlement.
+
+** Mathematical notes
+
+The premium leg is the present value of the running premium until
+maturity or default, the risky annuity. The protection leg is the
+present value of the loss on default, the notional minus recovery. The
+fair running premium makes the two legs equal. A fixed recovery CDS
+uses the contract's =FixedRecoveryRate= instead of the market
+recovery.
+
+** What moves its value (static sensitivities)
+
+- The credit curve of the reference entity. It is the dominant driver.
+  A spread widening raises the value of bought protection.
+- The discount curve of the premium currency. It prices the risky
+  annuity.
+- The recovery assumption. A lower recovery raises the protection
+  payment and the value.
+- The quanto FX rate, when the currencies differ. It converts premium
+  and protection flows.
+- The premium and the upfront fee. They fix the running cost.
+
+A protection buyer gains when the credit worsens. A protection seller
+gains when the credit improves.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade pays premium on its schedule until maturity or a credit
+event. At default, the protection payment settles and the trade ends.
+The risky annuity shortens as time passes, so the running premium
+carries less and less value. Near maturity, only near-term default
+risk matters. After the protection start date, all credit events count.
+
+** Why a customer would want it
+
+A lender or a bond holder buys CDS to hedge credit exposure. A bank
+sells protection to earn premium on names it likes. Dealers quote CDS
+to manage their credit books. In ORE Studio a customer books CDS to
+value them, run credit sensitivities, and feed XVA on the ORE engine.
+
+** Example
+
+ORE's catalogue shows the single-name form with a credit curve:
+
+#+begin_example
+<CreditDefaultSwapData>
+  <IssuerId>CPTY_A</IssuerId>
+  <CreditCurveId>RED:008CA0|SNRFOR|USD|MR14</CreditCurveId>
+  <SettlesAccrual>Y</SettlesAccrual>
+  <ProtectionPaymentTime>atDefault</ProtectionPaymentTime>
+  <ProtectionStart>20160206</ProtectionStart>
+  <UpfrontDate>20160208</UpfrontDate>
+  <UpfrontFee>0.0</UpfrontFee>
+  <LegData>
+    <LegType>Fixed</LegType>
+    <Payer>false</Payer>
+    ...
+  </LegData>
+</CreditDefaultSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditdefaultswap.tex=,
+listing =CreditDefaultSwap Data= (leg detail abbreviated).
+
+The family siblings are the [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] and the
+[[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Credit_default_swap][Wikipedia: Credit default swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/creditdefaultswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/creditdefaultswap.org
+++ b/doc/knowledge/domain/creditdefaultswap.org
@@ -40,7 +40,7 @@ or experiences a credit event, seller will compensate the buyer, in
 relation to a financial instrument issued by the reference entity.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditdefaultswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditdefaultswap.tex][creditdefaultswap.tex]].
 
 ** In plain terms
 
@@ -132,7 +132,7 @@ ORE's catalogue shows the single-name form with a credit curve:
 </CreditDefaultSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditdefaultswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditdefaultswap.tex][creditdefaultswap.tex]],
 listing =CreditDefaultSwap Data= (leg detail abbreviated).
 
 The family siblings are the [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] and the
@@ -145,6 +145,6 @@ The family siblings are the [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Cre
 
 - [[https://en.wikipedia.org/wiki/Credit_default_swap][Wikipedia: Credit default swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/creditdefaultswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditdefaultswap.tex][creditdefaultswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/creditlinkedswap.org
+++ b/doc/knowledge/domain/creditlinkedswap.org
@@ -136,6 +136,9 @@ follows the conventions of the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
   credit derivative family.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/creditlinkedswap.org
+++ b/doc/knowledge/domain/creditlinkedswap.org
@@ -1,0 +1,143 @@
+:PROPERTIES:
+:ID: B74A3D5C-1001-490D-9840-976C4E85E12F
+:END:
+#+title: Credit Linked Swap
+#+description: A swap with payments contingent on credit events of a reference; ORE's CreditLinkedSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:creditlinkedswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A credit linked swap mixes swap payments with credit contingency. ORE
+models it with the trade type =CreditLinkedSwap=. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A credit linked swap is a swap whose payments depend on credit events
+of a reference CDS. Some payments happen only if no credit event has
+occurred. Some happen when a credit event has occurred, weighted by
+recovery or loss given default. Some happen regardless of credit
+events. The trade data groups the legs by these classes. The product
+combines a swap structure with credit protection mechanics.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A credit linked swap is a swap where the payments are contingent on
+credit events occurring for a reference CDS.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditlinkedswap.tex=.
+
+ORE describes three classes of payments. One class pays only if no
+credit event has occurred for the reference CDS until the payment
+date. Another class pays when a credit event has occurred. Its amount
+is weighted by the recovery rate or by the loss given default rate,
+either actual or fixed by the trade. The third class pays
+independently of any credit events. Payment of the contingent classes
+can fall on the default date, the period end, or the trade maturity,
+per the trade terms.
+
+** In plain terms
+
+A credit linked swap is a swap with a trigger. Most of the time it
+pays like a normal swap. If a named credit defaults, some payments
+change or stop. The structure lets one side pass a credit risk into a
+swap format.
+
+** How it works in ORE
+
+The trade uses a =CreditLinkedSwapData= block. A =CreditCurveId=
+names the referenced CDS credit curve. A =ReferenceInformation= node
+can stand in for it. The payment legs are grouped by class. The
+=IndependentPayments= legs pay regardless of credit events.
+The =ContingentPayments= legs pay only if no credit event has occurred
+until the payment date. The =DefaultPayments= and =RecoveryPayments=
+legs pay when a credit event has occurred. A =FixedRecoveryRate= sets
+a fixed recovery when given. Otherwise the market recovery rate is
+used. =DefaultPaymentTime= controls when the default-dependent legs
+pay, at default, at period end, or at maturity. The underlying legs
+can pay any kind of coupon, fixed rate, Ibor, CMS, or fixed amounts.
+
+** Mathematical notes
+
+Each class of leg prices with its own survival assumption. The
+independent legs are plain swap legs. The contingent legs pay only
+while the reference survives. The default and recovery legs pay on
+the credit event, scaled by recovery or loss given default. The trade
+is a hybrid of swap cash flows and credit protection cash flows.
+
+** What moves its value (static sensitivities)
+
+- The credit curve of the reference CDS. It drives the survival and
+  default probabilities.
+- The discount curve of the payment currency.
+- The recovery assumption, actual or fixed.
+- The legs of each class. Their coupons, rates, and notionals set the
+  payment sizes.
+- The timing of the default-dependent payments.
+
+The credit sensitivity follows the direction of the contingent legs.
+The swap sensitivity follows the independent legs.
+
+** How the profile ages (dynamic sensitivities)
+
+A credit event rewrites the trade. The default and recovery legs
+settle. The contingent legs stop paying where the terms say so. Until
+then, the trade ages like a swap with a survival trigger. Near
+maturity the remaining contingent exposure narrows. At maturity all
+classes stop with the last payments.
+
+** Why a customer would want it
+
+A bank structures a swap so that part of its exposure to a credit is
+shared or hedged. The product links a funding or investment swap to
+credit protection in one contract. In ORE Studio a customer books
+credit linked swaps to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a trade with the four leg groups:
+
+#+begin_example
+<CreditLinkedSwapData>
+  <CreditCurveId>RED:46A844|SNRFOR|USD|XR14</CreditCurveId>
+  <SettlesAccrual>false</SettlesAccrual>
+  <FixedRecoveryRate>0.4</FixedRecoveryRate>
+  <DefaultPaymentTime>atDefault</DefaultPaymentTime>
+  <IndependentPayments>
+    <LegData> ... </LegData>
+  </IndependentPayments>
+  <ContingentPayments>
+    <LegData> ... </LegData>
+  </ContingentPayments>
+  <DefaultPayments>
+    <LegData> ... </LegData>
+  </DefaultPayments>
+  <RecoveryPayments>
+    <LegData> ... </LegData>
+  </RecoveryPayments>
+</CreditLinkedSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditlinkedswap.tex=,
+listing =Credit Linked Swap Data= (leg detail abbreviated).
+
+The example sets a fixed recovery of 40 percent. The reference curve
+follows the conventions of the
+[[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] family.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
+  credit derivative family.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/creditlinkedswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/creditlinkedswap.org
+++ b/doc/knowledge/domain/creditlinkedswap.org
@@ -33,7 +33,7 @@ A credit linked swap is a swap where the payments are contingent on
 credit events occurring for a reference CDS.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditlinkedswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditlinkedswap.tex][creditlinkedswap.tex]].
 
 ORE describes three classes of payments. One class pays only if no
 credit event has occurred for the reference CDS until the payment
@@ -127,7 +127,7 @@ ORE's catalogue shows a trade with the four leg groups:
 </CreditLinkedSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/creditlinkedswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditlinkedswap.tex][creditlinkedswap.tex]],
 listing =Credit Linked Swap Data= (leg detail abbreviated).
 
 The example sets a fixed recovery of 40 percent. The reference curve
@@ -141,6 +141,6 @@ follows the conventions of the
 
 - [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
   credit derivative family.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/creditlinkedswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/creditlinkedswap.tex][creditlinkedswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/doubledigitaloption.org
+++ b/doc/knowledge/domain/doubledigitaloption.org
@@ -176,6 +176,9 @@ underlying.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/doubledigitaloption.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/doubledigitaloption.org
+++ b/doc/knowledge/domain/doubledigitaloption.org
@@ -1,0 +1,181 @@
+:PROPERTIES:
+:ID: E63E99AD-6C5E-446B-BE14-57A8D9042AFD
+:END:
+#+title: Double Digital Option
+#+description: A binary option paying a fixed amount when two underlyings are simultaneously in the money; ORE's Double Digital Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:doubledigitaloption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A double digital option pays a fixed amount when two underlyings are
+simultaneously in the money at expiry. ORE prices it on FX, equity,
+commodity and interest-rate underlyings in any combination. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+The double digital is a binary option on two underlyings. Each
+underlying has its own strike levels and its own option type: call,
+put or collar. At expiry each underlying must be in the money with
+respect to its type. When both conditions hold at the same time, the
+fixed binary payout is due. When either fails, nothing is paid.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A double digital option is a binary option that pays out a fixed
+amount if the two underlyings (FX spots, Equity or Commodity prices,
+interest rates) are simultaneously in the money w.r.t. given strikes
+and option types at the option expiry.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+
+ORE notes the range of supported underlying types:
+
+#+begin_quote
+Equity, Commodity and IR underlyings are also supported in arbitrary
+combinations.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+
+** In plain terms
+
+A double digital option is an all-or-nothing bet on two markets at
+once. The buyer names a level, or a range, for each market. The
+payout happens only when both markets are on the right side of their
+levels on the same day. One missed market kills the payout. The trade
+suits a view on two markets together, and on how they move together,
+more than on either alone.
+
+** How it works in ORE
+
+The data node =DoubleDigitalOptionData= is the trade data container
+for the =DoubleDigitalOption= trade type. =Expiry= is the expiry date
+of the option and =Settlement= the payout settlement date.
+=BinaryPayout= is the amount paid when the option is in the money.
+
+Each underlying has its own strike node. =BinaryLevel1= is the strike
+for underlying 1, and =BinaryLevel2= the strike for underlying 2. For
+a call or put option the level is the strike; for a collar option it
+is the lower bound. =BinaryLevelUpper1= and =BinaryLevelUpper2= are
+the optional upper bounds, used by collar options only. The meaning
+of a level follows the underlying type. For an FX underlying it is
+the number of units of =CCY2= per unit of =CCY1=; for equity it is
+the price in the equity currency; for commodity the price in the
+commodity currency; for an interest rate it is the rate in decimal
+form. Allowable level values are non-negative numbers.
+
+=Type1= and =Type2= name the option type that applies to each
+underlying: =Call=, =Put= or =Collar=. ORE defines the in-the-money
+condition for a call and put as follows:
+
+#+begin_quote
+Underlying 1 is considered to be in the money if the spot is above
+(Call) / below (Put) the BinaryLevel1 resp. between (Collar) the
+BinaryLevel1 and BinaryLevelUpper1 at the expiry.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+
+Underlying 2 is in the money under the same rule with its own level
+and upper bound. =Position= takes =Long= or =Short=. =Underlying1= and
+=Underlying2= name the two underlyings; each takes =Equity=,
+=Commodity=, =FX= or =IR= as its type. The optional =Underlying3= and
+=Underlying4= turn each side into a spread: when =Underlying3= is
+defined, the first underlying is treated as the fixing of
+=Underlying1= minus the fixing of =Underlying3=. The same applies to
+=Underlying2= with =Underlying4=. Each spread side must match the type
+of the underlying it modifies. =PayCcy= is the currency in which the
+binary payout is paid.
+
+** Mathematical notes
+
+The payout is a fixed amount or nothing. The option pays the binary
+payout when both underlying values satisfy their in-the-money
+conditions at expiry, and pays zero otherwise. Each underlying
+condition is a digital in its own right: the spot above the level for
+a call, below it for a put, or inside the lower and upper bounds for
+a collar. The joint condition is the product of the two digitals. The
+position flag decides whether the holder receives or pays the payout.
+When a spread side is present, the underlying value is the difference
+of two fixings instead of a single fixing.
+
+** What moves its value (static sensitivities)
+
+- The spot levels of both underlyings at expiry. They decide the two
+  digital conditions.
+- The volatility of each underlying. It sets the probability of each
+  condition.
+- The correlation between the two underlyings. The joint condition
+  fires only when both are in the money, so its probability depends
+  on the dependence between them.
+- The strike levels and the upper bounds.
+- The binary payout amount.
+- The interest rates that discount the payout.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade has no cashflows before expiry. Both underlyings diffuse
+until the expiry date. At expiry each spot is compared with its
+levels and type. When both conditions hold, the fixed payout is paid
+on the settlement date. The value of the trade decays toward the
+discounted probability that both digitals fire together.
+
+** Why a customer would want it
+
+A double digital option packages two market views into one binary
+payout. It costs less than two single digitals because it demands
+both conditions at once. The structure suits investors who expect two
+markets to land in specific regions at the same date, and who want a
+known payout if they are right. In ORE Studio a customer books double
+digital options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a double digital on EUR-USD and JPY-USD. The
+trade pays 12000000 USD when EUR-USD is above 1.1 and JPY-USD sits
+between 0.006 and 0.008 on the expiry date:
+
+#+begin_example
+<DoubleDigitalOptionData>
+  <Expiry>2021-09-01</Expiry>
+  <Settlement>2021-09-03</Settlement>
+  <BinaryPayout>12000000</BinaryPayout>
+  <BinaryLevel1>1.1</BinaryLevel1>
+  <BinaryLevel2>0.006</BinaryLevel2>
+  <BinaryLevelUpper2>0.008</BinaryLevelUpper2>
+  <Type1>Call</Type1>
+  <Type2>Collar</Type2>
+  <Position>Long</Position>
+  <Underlying1>
+    <Type>FX</Type>
+    <Name>ECB-EUR-USD</Name>
+  </Underlying1>
+  <Underlying2>
+    <Type>FX</Type>
+    <Name>ECB-JPY-USD</Name>
+  </Underlying2>
+  <PayCcy>USD</PayCcy>
+</DoubleDigitalOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=,
+listing =Double Digital Option data=. The catalogue also walks through
+a term sheet variant of the same structure with a put on the second
+underlying.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/doubledigitaloption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/doubledigitaloption.org
+++ b/doc/knowledge/domain/doubledigitaloption.org
@@ -36,7 +36,7 @@ interest rates) are simultaneously in the money w.r.t. given strikes
 and option types at the option expiry.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/doubledigitaloption.tex][doubledigitaloption.tex]].
 
 ORE notes the range of supported underlying types:
 
@@ -45,7 +45,7 @@ Equity, Commodity and IR underlyings are also supported in arbitrary
 combinations.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/doubledigitaloption.tex][doubledigitaloption.tex]].
 
 ** In plain terms
 
@@ -84,7 +84,7 @@ Underlying 1 is considered to be in the money if the spot is above
 BinaryLevel1 and BinaryLevelUpper1 at the expiry.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/doubledigitaloption.tex][doubledigitaloption.tex]].
 
 Underlying 2 is in the money under the same rule with its own level
 and upper bound. =Position= takes =Long= or =Short=. =Underlying1= and
@@ -169,7 +169,7 @@ between 0.006 and 0.008 on the expiry date:
 </DoubleDigitalOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/doubledigitaloption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/doubledigitaloption.tex][doubledigitaloption.tex]],
 listing =Double Digital Option data=. The catalogue also walks through
 a term sheet variant of the same structure with a put on the second
 underlying.
@@ -179,6 +179,6 @@ underlying.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/doubledigitaloption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/doubledigitaloption.tex][doubledigitaloption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_asianoption.org
+++ b/doc/knowledge/domain/eq_asianoption.org
@@ -1,0 +1,163 @@
+:PROPERTIES:
+:ID: 90BB6829-31EC-4C86-BE17-FDABF670DDB6
+:END:
+#+title: Equity Asian Option
+#+description: An Asian option on the average equity price; ORE's EquityAsianOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_asianoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity Asian option pays on the averaged price of an equity
+underlying over a set period. The averaging smooths the payoff. ORE
+models it with the trade type =EquityAsianOption=. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An equity Asian option is a path-dependent option whose payoff depends
+on the averaged price of an equity underlying over a pre-set period.
+The average is arithmetic by default and can be geometric. A fixed-
+strike form compares the average to a strike. A floating-strike form
+compares the final price to the average. The container node is
+=EquityAsianOptionData=. It holds one =OptionData= sub-node and an
+=ObservationDates= schedule. The container node includes the strike,
+quantity and underlying.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Asian Option is a path-dependent option whose payoff depends
+upon the averaged price of an Equity underlying over a pre-set period
+of time.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_asianoption.tex=.
+
+** In plain terms
+
+An Asian option looks at the average price instead of the final price.
+Daily fixings over the observation period build the average. A
+customer who fears a price spike on one day prefers the average. The
+payoff is harder to manipulate and cheaper than a vanilla option.
+
+** How it works in ORE
+
+The =EquityAsianOptionData= node is the trade data container for the
+=EquityAsianOption= trade type. It has one =OptionData= trade
+component sub-node plus elements specific to the equity Asian option.
+=StrikeData= holds the strike in =Value= and the currency of the
+underlying and the strike in =Currency=. =Quantity= is the number of
+underlying equities. The node takes one =Underlying= element with
+=Type= set to =Equity=. The =OptionData= fields set =LongShort=,
+=OptionType=, =PayoffType= and the exercise date. =PayoffType= must be
+=Asian= or =AverageStrike=. The first identifies a fixed-strike Asian
+payoff and the second a floating-strike payoff. =PayoffType2= is
+optional and takes =Arithmetic= or =Geometric=. It defaults to
+=Arithmetic=. Exactly one =ExerciseDate= must be given. =Premiums=
+can represent deterministic option premia. =Settlement= is optional
+and defaults to the exercise date. =ObservationDates= holds the Asian
+observation period as a rules-based or dates-based schedule.
+
+** Mathematical notes
+
+The payoff is Payoff = Quantity x MAX(omega x (A(0,T) - K), 0). A(0,T)
+is the arithmetic average of the underlying equity spot price over
+the Asian observation period from start 0 to end T. K is the equity
+strike price. Omega is 1 for a call option and -1 for a put option.
+A geometric average is available through =PayoffType2=. The averaging
+reduces the volatility that reaches the payoff.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity.
+- The implied volatility of the underlying.
+- The strike and the exercise date.
+- The observation schedule and its remaining fixings.
+- The interest rates and dividends of the underlying.
+
+The average lags the spot. A move near the end of the period moves the
+average more than a move near the start.
+
+** How the profile ages (dynamic sensitivities)
+
+Each observation date adds a fixing to the average. Early fixings
+become fixed parts of the average. As the period fills, the average
+stiffens and the option's effective delta falls. Near the final
+observation the average is almost known and the option value
+approaches its settlement value.
+
+** Why a customer would want it
+
+A customer who receives or pays a periodic equity price, such as an
+average-priced buyback, wants an option on that average. The Asian
+payoff matches the exposure and costs less than a vanilla option of
+the same expiry. In ORE Studio a customer books equity Asian options
+to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long call on the average of the S&P 500 index
+over daily observations:
+
+#+begin_example
+<Trade id="EquityAsianOption">
+  <TradeType>EquityAsianOption</TradeType>
+  <Envelope>
+    <CounterParty>CPTY_A</CounterParty>
+    <NettingSetId>CPTY_A</NettingSetId>
+    <AdditionalFields />
+  </Envelope>
+  <EquityAsianOptionData>
+    <Quantity>100</Quantity>
+    <Currency>USD</Currency>
+    <StrikeData>
+      <Value>3100</Value>
+      <Currency>USD</Currency>
+    </StrikeData>
+    <Underlying>
+      <Type>Equity</Type>
+      <Name>RIC:.SPX</Name>
+      <Currency>USD</Currency>
+    </Underlying>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <OptionType>Call</OptionType>
+      <PayoffType>Asian</PayoffType>
+      <PayoffType2>Arithmetic</PayoffType2>
+      <ExerciseDates>
+        <ExerciseDate>2020-07-15</ExerciseDate>
+      </ExerciseDates>
+      <Premiums> ... </Premiums>
+    </OptionData>
+    <Settlement>2020-07-20</Settlement>
+    <ObservationDates>
+      <Rules>
+        <StartDate>2019-12-27</StartDate>
+        <EndDate>2020-07-06</EndDate>
+        <Tenor>1D</Tenor>
+        <Calendar>US</Calendar>
+        <Convention>F</Convention>
+        <TermConvention>F</TermConvention>
+        <Rule>Forward</Rule>
+      </Rules>
+    </ObservationDates>
+  </EquityAsianOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_asianoption.tex=,
+listing =Equity Asian Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_asianoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_asianoption.org
+++ b/doc/knowledge/domain/eq_asianoption.org
@@ -37,7 +37,7 @@ upon the averaged price of an Equity underlying over a pre-set period
 of time.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_asianoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_asianoption.tex][eq_asianoption.tex]].
 
 ** In plain terms
 
@@ -151,7 +151,7 @@ over daily observations:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_asianoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_asianoption.tex][eq_asianoption.tex]],
 listing =Equity Asian Option data=.
 
 * See also
@@ -161,6 +161,6 @@ listing =Equity Asian Option data=.
 
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_asianoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_asianoption.tex][eq_asianoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_asianoption.org
+++ b/doc/knowledge/domain/eq_asianoption.org
@@ -156,6 +156,9 @@ listing =Equity Asian Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_barrieroption.org
+++ b/doc/knowledge/domain/eq_barrieroption.org
@@ -1,0 +1,157 @@
+:PROPERTIES:
+:ID: 80C9B215-EBBA-4367-902B-C0687C0E43E8
+:END:
+#+title: Equity Barrier Option
+#+description: A barrier option on an equity price; ORE's EquityBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_barrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity barrier option exists only while the equity spot stays on
+one side of a barrier level. The barrier is monitored continuously.
+ORE models it with the trade type =EquityBarrierOption=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An equity barrier option is a path-dependent option whose existence
+depends on the equity spot rate reaching a pre-set barrier level.
+Exercise is European. The product has a continuously monitored single
+barrier with a vanilla European equity option underlying. Knock-in
+options become active when the barrier is reached. Knock-out options
+cease to exist when it is reached. The barrier level is quoted in the
+currency of the underlying equity spot. The container node is
+=EquityBarrierOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Barrier Option is a path-dependent option whose existence
+depends upon an Equity spot rate reaching a pre-set barrier level.
+Exercise is European.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=.
+
+ORE states the monitoring as follows:
+
+#+begin_quote
+This product has a continuously monitored single barrier with a
+Vanilla European Equity Option Underlying. A set number of shares of a
+single name equity or an equity index is specified by the "Quantity".
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=.
+
+** In plain terms
+
+A barrier option is a vanilla option with a tripwire. The tripwire
+sits above or below the current price. If the price crosses it, the
+option either switches on or switches off. The tripwire makes the
+option cheaper or more exotic than the vanilla form.
+
+** How it works in ORE
+
+The =EquityBarrierOptionData= node is the trade data container for the
+=EquityBarrierOption= trade type. It has one =OptionData= sub-node and
+one =BarrierData= sub-node. Only the European option style is
+allowed. The barrier level in =BarrierData= is quoted in the same
+currency as the underlying equity spot price. Changing the option from
+call to put does not require switching the barrier level. =StartDate=
+is optional. It starts the check for a barrier breach before today's
+date. Without it no check is made and no past breach is assumed.
+=Calendar= and =EQIndex= support that past check. The equity index
+format is =EQ-RIC:Code=. =StrikeData= holds the strike and supports
+=StrikePrice= only. Composite options with a strike currency different
+from the underlying equity currency are not supported. =Quantity= is
+the number of units of the underlying. =Currency= is the payment
+currency. Quanto payoffs are not allowed: the payment currency must
+equal the underlying equity currency up to the major or minor
+distinction.
+
+** Mathematical notes
+
+The four main types are up-and-out, down-and-out, up-and-in and
+down-and-in. An up option starts below the barrier and needs the price
+to rise. A down option starts above the barrier and needs the price to
+fall. A knock-out option dies when the barrier is reached. A knock-in
+option becomes a vanilla equity option when the barrier is reached. An
+option that expires inactive pays zero, or a cash rebate paid as a
+fraction of the original premium. The value of the product is the
+vanilla option value adjusted for the probability of the barrier
+event.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to the
+  barrier.
+- The implied volatility of the underlying. It drives the chance of a
+  breach.
+- The strike and the barrier level.
+- The interest rates and dividends of the underlying.
+- The rebate, when one applies.
+
+Close to the barrier the option is most sensitive to the spot and to
+volatility. The barrier probability dominates near the level.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier is monitored continuously from the start date. A knock-in
+option that triggers becomes a vanilla equity option for the rest of
+its life. A knock-out option that triggers ends at once. If no breach
+occurs, an out option ages like a vanilla option until expiry, while
+its survival probability falls as time passes without a touch.
+
+** Why a customer would want it
+
+A barrier structure lets a customer pay for the optionality they
+expect to use. A knock-out call suits a view that the index stays
+below the barrier. The rebate softens the loss when the option dies.
+In ORE Studio a customer books equity barrier options to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a call on the S&P 500 index with a strike of
+3200 and a start date in 2025:
+
+#+begin_example
+<EquityBarrierOptionData>
+    <OptionData>
+        ...
+    </OptionData>
+    <BarrierData>
+        ...
+    </BarrierData>
+    <StartDate>2025-01-25</StartDate>
+    <Calendar>TARGET</Calendar>
+    <EQIndex>EQ-RIC:.SPX</EQIndex>
+    <Name>RIC:.SPX</Name>
+    <StrikeData>
+      <StrikePrice>
+        <Value>3200.00</Value>
+        <Currency>USD</Currency>
+      </StrikePrice>
+    </StrikeData>
+    <Quantity>1000</Quantity>
+    <Currency>USD</Currency>
+</EquityBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=,
+listing =Equity Barrier Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_barrieroption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_barrieroption.org
+++ b/doc/knowledge/domain/eq_barrieroption.org
@@ -150,6 +150,9 @@ listing =Equity Barrier Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_barrieroption.org
+++ b/doc/knowledge/domain/eq_barrieroption.org
@@ -38,7 +38,7 @@ depends upon an Equity spot rate reaching a pre-set barrier level.
 Exercise is European.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_barrieroption.tex][eq_barrieroption.tex]].
 
 ORE states the monitoring as follows:
 
@@ -48,7 +48,7 @@ Vanilla European Equity Option Underlying. A set number of shares of a
 single name equity or an equity index is specified by the "Quantity".
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_barrieroption.tex][eq_barrieroption.tex]].
 
 ** In plain terms
 
@@ -145,7 +145,7 @@ ORE's catalogue shows a call on the S&P 500 index with a strike of
 </EquityBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_barrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_barrieroption.tex][eq_barrieroption.tex]],
 listing =Equity Barrier Option data=.
 
 * See also
@@ -155,6 +155,6 @@ listing =Equity Barrier Option data=.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_barrieroption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_barrieroption.tex][eq_barrieroption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_digitaloption.org
+++ b/doc/knowledge/domain/eq_digitaloption.org
@@ -139,6 +139,9 @@ listing =Equity Digital Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_digitaloption.org
+++ b/doc/knowledge/domain/eq_digitaloption.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: FCD38489-372D-4CD4-9A8A-DB0A332DE26E
+:END:
+#+title: Equity Digital Option
+#+description: A cash-or-nothing digital option on an equity; ORE's EquityDigitalOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_digitaloption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity digital option pays a fixed amount or nothing, decided by
+the equity spot at expiry. ORE models it with the trade type
+=EquityDigitalOption=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+An equity digital option is an option whose payout is either zero or a
+fixed predetermined amount. The payout is cash-or-nothing. It depends
+on whether the underlying equity spot expires in the money at the
+expiration date. The product has European exercise with payout at
+expiry. The buyer pays a premium to the seller. The container node is
+=EquityDigitalOptionData=. It holds one =OptionData= sub-node plus the
+strike, payoff amount and quantity.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Digital Option is an option whose payout is either zero or a
+fixed predetermined amount (Cash-or-Nothing). Payout depends on
+whether the underlying Equity spot rate expires in-the-money at the
+expiration date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=.
+
+ORE adds the exercise terms as follows:
+
+#+begin_quote
+Equity Digital Options have European exercise with payout at expiry.
+The buyer of a Equity Digital Option pays a premium to the seller.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=.
+
+** In plain terms
+
+A digital option is a binary bet on a share price. If the price ends
+on the right side of the strike, the buyer receives the fixed payoff
+amount. If not, the buyer receives nothing. There is no middle
+ground. The option is a pure view on the direction.
+
+** How it works in ORE
+
+The =EquityDigitalOptionData= node is the trade data container for the
+=EquityDigitalOption= trade type. It has one =OptionData= sub-node
+plus elements specific to the equity digital option. =LongShort=
+names the side. =OptionType= takes =Call= or =Put=. A call is in the
+money when the underlying equity price is above the strike. A put is
+in the money when it is below. The =Style= is =European= only. Exactly
+one =ExerciseDate= must be given. =Premiums= is optional and holds the
+premium amounts paid by the buyer. =Strike= is the option strike per
+unit of the underlying, expressed in the currency of the underlying
+equity. =PayoffCurrency= is the currency of the payoff amount and must
+be consistent with the currency of the underlying equity spot.
+=PayoffAmount= is the fixed payoff amount per unit of underlying,
+expressed in the payoff currency. The underlying comes from =Name= or
+an =Underlying= node. =Quantity= is the number of units of the
+underlying covered by the transaction.
+
+** Mathematical notes
+
+The payoff per unit is the fixed =PayoffAmount= when the option is in
+the money at expiry, and zero otherwise. For a call the condition is
+the spot above the strike at expiry. For a put it is the spot below
+the strike. The total payout scales with the quantity. The value is
+the discounted probability of finishing in the money times the payoff
+amount.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to the
+  strike.
+- The implied volatility of the underlying.
+- The strike and the expiry.
+- The interest rates and dividends of the underlying.
+
+Near the strike the digital is most sensitive to the spot and to
+volatility. The payout does not grow with the depth of the finish in
+the money.
+
+** How the profile ages (dynamic sensitivities)
+
+The digital decays toward its settlement as expiry approaches. Its
+value is the discounted probability of the payoff event. With the spot
+far from the strike, the payout becomes almost certain or almost
+worthless. At expiry the spot decides the payoff and the option
+settles.
+
+** Why a customer would want it
+
+A customer with a fixed view on a share price can take a binary
+payout. The digital pays a known amount for a known premium. It also
+builds spreads and structured payouts where a fixed cash amount is
+needed. In ORE Studio a customer books equity digital options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long call digital on the S&P 500 index that
+pays 1000 per unit above strike 3300:
+
+#+begin_example
+<EquityDigitalOptionData>
+    <OptionData>
+        <LongShort>Long</LongShort>
+        <OptionType>Call</OptionType>
+        <Style>European</Style>
+        <ExerciseDates>
+            <ExerciseDate>2027-02-26</ExerciseDate>
+        </ExerciseDates>
+        ...
+    </OptionData>
+    <Strike>3300</Strike>
+    <PayoffCurrency>USD</PayoffCurrency>
+    <PayoffAmount>1000</PayoffAmount>
+    <Name>RIC:.SPX</Name>
+    <Quantity>1000</Quantity>
+</EquityDigitalOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=,
+listing =Equity Digital Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_digitaloption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_digitaloption.org
+++ b/doc/knowledge/domain/eq_digitaloption.org
@@ -37,7 +37,7 @@ whether the underlying Equity spot rate expires in-the-money at the
 expiration date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_digitaloption.tex][eq_digitaloption.tex]].
 
 ORE adds the exercise terms as follows:
 
@@ -46,7 +46,7 @@ Equity Digital Options have European exercise with payout at expiry.
 The buyer of a Equity Digital Option pays a premium to the seller.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_digitaloption.tex][eq_digitaloption.tex]].
 
 ** In plain terms
 
@@ -134,7 +134,7 @@ pays 1000 per unit above strike 3300:
 </EquityDigitalOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_digitaloption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_digitaloption.tex][eq_digitaloption.tex]],
 listing =Equity Digital Option data=.
 
 * See also
@@ -144,6 +144,6 @@ listing =Equity Digital Option data=.
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_digitaloption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_digitaloption.tex][eq_digitaloption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_doublebarrieroption.org
+++ b/doc/knowledge/domain/eq_doublebarrieroption.org
@@ -39,7 +39,7 @@ pre-set barrier levels. Exercise is European, and barriers are
 American (continuously monitored).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doublebarrieroption.tex][eq_doublebarrieroption.tex]].
 
 ORE describes the barrier behaviour as follows:
 
@@ -55,7 +55,7 @@ exist/becomes inactive, if the one of the barriers is reached during
 the life of the option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doublebarrieroption.tex][eq_doublebarrieroption.tex]].
 
 ** In plain terms
 
@@ -158,7 +158,7 @@ corridor from 3000 to 3500:
 </EquityDoubleBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doublebarrieroption.tex][eq_doublebarrieroption.tex]],
 listing =Equity Double Barrier Option data=.
 
 * See also
@@ -168,6 +168,6 @@ listing =Equity Double Barrier Option data=.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doublebarrieroption.tex][eq_doublebarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_doublebarrieroption.org
+++ b/doc/knowledge/domain/eq_doublebarrieroption.org
@@ -1,0 +1,170 @@
+:PROPERTIES:
+:ID: 06615BB7-3A1C-407D-8745-010DB52BD053
+:END:
+#+title: Equity Double Barrier Option
+#+description: A double barrier option on an equity price; ORE's EquityDoubleBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_doublebarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity double barrier option exists only while the equity spot
+stays between two barrier levels. Both barriers are monitored
+continuously. ORE models it with the trade type
+=EquityDoubleBarrierOption=. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+An equity double barrier option is a path-dependent option whose
+existence depends on the equity spot rate reaching one of two pre-set
+barrier levels. Exercise is European and the barriers are American,
+that is continuously monitored. Knock-in and knock-out forms are
+supported. The two levels sit in the =BarrierData= node in ascending
+order. The barrier levels are quoted in the currency of the
+underlying equity spot. The container node is
+=EquityDoubleBarrierOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Double Barrier Option is a path-dependent option whose
+existence depends upon an Equity spot rate reaching one of the two
+pre-set barrier levels. Exercise is European, and barriers are
+American (continuously monitored).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+
+ORE describes the barrier behaviour as follows:
+
+#+begin_quote
+A knock-in option is a barrier option that only comes into
+existence/becomes active when the Equity spot rate reaches the one of
+the barrier level at any point in the option's life. Once a barrier is
+knocked-in, the option will not cease to exist until the option
+expires and effectively it becomes a Vanilla Equity Option.
+
+A knock-out option starts its life active, but ceases to
+exist/becomes inactive, if the one of the barriers is reached during
+the life of the option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+
+** In plain terms
+
+A double barrier option is a vanilla option inside a corridor. Two
+tripwires sit above and below the current price. If the price touches
+either one, the option either dies or comes alive. The corridor makes
+the option cheaper or more exotic than the single-barrier form.
+
+** How it works in ORE
+
+The =EquityDoubleBarrierOptionData= node is the trade data container
+for the =EquityDoubleBarrierOption= trade type. It has one =OptionData=
+sub-node and one =BarrierData= sub-node. The relevant =OptionData=
+fields are =LongShort=, =OptionType=, =Style= and =Settlement=. The
+style allows European exercise only. Settlement can be =Cash= or
+=Physical=. Exactly one =ExerciseDate= must be given. =BarrierData=
+holds the two levels in =Levels= in ascending order. =Type= takes
+=KnockOut= or =KnockIn=. The barrier levels are quoted in the currency
+of the underlying equity spot. The underlying comes from =Name= or an
+=Underlying= node. =Currency= is the currency of the option.
+=StrikeData= holds the strike and supports =StrikePrice= only.
+=Quantity= is the number of units. =StartDate=, =Calendar= and
+=EQIndex= support a check for a barrier breach before today's date.
+The equity index format is =EQ-RIC:Code=.
+
+** Mathematical notes
+
+A knock-in option becomes a vanilla equity option when either barrier
+is reached. A knock-out option ends when either barrier is reached. An
+expired knock-out option that never touched a barrier pays its vanilla
+payoff. An expired knock-in option that never touched a barrier pays
+nothing. The value of the product is the vanilla option value adjusted
+for the probability of touching either barrier.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to each
+  barrier.
+- The implied volatility of the underlying. It drives the chance of a
+  breach.
+- The width of the corridor between the two levels.
+- The strike and the exercise date.
+- The interest rates and dividends of the underlying.
+
+Close to a barrier the option is most sensitive to the spot and to
+volatility. The corridor width sets how long the option can survive.
+
+** How the profile ages (dynamic sensitivities)
+
+Both barriers are monitored continuously. A knock-out option that
+touches a barrier ends at once. A knock-in option that touches a
+barrier becomes a vanilla equity option for the rest of its life. An
+out option that survives ages like a vanilla option, with its
+survival probability falling as time passes without a touch.
+
+** Why a customer would want it
+
+A double barrier structure prices the range view of a customer. A
+knock-out call inside a corridor is cheaper than its vanilla
+equivalent. The corridor can also express the expectation that the
+index stays between two levels. In ORE Studio a customer books equity
+double barrier options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a knock-out call on the S&P 500 index inside a
+corridor from 3000 to 3500:
+
+#+begin_example
+<EquityDoubleBarrierOptionData>
+    <OptionData>
+        <LongShort>Long</LongShort>
+        <OptionType>Call</OptionType>
+        <Style>European</Style>
+        <Settlement>Cash</Settlement>
+        <ExerciseDates>
+            <ExerciseDate>2021-01-29</ExerciseDate>
+        </ExerciseDates>
+    </OptionData>
+    <BarrierData>
+        <Type>KnockOut</Type>
+        <Levels>
+            <Level>3000.00</Level>
+            <Level>3500.00</Level>
+        </Levels>
+    </BarrierData>
+    <Name>RIC:.SPX</Name>
+    <Currency>USD</Currency>
+    <StrikeData>
+      <StrikePrice>
+        <Value>3200.00</Value>
+        <Currency>USD</Currency>
+      </StrikePrice>
+    </StrikeData>
+    <Quantity>1000</Quantity>
+    <StartDate>2019-12-27</StartDate>
+    <Calendar>US-NYSE</Calendar>
+    <EQIndex>EQ-RIC:.SPX</EQIndex>
+</EquityDoubleBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=,
+listing =Equity Double Barrier Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_doublebarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_doublebarrieroption.org
+++ b/doc/knowledge/domain/eq_doublebarrieroption.org
@@ -163,6 +163,9 @@ listing =Equity Double Barrier Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_doubletouchoption.org
+++ b/doc/knowledge/domain/eq_doubletouchoption.org
@@ -40,7 +40,7 @@ payoff amount or zero (Cash-or-Nothing) depending upon an Equity spot
 rate reaching one of the pre-set barrier levels.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doubletouchoption.tex][eq_doubletouchoption.tex]].
 
 ORE describes the two forms as follows:
 
@@ -52,7 +52,7 @@ A Knock-Out or Double No-Touch option has no payout if one of the
 barriers is breached, and fixed payout otherwise.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doubletouchoption.tex][eq_doubletouchoption.tex]].
 
 ORE notes that the current implementation supports equity double
 touch options with payout at expiry only.
@@ -156,7 +156,7 @@ pays one million when the spot touches 3000 or 4500:
 </EquityDoubleTouchOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doubletouchoption.tex][eq_doubletouchoption.tex]],
 listing =Equity Double Touch Option data=.
 
 * See also
@@ -166,6 +166,6 @@ listing =Equity Double Touch Option data=.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_doubletouchoption.tex][eq_doubletouchoption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_doubletouchoption.org
+++ b/doc/knowledge/domain/eq_doubletouchoption.org
@@ -1,0 +1,168 @@
+:PROPERTIES:
+:ID: 44BB5D47-C9CF-4E77-A4A9-50F14044A535
+:END:
+#+title: Equity Double Touch Option
+#+description: A cash-or-nothing double touch option on an equity; ORE's EquityDoubleTouchOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_doubletouchoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity double touch option pays a fixed amount or nothing, decided
+by two barrier levels on the equity spot. ORE models it with the trade
+type =EquityDoubleTouchOption=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An equity double touch option has two continuously monitored barriers
+with a cash-or-nothing digital underlying. It pays either a fixed
+predetermined payoff amount or zero, depending on whether the equity
+spot reaches one of the barriers. The knock-in form, or double one-
+touch, pays when a barrier is breached. The knock-out form, or double
+no-touch, pays when no barrier is breached. The current
+implementation supports payout at expiry only. The container node is
+=EquityDoubleTouchOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product has two continuously monitored barriers with a
+Cash-or-Nothing digital underlying.
+
+An Equity Double Touch option pays either a fixed predetermined
+payoff amount or zero (Cash-or-Nothing) depending upon an Equity spot
+rate reaching one of the pre-set barrier levels.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+
+ORE describes the two forms as follows:
+
+#+begin_quote
+A Knock-In or Double One-Touch option has a fixed payout if one of the
+barriers is breached, and no payout otherwise.
+
+A Knock-Out or Double No-Touch option has no payout if one of the
+barriers is breached, and fixed payout otherwise.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+
+ORE notes that the current implementation supports equity double
+touch options with payout at expiry only.
+
+** In plain terms
+
+A double touch option is a bet on a corridor. Two levels sit above
+and below the current price. The double one-touch form pays when the
+price touches either level. The double no-touch form pays when the
+price stays inside the corridor for the whole life. Either way the
+payout is a fixed cash amount or nothing.
+
+** How it works in ORE
+
+The =EquityDoubleTouchOptionData= node is the trade data container for
+the =EquityDoubleTouchOption= trade type. It has one =OptionData= sub-
+node and one =BarrierData= sub-node. The =OptionType= can be omitted.
+=LongShort= names the side. =PayOffAtExpiry= takes =true= for payoff
+at expiry and =false= for payoff at hit. Only payoff at expiry is
+currently supported, for both knock-out and knock-in barriers. It
+defaults to =true=. Exactly one =ExerciseDate= must be given.
+=Premiums= is optional. =BarrierData= holds two levels in =Levels= in
+ascending order. =Type= takes =KnockOut= or =KnockIn=. =StrictComparison=
+is optional: it selects <= and >= or the strict < and > for the
+barrier check. It defaults to the non-strict comparison. The barrier
+levels are quoted in the same currency as the underlying equity spot.
+=PayoffCurrency= must be consistent with that currency. =PayoffAmount=
+is the fixed payoff amount. The underlying comes from =Name= or an
+=Underlying= node. =StartDate=, =Calendar= and =EQIndex= support a
+check for a barrier breach before today's date. The equity index
+format is =EQ-RIC:Code=.
+
+** Mathematical notes
+
+The product is a digital claim on a corridor event. The double one-
+touch form pays the payoff amount if the spot touches either barrier
+at any time during the life. The double no-touch form pays if the spot
+stays between the two barriers for the whole life. No rebates are
+supported. The value is the discounted probability of the event times
+the payoff amount.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to each
+  barrier.
+- The implied volatility of the underlying. It drives the chance of a
+  touch.
+- The width of the corridor between the two levels.
+- The time to expiry and the payoff amount.
+
+Close to a barrier the chance of a touch rises quickly. The no-touch
+form loses value as the spot nears either level.
+
+** How the profile ages (dynamic sensitivities)
+
+Both barriers are monitored continuously. A double one-touch option
+that touches a barrier has its event decided, and pays at expiry. A
+double no-touch option that touches a barrier is dead from that
+moment. A no-touch option that survives ages toward a more certain
+payout, while its survival probability falls with every day that
+passes without a touch.
+
+** Why a customer would want it
+
+A double no-touch pays when the market stays calm inside a range. It
+suits a customer who expects the index to trade sideways. The double
+one-touch pays when the range breaks, which suits a view of a large
+move in either direction. In ORE Studio a customer books equity double
+touch options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a double one-touch on the S&P 500 index that
+pays one million when the spot touches 3000 or 4500:
+
+#+begin_example
+<EquityDoubleTouchOptionData>
+    <OptionData>
+        <LongShort>Long</LongShort>
+        <PayOffAtExpiry>true</PayOffAtExpiry>
+        <ExerciseDates>
+          <ExerciseDate>2021-12-14</ExerciseDate>
+        </ExerciseDates>
+        ...
+    </OptionData>
+    <BarrierData>
+        ...
+        <Type>KnockIn</Type> <!-- KnockOut or KnockIn -->
+        <Levels>
+            <Level>3000</Level>
+            <Level>4500</Level>
+        </Levels>
+        ...
+    </BarrierData>
+    <PayoffCurrency>USD</PayoffCurrency>
+    <PayoffAmount>1000000</PayoffAmount>
+    <Name>RIC:.SPX</Name>
+    <StartDate>2021-03-01</StartDate>
+    <Calendar>USD</Calendar>
+    <EQIndex>EQ-RIC:.SPX</EQIndex>
+</EquityDoubleTouchOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=,
+listing =Equity Double Touch Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_doubletouchoption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_doubletouchoption.org
+++ b/doc/knowledge/domain/eq_doubletouchoption.org
@@ -161,6 +161,9 @@ listing =Equity Double Touch Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_europeanbarrieroption.org
+++ b/doc/knowledge/domain/eq_europeanbarrieroption.org
@@ -1,0 +1,151 @@
+:PROPERTIES:
+:ID: 0415E392-7423-411F-A83B-C791E6BE3078
+:END:
+#+title: Equity European Barrier Option
+#+description: A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_europeanbarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity European barrier option gives the buyer a right that may be
+withdrawn by the equity price at expiry. The barrier is checked once.
+ORE models it with the trade type =EquityEuropeanBarrierOption=. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An equity European barrier option gives the buyer the right to buy a
+set number of shares at a strike at one predetermined time in the
+future. The right may be withdrawn if the equity spot reaches a
+barrier level at that time. The underlying is monitored only at
+expiry, with a single barrier. Exercise is European and the barrier
+is European. Knock-in and knock-out forms are supported. Settlement
+can be cash or physical. The container node is
+=EquityEuropeanBarrierOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity European Barrier option gives the buyer the right, but not
+the obligation, to buy a set number of shares of a single name equity
+or an equity index, at a predetermined strike price, at one
+predetermined time in the future. This right may be withdrawn
+depending upon an Equity spot price or index reaching a predetermined
+barrier level at the predetermined time, the underlying is monitored
+only at expiry with a single barrier.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+
+ORE adds the settlement terms as follows:
+
+#+begin_quote
+For this right the buyer pays a premium to the seller. Settlement can
+be either cash or physical delivery.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+
+** In plain terms
+
+A European barrier option is the once-checked relative of the barrier
+family. The barrier does not watch the price through the life of the
+option. It is checked at expiry only. If the price sits on the wrong
+side of the barrier at that moment, the option dies. Otherwise it
+settles like a vanilla option.
+
+** How it works in ORE
+
+The =EquityEuropeanBarrierOptionData= node is the trade data container
+for the =EquityEuropeanBarrierOption= trade type. It has one
+=OptionData= sub-node and one =BarrierData= sub-node. Only the
+European option style is allowed. The barrier level in =BarrierData=
+is quoted in the same currency as the underlying equity spot. Changing
+the option from call to put does not require switching the barrier
+level. The underlying comes from =Name= or an =Underlying= node.
+=StrikeData= holds the strike and supports =StrikePrice= only.
+=Quantity= is the number of units of the underlying covered by the
+transaction.
+
+** Mathematical notes
+
+The four main types are up-and-out, down-and-out, up-and-in and
+down-and-in. An up option starts below the barrier. A down option
+starts above it. The barrier is compared with the spot at expiry, not
+through the life of the option. A knock-out option that expires on the
+wrong side of the barrier pays zero, or a cash rebate paid as a
+fraction of the original premium. A knock-in option becomes active
+only if the spot is on the right side at expiry. The value of the
+product is the vanilla value adjusted for the probability of the spot
+finishing on the wrong side of the barrier.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to the
+  barrier.
+- The implied volatility of the underlying. It drives the chance of
+  the expiry check failing.
+- The strike and the barrier level.
+- The interest rates and dividends of the underlying.
+
+Only the terminal spot matters for the barrier, so the product
+behaves like a vanilla option until near expiry.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier event is decided at expiry, so no breach can end the
+option early. The product ages like a European option for its whole
+life. At expiry the spot is checked against the barrier. A knock-out
+option on the wrong side pays zero or the rebate. A knock-in option
+on the right side pays its vanilla payoff.
+
+** Why a customer would want it
+
+The European barrier is cheaper than a vanilla option and less
+path-dependent than a continuously monitored barrier. It suits a
+customer who accepts a barrier check at the settlement moment only. In
+ORE Studio a customer books equity European barrier options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an option on the S&P 500 index with a strike of
+3200 and a quantity of 1000:
+
+#+begin_example
+<EquityEuropeanBarrierOptionData>
+    <OptionData>
+        ...
+    </OptionData>
+    <BarrierData>
+        ...
+    </BarrierData>
+    <Name>RIC:.SPX</Name>
+    <StrikeData>
+      <StrikePrice>
+        <Value>3200.00</Value>
+        <Currency>USD</Currency>
+      </StrikePrice>
+    </StrikeData>
+    <Quantity>1000</Quantity>
+</EquityEuropeanBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=,
+listing =Equity European Barrier Option data=. The source ends the
+=Quantity= line with a stray =>= character; it is normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_europeanbarrieroption.org
+++ b/doc/knowledge/domain/eq_europeanbarrieroption.org
@@ -42,7 +42,7 @@ barrier level at the predetermined time, the underlying is monitored
 only at expiry with a single barrier.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex][eq_europeanbarrieroption.tex]].
 
 ORE adds the settlement terms as follows:
 
@@ -51,7 +51,7 @@ For this right the buyer pays a premium to the seller. Settlement can
 be either cash or physical delivery.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex][eq_europeanbarrieroption.tex]].
 
 ** In plain terms
 
@@ -138,7 +138,7 @@ ORE's catalogue shows an option on the S&P 500 index with a strike of
 </EquityEuropeanBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex][eq_europeanbarrieroption.tex]],
 listing =Equity European Barrier Option data=. The source ends the
 =Quantity= line with a stray =>= character; it is normalised here.
 
@@ -149,6 +149,6 @@ listing =Equity European Barrier Option data=. The source ends the
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_europeanbarrieroption.tex][eq_europeanbarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_europeanbarrieroption.org
+++ b/doc/knowledge/domain/eq_europeanbarrieroption.org
@@ -144,6 +144,9 @@ listing =Equity European Barrier Option data=. The source ends the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/eq_outperformance.org
+++ b/doc/knowledge/domain/eq_outperformance.org
@@ -1,0 +1,201 @@
+:PROPERTIES:
+:ID: 9033DF60-3AD6-45FB-9DF7-1094D9B489FF
+:END:
+#+title: Equity Outperformance Option
+#+description: An option paying the outperformance of one asset over another; ORE's Equity Outperformance Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_outperformance:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+An equity outperformance option pays the difference between the
+returns of two equity indices, against a strike return. ORE prices it
+as a European cash-settled option, with optional knock-in and
+knock-out prices on the second index. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+The outperformance payoff is the positive part of the return of the
+first index minus the return of the second index, minus a strike
+return. The buyer receives that outperformance and pays the strike
+return. The trade may carry a knock-in price and a knock-out price.
+The payoff is then paid only when the second index sits between the
+two prices on the exercise date.
+
+* Detail
+
+** What it is
+
+ORE introduces the product as follows:
+
+#+begin_quote
+An Equity Outperformance option has a payoff that depends on the
+`outperformance' of two equity indices (i.e. the difference between
+their returns) against a strike return. The buyer has the right but
+not the obligation to receive the outperformance in exchange for the
+strike rate at a predetermined time in the future.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+
+ORE describes the barrier condition as follows:
+
+#+begin_quote
+A knockIn and knockOut price may be provided. The payoff is then only
+paid if on the exercise date the price of Index2 is above the
+knockIn price and below the knockOut price.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+
+** In plain terms
+
+An outperformance option is a bet on relative performance. The buyer
+is long the return of index one and short the return of index two,
+through one option. The buyer profits when index one beats index two
+by more than the strike return. A call expects index one to win; a
+put expects index two to win. The barrier condition ties the payout
+to the level of index two on the exercise date.
+
+** How it works in ORE
+
+The data node =EquityOutperformanceOptionData= is the trade data
+container for the =EquityOutperformanceOption= trade type:
+
+#+begin_quote
+The EquityOutperformanceOptionData node includes one OptionData trade
+component sub-node plus elements specific to the Equity
+Outperformance Option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+
+=OptionData= holds the option terms. =LongShort= takes =Long= or
+=Short=. =OptionType= takes =Call= or =Put=. A call gives the holder
+the right, but not the obligation, to receive the outperformance and
+pay the strike return; a put gives the holder the right to pay the
+outperformance and receive the strike return. =Style= takes
+=European= only, the sole style the trade type allows. =Settlement=
+takes =Cash= or =Physical=. The =ExerciseDates= node must carry
+exactly one =ExerciseDate=. A =Premiums= node is optional and holds
+the premium amounts paid by the option buyer to the seller.
+
+=Currency= is the currency of the option. =Underlying1= and
+=Underlying2= name the two equity underlyings and the equity curves
+used for pricing. ORE notes a constraint on them:
+
+#+begin_quote
+Also note that the equities in Underlying1 and Underlying2 must be
+quoted in the same currency.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+
+=InitialPrice1= and =InitialPrice2= hold the initial prices of the
+two underlyings. =StrikeReturn= is the strike return of the option.
+=Notional= is the notional amount of the trade. All three take any
+positive real number. The optional =KnockInPrice= and
+=KnockOutPrice= bound the second index on the settlement date: the
+payoff pays only when the price of underlying two is above the
+knock-in value and below the knock-out value.
+
+The optional =InitialPriceCurrency1= and =InitialPriceCurrency2=
+apply when an initial price is given in a currency other than its
+underlying's currency. Each then requires its =InitialPriceFXTerms=
+node, which carries the =FXIndex= for the conversion.
+
+** Mathematical notes
+
+ORE states the payoff of the option as the notional N times the
+positive part of the return of index one minus the return of index
+two, minus the strike return:
+
+N x max(0, R1 - R2 - K).
+
+R1 and R2 are the returns of =Underlying1= and =Underlying2=, and K
+is the =StrikeReturn=. The payoff is zero when the second index's
+return closes the gap to the first by K or more. The knock-in and
+knock-out prices add a binary condition on the price of index two at
+the exercise date. ORE states that the pricing methodology was
+generalised from Brigo and Mercurio 2006, section 13.16.2.
+
+** What moves its value (static sensitivities)
+
+- The level of each index at expiry. The return spread decides the
+  payoff.
+- The volatility of each index. Higher volatility widens the
+  distribution of the return spread.
+- The correlation between the two indices. It sets the volatility of
+  the spread: the spread is less volatile than either index.
+- The strike return.
+- The knock-in and knock-out prices, which filter the payoff
+  binarily.
+- The interest rates that discount the payoff.
+
+The payoff is a call on the return spread. The barrier condition
+makes the trade sensitive to the joint level of index two at expiry.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade holds until its single exercise date. Each index return is
+measured from its initial price. At expiry the payoff is the positive
+part of the spread minus the strike return, scaled by the notional.
+The barrier condition checks the price of index two on the same date.
+Cash settlement follows on the settlement date.
+
+** Why a customer would want it
+
+An outperformance option prices a view on relative performance
+directly. It lets an investor benefit when one market beats another,
+without taking a position in either market alone. Banks and asset
+managers use it to trade pairs of indices. In ORE Studio a customer
+books equity outperformance options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a European cash-settled call on the
+outperformance of the S&P 500 over the NASDAQ 100, with a strike
+return of 1% and a knock-in and knock-out window on the second
+index:
+
+#+begin_example
+<EquityOutperformanceOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <ExerciseDates>
+      <ExerciseDate>2022-09-21</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <Currency>USD</Currency>
+  <Notional>500000</Notional>
+  <Underlying1>
+    <Type>Equity</Type>
+    <Name>RIC:.SPX</Name>
+  </Underlying1>
+  <Underlying2>
+    <Type>Equity</Type>
+    <Name>RIC:.NDX</Name>
+  </Underlying2>
+  <InitialPrice1>2140</InitialPrice1>
+  <InitialPrice2>13000</InitialPrice2>
+  <StrikeReturn>0.01</StrikeReturn>
+  <KnockInPrice>12500</KnockInPrice>
+  <KnockOutPrice>14000</KnockOutPrice>
+</EquityOutperformanceOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=,
+listing =Equity Outperformance Option Data=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_outperformance.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_outperformance.org
+++ b/doc/knowledge/domain/eq_outperformance.org
@@ -38,7 +38,7 @@ not the obligation to receive the outperformance in exchange for the
 strike rate at a predetermined time in the future.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]].
 
 ORE describes the barrier condition as follows:
 
@@ -48,7 +48,7 @@ paid if on the exercise date the price of Index2 is above the
 knockIn price and below the knockOut price.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]].
 
 ** In plain terms
 
@@ -70,7 +70,7 @@ component sub-node plus elements specific to the Equity
 Outperformance Option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]].
 
 =OptionData= holds the option terms. =LongShort= takes =Long= or
 =Short=. =OptionType= takes =Call= or =Put=. A call gives the holder
@@ -91,7 +91,7 @@ Also note that the equities in Underlying1 and Underlying2 must be
 quoted in the same currency.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]].
 
 =InitialPrice1= and =InitialPrice2= hold the initial prices of the
 two underlyings. =StrikeReturn= is the strike return of the option.
@@ -191,7 +191,7 @@ index:
 </EquityOutperformanceOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_outperformance.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]],
 listing =Equity Outperformance Option Data=.
 
 * See also
@@ -199,6 +199,6 @@ listing =Equity Outperformance Option Data=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_outperformance.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_outperformance.tex][eq_outperformance.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_outperformance.org
+++ b/doc/knowledge/domain/eq_outperformance.org
@@ -196,6 +196,9 @@ listing =Equity Outperformance Option Data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/eq_outperformance.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_touchoption.org
+++ b/doc/knowledge/domain/eq_touchoption.org
@@ -1,0 +1,164 @@
+:PROPERTIES:
+:ID: 45585B0A-31A1-49D9-9CF3-A5C240F9607D
+:END:
+#+title: Equity Touch Option
+#+description: A cash-or-nothing one-touch option on an equity; ORE's EquityTouchOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:eq_touchoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity touch option pays a fixed amount or nothing, decided by a
+single barrier on the equity spot. The barrier is monitored
+continuously. ORE models it with the trade type =EquityTouchOption=.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+An equity touch option has a continuously monitored single barrier
+with a cash-or-nothing digital underlying. At expiry it pays either a
+fixed predetermined payoff amount or zero, depending on whether the
+equity spot reached the barrier. The four main types are up-and-out,
+down-and-out, up-and-in and down-and-in. A knock-in, or one-touch,
+pays when the barrier is breached. A knock-out, or no-touch, pays when
+it is not. The container node is =EquityTouchOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product has a continuously monitored single barrier with a
+Cash-or-Nothing digital underlying.
+
+At expiry an Equity Touch Option pays either a fixed predetermined
+payoff amount or zero (Cash-or-Nothing) depending upon an Equity spot
+rate reaching a pre-set barrier level.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=.
+
+ORE describes the four forms as follows:
+
+#+begin_quote
+A Knock-In or One-Touch option has a fixed payout if the barrier is
+breached, and no payout otherwise. The payout can be at expiry or at
+hit.
+
+A Knock-Out or No-Touch option has no payout if the barrier is
+breached, and fixed payout at expiry otherwise.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=.
+
+** In plain terms
+
+A touch option is a binary bet on a level. One level sits above or
+below the current price. The one-touch form pays when the price hits
+the level at any time. The no-touch form pays when the price never
+hits it. The payout is a fixed cash amount or nothing.
+
+** How it works in ORE
+
+The =EquityTouchOptionData= node is the trade data container for the
+=EquityTouchOption= trade type. It has one =OptionData= sub-node and
+one =BarrierData= sub-node. The =OptionType= is not required. It is
+inferred from the barrier type: =Call= for an up barrier and =Put=
+for a down barrier. =LongShort= names the side. =PayOffAtExpiry= is
+optional: =true= for payoff at expiry and =false= for payoff at hit.
+For up-and-out and down-and-out barriers only payoff at expiry is
+supported. It defaults to =true=. =Settlement= takes =Cash= or
+=Physical=. Exactly one =ExerciseDate= must be given. =Premiums= is
+optional. =BarrierData= holds the level in =Levels=. The level is
+quoted in the same currency as the underlying equity spot.
+=StrictComparison= is optional and selects the strict or non-strict
+barrier check. =PayoffCurrency= must be consistent with the currency
+of the underlying equity spot. =PayoffAmount= is the fixed payoff
+amount. The underlying comes from =Name= or an =Underlying= node.
+=StartDate=, =Calendar= and =EQIndex= support a check for a barrier
+breach before today's date. The equity index format is =EQ-RIC:Code=.
+
+** Mathematical notes
+
+The product is a digital claim on a barrier event. The one-touch form
+pays the payoff amount if the spot touches the barrier at any time
+during the life. The payout can be at the moment of the hit or at
+expiry. The no-touch form pays at expiry if the spot never touched the
+barrier. No rebates are supported. The value is the discounted
+probability of the event times the payoff amount.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity and its distance to the
+  barrier.
+- The implied volatility of the underlying. It drives the chance of a
+  touch.
+- The barrier level and the time to expiry.
+- The payoff amount and the timing of the payout.
+
+Close to the barrier the chance of a touch rises quickly. The no-touch
+form loses value as the spot nears the level.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier is monitored continuously from the start date. A one-touch
+option that touches the barrier has its event decided. The payout
+arrives at the hit or at expiry as the trade specifies. A no-touch
+option that touches the barrier is dead from that moment. A no-touch
+option that survives ages toward a more certain payout, while its
+survival probability falls as time passes without a touch.
+
+** Why a customer would want it
+
+A one-touch pays when a level breaks, which suits a customer who
+expects a large move. A no-touch pays when the price stays on one side
+of the level. The fixed payout and known premium make the trade easy
+to size. In ORE Studio a customer books equity touch options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an up-and-in touch on the S&P 500 index that
+pays one million when the spot reaches 3300:
+
+#+begin_example
+<EquityTouchOptionData>
+    <OptionData>
+        <LongShort>Long</LongShort>
+        <PayOffAtExpiry>true</PayOffAtExpiry>
+        <Settlement>Cash</Settlement>
+        <ExerciseDates>
+          <ExerciseDate>2022-03-01</ExerciseDate>
+        </ExerciseDates>
+        ...
+    </OptionData>
+    <BarrierData>
+      <Type>UpAndIn</Type>
+      <Levels>
+        <Level>3300</Level>
+      </Levels>
+    </BarrierData>
+    <PayoffCurrency>USD</PayoffCurrency>
+    <PayoffAmount>1000000</PayoffAmount>
+    <Name>RIC:.SPX</Name>
+    <StartDate>2019-12-27</StartDate>
+    <Calendar>US-NYSE</Calendar>
+    <EQIndex>EQ-RIC:.SPX</EQIndex>
+</EquityTouchOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=,
+listing =Equity Touch Option data=. The source ends the =EQIndex= line
+with a stray =>= character; it is normalised here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/eq_touchoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_touchoption.org
+++ b/doc/knowledge/domain/eq_touchoption.org
@@ -40,7 +40,7 @@ payoff amount or zero (Cash-or-Nothing) depending upon an Equity spot
 rate reaching a pre-set barrier level.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_touchoption.tex][eq_touchoption.tex]].
 
 ORE describes the four forms as follows:
 
@@ -53,7 +53,7 @@ A Knock-Out or No-Touch option has no payout if the barrier is
 breached, and fixed payout at expiry otherwise.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_touchoption.tex][eq_touchoption.tex]].
 
 ** In plain terms
 
@@ -151,7 +151,7 @@ pays one million when the spot reaches 3300:
 </EquityTouchOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/eq_touchoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_touchoption.tex][eq_touchoption.tex]],
 listing =Equity Touch Option data=. The source ends the =EQIndex= line
 with a stray =>= character; it is normalised here.
 
@@ -162,6 +162,6 @@ with a stray =>= character; it is normalised here.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/eq_touchoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/eq_touchoption.tex][eq_touchoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/eq_touchoption.org
+++ b/doc/knowledge/domain/eq_touchoption.org
@@ -157,6 +157,9 @@ with a stray =>= character; it is normalised here.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityautodeltahedgedoption.org
+++ b/doc/knowledge/domain/equityautodeltahedgedoption.org
@@ -39,7 +39,7 @@ more batches of European equity options with an embedded discrete
 delta-hedging strategy.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex][equityautodeltahedgedoption.tex]].
 
 ** In plain terms
 
@@ -146,7 +146,7 @@ hedging volatility at 5 percent and no drift:
 </EquityAutoDeltaHedgedOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex][equityautodeltahedgedoption.tex]],
 listing =Equity Auto Delta Hedged Option data=, further batches
 elided.
 
@@ -157,7 +157,7 @@ elided.
 
 - [[https://en.wikipedia.org/wiki/Delta_neutral][Wikipedia: Delta neutral]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
   which inputs
-  =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=. The
+  [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex][equityautodeltahedgedoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityautodeltahedgedoption.org
+++ b/doc/knowledge/domain/equityautodeltahedgedoption.org
@@ -152,6 +152,9 @@ elided.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Delta_neutral][Wikipedia: Delta neutral]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityautodeltahedgedoption.org
+++ b/doc/knowledge/domain/equityautodeltahedgedoption.org
@@ -1,0 +1,160 @@
+:PROPERTIES:
+:ID: E9DCA7FE-1680-435D-BAD3-956E809BD71C
+:END:
+#+title: Equity Auto Delta Hedged Option
+#+description: Batches of European equity options with an embedded delta-hedging strategy; ORE's EquityAutoDeltaHedgedOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityautodeltahedgedoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity auto delta hedged option packages European equity options
+with their delta-hedging strategy in one trade. The hedge parameters
+are contractual. ORE models it with the trade type
+=EquityAutoDeltaHedgedOption=. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+The trade type represents a structured product with one or more
+batches of European equity options and an embedded discrete
+delta-hedging strategy. Each batch sits in an =Underlying= node. The
+=Volatility= element sets the hedging volatility used in the
+Black-Scholes delta. The =DriftRate= element sets the rate of the
+contractual forward. The =ObservationStartDate= starts the discrete
+hedging observations. Historical fixings between that date and the
+valuation date feed the realised hedge P&L. The container node is
+=EquityAutoDeltaHedgedOptionData=.
+
+* Detail
+
+** What it is
+
+ORE introduces the product as follows:
+
+#+begin_quote
+This trade type represents a structured product consisting of one or
+more batches of European equity options with an embedded discrete
+delta-hedging strategy.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=.
+
+** In plain terms
+
+The trade is an option and its hedge sold as one contract. The option
+pays out in the usual way. The hedge leg replays a fixed hedging
+recipe: a stated volatility for the deltas, a stated drift for the
+forward, and daily rebalancing. The customer knows the hedge rules in
+advance.
+
+** How it works in ORE
+
+The =EquityAutoDeltaHedgedOptionData= node is the trade data container
+for the =EquityAutoDeltaHedgedOption= trade type. =Volatility= is
+mandatory. It is the hedging volatility sigma_h used in the
+Black-Scholes delta computation for the daily delta-hedge
+rebalancing, expressed as a decimal. =DriftRate= is mandatory. It is
+the continuously compounded rate r used in the contractual forward
+formula F = S_t x e^(r x tau), where tau is the Actual/365 (Fixed)
+year fraction from the observation date to expiry. =Underlyings= is a
+container holding one or more =Underlying= child nodes. Each defines a
+single batch of options. The =OptionData= sub-node holds the option
+terms: =LongShort=, =OptionType=, =Style=, =Settlement=, exactly one
+=ExerciseDate= and one premium per underlying. The style must be
+=European= and the settlement must be =Cash=. The premium is included
+in the equity amount calculation at expiry. Each underlying also
+carries =Name=, =Currency=, =Strike=, =StrikeCurrency= and =Quantity=.
+=ObservationStartDate= is mandatory. It is the date from which the
+discrete delta-hedging observation begins. Historical fixings between
+this date and the valuation date are used to compute the realised
+hedge P&L.
+
+** Mathematical notes
+
+The product combines the option payoffs of its batches with the P&L of
+a discrete delta-hedging strategy. Each day the hedge holds the
+Black-Scholes delta of the options, computed with the contractual
+hedging volatility. The contractual forward F = S_t x e^(r x tau)
+gives the drift of the hedge. The realised hedge P&L accumulates from
+the observation start date. At expiry the equity amount includes the
+premiums.
+
+** What moves its value (static sensitivities)
+
+- The spot price of each underlying equity, through the option delta
+  and the hedge.
+- The implied volatility of each underlying.
+- The contractual hedging volatility and drift rate.
+- The strikes, quantities and exercise dates of the batches.
+- The interest rates and dividends that drive the forward.
+
+The hedge dampens the spot sensitivity of the raw option position. The
+choice of hedging volatility sets how the hedge behaves.
+
+** How the profile ages (dynamic sensitivities)
+
+The hedge rebalances daily from the observation start date. Realised
+hedge P&L accumulates as the underlying moves. Near expiry the hedge
+tends toward the option deltas at expiry, and the batches settle in
+cash. After the last exercise date the product is settled and the
+exposure ends.
+
+** Why a customer would want it
+
+A customer who sells structured equity products wants the hedge
+economics inside the trade. The auto delta hedged option fixes the
+hedge parameters contractually, so the payoff and the hedge P&L are
+valued as one. In ORE Studio a customer books auto delta hedged
+options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a batch of long European calls on HSBC, with the
+hedging volatility at 5 percent and no drift:
+
+#+begin_example
+<EquityAutoDeltaHedgedOptionData>
+  <Volatility>0.05</Volatility>
+  <DriftRate>0.00</DriftRate>
+  <Underlyings>
+    <Underlying>
+      <OptionData>
+        <LongShort>Long</LongShort>
+        <OptionType>Call</OptionType>
+        <Style>European</Style>
+        <Settlement>Cash</Settlement>
+        <ExerciseDates>
+          <ExerciseDate>2021-01-29</ExerciseDate>
+        </ExerciseDates>
+        <PremiumAmount>9.36</PremiumAmount>
+        <PremiumCurrency>USD</PremiumCurrency>
+        <PremiumPayDate>2019-03-01</PremiumPayDate>
+      </OptionData>
+      <Name>RIC:HSBA.L</Name>
+      <Currency>USD</Currency>
+      <Strike>3.5</Strike>
+      <StrikeCurrency>USD</StrikeCurrency>
+      <Quantity>51400</Quantity>
+    </Underlying>
+    <Underlying>
+      ...
+    </Underlying>
+  </Underlyings>
+  <ObservationStartDate>2020-11-11</ObservationStartDate>
+</EquityAutoDeltaHedgedOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=,
+listing =Equity Auto Delta Hedged Option data=, further batches
+elided.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Delta_neutral][Wikipedia: Delta neutral]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs
+  =Docs/UserGuide/tradedata/equityautodeltahedgedoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equitycliquetoption.org
+++ b/doc/knowledge/domain/equitycliquetoption.org
@@ -1,0 +1,169 @@
+:PROPERTIES:
+:ID: F3398C7E-E978-45C4-94AA-6EBB6DA98EC9
+:END:
+#+title: Equity Cliquet Option
+#+description: A series of forward-start equity options with local and global caps; ORE's EquityCliquetOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equitycliquetoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A cliquet option is a series of consecutive forward-start equity
+options. Each option is struck at a given moneyness when it becomes
+active. ORE models it with the trade type =EquityCliquetOption=. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A cliquet option consists of a series of consecutive forward starting
+equity options. Each option is struck at a given moneyness, commonly
+at the money, when it becomes active. The per-period returns can carry
+local caps and floors. The total return can carry a global cap and a
+global floor. The container node is =EquityCliquetOptionData=. A
+=ScheduleData= node defines the valuation dates. The first date starts
+the first option. Each following date closes one period and starts the
+next. The final valuation date settles the whole product.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A cliquet option is an exotic option consisting of a series of
+consecutive forward start options, with each option being struck
+at-the-money when it becomes active.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=.
+
+ORE restates the setup as follows:
+
+#+begin_quote
+A cliquet option consists of a series of consecutive forward starting
+equity options, with each option being struck at a given moneyness
+(commonly at-the-money) when it becomes active.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=.
+
+** In plain terms
+
+A cliquet option resets itself every period. Each period starts a new
+option at the then-current price. The gain of each period is added up.
+Caps and floors limit each period and the total. The buyer collects
+the sum of the good periods while the caps and floors control the
+cost.
+
+** How it works in ORE
+
+The =EquityCliquetOptionData= node is the trade data container for the
+=EquityCliquetOption= trade type. The underlying comes from =Name= or
+an =Underlying= node. =Currency= is the currency of the notional and
+must equal the currency of the underlying equity. =Notional= scales
+the payoff. =LongShort= names the side and =OptionType= the call or
+put direction. =Moneyness= sets the strike of each forward starting
+option. A value of 1.0 is at the money, 1.1 is 110 percent of the at-
+the-money strike, 0.9 is 90 percent. =LocalCap= and =LocalFloor= limit
+each period's return. =GlobalCap= and =GlobalFloor= limit the total
+return. The =ScheduleData= node defines the valuation dates. The last
+date is the final valuation date. The whole payoff is paid at that
+date plus =SettlementDays=. =SettlementDays= defaults to zero.
+=Premium= is paid for the option and is expressed relative to the
+notional. If a premium is specified, a =PremiumPaymentDate= must also
+be specified. =PremiumCurrency= defaults to the currency of the
+notional.
+
+** Mathematical notes
+
+The payoff is N x min(cap_g, max(floor_g, sum over the periods of the
+period returns)). Each period return is delta x min(cap_l,
+max(floor_l, S_ti / S_ti-1 - M)). S_ti is the price of the underlying
+at the period end. M is the moneyness. Delta is 1 for a call and -1
+for a put. cap_l and floor_l are the local cap and floor. cap_g and
+floor_g are the global cap and floor over the whole product. The local
+limits bind period by period. The global limits bind the accumulated
+sum.
+
+** What moves its value (static sensitivities)
+
+- The spot level of the underlying at each reset date.
+- The implied volatility surface across the option tenors.
+- The local caps and floors of each period.
+- The global cap and floor of the product.
+- The moneyness of the forward-start strikes.
+- The interest rates and dividends of the underlying.
+
+Each period is a new at-the-money option, so the structure is
+sensitive to the volatility term structure. The caps and floors set
+how much optionality each period keeps.
+
+** How the profile ages (dynamic sensitivities)
+
+Period by period a return is locked in. A local cap or floor applies
+when the period return tries to exceed it. The accumulated total moves
+toward the global cap or floor. Once the global cap is reached, the
+remaining periods add nothing. Once the global floor binds, later
+gains rebuild the total. The number of live periods shrinks as the
+schedule advances. The final payoff settles at the last valuation date
+plus the settlement days.
+
+** Why a customer would want it
+
+A cliquet structure suits a customer who expects the market to grind
+upward with periodic setbacks. Each reset gives a fresh at-the-money
+option, so the customer never holds a deep out-of-the-money strike.
+The caps and floors shape the price. In ORE Studio a customer books
+equity cliquet options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a short call cliquet on the S&P 500 index with
+annual resets:
+
+#+begin_example
+<EquityCliquetOptionData>
+    <Underlying>
+      <Type>Equity</Type>
+      <Name>.SPX</Name>
+      <IdentifierType>RIC</IdentifierType>
+    </Underlying>
+    <Currency>USD</Currency>
+    <Notional>1000000.0</Notional>
+    <LongShort>Short</LongShort>
+    <OptionType>Call</OptionType>
+    <Moneyness>1.0</Moneyness>
+    <LocalCap>0.07</LocalCap>
+    <LocalFloor>-0.06</LocalFloor>
+    <GlobalCap>0.07</GlobalCap>
+    <GlobalFloor>-0.07</GlobalFloor>
+    <ScheduleData>
+      <Dates>
+        <Date>20171231</Date>
+        <Date>20181231</Date>
+        ...
+      </Dates>
+      <Calendar>USD</Calendar>
+      <Convention>F</Convention>
+    </ScheduleData>
+    <SettlementDays>5</SettlementDays>
+    <Premium>0.027</Premium>
+    <PremiumPaymentDate>31-12-2017</PremiumPaymentDate>
+    <PremiumCurrency>USD</PremiumCurrency>
+</EquityCliquetOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=,
+listing =Cliquet Option data=, intermediate schedule dates elided.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Cliquet_option][Wikipedia: Cliquet option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equitycliquetoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equitycliquetoption.org
+++ b/doc/knowledge/domain/equitycliquetoption.org
@@ -38,7 +38,7 @@ consecutive forward start options, with each option being struck
 at-the-money when it becomes active.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equitycliquetoption.tex][equitycliquetoption.tex]].
 
 ORE restates the setup as follows:
 
@@ -48,7 +48,7 @@ equity options, with each option being struck at a given moneyness
 (commonly at-the-money) when it becomes active.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equitycliquetoption.tex][equitycliquetoption.tex]].
 
 ** In plain terms
 
@@ -157,7 +157,7 @@ annual resets:
 </EquityCliquetOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equitycliquetoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equitycliquetoption.tex][equitycliquetoption.tex]],
 listing =Cliquet Option data=, intermediate schedule dates elided.
 
 * See also
@@ -167,6 +167,6 @@ listing =Cliquet Option data=, intermediate schedule dates elided.
 
 - [[https://en.wikipedia.org/wiki/Cliquet_option][Wikipedia: Cliquet option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equitycliquetoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equitycliquetoption.tex][equitycliquetoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equitycliquetoption.org
+++ b/doc/knowledge/domain/equitycliquetoption.org
@@ -162,6 +162,9 @@ listing =Cliquet Option data=, intermediate schedule dates elided.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Cliquet_option][Wikipedia: Cliquet option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityforward.org
+++ b/doc/knowledge/domain/equityforward.org
@@ -38,7 +38,7 @@ contract. An equity forward does not involve any upfront payment, does
 not pay dividends, and settlement is cash.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityforward.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityforward.tex][equityforward.tex]].
 
 ** In plain terms
 
@@ -120,7 +120,7 @@ ORE's catalogue shows a long US dollar forward on the S&P 500 index:
 </EquityForwardData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityforward.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityforward.tex][equityforward.tex]],
 listing =Equity Forward data=.
 
 The optional counterpart to this product is the
@@ -133,6 +133,6 @@ The optional counterpart to this product is the
 
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityforward.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityforward.tex][equityforward.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityforward.org
+++ b/doc/knowledge/domain/equityforward.org
@@ -128,6 +128,9 @@ The optional counterpart to this product is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityforward.org
+++ b/doc/knowledge/domain/equityforward.org
@@ -1,0 +1,135 @@
+:PROPERTIES:
+:ID: D60CBEE4-AE5C-421B-AAEF-5E56DC75A662
+:END:
+#+title: Equity Forward
+#+description: An agreement to buy or sell shares at a future price; ORE's EquityForward product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityforward:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity forward locks the price of shares to be bought or sold at a
+future date. The contract is cash settled and pays no dividends. ORE
+models it with the trade type =EquityForward=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An equity forward is an agreement to buy or sell a set number of
+shares of a single equity name or an equity index at a fixed strike at
+maturity. The product involves no upfront payment. It pays no
+dividends. Settlement is cash. Vanilla equity forwards are supported.
+The container node is =EquityForwardData=. The =LongShort= element
+names the direction. =Maturity= is the buy or sell date. =Strike= is
+quoted in the currency of the underlying.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Forward contract is an agreement between two counterparties
+to buy/sell a set number of shares of a single name equity or an
+equity index, at a predetermined strike price, at the end of the
+contract. An equity forward does not involve any upfront payment, does
+not pay dividends, and settlement is cash.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityforward.tex=.
+
+** In plain terms
+
+An equity forward is a promise to trade shares later at a price agreed
+today. No money changes hands at inception. At maturity the difference
+between the market price and the agreed price is settled in cash. A
+long forward profits when the share price rises. A short forward
+profits when it falls.
+
+** How it works in ORE
+
+The =EquityForwardData= node is the trade data container for the
+=EquityForward= trade type. Only vanilla equity forwards are
+supported. =LongShort= names the direction: =Long= buys the underlying,
+=Short= sells it. =Maturity= is the date when the shares are bought or
+sold. The underlying is a single equity or an equity index, given by
+=Name= or by an =Underlying= node. That node defines the equity curve
+used for pricing. =Quantity= is the number of units. =Currency= is the
+payment currency. If the underlying is quoted in another currency, the
+=SettlementData= sub-node must carry an =FXIndex= to convert the
+payoff. =Strike= is the agreed buy or sell price. It must be quoted in
+the same currency as the underlying. =StrikeCurrency= is optional and
+defaults to the payment currency. Minor-currency values are converted
+to the major currency. The =SettlementData= node can set a payment
+=Date=. Alternatively its =Rules= sub-node derives the payment date
+from maturity with =PaymentLag=, =PaymentCalendar= and
+=PaymentConvention=.
+
+** Mathematical notes
+
+The payoff of a long forward at maturity is the quantity times the
+difference between the spot and the strike, Quantity x (S_T - K). The
+sign reverses for a short forward. A fair new trade has no upfront
+payment, so its strike equals the market forward price. The forward
+price grows the spot at the risk-free rate and deducts expected
+dividends. Volatility does not enter a linear forward price.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity or index. Each unit of spot
+  moves the value almost one for one.
+- The expected dividends of the underlying.
+- The risk-free rates in the underlying currency.
+- The FX rate when the payment currency differs from the underlying
+  currency.
+- The discount curve in the payment currency.
+
+A long forward gains as the spot rises. A short forward gains as it
+falls.
+
+** How the profile ages (dynamic sensitivities)
+
+The forward ages linearly. Each unit of spot moves the value one for
+one from the moment of the trade. The financing component decays as
+maturity approaches. At maturity the value equals the payoff. The
+contract then settles in cash and the exposure ends.
+
+** Why a customer would want it
+
+A customer can lock the future purchase or sale price of shares or an
+index without paying cash today. The contract hedges a planned equity
+trade. It also expresses a directional view with leverage. Cash
+settlement avoids delivery. In ORE Studio a customer books equity
+forwards to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long US dollar forward on the S&P 500 index:
+
+#+begin_example
+<EquityForwardData>
+  <LongShort>Long</LongShort>
+  <Maturity>2018-06-30</Maturity>
+  <Name>RIC:.SPX</Name>
+  <Currency>USD</Currency>
+  <Strike>2147.56</Strike>
+  <StrikeCurrency>USD</StrikeCurrency>
+  <Quantity>17000</Quantity>
+</EquityForwardData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityforward.tex=,
+listing =Equity Forward data=.
+
+The optional counterpart to this product is the
+[[id:803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1][Equity Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityforward.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityfuturesoption.org
+++ b/doc/knowledge/domain/equityfuturesoption.org
@@ -37,7 +37,7 @@ EquityFutureOption trade type. Equity options with exercise styles
 European and American are supported.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityfuturesoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityfuturesoption.tex][equityfuturesoption.tex]].
 
 ** In plain terms
 
@@ -129,7 +129,7 @@ index, with a future expiry before the option expiry:
 </EquityFutureOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityfuturesoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityfuturesoption.tex][equityfuturesoption.tex]],
 listing =Equity Future Option data=.
 
 The spot-based relative of this product is the
@@ -142,6 +142,6 @@ The spot-based relative of this product is the
 
 - [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityfuturesoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityfuturesoption.tex][equityfuturesoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityfuturesoption.org
+++ b/doc/knowledge/domain/equityfuturesoption.org
@@ -137,6 +137,9 @@ The spot-based relative of this product is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityfuturesoption.org
+++ b/doc/knowledge/domain/equityfuturesoption.org
@@ -1,0 +1,144 @@
+:PROPERTIES:
+:ID: 67ECE260-9D52-4183-882D-06F795AF9BA1
+:END:
+#+title: Equity Futures Option
+#+description: An option on an equity future contract; ORE's EquityFutureOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityfuturesoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity futures option is an option on the settlement price of an
+equity future. European and American exercise styles are supported.
+ORE models it with the trade type =EquityFutureOption=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An equity futures option follows the shape of an equity option. Its
+underlying is a future contract settlement price rather than a spot
+price. European and American styles are supported. The container node
+is =EquityFutureOptionData=. It holds one =OptionData= sub-node and a
+=StrikeData= node. The optional =FutureExpiryDate= names the expiry of
+the underlying future when the future price flag is set. Without it,
+the future is assumed to expire with the option.
+
+* Detail
+
+** What it is
+
+ORE introduces the product as follows:
+
+#+begin_quote
+The EquityFutureOptionData node is the trade data container for the
+EquityFutureOption trade type. Equity options with exercise styles
+European and American are supported.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityfuturesoption.tex=.
+
+** In plain terms
+
+An equity futures option is an option whose payout depends on a future
+price, not on a spot price. The future price already carries the
+financing and dividend expectations of the share. The option then bets
+on where that future price lands.
+
+** How it works in ORE
+
+The =EquityFutureOptionData= node is the trade data container for the
+=EquityFutureOption= trade type. It has one and only one =OptionData=
+trade component sub-node plus elements specific to the equity future
+option. =LongShort= names the side and =OptionType= the call or put
+right. =Settlement= takes =Cash= or =Physical=. Exactly one
+=ExerciseDate= must be given. =Premiums= carries the option premium.
+The underlying equity comes from =Name= or an =Underlying= node.
+=Currency= is the currency of the option. =StrikeData= holds the strike
+and supports =StrikePrice= only. =Quantity= is the number of units.
+=FutureExpiryDate= is optional. When =IsFuturePrice= is true and the
+underlying is a future contract settlement price, this element names
+the expiry of that future. Without it the future is assumed to expire
+with the option.
+
+** Mathematical notes
+
+The payoff follows the option form on the future price: the call pays
+max(F - K, 0) per unit and the put pays max(K - F, 0). The future price
+moves with the spot, the rates and the dividends of the underlying
+equity. The value of the option therefore inherits those drivers
+through the forward curve.
+
+** What moves its value (static sensitivities)
+
+- The price of the underlying future or forward.
+- The spot price of the equity, through the future price.
+- The implied volatility of the future price.
+- The expected dividends and the rates that set the future basis.
+- The strike, the expiry and the style of the option.
+
+The future price rises and falls with the underlying equity. An option
+on the future moves in the same direction.
+
+** How the profile ages (dynamic sensitivities)
+
+The option decays toward its intrinsic value as expiry approaches. The
+underlying future also ages and converges to the spot at its own
+expiry. If the future expires before the option, the option's
+underlying becomes the settled spot value. American options keep the
+early exercise right until their last exercise date.
+
+** Why a customer would want it
+
+A customer who trades equity futures wants options on the same
+instrument. The option hedges a future position or expresses a view on
+its direction. Pricing against the future removes the need to model
+the spot-to-future basis inside the option. In ORE Studio a customer
+books equity futures options to value them and run sensitivities on
+the ORE engine.
+
+** Example
+
+ORE's catalogue shows an American call whose underlying is the S&P 500
+index, with a future expiry before the option expiry:
+
+#+begin_example
+<EquityFutureOptionData>
+    <OptionData>
+         <LongShort>Long</LongShort>
+         <OptionType>Call</OptionType>
+         <Style>American</Style>
+         <Settlement>Cash</Settlement>
+         <PayOffAtExpiry>true</PayOffAtExpiry>
+         <ExerciseDates>
+             <ExerciseDate>2022-03-01</ExerciseDate>
+         </ExerciseDates>
+         ...
+    </OptionData>
+    <Name>RIC:.SPX</Name>
+    <Currency>USD</Currency>
+    <StrikeData>
+        <StrikePrice>
+            <Value>2147.56</Value>
+            <Currency>USD</Currency>
+        </StrikePrice>
+    </StrikeData>
+    <Quantity>17000</Quantity>
+    <FutureExpiryDate>2021-01-29</FutureExpiryDate>
+</EquityFutureOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityfuturesoption.tex=,
+listing =Equity Future Option data=.
+
+The spot-based relative of this product is the
+[[id:803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1][Equity Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Futures_contract][Wikipedia: Futures contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityfuturesoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityoption.org
+++ b/doc/knowledge/domain/equityoption.org
@@ -1,0 +1,173 @@
+:PROPERTIES:
+:ID: 803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1
+:END:
+#+title: Equity Option
+#+description: An option to buy or sell shares at a strike price; ORE's EquityOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity option gives the buyer the right to buy or sell shares at a
+strike price. European, American, quanto and composite forms are
+supported. ORE models the family with the trade type =EquityOption=.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+An equity option gives the buyer the right, but not the obligation, to
+buy or sell a set number of shares of a single equity name or an
+equity index at a predetermined strike price. A European option
+exercises at the end of the contract. An American option exercises at
+any time up to expiration. In a quanto option the payoff currency
+differs from the currency the equity is quoted in. In a composite
+option the strike currency differs from the underlying currency.
+Settlement can be cash or physical. The container node is
+=EquityOptionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the European and American forms as follows:
+
+#+begin_quote
+A European Equity Option gives the buyer the right, but not the
+obligation, to buy a set number of shares of a single name equity or
+an equity index, at a predetermined strike price, at the end of the
+contract. For this right the buyer pays a premium to the seller.
+
+An American Equity Option gives the buyer the right to buy at any time
+during the life of the option up until the expiration date. The right
+to buy the shares can only be exercised once.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=.
+
+ORE defines the quanto and composite forms as follows:
+
+#+begin_quote
+A Quanto European Equity Option is a European Equity Option where the
+currency that the underlying equity (or equity index) is quoted in and
+the option payoff currency are different. The implied FX rate between
+the underlying currency and payoff currency at the option settlement
+date is then equal to one.
+
+In a European Equity Composite Option the strike currency is different
+from the underlying currency. This is unrelated to the CompositeTrade
+trade type.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=.
+
+** In plain terms
+
+An equity option is an insurance-like right on a share price. The
+buyer pays a premium up front. In return the buyer can buy at the
+strike if the price rises above it, or sell at the strike if the price
+falls below it. Losses never exceed the premium. A quanto option pays
+in a different currency and ignores the exchange rate at settlement. A
+composite option keeps its strike in a different currency.
+
+** How it works in ORE
+
+The =EquityOptionData= node is the trade data container for the
+=EquityOption= trade type. It has one and only one =OptionData= trade
+component sub-node. =LongShort= names the side, =OptionType= the call
+or put right. =Style= takes =European= or =American=. =Settlement=
+takes =Cash= or =Physical=. A quanto payoff must settle in cash.
+=PayOffAtExpiry= is relevant for American options and defaults to
+=PayOffAtExpiry true=. Exactly one =ExerciseDate= must be given. For
+American options it is the last exercise date. =PaymentData= can set a
+payment date other than the exercise date, except for quanto and
+composite options. =Premiums= carries the premium amounts. The
+underlying comes from =Name= or an =Underlying= node. =Currency= is the
+payment currency. If it differs from the currency the equity is quoted
+in, a quanto payoff applies. For a quanto option, =StrikeCurrency= must
+equal the currency the equity is quoted in. For a composite option it
+must equal the payment currency. The strike can also sit in a
+=StrikeData= node, which supports =StrikePrice= only.
+
+** Mathematical notes
+
+The call payoff per share is max(S - K, 0) and the put payoff is
+max(K - S, 0), scaled by the quantity of shares. A quanto option
+converts the payoff at an implied FX rate of one. For a composite call
+the payoff at expiry is max(X(t) x S(t) - K, 0). Here X(t) is the
+exchange rate at expiry that converts from the underlying currency
+into the strike currency. The payoff can take place at exercise or at
+expiry.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity or index. It sets the
+  moneyness.
+- The implied volatility of the underlying.
+- The strike, the expiry and the style of the option.
+- The expected dividends of the underlying.
+- The interest rates in the payment and underlying currencies.
+- For quanto options, the FX volatility and the equity-FX
+  correlation.
+- For composite options, the FX spot level.
+
+Calls gain when the spot rises. Puts gain when it falls. Time decay
+works against the option buyer.
+
+** How the profile ages (dynamic sensitivities)
+
+An option loses time value as expiry approaches. Its value converges
+to the intrinsic value. A European option cannot exercise early. An
+American option can, and early exercise may be optimal just before a
+dividend. At expiry the option settles in cash or delivers the shares.
+The quanto and composite conversions apply at the settlement date.
+
+** Why a customer would want it
+
+An equity option caps the downside of a share position or a planned
+trade. The buyer pays a known premium and keeps unlimited upside
+potential. American exercise suits holders who may need to act before
+expiry. Quanto options give equity exposure in a home currency without
+FX risk. Composite options express a view on both the equity and the
+exchange rate. In ORE Studio a customer books equity options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an American call on the S&P 500 index:
+
+#+begin_example
+<EquityOptionData>
+    <OptionData>
+         <LongShort>Long</LongShort>
+         <OptionType>Call</OptionType>
+         <Style>American</Style>
+         <Settlement>Cash</Settlement>
+         <PayOffAtExpiry>true</PayOffAtExpiry>
+         <ExerciseDates>
+             <ExerciseDate>2022-03-01</ExerciseDate>
+         </ExerciseDates>
+         ...
+    </OptionData>
+    <Name>RIC:.SPX</Name>
+    <Currency>USD</Currency>
+    <Strike>2147.56</Strike>
+    <StrikeCurrency>USD</StrikeCurrency>
+    <Quantity>17000</Quantity>
+</EquityOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=,
+listing =Equity Option data=.
+
+The linear counterpart is the [[id:D60CBEE4-AE5C-421B-AAEF-5E56DC75A662][Equity Forward]]. The
+option-on-future variant is the [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equity Futures Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityoption.org
+++ b/doc/knowledge/domain/equityoption.org
@@ -44,7 +44,7 @@ during the life of the option up until the expiration date. The right
 to buy the shares can only be exercised once.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoption.tex][equityoption.tex]].
 
 ORE defines the quanto and composite forms as follows:
 
@@ -60,7 +60,7 @@ from the underlying currency. This is unrelated to the CompositeTrade
 trade type.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoption.tex][equityoption.tex]].
 
 ** In plain terms
 
@@ -158,7 +158,7 @@ ORE's catalogue shows an American call on the S&P 500 index:
 </EquityOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoption.tex][equityoption.tex]],
 listing =Equity Option data=.
 
 The linear counterpart is the [[id:D60CBEE4-AE5C-421B-AAEF-5E56DC75A662][Equity Forward]]. The
@@ -171,6 +171,6 @@ option-on-future variant is the [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equit
 
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoption.tex][equityoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityoption.org
+++ b/doc/knowledge/domain/equityoption.org
@@ -166,6 +166,9 @@ option-on-future variant is the [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equit
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityoptionposition.org
+++ b/doc/knowledge/domain/equityoptionposition.org
@@ -1,0 +1,163 @@
+:PROPERTIES:
+:ID: 643843A9-B265-49B3-85BA-0E2F261DE7A9
+:END:
+#+title: Equity Option Position
+#+description: A position in a single equity option or a weighted option basket; ORE's EquityOptionPosition product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityoptionposition:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity option position is exposure to one equity option or to a
+weighted basket of equity options. It works as a stand-alone trade
+type and as a building block inside other products. ORE models it with
+the trade type =EquityOptionPosition=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An equity option position holds one option underlying or several
+weighted option underlyings. As a stand-alone trade it uses the trade
+type =EquityOptionPosition=. As a trade component it is the
+=EquityOptionPositionData= node inside the =TotalReturnSwap= (Generic
+TRS) trade type, where it sets up equity option basket trades. Each
+underlying pairs an equity block with an =OptionData= block and a
+=Strike=. Negative weights flip the side of the position. The position
+price is the quantity times the weighted sum of the option prices.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An equity option position represents a position in a single equity
+option - using a single Underlying node, or in a weighted basket of
+underlying equity options - using multiple Underlying nodes.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+
+ORE states the dual role as follows:
+
+#+begin_quote
+An Equity Option Position can be used both as a stand alone trade type
+(TradeType: EquityOptionPosition) or as a trade component
+(EquityOptionPositionData) used within the TotalReturnSwap (Generic
+TRS) trade type, to set up for example Equity Option Basket trades.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+
+** In plain terms
+
+An equity option position is a list of options priced as one trade.
+Each line names an equity, its option terms and its strike. Weights
+scale each line. A negative weight turns a long position into a short
+one. The same block can feed an option basket leg inside a total
+return swap.
+
+** How it works in ORE
+
+The =EquityOptionPositionData= node is the trade data container for
+the =EquityOptionPosition= trade type. =Quantity= is the number of
+options written on one underlying share, or the number of units of the
+option basket. The node takes one or more =Underlying= descriptions.
+Each description holds an equity =Underlying= block, an =OptionData=
+block and a =Strike= element, in that order. The option block carries
+=LongShort=, =OptionType=, =Style=, =Settlement= and =ExerciseDates=.
+The style can be =European= or =American=. Exactly one exercise date
+must be given. It represents the European exercise date or the last
+American exercise date. Negative weights are allowed. A long position
+with a negative weight results in a short position, and the other way
+around. For a basket each equity carries a =Weight= value.
+
+** Mathematical notes
+
+The weighted basket price is Basket-Price = Quantity x sum over i of
+Weight_i x p_i x FX_i. Here p_i is the price of the ith option in the
+basket, written on one underlying share. FX_i is the FX spot
+converting from the ith equity currency to the first equity currency,
+which is the currency in which the net present value of the basket is
+expressed.
+
+** What moves its value (static sensitivities)
+
+- The spot price of each underlying equity.
+- The implied volatility of each underlying.
+- The expected dividends and rates that price each option.
+- The weights of the basket lines, including their signs.
+- The FX spot rates between the equity currencies and the first
+  equity currency.
+- The strikes and exercise dates of the options.
+
+Each option line moves with its own underlying and volatility. The
+basket value is the weighted sum of those moves.
+
+** How the profile ages (dynamic sensitivities)
+
+Each option in the basket decays toward its intrinsic value as its
+exercise date approaches. A basket with one expiry behaves like a
+single portfolio of options. After exercise the settled lines drop
+out. The FX conversion rates refresh with each valuation.
+
+** Why a customer would want it
+
+A customer can hold a spread or a basket of equity options in one
+trade. The weighted lines express relative views, such as a call
+spread on the same index. Negative weights build hedged structures
+without separate trades. In ORE Studio a customer books equity option
+positions to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a basket of two S&P 500 calls with strikes 3300
+and 3400, weighted equally:
+
+#+begin_example
+<Trade id="EquityOptionPositionTrade">
+  <TradeType>EquityOptionPosition</TradeType>
+  <EquityOptionPositionData>
+    <!-- basket price = quantity x sum_i ( weight_i x equityOptionPrice_i x fx_i ) -->
+    <Quantity>1000</Quantity>
+    <!-- option #1 -->
+    <Underlying>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>.SPX</Name>
+        <Weight>0.5</Weight>
+        <IdentifierType>RIC</IdentifierType>
+      </Underlying>
+      <OptionData>
+        <LongShort>Long</LongShort>
+        <OptionType>Call</OptionType>
+        <Style>European</Style>
+        <Settlement>Cash</Settlement>
+        <ExerciseDates>
+          <ExerciseDate>2021-01-29</ExerciseDate>
+        </ExerciseDates>
+      </OptionData>
+      <Strike>3300</Strike>
+    </Underlying>
+    <Underlying>
+      ...
+    </Underlying>
+  </EquityOptionPositionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=,
+listing =Equity Option position data=, second basket line elided.
+
+The spot-based relative of this product is the
+[[id:0AE749B3-E51A-4036-8561-622F5EE69C02][Equity Position]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityoptionposition.org
+++ b/doc/knowledge/domain/equityoptionposition.org
@@ -156,6 +156,9 @@ The spot-based relative of this product is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityoptionposition.org
+++ b/doc/knowledge/domain/equityoptionposition.org
@@ -38,7 +38,7 @@ option - using a single Underlying node, or in a weighted basket of
 underlying equity options - using multiple Underlying nodes.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoptionposition.tex][equityoptionposition.tex]].
 
 ORE states the dual role as follows:
 
@@ -49,7 +49,7 @@ An Equity Option Position can be used both as a stand alone trade type
 TRS) trade type, to set up for example Equity Option Basket trades.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoptionposition.tex][equityoptionposition.tex]].
 
 ** In plain terms
 
@@ -148,7 +148,7 @@ and 3400, weighted equally:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityoptionposition.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoptionposition.tex][equityoptionposition.tex]],
 listing =Equity Option position data=, second basket line elided.
 
 The spot-based relative of this product is the
@@ -161,6 +161,6 @@ The spot-based relative of this product is the
 
 - [[https://en.wikipedia.org/wiki/Option_(finance)][Wikipedia: Option (finance)]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityoptionposition.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityoptionposition.tex][equityoptionposition.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityposition.org
+++ b/doc/knowledge/domain/equityposition.org
@@ -1,0 +1,150 @@
+:PROPERTIES:
+:ID: 0AE749B3-E51A-4036-8561-622F5EE69C02
+:END:
+#+title: Equity Position
+#+description: A position in a single equity or a weighted equity basket; ORE's EquityPosition product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityposition:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity position is direct exposure to a single equity or to a
+weighted basket of equities. It works as a stand-alone trade type and
+as a building block inside other products. ORE models it with the
+trade type =EquityPosition=. This note records the domain grounding, as
+ORE documents it in its product catalogue.
+
+* Summary
+
+An equity position holds one equity underlying or several weighted
+equity underlyings. As a stand-alone trade it uses the trade type
+=EquityPosition=. As a trade component it is the =EquityPositionData=
+node inside the =TotalReturnSwap= (Generic TRS) trade type, where it
+sets up equity basket trades. The position price is the quantity times
+the weighted sum of the underlying prices, each converted to the first
+underlying currency. The container node is =EquityPositionData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An equity position represents a position in a single equity - using a
+single Underlying node, or in a weighted basket of underlying equities
+- using multiple Underlying nodes.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=.
+
+ORE states the dual role as follows:
+
+#+begin_quote
+An Equity Position can be used both as a stand alone trade type
+(TradeType: EquityPosition) or as a trade component (EquityPositionData)
+used within the TotalReturnSwap (Generic TRS) trade type, to set up for
+example Equity Basket trades.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=.
+
+** In plain terms
+
+An equity position is the spot view of the equity family. It says how
+many shares or basket units are held. One share name is enough. A
+basket is a list of names with weights, priced in the currency of the
+first name. The same block also works inside a total return swap when
+the swap pays the return of an equity basket.
+
+** How it works in ORE
+
+The =EquityPositionData= node is the trade data container for the
+=EquityPosition= trade type. =Quantity= is the number of shares or the
+number of basket units held. The node takes one or more =Underlying=
+descriptions. Only equity underlyings are allowed. For a basket each
+underlying carries a =Weight= value. The underlying block names the
+equity with fields such as =Type=, =Name=, =IdentifierType=,
+=Currency= and =Exchange=. The first equity currency is by definition
+the currency in which the net present value of the basket is
+expressed. Other equity currencies convert into it through the FX
+spot.
+
+** Mathematical notes
+
+The weighted basket price is Basket-Price = Quantity x sum over i of
+Weight_i x S_i x FX_i. Here S_i is the price of the ith share in the
+basket. FX_i is the FX spot converting from the ith equity currency to
+the first equity currency. A single-name position is the special case
+of one underlying with a weight of one.
+
+** What moves its value (static sensitivities)
+
+- The spot price of each underlying equity.
+- The weight of each name in the basket.
+- The FX spot rates between the equity currencies and the first
+  equity currency.
+- The quantity of shares or basket units.
+
+The position gains when its underlying prices rise. A name with a
+larger weight moves the position more.
+
+** How the profile ages (dynamic sensitivities)
+
+An equity position is a spot holding. It carries no schedule and no
+optionality. Its value follows the underlying prices day by day until
+the position is closed. The FX conversion rates refresh with each
+valuation.
+
+** Why a customer would want it
+
+A customer can hold direct equity exposure in one trade, single name
+or basket. The same position block plugs into a total return swap when
+the swap needs an equity basket leg. In ORE Studio a customer books
+equity positions to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows an equity basket position with two European
+names, weighted equally:
+
+#+begin_example
+<Trade id="EquityPosition">
+  <TradeType>EquityPosition</TradeType>
+  <Envelope>...</Envelope>
+  <EquityPositionData>
+    <Quantity>1000</Quantity>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>BE0003565737</Name>
+        <Weight>0.5</Weight>
+        <IdentifierType>ISIN</IdentifierType>
+        <Currency>EUR</Currency>
+        <Exchange>XFRA</Exchange>
+      </Underlying>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>GB00BH4HKS39</Name>
+        <Weight>0.5</Weight>
+        <IdentifierType>ISIN</IdentifierType>
+        <Currency>GBP</Currency>
+        <Exchange>XLON</Exchange>
+      </Underlying>
+  </EquityPositionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=,
+listing =Equity position data=.
+
+The option-based relative of this product is the
+[[id:643843A9-B265-49B3-85BA-0E2F261DE7A9][Equity Option Position]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Stock][Wikipedia: Stock]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityposition.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityposition.org
+++ b/doc/knowledge/domain/equityposition.org
@@ -144,6 +144,9 @@ The option-based relative of this product is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Stock][Wikipedia: Stock]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/equityposition.tex=. The

--- a/doc/knowledge/domain/equityposition.org
+++ b/doc/knowledge/domain/equityposition.org
@@ -37,7 +37,7 @@ single Underlying node, or in a weighted basket of underlying equities
 - using multiple Underlying nodes.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityposition.tex][equityposition.tex]].
 
 ORE states the dual role as follows:
 
@@ -48,7 +48,7 @@ used within the TotalReturnSwap (Generic TRS) trade type, to set up for
 example Equity Basket trades.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityposition.tex][equityposition.tex]].
 
 ** In plain terms
 
@@ -136,7 +136,7 @@ names, weighted equally:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityposition.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityposition.tex][equityposition.tex]],
 listing =Equity position data=.
 
 The option-based relative of this product is the
@@ -148,6 +148,6 @@ The option-based relative of this product is the
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Stock][Wikipedia: Stock]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityposition.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityposition.tex][equityposition.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityswap.org
+++ b/doc/knowledge/domain/equityswap.org
@@ -1,0 +1,196 @@
+:PROPERTIES:
+:ID: D45F8289-3F31-462F-9C98-460CE820F75F
+:END:
+#+title: Equity Swap
+#+description: A swap of an equity return against a fixed or floating leg; ORE's EquitySwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity swap exchanges the return of an equity leg against a fixed
+or floating funding leg. The equity leg can pay price return, total
+return or dividends. ORE models the family with the trade type
+=EquitySwap=. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+An equity swap has one leg of type =Equity= and one funding leg of
+type =Fixed= or =Floating=. The equity leg links its coupons to the
+price of one single equity name or index. Its notional can be fixed or
+resettable. A resettable notional equates to a fixed quantity of
+shares. Price return coupons pay the price difference over the
+period. Total return coupons add the dividends. The =ReturnType= of
+=Dividend= builds a dividend swap on the same trade type. ORE prices
+equity swaps on discounted cashflows. The container node is
+=EquitySwapData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An equity swap is a swap where one of the legs has a floating rate
+with coupon payments linked to an equity price, either a single stock
+or equity index.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+
+ORE describes the coupon types as follows:
+
+#+begin_quote
+There are two types of equity coupons, Price Return and Total Return.
+Price Return coupons pay the difference in equity price between the
+coupon start and end dates, while a Total Return coupon also includes
+dividend payments during the period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+
+ORE describes the setup as follows:
+
+#+begin_quote
+An Equity Swap uses its own trade type EquitySwap, and is set up using
+a EquitySwapData node with one leg of type Equity and one more leg -
+called Funding leg - that can be either Fixed or Floating.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+
+ORE contrasts the pricing method with the total return swap as
+follows:
+
+#+begin_quote
+Note that pricing for an EquitySwap is based on discounted cashflows,
+whereas pricing for a TotalReturnSwap (GenericTRS) on an equity
+underlying uses the accrual method. The accrual method is common
+practice when daily unwind rights are present in the trade terms.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+
+** In plain terms
+
+An equity swap turns equity returns into a stream of cashflows. One
+side pays what the share does over each period. The other side pays a
+fixed coupon or a floating rate. The trade separates the equity
+exposure from owning the share. A dividend variant pays only the
+dividends of the name.
+
+** How it works in ORE
+
+The =EquitySwapData= node is the trade data container for the
+=EquitySwap= trade type. It holds one leg of type =Equity= and one
+funding leg of type =Fixed= or =Floating=. The equity leg carries an
+=EquityLegData= block. The equity leg can include one single
+underlying equity name only, which may be an equity index. Multi-name
+structures use the =TotalReturnSwap= trade type instead. Cross-currency
+equity swaps are supported. If the funding leg uses =Indexings= with
+=FromAssetLeg= set to true, its notionals derive from the equity leg
+and it must share the equity leg's currency. The =DayCounter= field is
+optional on an equity leg and defaults to =ACT/365=. It does not impact
+pricing, only the accrued amount shown in the cashflows. Within
+=EquityLegData=, =ReturnType= selects the coupon type. =Quantity= and
+=Underlying= name the exposure. =InitialPrice= anchors the first
+period. =NotionalReset= set to true turns the notional into a fixed
+quantity of shares. =FXTerms= converts the equity price from the
+equity currency to the leg currency at the fixing dates. A =ReturnType=
+of =Dividend= builds a dividend swap on the same trade type: it swaps
+the dividends of the name against a fixed or floating leg.
+
+** Mathematical notes
+
+The equity coupons follow the equity return over each period. A price
+return coupon with a resettable notional pays Quantity x (S_end -
+S_start). A total return coupon adds the dividends paid over the
+period. Without notional reset the coupon scales a fixed notional by
+the relative price move. A dividend swap pays the realised dividends.
+The funding leg pays a fixed coupon or a floating index over the same
+schedule. ORE values each cashflow on the discount curve.
+
+** What moves its value (static sensitivities)
+
+- The spot price of the underlying equity or index.
+- The forward prices of the equity, set by rates and expected
+  dividends.
+- The dividend schedule of the underlying.
+- The funding rates of the fixed or floating leg.
+- The FX spot rate when the equity currency differs from the leg
+  currency.
+
+A long equity leg gains as the equity rises. Each settled period locks
+in its realised return.
+
+** How the profile ages (dynamic sensitivities)
+
+Each period the equity coupon is fixed and settled. Resettable
+notionals keep the exposure at a fixed quantity of shares period by
+period. Realised returns replace the forward expectations as time
+passes. The number of remaining coupons shrinks. Late in life the swap
+runs down like a short-dated swap and pays its final coupon at
+maturity.
+
+** Why a customer would want it
+
+A customer can take equity exposure without buying the shares. The
+swap pays the return of the name and receives funding, so it suits a
+funding-versus-equity trade. An equity receiver hedges a planned share
+purchase. A dividend swap monetises or hedges the dividend stream of a
+holding. In ORE Studio a customer books equity swaps to value them and
+run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an equity swap with a resettable notional and FX
+indexing. The funding leg derives its notional from the equity leg:
+
+#+begin_example
+<EquitySwapData>
+  <LegData>
+    <LegType>Floating</LegType>
+    <Currency>USD</Currency>
+    ...
+    <!-- Notionals node is not required, set to 1 internally -->
+    ...
+    <Indexings>
+      <!-- derive the indexing information (equity price, FX) from the Equity leg -->
+      <FromAssetLeg>true</FromAssetLeg>
+    </Indexings>
+  </LegData>
+  <LegData>
+    <LegType>Equity</LegType>
+      <Currency>USD</Currency>
+      ...
+      <EquityLegData>
+        <Quantity>1000</Quantity>
+        <Underlying>
+          <Type>Equity</Type>
+          <Name>.STOXX50E</Name>
+          <IdentifierType>RIC</IdentifierType>
+        </Underlying>
+        <InitialPrice>2937.36</InitialPrice>
+        <NotionalReset>true</NotionalReset>
+        <FXTerms>
+          <EquityCurrency>EUR</EquityCurrency>
+          <FXIndex>FX-ECB-EUR-USD</FXIndex>
+        </FXTerms>
+      </EquityLegData>
+      ...
+  </LegData>
+</EquitySwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=,
+listing =Equity Swap Data with notional reset and FX indexing=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Equity_swap][Wikipedia: Equity swap]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityswap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityswap.org
+++ b/doc/knowledge/domain/equityswap.org
@@ -190,6 +190,9 @@ listing =Equity Swap Data with notional reset and FX indexing=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Equity_swap][Wikipedia: Equity swap]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/equityswap.tex=. The upstream

--- a/doc/knowledge/domain/equityswap.org
+++ b/doc/knowledge/domain/equityswap.org
@@ -39,7 +39,7 @@ with coupon payments linked to an equity price, either a single stock
 or equity index.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]].
 
 ORE describes the coupon types as follows:
 
@@ -50,7 +50,7 @@ coupon start and end dates, while a Total Return coupon also includes
 dividend payments during the period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]].
 
 ORE describes the setup as follows:
 
@@ -60,7 +60,7 @@ a EquitySwapData node with one leg of type Equity and one more leg -
 called Funding leg - that can be either Fixed or Floating.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]].
 
 ORE contrasts the pricing method with the total return swap as
 follows:
@@ -72,7 +72,7 @@ underlying uses the accrual method. The accrual method is common
 practice when daily unwind rights are present in the trade terms.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]].
 
 ** In plain terms
 
@@ -185,7 +185,7 @@ indexing. The funding leg derives its notional from the equity leg:
 </EquitySwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]],
 listing =Equity Swap Data with notional reset and FX indexing=.
 
 * See also
@@ -194,6 +194,6 @@ listing =Equity Swap Data with notional reset and FX indexing=.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Equity_swap][Wikipedia: Equity swap]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityswap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityswap.tex][equityswap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityvarianceswap.org
+++ b/doc/knowledge/domain/equityvarianceswap.org
@@ -149,6 +149,9 @@ name as =EqutiyVarianceSwapData=; it is reproduced verbatim here.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/equityvarianceswap.org
+++ b/doc/knowledge/domain/equityvarianceswap.org
@@ -1,0 +1,156 @@
+:PROPERTIES:
+:ID: D69C0964-9F15-43BC-8A13-66ECED718BED
+:END:
+#+title: Equity Variance Swap
+#+description: A swap of realised equity variance against a volatility strike; ORE's EquityVarianceSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:equityvarianceswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An equity variance swap exchanges the realised variance of an equity
+against a pre-agreed volatility strike. Individual stocks and indices
+are supported. ORE models it with the trade type =EquityVarianceSwap=.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+An equity variance swap has a payoff that depends on the volatility of
+an underlying equity instrument. The counterparties exchange a
+pre-agreed variance level, the strike, for the actual amount of
+variance realised over an observation period. The strike is typically
+set at the money so the swap starts with zero value. Only vanilla
+variance swaps are supported. The notional is quoted as a vega
+notional in volatility units. The container node is
+=EquityVarianceSwapData=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Equity Variance Swap has a payoff that depends on the volatility of
+an underlying equity instrument. Underlying individual stocks and
+indices are supported. The swap counterparties agree to exchange a
+pre-agreed variance level (the strike) for the actual amount of
+variance realized over an observation period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=.
+
+ORE limits the product as follows:
+
+#+begin_quote
+Only vanilla variance swaps are supported.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=.
+
+** In plain terms
+
+A variance swap is a bet on how much a share bounces around. The
+parties agree a volatility level at trade time. If the share then
+moves more than that level, the buyer of variance receives the
+difference. If it moves less, the buyer pays it. Direction does not
+matter: only the size of the daily moves counts.
+
+** How it works in ORE
+
+The =EquityVarianceSwapData= node is the trade data container for the
+=EquityVarianceSwap= trade type. ORE's guide spells the container node
+name as =EqutiyVarianceSwapData=, without the second =i=, in its prose
+and listings. =StartDate= and =EndDate= bound the observation period.
+=Underlying= or =Name= names the equity or index. =LongShort= names
+the side. A long variance swap has positive value if the realised
+variance exceeds the variance strike. =Strike= is the volatility
+strike quoted absolutely, not as a percent. If the swap was struck in
+terms of variance, the square root of that variance is used here.
+=Notional= is the vega notional, that is the notional in volatility
+units. =Calendar= sets the fixing dates. The calendar of the equity
+curve configuration combines with it. =MomentType= distinguishes a
+swap struck in terms of volatility from one struck in terms of
+variance. It defaults to =Variance=. The strike is always quoted as a
+volatility. =AddPastDividends= adds past dividend payments to the
+fixings when calculating accrued variance. It defaults to =false=.
+
+** Mathematical notes
+
+The payoff is N x (RealisedVol squared minus K squared). Here N is the
+variance notional, determined as the vega notional divided by twice
+the strike. K is the strike volatility. RealisedVol is the annualised
+volatility of the daily log returns over the observation period. Each
+daily log return ln(P_t / P_t-1) is squared and summed. The sum is
+scaled by 252 over the expected number of scheduled trading days and
+the square root is taken. P_0 is the official closing price at the
+observation start date. P_t is the official closing price at each
+observation date.
+
+** What moves its value (static sensitivities)
+
+- The implied volatility of the underlying. It sets the fair strike.
+- The realised volatility from the observation start date onward.
+- The dividend treatment of the underlying, through the fixing
+  adjustment flag.
+- The expected number of trading days and the calendar.
+- The discount rate over the observation period.
+
+A swap struck at the market level of variance starts near zero value.
+A long position gains as realised volatility runs above the strike.
+
+** How the profile ages (dynamic sensitivities)
+
+Variance accrues day by day from the observation start date. The
+realised part becomes fixed as fixings land. The remaining
+uncertainty shrinks with the remaining trading days. Close to the end
+date the realised variance is almost known, so the swap value moves
+toward its final payoff. A long swap near expiry behaves like a fixed
+claim.
+
+** Why a customer would want it
+
+A variance swap trades volatility directly, without a directional view
+on the share. Option desks use it to hedge the vega of their books. A
+customer can also express the view that implied volatility is too high
+or too low against realised. The payoff is linear in variance, unlike
+an option position. In ORE Studio a customer books equity variance
+swaps to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long USD variance swap on the S&P 500 index,
+struck at 20 percent volatility:
+
+#+begin_example
+<EquityVarianceSwapData>
+    <StartDate>2016-01-29</StartDate>
+    <EndDate>2016-05-05</EndDate>
+    <Currency>USD</Currency>
+    <Underlying>
+      <Type>Equity</Type>
+      <Name>.SPX</Name>
+      <IdentifierType>RIC</IdentifierType>
+    </Underlying>
+    <LongShort>Long</LongShort>
+    <Strike>0.20</Strike>
+    <Notional>50000</Notional>
+    <Calendar>US</Calendar>
+    <MomentType>Variance</MomentType>
+    <AddPastDividends>true</AddPastDividends>
+</EquityVarianceSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=,
+listing =Variance Swap data=. The source spells the container node
+name as =EqutiyVarianceSwapData=; it is reproduced verbatim here.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/equityvarianceswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/equityvarianceswap.org
+++ b/doc/knowledge/domain/equityvarianceswap.org
@@ -40,7 +40,7 @@ pre-agreed variance level (the strike) for the actual amount of
 variance realized over an observation period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityvarianceswap.tex][equityvarianceswap.tex]].
 
 ORE limits the product as follows:
 
@@ -48,7 +48,7 @@ ORE limits the product as follows:
 Only vanilla variance swaps are supported.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityvarianceswap.tex][equityvarianceswap.tex]].
 
 ** In plain terms
 
@@ -143,7 +143,7 @@ struck at 20 percent volatility:
 </EquityVarianceSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/equityvarianceswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityvarianceswap.tex][equityvarianceswap.tex]],
 listing =Variance Swap data=. The source spells the container node
 name as =EqutiyVarianceSwapData=; it is reproduced verbatim here.
 
@@ -154,6 +154,6 @@ name as =EqutiyVarianceSwapData=; it is reproduced verbatim here.
 
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/equityvarianceswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/equityvarianceswap.tex][equityvarianceswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
+++ b/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
@@ -217,6 +217,9 @@ pays a premium of 114.40 EUR per contract on 2019-12-13.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs
   =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.

--- a/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
+++ b/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
@@ -1,0 +1,224 @@
+:PROPERTIES:
+:ID: F0727CDB-4696-4C25-BFF5-AF0D302B5A71
+:END:
+#+title: European Option Contingent on a Barrier
+#+description: A plain vanilla European option whose payoff depends on a barrier on another underlying; ORE's EuropeanOptionBarrier product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:europeanoptioncontingentonabarrier:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A European option contingent on a barrier is a plain vanilla European
+option on one underlying, whose payoff depends on a barrier on a
+second underlying. ORE prices it with American or European barrier
+monitoring. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+The product pairs a vanilla European option with a knock-in or
+knock-out barrier on a different asset. The barrier is monitored
+continuously in the American style, or once at expiry in the European
+style. A knock-in makes the option valid only when the barrier
+condition is met. A knock-out kills the payoff when the condition is
+met. The two underlyings can be of different asset classes.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product is a plain vanilla European option on a single
+underlying (FX, Equity, Commodity or InterestRate) with a
+knock-in/knock-out feature on another underlying asset. The barrier
+can be continuously monitored (American) or only at the option expiry
+date (European).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+
+ORE describes the knock-in and knock-out logic:
+
+#+begin_quote
+For a knock-in (knock-out) barrier, the option is valid when the
+price of the underlying barrier moves inside (outside) the barrier,
+otherwise the payoff is zero.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+
+ORE scopes the supported asset classes:
+
+#+begin_quote
+For a European-style barrier, we support FX, Equity, Commodity and
+InterestRate underlyings. We do not support InterestRate for
+American-style barriers.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+
+** In plain terms
+
+This trade is an option on one market, gated by another market. The
+option part is a normal European call or put on the option
+underlying. The gate is a barrier on a second underlying. With a
+down-and-in barrier, the option only lives when the second market has
+touched the level from above. With an up-and-out barrier, a touch
+from below kills the option. The gate can watch the second market all
+the time, or only on the expiry date.
+
+** How it works in ORE
+
+The trade container for this product is the
+=EuropeanOptionBarrierData= node, and the trade type is
+=EuropeanOptionBarrier=. =Quantity= is the number of option
+contracts, =PutCall= the option type and =LongShort= the own party
+position. =Strike= is the option strike price. The premium terms are
+=PremiumAmount=, =PremiumCurrency= and =PremiumDate=. =OptionExpiry=
+is the option expiry date. =OptionUnderlying= names the asset the
+option is written on; its supported types are equity, FX, commodity
+and interest rate. =PayCcy= is the settlement currency, and
+=SettlementDate= the settlement date of the exercise payoff, on or
+after the option expiry date.
+
+=BarrierUnderlying= is the underlying monitored against the barrier
+level. Its supported types follow the barrier style. ORE describes
+the European-style input as follows:
+
+#+begin_quote
+For a European-style barrier, the BarrierType must be set to European
+and the BarrierSchedule can be omitted.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+
+=BarrierLevel= is the knock-in or knock-out level. =BarrierType=
+takes =DownIn=, =UpIn=, =DownOut= or =UpOut=. =BarrierStyle= takes
+=American= or =European=. =BarrierSchedule= is optional and lists the
+trading days over which a continuous barrier is monitored. It is
+required only for the American style.
+
+ORE illustrates the barrier mechanics with two examples:
+
+#+begin_quote
+For example, for a European option with a continuous down-in barrier,
+the option payoff will only apply if the barrier underlying price was
+less than or equal to the agreed barrier level at any point over the
+life of the trade.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+
+The companion example describes an up-out barrier: the option is
+knocked out when the barrier underlying price reaches or exceeds the
+agreed level at any point over the life of the trade, and the final
+payoff is then zero.
+
+** Mathematical notes
+
+The payoff is the payoff of a vanilla European option on the option
+underlying, scaled by a barrier indicator on the barrier underlying.
+The barrier indicator is one when the barrier condition holds, and
+zero otherwise. For a knock-in the option is valid only when the
+indicator is one. For a knock-out the option is valid only when the
+indicator is zero. Under American monitoring the condition checks the
+barrier underlying at every point of the barrier schedule. Under
+European monitoring it checks the barrier underlying once, at the
+option expiry date.
+
+** What moves its value (static sensitivities)
+
+- The level of the option underlying at expiry. It drives the vanilla
+  payoff.
+- The volatility of the option underlying.
+- The path of the barrier underlying. It decides whether the barrier
+  condition fires.
+- The volatility of the barrier underlying, and its correlation with
+  the option underlying. Both shape the probability that the barrier
+  is touched.
+- The barrier level, the barrier type and the barrier style.
+- The strike, and the interest rates that discount the payoff.
+
+** How the profile ages (dynamic sensitivities)
+
+Until expiry the option is a vanilla European option whose life
+depends on the barrier. Under the American style the barrier
+underlying is watched on each day of the barrier schedule; a touch
+knocks the option in or out there and then. Under the European style
+the barrier is decided once at expiry, together with the option
+payoff. The payoff settles on the settlement date when the option
+survives.
+
+** Why a customer would want it
+
+A barrier on a second asset prices in a view on two markets with one
+payoff. The knock-in form is cheaper than the plain option because it
+demands a condition on another market. The structure suits investors
+who want equity exposure, say, whose payoff depends on an FX level or
+an interest rate. In ORE Studio a customer books European options
+contingent on barriers to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a short call on the Euro Stoxx 50 with a
+continuous down-and-in FX barrier on EUR-USD. The trade is
+continuously monitored from 2019-12-11 to the expiry date:
+
+#+begin_example
+<Trade id="Equity_EuropeanOptionWithAmericanFxBarrier">
+  <TradeType>EuropeanOptionBarrier</TradeType>
+  <Envelope>
+    .....
+  </Envelope>
+  <EuropeanOptionBarrierData>
+    <Quantity>8523</Quantity>
+    <PutCall>Call</PutCall>
+    <LongShort>Short</LongShort>
+    <Strike>3520</Strike>
+    <PremiumAmount>114.40</PremiumAmount>
+    <PremiumCurrency>EUR</PremiumCurrency>
+    <PremiumDate>2019-12-13</PremiumDate>
+    <OptionExpiry>2020-06-19</OptionExpiry>
+    <OptionUnderlying>
+      <Type>Equity</Type>
+      <Name>RIC:.STOXX50E</Name>
+    </OptionUnderlying>
+    <BarrierUnderlying>
+      <Type>FX</Type>
+      <Name>ECB-EUR-USD</Name>
+    </BarrierUnderlying>
+    <BarrierLevel>1.09335</BarrierLevel>
+    <BarrierType>DownAndIn</BarrierType>
+    <BarrierStyle>American</BarrierStyle>
+    <BarrierSchedule>
+      <Rules>
+        <StartDate>2019-12-11</StartDate>
+        <EndDate>2020-06-19</EndDate>
+        <Tenor>1D</Tenor>
+        <Calendar>USA</Calendar>
+        <Convention>Following</Convention>
+        <TermConvention>Following</TermConvention>
+        <Rule>Forward</Rule>
+      </Rules>
+    </BarrierSchedule>
+    <SettlementDate>2020-06-24</SettlementDate>
+    <PayCcy>USD</PayCcy>
+  </EuropeanOptionBarrierData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=,
+listing =European Option Barrier data (continuous barrier)=. The call
+pays a premium of 114.40 EUR per contract on 2019-12-13.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs
+  =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+  The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
+++ b/doc/knowledge/domain/europeanoptioncontingentonabarrier.org
@@ -38,7 +38,7 @@ can be continuously monitored (American) or only at the option expiry
 date (European).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
 
 ORE describes the knock-in and knock-out logic:
 
@@ -48,7 +48,7 @@ price of the underlying barrier moves inside (outside) the barrier,
 otherwise the payoff is zero.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
 
 ORE scopes the supported asset classes:
 
@@ -58,7 +58,7 @@ InterestRate underlyings. We do not support InterestRate for
 American-style barriers.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
 
 ** In plain terms
 
@@ -93,7 +93,7 @@ For a European-style barrier, the BarrierType must be set to European
 and the BarrierSchedule can be omitted.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
 
 =BarrierLevel= is the knock-in or knock-out level. =BarrierType=
 takes =DownIn=, =UpIn=, =DownOut= or =UpOut=. =BarrierStyle= takes
@@ -110,7 +110,7 @@ less than or equal to the agreed barrier level at any point over the
 life of the trade.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
 
 The companion example describes an up-out barrier: the option is
 knocked out when the barrier underlying price reaches or exceeds the
@@ -211,7 +211,7 @@ continuously monitored from 2019-12-11 to the expiry date:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]],
 listing =European Option Barrier data (continuous barrier)=. The call
 pays a premium of 114.40 EUR per contract on 2019-12-13.
 
@@ -220,8 +220,8 @@ pays a premium of 114.40 EUR per contract on 2019-12-13.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
   which inputs
-  =Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex=.
+  [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/europeanoptioncontingentonabarrier.tex][europeanoptioncontingentonabarrier.tex]].
   The upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/extendedaccumulator.org
+++ b/doc/knowledge/domain/extendedaccumulator.org
@@ -224,6 +224,9 @@ the extended accumulator example trade.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/extendedaccumulator.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/extendedaccumulator.org
+++ b/doc/knowledge/domain/extendedaccumulator.org
@@ -1,0 +1,229 @@
+:PROPERTIES:
+:ID: 90DDE9BB-770F-4337-AF0E-69698AF2A2A1
+:END:
+#+title: Extended Accumulator
+#+description: An accumulator that can extend past a barrier decision date; ORE's ExtendedAccumulator product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:extendedaccumulator:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+An extended accumulator is an accumulator whose life can extend past
+a barrier decision date. ORE represents it as a scripted trade with
+the node =ExtendedAccumulatorData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An extended accumulator trades like an accumulator: at each regular
+observation date it buys, or sells, a fixed amount of the underlying
+at a fixed strike. It adds a European barrier decision on the
+=ExtensionDecisionDate=. When the underlying is above the
+=ExtensionTrigger= on that date, the trade continues on the
+conditional observation dates. Otherwise it terminates at the last
+regular observation date.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Extended Accumulator is like an Accumulator with regular and
+conditional observation and settlement dates. After the regular
+observation dates a European barrier is applied on the Extension
+Decision Date. If the barrier is hit the trade terminates, otherwise
+the trade continues with cashflows generated on the conditional
+observation dates.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=.
+
+** In plain terms
+
+An extended accumulator is a forward purchase program with a
+possible second life. The program buys a fixed amount of an asset on
+each observation date, at a fixed strike. On a set decision date the
+underlying is checked against a trigger. Above the trigger, the
+program extends into a second set of observation dates. At or below
+the trigger, the program stops after its regular dates.
+
+** How it works in ORE
+
+The trade is a scripted trade: the trade type is =ScriptedTrade= and
+the node is =ExtendedAccumulatorData=. =LongShort= defines whether
+the trade is long or short. Long means the holder buys the underlying
+asset at each observation date; short means the holder sells it.
+=Strike= is the strike of the installments. For FX it is the amount
+in the domestic currency, =CCY2=, for one unit of the foreign
+currency, =CCY1=. For equity and commodity it is the value for one
+unit of the underlying, expressed in the domestic currency.
+=Underlying= names the underlying index. For FX it has the form
+=FX-SOURCE-CCY1-CCY2=, where =SOURCE= is the fixing source.
+=FixingAmount= is the amount accumulated at each fixing date. For FX
+it is expressed in the foreign currency. For equity it is the number
+of shares. For commodity it is the number of units. A negative
+amount turns a long trade into a short one. =PayCurrency= is the
+payout currency; for a non-quanto trade it is the domestic currency.
+
+The schedule nodes define the two lives of the trade.
+=ObservationDates= and =ObservationSettlementDates= hold the regular
+observation dates and their settlement dates. =ConditionalObservationDates=
+and =ConditionalSettlementDates= hold the conditional dates, which
+pay only when the trade extends. =ExtensionDecisionDate= is the date
+on which the extension condition is decided. =ExtensionTrigger= is
+the level of the underlying below which a trigger event occurs; it
+is expressed in the same way as the strike. When the underlying on
+the decision date is above the trigger, the extension fires and the
+conditional dates pay. Otherwise the trade terminates at the last
+observation date.
+
+ORE summarises the direction of the condition as follows:
+
+#+begin_quote
+If the underlying on the extension decision date is above the
+barrier level, it triggers the extension on conditional observation
+dates. Else, the trade terminate at last observation date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=.
+
+** Mathematical notes
+
+ORE states the payoff formula as follows:
+
+PayOff = omega x FixingAmount x (K - X_A(T)), summed over the
+observation dates.
+
+Here =omega= is 1 for a long position and minus 1 for a short
+position. =FixingAmount= is the fixing amount in currency or units of
+the underlying asset A. =K= is the strike. =X_A(T)= is the fixing
+value of the asset A at each observation date T. The script that
+implements the formula pays every regular installment first. It then
+tests the underlying on the extension decision date. When the
+underlying is above the trigger, it pays the conditional installments
+as well. The current notional of the trade is the fixing amount times
+the strike.
+
+** What moves its value (static sensitivities)
+
+- The underlying price. Each fixing decides the sign and size of an
+  installment.
+- The volatility of the underlying. It drives how often the fixings
+  fall on the profitable side of the strike.
+- The strike and the trigger level.
+- The interest rates that discount the installment payments.
+
+The payoff of every installment is linear in the fixing. The
+extension condition adds a binary path dependence: the value of the
+conditional leg exists only when the trigger fires.
+
+** How the profile ages (dynamic sensitivities)
+
+The regular installments settle on their own dates until the
+decision date. On that date the barrier is observed once, in the
+European style. Above the trigger, the conditional installments
+continue to their last settlement date. At or below the trigger, the
+program stops. The current notional of the trade steps with each
+fixing amount as installments accumulate.
+
+** Why a customer would want it
+
+An accumulator lets a customer accumulate a position in an asset at a
+fixed price over time, instead of buying it today. The extended form
+adds a conditional second phase. In ORE Studio a customer books
+extended accumulators to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a long extended accumulator on EUR-USD. Six
+monthly installments run from September 2019, with the extension
+decision on 25 February 2020:
+
+#+begin_example
+<Trade id="FxExtendedAccumulatorLong">
+  <TradeType>ScriptedTrade</TradeType>
+  <Envelope>
+    <CounterParty>CPTY_A</CounterParty>
+    <NettingSetId>CRIF_20191230</NettingSetId>
+    <AdditionalFields/>
+  </Envelope>
+  <ExtendedAccumulatorData>
+    <LongShort type="longShort">Long</LongShort>
+    <FixingAmount type="number">840336</FixingAmount>
+    <Strike type="number">1.19</Strike>
+    <PayCurrency type="currency">USD</PayCurrency>
+    <Underlying type="index">FX-ECB-EUR-USD</Underlying>
+    <ObservationDates type="event">
+      <ScheduleData>
+        <Dates>
+          <Dates>
+            <Date>2019-09-30</Date>
+            <Date>2019-10-31</Date>
+            <Date>2019-11-28</Date>
+            <Date>2019-12-31</Date>
+            <Date>2020-01-30</Date>
+            <Date>2020-02-27</Date>
+          </Dates>
+        </Dates>
+      </ScheduleData>
+    </ObservationDates>
+    <ObservationSettlementDates type="event">
+      <ScheduleData>
+        <Dates>
+          <Dates>
+            <Date>2019-10-02</Date>
+            <Date>2019-11-02</Date>
+            <Date>2019-12-30</Date>
+            <Date>2020-01-02</Date>
+            <Date>2020-02-03</Date>
+            <Date>2020-03-30</Date>
+          </Dates>
+        </Dates>
+      </ScheduleData>
+    </ObservationSettlementDates>
+    <ExtensionDecisionDate type="event">2020-02-25</ExtensionDecisionDate>
+    <ExtensionTrigger type="number">1.19</ExtensionTrigger>
+    <ConditionalObservationDates type="event">
+      <ScheduleData>
+        <Dates>
+          <Dates>
+            <Date>2020-03-31</Date>
+            <Date>2020-04-30</Date>
+            <Date>2020-05-29</Date>
+            <Date>2020-06-30</Date>
+            <Date>2020-07-31</Date>
+            <Date>2020-08-31</Date>
+          </Dates>
+        </Dates>
+      </ScheduleData>
+    </ConditionalObservationDates>
+    <ConditionalSettlementDates type="event">
+      <ScheduleData>
+        <Dates>
+          <Dates>
+            <Date>2020-03-31</Date>
+            <Date>2020-04-30</Date>
+            <Date>2020-05-29</Date>
+            <Date>2020-06-30</Date>
+            <Date>2020-07-31</Date>
+            <Date>2020-08-31</Date>
+          </Dates>
+        </Dates>
+      </ScheduleData>
+    </ConditionalSettlementDates>
+  </ExtendedAccumulatorData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=,
+the extended accumulator example trade.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/extendedaccumulator.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/extendedaccumulator.org
+++ b/doc/knowledge/domain/extendedaccumulator.org
@@ -39,7 +39,7 @@ the trade continues with cashflows generated on the conditional
 observation dates.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/extendedaccumulator.tex][extendedaccumulator.tex]].
 
 ** In plain terms
 
@@ -88,7 +88,7 @@ barrier level, it triggers the extension on conditional observation
 dates. Else, the trade terminate at last observation date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/extendedaccumulator.tex][extendedaccumulator.tex]].
 
 ** Mathematical notes
 
@@ -219,7 +219,7 @@ decision on 25 February 2020:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/extendedaccumulator.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/extendedaccumulator.tex][extendedaccumulator.tex]],
 the extended accumulator example trade.
 
 * See also
@@ -227,6 +227,6 @@ the extended accumulator example trade.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/extendedaccumulator.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/extendedaccumulator.tex][extendedaccumulator.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/flexiswap.org
+++ b/doc/knowledge/domain/flexiswap.org
@@ -36,7 +36,7 @@ to further reduce the notional in each period to each value between
 the current notional and a specified lower bound for that period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/flexiswap.tex][flexiswap.tex]].
 
 ORE states the pricing approach as follows:
 
@@ -48,7 +48,7 @@ Product Type "Bermudan Swaption". Flexi Swaps can be single or cross
 currency.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/flexiswap.tex][flexiswap.tex]].
 
 ORE notes that flexi swaps are typically used for swaps linked to
 Asset Backed Securities with flexible amortisation.
@@ -138,7 +138,7 @@ given by =LowerNotionalBounds=:
 </FlexiSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/flexiswap.tex][flexiswap.tex]],
 listing =Flexi Swap data=.
 
 A Balance Guaranteed Swap is priced through an auxiliary flexi swap,
@@ -152,6 +152,6 @@ note.
 
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/flexiswap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/flexiswap.tex][flexiswap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/flexiswap.org
+++ b/doc/knowledge/domain/flexiswap.org
@@ -147,6 +147,9 @@ note.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/flexiswap.org
+++ b/doc/knowledge/domain/flexiswap.org
@@ -1,0 +1,154 @@
+:PROPERTIES:
+:ID: A4785FCB-5001-46DF-8F65-F63BB12526F3
+:END:
+#+title: Flexi Swap
+#+description: A swap with an option to cut the notional toward a lower bound; ORE's FlexiSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:flexiswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A flexi swap is an amortising swap with an option to cut the notional
+further. The cut can go down to a lower bound in each period. ORE
+models it with the trade type =FlexiSwap=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A flexi swap is an amortising swap in which one party has the option
+to reduce the notional further in each period. The notional can move
+to any value between the current notional and a specified lower bound
+for that period. ORE prices the product with the Replication Approach
+described in F. Jamshidian 2005. The replicating basket of Bermudan
+Swaptions is priced with the Bermudan Swaption method. Flexi swaps
+can be single or cross currency.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Flexi Swap is an amortizing swap in which one party has the option
+to further reduce the notional in each period to each value between
+the current notional and a specified lower bound for that period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=.
+
+ORE states the pricing approach as follows:
+
+#+begin_quote
+Flexi Swaps are priced in ORE following the Replication Approach
+described in (F. Jamshidian, 2005). The replicating basket of
+Bermudan Swaptions is priced using the method as described under
+Product Type "Bermudan Swaption". Flexi Swaps can be single or cross
+currency.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=.
+
+ORE notes that flexi swaps are typically used for swaps linked to
+Asset Backed Securities with flexible amortisation.
+
+** In plain terms
+
+A flexi swap lets the notional breathe. The schedule amortises in the
+usual way. On top of that, one party may cut the notional further in
+each period. The cut can land anywhere between the current notional
+and a stated lower bound. The right matters when the underlying
+collateral prepays at an uncertain speed.
+
+** How it works in ORE
+
+The =FlexiSwapData= node is the trade data container for the flexi
+swap. The swap legs carry an amortising notional and are represented
+by =LegData= sub-nodes. The node also contains an =OptionLongShort=
+element. It names the holder of the prepayment option. A further
+sub-node describes the optional prepayments. In ORE's example the
+sub-node is =LowerNotionalBounds=. It means the notional can be
+reduced to any value between the given lower bound and the original
+notional in each fixed leg period.
+
+** Mathematical notes
+
+A flexi swap is an amortising swap plus a strip of reduction rights.
+Each right allows the holder to cut the notional down to a lower
+bound in one period. ORE prices the rights by the Replication
+Approach. The approach replicates the reduction rights with a basket
+of Bermudan Swaptions. Each Bermudan Swaption in the basket prices
+with the method described under Product Type "Bermudan Swaption".
+The holder exercises a right only when the cut improves the swap
+value.
+
+** What moves its value (static sensitivities)
+
+- The swap rate levels against the fixed coupon.
+- The volatility of the swap rates, through the swaption basket.
+- The amortisation schedule and the lower notional bounds.
+- The identity of the option holder.
+- The discount curve and the index spreads.
+
+The reduction right is worth more when the swap has moved against the
+party that must keep receiving it. The fixed legs and the lower
+bounds define how much notional each right can release.
+
+** How the profile ages (dynamic sensitivities)
+
+Period by period the holder decides whether to cut. A period that
+passes without exercise consumes that period's right. Actual cuts
+shrink the remaining notional. Later exposure shrinks with it. Late
+in life few rights remain. The swap then runs on the reduced schedule
+to maturity.
+
+** Why a customer would want it
+
+A customer in an Asset Backed Security trade needs a swap that
+follows flexible amortisation. The collateral prepays at an uncertain
+speed. A fixed amortisation schedule would mismatch the security. The
+flexi swap lets the notional track the collateral. In ORE Studio a
+customer books flexi swaps to value them and run sensitivities on the
+ORE engine.
+
+** Example
+
+ORE's catalogue shows a flexi swap whose optional prepayments are
+given by =LowerNotionalBounds=:
+
+#+begin_example
+<FlexiSwapData>
+  <LowerNotionalBounds>
+        <Notional>451389557.145667</Notional>
+        <Notional>427876791.621303</Notional>
+        <Notional>404435982.369285</Notional>
+        <Notional>379353200.32956</Notional>
+        ...
+  </LowerNotionalBounds>
+  <OptionLongShort>Short</OptionLongShort>
+  <LegData>
+    <LegType>Fixed</LegType>
+    ...
+  </LegData>
+  <LegData>
+    <LegType>Floating</LegType>
+    ...
+  </LegData>
+</FlexiSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/flexiswap.tex=,
+listing =Flexi Swap data=.
+
+A Balance Guaranteed Swap is priced through an auxiliary flexi swap,
+see the [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]]
+note.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/flexiswap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/forwardbond.org
+++ b/doc/knowledge/domain/forwardbond.org
@@ -37,7 +37,7 @@ bond at a future point in time (the ForwardMaturityDate) at an agreed
 price (the settlement Amount).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]].
 
 ORE describes the T-Lock and J-Lock forms as follows:
 
@@ -49,7 +49,7 @@ rather then a settlement amount. The cash settlement amount is given
 by (bond yield at maturity - lock rate) x DV01 in this case.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]].
 
 ** In plain terms
 
@@ -67,7 +67,7 @@ A Forward Bond is set up using a ForwardBondData block as shown below
 and the trade type is ForwardBond.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]].
 
 The =BondData= block specifies the underlying bond. A long position
 must be taken in the bond, so the =Payer= flag must be =true=. The
@@ -113,7 +113,7 @@ As for the ordinary bond the forward bond pricing requires a recovery
 rate that can be specified in ORE per SecurityId.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]].
 
 ** Mathematical notes
 
@@ -192,7 +192,7 @@ settlement amount of one million:
 </ForwardBondData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]],
 listing =Forward Bond Data=. The source spells the settlement value
 =Physcial= and closes the =IncomeCurveId= element without the leading
 slash; both are normalised here. The catalogue also shows the same
@@ -206,6 +206,6 @@ T-Lock form.
 
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/forwardbond.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardbond.tex][forwardbond.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/forwardbond.org
+++ b/doc/knowledge/domain/forwardbond.org
@@ -201,6 +201,9 @@ T-Lock form.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/forwardbond.org
+++ b/doc/knowledge/domain/forwardbond.org
@@ -1,0 +1,208 @@
+:PROPERTIES:
+:ID: 8CCD37D5-1D16-4972-8582-13595E62381C
+:END:
+#+title: Forward Bond
+#+description: A forward contract to buy or sell an underlying bond at a future date; ORE's ForwardBond product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:forwardbond:
+#+created: 2026-09-06
+#+updated: 2026-09-07
+
+A forward bond is a contract to buy or sell a bond at a future date
+at an agreed price. ORE models it with the trade type =ForwardBond=.
+The container node is =ForwardBondData=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A forward bond establishes an agreement to buy or sell an underlying
+bond at a future date at an agreed price. The direction of the
+contract is set by =LongInForward=. Settlement can be physical or
+cash. A T-Lock is a forward bond on a US Treasury bond, priced by a
+lock-in yield instead of an amount. A J-Lock is the same contract on
+a Japanese Government Bond. The forward bond is priced with the
+=DiscountingForwardBondEngine=.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Forward Bond (or Bond Forward) is a contract that establishes an
+agreement to buy or sell (determined by LongInForward) an underlying
+bond at a future point in time (the ForwardMaturityDate) at an agreed
+price (the settlement Amount).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+
+ORE describes the T-Lock and J-Lock forms as follows:
+
+#+begin_quote
+A T-Lock is a Forward Bond with a US Treasury Bond as underlying,
+whereas a J-Lock is a Forward Bond with a Japanese Government Bond as
+underlying. T-Locks can be specified in terms of a lock-in yield
+rather then a settlement amount. The cash settlement amount is given
+by (bond yield at maturity - lock rate) x DV01 in this case.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+
+** In plain terms
+
+A forward bond is a promise to buy or sell a bond at a fixed future
+date at a price agreed today. It locks the price of a bond trade that
+happens later. A T-Lock is the same contract on a US Treasury, stated
+as a yield instead of a price.
+
+** How it works in ORE
+
+ORE describes the setup as follows:
+
+#+begin_quote
+A Forward Bond is set up using a ForwardBondData block as shown below
+and the trade type is ForwardBond.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+
+The =BondData= block specifies the underlying bond. A long position
+must be taken in the bond, so the =Payer= flag must be =true=. The
+block carries one extra field for forward bonds: =IncomeCurveId=
+names the benchmark curve to use for compounding. It must match a
+curve in the yield curves or index curve block of
+=todaysmarket.xml=. The field is optional. When it is left out, the
+market reference yield curve is used for compounding.
+
+The =SettlementData= block defines the terms of settlement.
+=ForwardMaturityDate= is the maturity date of the forward contract.
+=Settlement= is optional and takes =Cash= or =Physical=; it defaults
+to =Physical=, except when the settlement is defined by =LockRate=,
+in which case it defaults to =Cash=. =Amount= is optional: it is the
+settlement amount, also called the strike, transferred at forward
+maturity in return for the bond, or as a cash amount equal to the
+dirty price of the bond for cash settlement. It cannot be negative
+and is assumed to be in the currency of the underlying bond. Exactly
+one of =Amount= and =LockRate= must be given. =LockRate= defines a
+payoff of the yield at forward maturity minus the lock rate, times
+the DV01, for a long forward. When it is given, settlement must be
+cash. =LockRateDayCounter= is optional and defaults to =A360=.
+=SettlementDirty= decides whether the settlement amount reflects a
+clean or a dirty price. In either case the dirty amount is actually
+paid on the forward maturity date. When it is =false=, the forward
+accruals are computed internally and added to the given amount. It
+defaults to =true=.
+
+The =PremiumData= block is optional and defines a potential premium
+payment. =Date= is the payment date and =Amount= is the amount paid.
+The amount is transferred from the party that is long to the party
+that is short, and cannot be negative. =LongInForward= decides
+whether the contract is entered in a long or a short position.
+=KnockOut= is optional. When it is =true=, the contract terminates
+without payout if the underlying bond defaults before the forward
+maturity date. When it is not given, it defaults to =false= for a
+vanilla payoff and to =true= for a lock rate payoff.
+
+ORE notes the credit input as follows:
+
+#+begin_quote
+As for the ordinary bond the forward bond pricing requires a recovery
+rate that can be specified in ORE per SecurityId.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=.
+
+** Mathematical notes
+
+A physically settled forward pays the settlement amount at the
+forward maturity date and receives the bond. A cash settled forward
+pays or receives a cash amount equal to the dirty price of the bond,
+against the settlement amount. The amount is the price locked today
+for a trade that happens at the forward date.
+
+A T-Lock states the contract as a yield. Its payoff is the bond yield
+at forward maturity minus the lock rate, scaled by the DV01 of the
+bond. The compounding of the forward uses the benchmark curve named
+by =IncomeCurveId=, or the market reference yield curve when the
+field is absent. The pricing engine is the
+=DiscountingForwardBondEngine=, configured with a product type of
+=ForwardBond= and a three-month time step.
+
+** What moves its value (static sensitivities)
+
+- The yield curve of the underlying bond. It drives the forward price
+  and the discounting.
+- The compounding curve, named by =IncomeCurveId=, which carries the
+  bond from today to the forward date.
+- The credit of the issuer and the recovery rate per =SecurityId=.
+- The DV01 of the bond, for a T-Lock: it scales the whole payoff.
+- The passage of the settlement conventions and the premium.
+
+The forward price tracks the spot price minus the cost of carrying
+the bond to the forward date. The value of the contract is the
+difference between the locked amount and the prevailing forward
+price.
+
+** How the profile ages (dynamic sensitivities)
+
+The contract ages toward the =ForwardMaturityDate=. The forward price
+converges to the spot price of the bond as the date approaches. The
+accrued interest of the bond grows into the dirty price that
+settlement pays. At the forward date the trade settles and ends. When
+the underlying bond defaults before maturity, a knock-out contract
+terminates without payout; otherwise the default path is priced
+through the recovery rate.
+
+** Why a customer would want it
+
+A forward bond locks the price of a bond purchase or sale that
+happens later. It removes the price risk of a planned trade. A
+customer who must buy a bond at a known future date fixes the cost
+today. T-Locks are the standard way to trade US Treasury yield levels
+forward. In ORE Studio a customer books forward bonds to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long, physically settled forward bond with a
+premium. The example names a benchmark compounding curve and a
+settlement amount of one million:
+
+#+begin_example
+<ForwardBondData>
+  <BondData>
+    ...
+    <IncomeCurveId>BENCHMARKINCOME-EUR</IncomeCurveId>
+  </BondData>
+  <SettlementData>
+    <ForwardMaturityDate>20160808</ForwardMaturityDate>
+    <Settlement>Physical</Settlement>
+    <ForwardSettlementDate>20160810</ForwardSettlementDate>
+    <Amount>1000000.00</Amount>
+    <SettlementDirty>true</SettlementDirty>
+  </SettlementData>
+  <PremiumData>
+    <Amount>1000.00</Amount>
+    <Date>20160808</Date>
+  </PremiumData>
+  <LongInForward>true</LongInForward>
+</ForwardBondData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardbond.tex=,
+listing =Forward Bond Data=. The source spells the settlement value
+=Physcial= and closes the =IncomeCurveId= element without the leading
+slash; both are normalised here. The catalogue also shows the same
+structure with a =LockRate= of 0.02365 in place of the =Amount=, its
+T-Lock form.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/forwardbond.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/forwardrateagreement.org
+++ b/doc/knowledge/domain/forwardrateagreement.org
@@ -128,6 +128,9 @@ listing =Forward Rate Agreement Data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_rate_agreement][Wikipedia: Forward rate agreement]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/forwardrateagreement.org
+++ b/doc/knowledge/domain/forwardrateagreement.org
@@ -1,0 +1,135 @@
+:PROPERTIES:
+:ID: 11714B3F-A790-4797-BE01-41426289E7C7
+:END:
+#+title: Forward Rate Agreement
+#+description: A single-period lock on a future interest rate; ORE's ForwardRateAgreement product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:forwardrateagreement:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A forward rate agreement locks the rate of a single future interest
+period. The lock is benchmarked to a reference IBOR index. ORE models
+it with the trade type =ForwardRateAgreement=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A forward rate agreement sets a fixed forward rate against a
+reference IBOR index rate and tenor. The difference between the
+forward rate and the reference rate is paid or received at the end of
+the contract. Interest accrues on a predetermined notional from an
+agreed start date to the end of the contract. No notional changes
+hands. ORE settles the contract on its start date.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Forward Rate Agreement is a contract between two counterparties
+that determines a fixed forward interest rate benchmarked to a
+reference IBOR index rate and tenor.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+
+ORE states three properties of the contract:
+
+#+begin_quote
+Difference between the forward rate and the reference rate is to be
+paid/received at the end of the contract.
+Interest is accrued on a predetermined notional amount from an agreed
+upon start date to the end of the FRA contract.
+There are no exchanges of notional.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+
+** In plain terms
+
+A borrower who needs a loan in the future locks its rate today. The
+FRA then pays the difference between the locked rate and the rate
+that actually fixes. The contract creates no loan. The notional only
+scales the payment.
+
+** How it works in ORE
+
+The trade uses the =ForwardRateAgreementData= block. =StartDate= is
+the date on which the FRA expires and settles. =EndDate= is when the
+forward loan or deposit ends. The difference between the two dates is
+the tenor of the underlying loan. =Currency= names the currency of
+the notional. =Index= names the benchmark rate. It has the form
+CCY-INDEX-TENOR, with an integer followed by D, W, M, or Y as the
+tenor. Overnight indices carry no tenor. =LongShort= sets the
+direction. A long position receives the agreed rate. A short position
+pays it. =Strike= is the agreed forward rate in decimal form. The
+value 0.05 means a rate of 5 percent. =Notional= is constant. It
+carries no accretion or amortisation.
+
+** Mathematical notes
+
+An FRA is a forward on one IBOR fixing. At trade time the parties
+agree the strike. At the fixing the reference rate realises. The
+payoff is the difference between the two, scaled by the notional and
+the accrual of the period. The payment lands at the end of the
+contract. No principal ever moves.
+
+** What moves its value (static sensitivities)
+
+- The forward rate for the contract tenor and reference index.
+- The strike and the direction of the position.
+- The discount curve to the payment date.
+- The day-count convention of the accrual period.
+- The distance to the fixing date.
+
+Before the fixing the trade moves one for one with the forward rate.
+The delta is one unit of rate exposure on the notional.
+
+** How the profile ages (dynamic sensitivities)
+
+Until its fixing the trade behaves like a forward on the reference
+index. On the start date the reference rate fixes. The payoff becomes
+a known cash amount from that moment. Only discount risk remains
+until the payment at the end date. At the end date the cash settles
+and the trade stops.
+
+** Why a customer would want it
+
+A customer locks a future borrowing or lending rate without a loan on
+the balance sheet. A treasurer hedges an upcoming funding need. A
+trader takes a view on the short end of the curve. The FRA is also
+the building block of swap replication. In ORE Studio a customer
+books forward rate agreements to value them and run sensitivities on
+the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long FRA on euro six-month Euribor struck at
+0.1 percent:
+
+#+begin_example
+<ForwardRateAgreementData>
+    <StartDate>20161028</StartDate>
+    <EndDate>20351028</EndDate>
+    <Currency>EUR</Currency>
+    <Index>EUR-EURIBOR-6M</Index>
+    <LongShort>Long</LongShort>
+    <Strike>0.001</Strike>
+    <Notional>1000000000</Notional>
+</ForwardRateAgreementData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=,
+listing =Forward Rate Agreement Data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_rate_agreement][Wikipedia: Forward rate agreement]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/forwardrateagreement.org
+++ b/doc/knowledge/domain/forwardrateagreement.org
@@ -35,7 +35,7 @@ that determines a fixed forward interest rate benchmarked to a
 reference IBOR index rate and tenor.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardrateagreement.tex][forwardrateagreement.tex]].
 
 ORE states three properties of the contract:
 
@@ -47,7 +47,7 @@ upon start date to the end of the FRA contract.
 There are no exchanges of notional.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardrateagreement.tex][forwardrateagreement.tex]].
 
 ** In plain terms
 
@@ -123,7 +123,7 @@ ORE's catalogue shows a long FRA on euro six-month Euribor struck at
 </ForwardRateAgreementData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/forwardrateagreement.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardrateagreement.tex][forwardrateagreement.tex]],
 listing =Forward Rate Agreement Data=.
 
 * See also
@@ -133,6 +133,6 @@ listing =Forward Rate Agreement Data=.
 
 - [[https://en.wikipedia.org/wiki/Forward_rate_agreement][Wikipedia: Forward rate agreement]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/forwardrateagreement.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/forwardrateagreement.tex][forwardrateagreement.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_asianoption.org
+++ b/doc/knowledge/domain/fx_asianoption.org
@@ -1,0 +1,156 @@
+:PROPERTIES:
+:ID: 9C395333-73C7-401D-9E71-5333E1645E1A
+:END:
+#+title: FX Asian Option
+#+description: An FX option on an averaged exchange rate; ORE's FxAsianOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_asianoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX Asian option is the averaging option of the FX family. Its
+payoff depends on the average of an exchange rate over a period. ORE
+models it with the trade type =FxAsianOption=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX Asian option pays on the averaged foreign exchange rate over a
+pre-set period. At expiry the buyer obtains a cash amount based on the
+average rate, in return for a predetermined strike. The buyer pays a
+premium. The averaging can be arithmetic or geometric. The strike can
+be fixed or floating. The observation dates form a schedule.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+For an FX Asian option, the payoff is determined by the averaged
+foreign exchange rate over a pre-set period of time. At the expiration
+date, this product gives the buyer the right, but not the obligation,
+to obtain a cash amount of averaged rate in return for a predetermined
+strike rate. For this right the buyer pays a premium to the seller.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_asianoption.tex=.
+
+ORE adds that an FX Asian option is a path-dependent option whose
+payoff depends upon the averaged foreign exchange rate over a pre-set
+period of time.
+
+** In plain terms
+
+An FX Asian option is a bet on an average. The exchange rate is
+measured many times over a period. The average decides the payoff, not
+any single day. The average smooths the swings of the rate.
+
+** How it works in ORE
+
+The =FxAsianOptionData= node carries one =OptionData= node plus
+elements specific to the option. The =Currency= is the payoff
+currency. The =Quantity= scales the payoff. The =Strike= is the
+strike rate. The =Underlying= names the FX pair, with =Type= FX. The
+=OptionData= sets the direction and the payoff type.
+=PayoffType= =Asian= or =AverageStrike= identifies a fixed or
+floating strike. =PayoffType2= selects =Arithmetic= or =Geometric=
+averaging, with arithmetic the default. The =ObservationDates= node
+builds the averaging schedule, rules-based or date-based, like a
+=ScheduleData= node. =Settlement= defaults to the exercise date.
+
+** Mathematical notes
+
+ORE states the payoff as follows:
+
+Quantity x max(w x (A(0,T) - K), 0)
+
+A(0,T) is the arithmetic average FX rate over the observation period,
+as amount of CCY2 per one unit of CCY1. K is the strike rate, in the
+same terms. w is 1 for a call, which receives the averaged FX and
+pays the strike, and -1 for a put. In the average-strike form, the
+strike is the average itself.
+
+** What moves its value (static sensitivities)
+
+- The FX forward curve at each observation date. It drives the
+  expected average.
+- The volatility of the rate over the window. The average damps it.
+- The strike and the quantity.
+- The observation schedule and the averaging convention.
+- The discount rate of the payoff currency.
+
+A call gains when the average rises above the strike. A put gains when
+the average falls below it.
+
+** How the profile ages (dynamic sensitivities)
+
+Each observation turns part of the average from unknown to known. The
+remaining observations keep their market exposure. The averaging
+window closes as the period end approaches. Near the end the average
+is largely determined. At expiry the option settles on the final
+average.
+
+** Why a customer would want it
+
+A customer with a stream of FX conversions over time wants protection
+on the average rate, not on one date. The average makes the hedge
+cheaper than a single-date option. In ORE Studio a customer books FX
+Asian options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long arithmetic Asian call:
+
+#+begin_example
+<Trade id="FxAsianOption">
+  <TradeType>FxAsianOption</TradeType>
+  <Envelope>
+    <CounterParty>CPTY_A</CounterParty>
+    <NettingSetId>CPTY_A</NettingSetId>
+    <AdditionalFields />
+  </Envelope>
+  <FxAsianOptionData>
+    <Currency>USD</Currency>
+    <Quantity>100</Quantity>
+    <Strike>1.05</Strike>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-EUR-USD</Name>
+    </Underlying>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <OptionType>Call</OptionType>
+      <PayoffType>Asian</PayoffType>
+      <PayoffType2>Arithmetic</PayoffType2>
+      <ExerciseDates>
+        <ExerciseDate>2020-07-15</ExerciseDate>
+      </ExerciseDates>
+    </OptionData>
+    <Settlement>2020-07-20</Settlement>
+    <ObservationDates>
+      <Rules>
+        <StartDate>2019-12-27</StartDate>
+        <EndDate>2020-07-06</EndDate>
+        <Tenor>1D</Tenor>
+        <Calendar>US</Calendar>
+        <Convention>F</Convention>
+        <TermConvention>F</TermConvention>
+        <Rule>Forward</Rule>
+      </Rules>
+    </ObservationDates>
+  </FxAsianOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_asianoption.tex=,
+listing =FX Asian Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_asianoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_asianoption.org
+++ b/doc/knowledge/domain/fx_asianoption.org
@@ -36,7 +36,7 @@ to obtain a cash amount of averaged rate in return for a predetermined
 strike rate. For this right the buyer pays a premium to the seller.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_asianoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_asianoption.tex][fx_asianoption.tex]].
 
 ORE adds that an FX Asian option is a path-dependent option whose
 payoff depends upon the averaged foreign exchange rate over a pre-set
@@ -145,7 +145,7 @@ ORE's catalogue shows a long arithmetic Asian call:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_asianoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_asianoption.tex][fx_asianoption.tex]],
 listing =FX Asian Option data=.
 
 * See also
@@ -154,6 +154,6 @@ listing =FX Asian Option data=.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_asianoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_asianoption.tex][fx_asianoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_asianoption.org
+++ b/doc/knowledge/domain/fx_asianoption.org
@@ -150,6 +150,9 @@ listing =FX Asian Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Asian_option][Wikipedia: Asian option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_asianoption.tex=. The

--- a/doc/knowledge/domain/fx_barrieroption.org
+++ b/doc/knowledge/domain/fx_barrieroption.org
@@ -1,0 +1,164 @@
+:PROPERTIES:
+:ID: 6CAED5F9-21CB-4300-B1B0-89599CFBFC7C
+:END:
+#+title: FX Barrier Option
+#+description: An FX option with a single barrier; ORE's FxBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_barrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX barrier option is the path-dependent core of the FX exotic
+family. Its life depends on a spot rate reaching a level. ORE models
+it with the trade type =FxBarrierOption=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX barrier option exists only while an FX spot condition holds.
+The product has a single continuously monitored barrier around a
+vanilla European FX option. Exercise is European. A knock-in option
+becomes active when spot reaches the barrier. A knock-out option dies
+when spot reaches it. On inactive expiry the payoff is zero or a cash
+rebate. The four main types are up-and-in, down-and-in, up-and-out,
+and down-and-out.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An FX Barrier option is a path-dependent option whose existence
+depends upon an FX spot rate reaching a pre-set barrier level.
+Exercise is European.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=.
+
+ORE adds that the product has a continuously monitored single barrier
+with a vanilla European FX option underlying.
+
+ORE defines the two life modes as follows:
+
+#+begin_quote
+A knock-in option is a barrier option that only comes into
+existence/becomes active when the FX spot rate reaches the barrier
+level at any point in the option's life. Once a barrier is
+knocked-in, the option will not cease to exist until the option
+expires and effectively it becomes a Vanilla FX Option.
+#+end_quote
+
+#+begin_quote
+A knock-out option starts its life active, but ceases to
+exist/becomes inactive, if the barrier is reached during the life of
+the option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=.
+
+** In plain terms
+
+An FX barrier option is a vanilla option with a condition. The
+condition is a rate level. If the rate touches the level, the option
+switches on or off. The four types pair the level above or below with
+the switching direction.
+
+** How it works in ORE
+
+The =FxBarrierOptionData= node includes one =OptionData= node and one
+=BarrierData= node. The barrier level is quoted as the amount in
+=SoldCurrency= per unit =BoughtCurrency=. The barrier =Type= selects
+one of the four main types. =Levels= holds the level, and =Rebate=
+the cash rebate paid on inactive expiry. =StartDate= sets the start
+of the barrier monitoring, with the associated =Calendar= and
+=FXIndex=. The bought and sold currencies and amounts set the
+underlying exchange.
+
+** Mathematical notes
+
+A barrier option prices as a vanilla option plus a correction for the
+barrier. The knock-in form is a vanilla option that becomes active.
+The knock-out form is a vanilla option that can disappear. When the
+option expires inactive, the payoff is zero or the rebate, a fraction
+of the original premium. The value depends on the distance of spot
+from the barrier and on the volatility.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its distance from the barrier sets the state.
+- The volatility of the pair. It drives the probability of touching
+  the barrier.
+- The interest rates in both currencies.
+- The strike, the barrier level, and the rebate.
+- The time to expiry.
+
+Near the barrier the exposure to spot and volatility changes
+direction. This is the classic barrier skew. A knock-out loses value
+as spot approaches the barrier. A knock-in gains.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier is monitored continuously through the option's life. A
+knock-out can end at any moment. A knock-in waits to activate. After a
+knock-out the trade ends with the rebate or nothing. After a
+knock-in the trade becomes a vanilla FX option and ages like one. At
+expiry the option settles in the money or expires.
+
+** Why a customer would want it
+
+A customer who holds a view on a rate range buys a barrier option at a
+lower premium than the vanilla. An exporter who expects the rate to
+stay in a band sells a knock-out. Barrier options shape the cost of
+hedging. In ORE Studio a customer books FX barrier options to value
+them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European call with an up-and-in barrier:
+
+#+begin_example
+<FxBarrierOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>UpAndIn</Type>
+    <Levels>
+      <Level>1.2</Level>
+    </Levels>
+    <Rebate>0.0</Rebate>
+  </BarrierData>
+  <StartDate>2019-01-25</StartDate>
+  <Calendar>TARGET</Calendar>
+  <FXIndex>FX-ECB-EUR-USD</FXIndex>
+  <BoughtCurrency>EUR</BoughtCurrency>
+  <BoughtAmount>1000000</BoughtAmount>
+  <SoldCurrency>USD</SoldCurrency>
+  <SoldAmount>1100000</SoldAmount>
+</FxBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=,
+listing =FX Barrier Option data= (optional elements omitted).
+
+The family includes the
+[[id:0AA6F04D-C049-43D5-8307-82A9562E2883][FX Double Barrier Option]], the
+[[id:4BAF88FA-7FDF-4B01-9A52-7AAE733A02B5][FX European Barrier Option]], and the
+[[id:B6A26725-EC1A-482D-A920-3CAB8834ED6D][FX KIKO Barrier Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_barrieroption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_barrieroption.org
+++ b/doc/knowledge/domain/fx_barrieroption.org
@@ -158,6 +158,9 @@ The family includes the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_barrieroption.tex=. The

--- a/doc/knowledge/domain/fx_barrieroption.org
+++ b/doc/knowledge/domain/fx_barrieroption.org
@@ -36,7 +36,7 @@ depends upon an FX spot rate reaching a pre-set barrier level.
 Exercise is European.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_barrieroption.tex][fx_barrieroption.tex]].
 
 ORE adds that the product has a continuously monitored single barrier
 with a vanilla European FX option underlying.
@@ -57,7 +57,7 @@ exist/becomes inactive, if the barrier is reached during the life of
 the option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_barrieroption.tex][fx_barrieroption.tex]].
 
 ** In plain terms
 
@@ -148,7 +148,7 @@ ORE's catalogue shows a long European call with an up-and-in barrier:
 </FxBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_barrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_barrieroption.tex][fx_barrieroption.tex]],
 listing =FX Barrier Option data= (optional elements omitted).
 
 The family includes the
@@ -162,6 +162,6 @@ The family includes the
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_barrieroption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_barrieroption.tex][fx_barrieroption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_digitalbarrieroption.org
+++ b/doc/knowledge/domain/fx_digitalbarrieroption.org
@@ -35,7 +35,7 @@ This product has a continuously monitored single barrier with an
 Cash-or-Nothing digital underlying option.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex][fx_digitalbarrieroption.tex]].
 
 ORE states the payoff condition as follows:
 
@@ -45,7 +45,7 @@ digital Cash-or-Nothing underlying option depending upon an FX spot
 rate reaching a pre-set barrier level.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex][fx_digitalbarrieroption.tex]].
 
 ORE also notes that the option can be of the same four main types as a
 regular barrier FX option: up-and-out, down-and-out, up-and-in, and
@@ -146,7 +146,7 @@ barrier:
 </FxDigitalBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex][fx_digitalbarrieroption.tex]],
 listing =FX Digital Barrier Option data= (optional elements omitted).
 
 * See also
@@ -156,6 +156,6 @@ listing =FX Digital Barrier Option data= (optional elements omitted).
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the digital payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex][fx_digitalbarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_digitalbarrieroption.org
+++ b/doc/knowledge/domain/fx_digitalbarrieroption.org
@@ -1,0 +1,158 @@
+:PROPERTIES:
+:ID: 8668F997-2609-47C6-BF5C-EE35F21405EE
+:END:
+#+title: FX Digital Barrier Option
+#+description: An FX digital option combined with a barrier; ORE's FxDigitalBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_digitalbarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX digital barrier option couples a digital payout with a barrier
+condition. It pays a fixed amount if the rate both touches a level and
+settles on the right side of a strike. ORE models it with the trade
+type =FxDigitalBarrierOption=. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX digital barrier option combines a cash-or-nothing digital
+underlying with a continuously monitored single barrier. At expiry it
+pays either the digital payoff or nothing, depending on whether the
+rate reached the barrier. The four main barrier types apply. A
+knock-in pays if the barrier is breached. A knock-out pays if it is
+not. The strike test at expiry decides the digital payout.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product has a continuously monitored single barrier with an
+Cash-or-Nothing digital underlying option.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+
+ORE states the payoff condition as follows:
+
+#+begin_quote
+At expiry a digital FX Barrier option pays either the payoff of a
+digital Cash-or-Nothing underlying option depending upon an FX spot
+rate reaching a pre-set barrier level.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+
+ORE also notes that the option can be of the same four main types as a
+regular barrier FX option: up-and-out, down-and-out, up-and-in, and
+down-and-in. A knock-in or one-touch pays the underlying option payoff
+if the barrier is breached, and no payout otherwise. A knock-out or
+no-touch pays nothing if the barrier is breached, and the underlying
+option payoff otherwise.
+
+** In plain terms
+
+An FX digital barrier option is a digital option with a door. The door
+opens or closes when the rate touches a level. On the paying side, the
+rate must also end past the strike. Both conditions decide the fixed
+payout.
+
+** How it works in ORE
+
+The =FxDigitalBarrierOptionData= node includes one =OptionData= node
+and one =BarrierData= node. This is a single-barrier instrument, so
+the barrier data holds one level. The level is quoted as the amount in
+=DomesticCurrency= per one unit of =ForeignCurrency=. The barrier
+=Type= is one of the four main types. =StrictComparison= chooses the
+boundary of the barrier check. The =Strike= test at expiry uses the
+same currency terms. Call pays when the rate at expiry is above the
+strike. Put pays when it is below. =PayoffAmount= and
+=PayoffCurrency= set the payout. A =StartDate= before today triggers a
+check of past fixings for a breach, with the =Calendar= and
+=FXIndex= naming the fixing source. =FXIndexDailyLows= and
+=FXIndexDailyHighs= track intraday barrier breaches.
+
+** Mathematical notes
+
+The value is the probability that the barrier condition and the
+strike condition both resolve in favour of the buyer, discounted. The
+barrier path probability and the terminal moneyness interact. The
+payout is fixed, so volatility acts through the joint probability,
+not through a payoff tail.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its distance from the barrier and the strike sets
+  the state.
+- The volatility of the pair. It drives both the touch probability and
+  the terminal moneyness.
+- The interest rates in both currencies.
+- The barrier level, the strike, and the fixed payout.
+- The payoff currency and the fixing source.
+
+The sensitivities change sign near the barrier. A knock-in gains as
+spot approaches the barrier. A knock-out loses. A digital near the
+strike is sensitive to the terminal rate.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier is monitored continuously through the option's life. A
+knock-out can end at any moment. A knock-in waits for its breach. At
+expiry the digital strike test decides the final payout. The payout
+settles in the payoff currency and the trade stops.
+
+** Why a customer would want it
+
+A customer who wants a fixed payout on a rate range view buys a
+digital barrier option. The barrier shapes the payout at a lower
+premium than a plain digital. In ORE Studio a customer books FX
+digital barrier options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a long European digital call with a down-and-in
+barrier:
+
+#+begin_example
+<FxDigitalBarrierOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>DownAndIn</Type>
+    <Levels>
+      <Level>1.18</Level>
+    </Levels>
+  </BarrierData>
+  <StartDate>2019-01-25</StartDate>
+  <Calendar>TARGET</Calendar>
+  <FXIndex>FX-ECB-EUR-USD</FXIndex>
+  <Strike>1.1</Strike>
+  <PayoffAmount>100000</PayoffAmount>
+  <PayoffCurrency>USD</PayoffCurrency>
+  <ForeignCurrency>EUR</ForeignCurrency>
+  <DomesticCurrency>USD</DomesticCurrency>
+</FxDigitalBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=,
+listing =FX Digital Barrier Option data= (optional elements omitted).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the digital payout concept.
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_digitalbarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_digitalbarrieroption.org
+++ b/doc/knowledge/domain/fx_digitalbarrieroption.org
@@ -151,6 +151,9 @@ listing =FX Digital Barrier Option data= (optional elements omitted).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the digital payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/fx_digitaloption.org
+++ b/doc/knowledge/domain/fx_digitaloption.org
@@ -119,6 +119,9 @@ listing =FX Digital Option data= (optional elements omitted).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_digitaloption.tex=. The

--- a/doc/knowledge/domain/fx_digitaloption.org
+++ b/doc/knowledge/domain/fx_digitaloption.org
@@ -36,7 +36,7 @@ whether the underlying FX spot rate expires in-the-money at the
 expiration date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitaloption.tex][fx_digitaloption.tex]].
 
 ORE adds that digital FX options have European exercise with payout at
 expiry. The buyer of a digital FX option pays a premium to the seller.
@@ -114,7 +114,7 @@ ORE's catalogue shows a long European digital call:
 </FxDigitalOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitaloption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitaloption.tex][fx_digitaloption.tex]],
 listing =FX Digital Option data= (optional elements omitted).
 
 * See also
@@ -123,6 +123,6 @@ listing =FX Digital Option data= (optional elements omitted).
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_digitaloption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_digitaloption.tex][fx_digitaloption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_digitaloption.org
+++ b/doc/knowledge/domain/fx_digitaloption.org
@@ -1,0 +1,125 @@
+:PROPERTIES:
+:ID: C880CEB4-4FB7-41AA-8A4A-A650B6FC388C
+:END:
+#+title: FX Digital Option
+#+description: An FX option paying a fixed amount when the rate settles; ORE's FxDigitalOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_digitaloption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX digital option is the binary bet of the FX family. It pays a
+fixed amount or nothing. ORE models it with the trade type
+=FxDigitalOption=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A digital FX option pays either zero or a fixed predetermined amount,
+cash or nothing. The payout depends on whether the underlying FX spot
+rate expires in the money at the expiration date. Exercise is
+European, with payout at expiry. The buyer pays a premium. The trade
+data names the strike, the payoff amount and currency, and the foreign
+and domestic currencies.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Digital FX Option is an option whose payout is either zero or a
+fixed predetermined amount (Cash-or-Nothing). Payout depends on
+whether the underlying FX spot rate expires in-the-money at the
+expiration date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitaloption.tex=.
+
+ORE adds that digital FX options have European exercise with payout at
+expiry. The buyer of a digital FX option pays a premium to the seller.
+
+** In plain terms
+
+An FX digital option is a bet on one outcome. If the rate settles on
+the right side of the strike, the payout is fixed. If not, the payout
+is zero. There is no middle ground. The fixed payout makes the value
+easy to read as a probability.
+
+** How it works in ORE
+
+The =FxDigitalOptionData= node includes one =OptionData= node plus
+elements specific to the option. The =Strike= sets the boundary. The
+=PayoffAmount= and =PayoffCurrency= set the fixed payout.
+=ForeignCurrency= and =DomesticCurrency= name the rate. The call
+pays when the rate at expiry sits above the strike. The put pays when
+it sits below.
+
+** Mathematical notes
+
+A digital option equals the limit of a call spread as the two strikes
+converge. Its value is the discounted probability that the rate ends
+on the right side of the strike. Volatility changes the value through
+the probability, not through the payoff size. The payoff amount is
+fixed, so the option has no linear payoff tail.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its position against the strike sets the odds.
+- The volatility of the pair. It spreads the terminal rate around the
+  forward.
+- The interest rates in both currencies.
+- The strike, the payoff amount, and the payoff currency.
+
+A digital near the strike is volatile to spot. Its delta is highest at
+the money. Away from the strike the value saturates near zero or near
+the full payoff.
+
+** How the profile ages (dynamic sensitivities)
+
+The option loses time value as expiry approaches. At the money, the
+value converges to a coin flip on the payoff. In the money, it
+converges toward the full payoff. Out of the money, it decays to
+zero. At expiry the payout is decided by the fixing and settles.
+
+** Why a customer would want it
+
+A customer who wants a fixed payout on a rate view buys a digital. The
+payout is known in advance, which suits structured products. Dealers
+use digitals to shape option books. In ORE Studio a customer books FX
+digital options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European digital call:
+
+#+begin_example
+<FxDigitalOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <Strike>1.1</Strike>
+  <PayoffCurrency>USD</PayoffCurrency>
+  <PayoffAmount>100000</PayoffAmount>
+  <ForeignCurrency>EUR</ForeignCurrency>
+  <DomesticCurrency>USD</DomesticCurrency>
+</FxDigitalOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_digitaloption.tex=,
+listing =FX Digital Option data= (optional elements omitted).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_digitaloption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_doublebarrieroption.org
+++ b/doc/knowledge/domain/fx_doublebarrieroption.org
@@ -36,7 +36,7 @@ depends upon an FX spot rate reaching one of the two pre-set barrier
 levels. Exercise is European.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doublebarrieroption.tex][fx_doublebarrieroption.tex]].
 
 ORE adds that the product has two continuously monitored barriers with
 a vanilla European FX option underlying.
@@ -134,7 +134,7 @@ levels:
 </FxDoubleBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doublebarrieroption.tex][fx_doublebarrieroption.tex]],
 listing =FX Double Barrier Option data= (optional elements omitted).
 
 The single-level form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]]. The
@@ -146,6 +146,6 @@ The single-level form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barri
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doublebarrieroption.tex][fx_doublebarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_doublebarrieroption.org
+++ b/doc/knowledge/domain/fx_doublebarrieroption.org
@@ -142,6 +142,9 @@ The single-level form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barri
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=.

--- a/doc/knowledge/domain/fx_doublebarrieroption.org
+++ b/doc/knowledge/domain/fx_doublebarrieroption.org
@@ -1,0 +1,148 @@
+:PROPERTIES:
+:ID: 0AA6F04D-C049-43D5-8307-82A9562E2883
+:END:
+#+title: FX Double Barrier Option
+#+description: An FX option with two barriers around the strike; ORE's FxDoubleBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_doublebarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX double barrier option is the two-level form of the FX barrier
+family. Its life depends on a rate reaching either of two levels. ORE
+models it with the trade type =FxDoubleBarrierOption=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An FX double barrier option exists while an FX spot condition between
+two levels holds. The product has two continuously monitored barriers
+around a vanilla European FX option. Exercise is European. The option
+is knock-in or knock-out as a whole. On inactive expiry the payoff is
+zero or a cash rebate. Knock-in knock-out combinations are not
+supported here; the KIKO product covers them.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An FX Double Barrier option is a path-dependent option whose existence
+depends upon an FX spot rate reaching one of the two pre-set barrier
+levels. Exercise is European.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=.
+
+ORE adds that the product has two continuously monitored barriers with
+a vanilla European FX option underlying.
+
+ORE notes that the current implementation does not support options
+with knock-in knock-out (KIKO) or knock-out knock-in (KOKI) barrier
+combinations. The former is covered by the separate FX KIKO Barrier
+Option instrument.
+
+** In plain terms
+
+An FX double barrier option is a vanilla option inside a corridor.
+The corridor has a floor and a ceiling. A knock-in option comes alive
+when the rate touches either level. A knock-out option dies when the
+rate touches either level.
+
+** How it works in ORE
+
+The =FxDoubleBarrierOptionData= node includes one =OptionData= node
+and one =BarrierData= node. The barrier levels are quoted as the
+amount in =SoldCurrency= per unit =BoughtCurrency=. The barrier
+=Type= is =KnockOut= or =KnockIn= for the pair of levels. =Levels=
+holds the two levels, and =Rebate= the cash rebate on inactive
+expiry. The bought and sold currencies and amounts set the underlying
+exchange.
+
+** Mathematical notes
+
+A double barrier option prices as a vanilla option plus a two-sided
+corridor correction. The value depends on the distance of spot from
+both levels. The probability of touching either level rises with
+volatility and with time. When the option expires inactive, the
+payoff is zero or the rebate.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its position inside the corridor sets the state.
+- The volatility of the pair. It drives the touch probability of
+  either level.
+- The interest rates in both currencies.
+- The strike, the two barrier levels, and the rebate.
+- The time to expiry.
+
+A knock-out loses value as spot approaches either barrier. A knock-in
+gains. Near the barriers the exposure to spot and volatility changes
+direction.
+
+** How the profile ages (dynamic sensitivities)
+
+The two barriers are monitored continuously. A knock-out can end at
+any moment. A knock-in waits for its first touch. After a knock-out
+the trade ends with the rebate or nothing. After a knock-in the trade
+becomes a vanilla FX option. At expiry the option settles in the money
+or expires.
+
+** Why a customer would want it
+
+A customer who expects the rate to stay inside a range buys a
+double knock-out at a lower premium than a single barrier. A customer
+who expects a breakout buys a double knock-in. In ORE Studio a
+customer books FX double barrier options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European call inside two knock-out
+levels:
+
+#+begin_example
+<FxDoubleBarrierOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>KnockOut</Type>
+    <Levels>
+      <Level>1.1</Level>
+      <Level>1.2</Level>
+    </Levels>
+    <Rebate>0.0</Rebate>
+  </BarrierData>
+  <StartDate>2019-01-25</StartDate>
+  <Calendar>TARGET</Calendar>
+  <FXIndex>FX-ECB-EUR-USD</FXIndex>
+  <BoughtCurrency>EUR</BoughtCurrency>
+  <BoughtAmount>1000000</BoughtAmount>
+  <SoldCurrency>USD</SoldCurrency>
+  <SoldAmount>1100000</SoldAmount>
+</FxDoubleBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=,
+listing =FX Double Barrier Option data= (optional elements omitted).
+
+The single-level form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]]. The
+[[id:B6A26725-EC1A-482D-A920-3CAB8834ED6D][FX KIKO Barrier Option]] pairs one knock-in with one knock-out.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_doublebarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_doubletouchoption.org
+++ b/doc/knowledge/domain/fx_doubletouchoption.org
@@ -36,7 +36,7 @@ This product has two continuously monitored barriers with a
 Cash-or-Nothing digital underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doubletouchoption.tex][fx_doubletouchoption.tex]].
 
 ORE states the payoff condition as follows:
 
@@ -46,7 +46,7 @@ amount or zero (Cash-or-Nothing) depending upon an FX spot rate
 reaching one of the pre-set barrier levels.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doubletouchoption.tex][fx_doubletouchoption.tex]].
 
 ORE also states the two forms. A knock-in, or double one-touch, has a
 fixed payout if one of the barriers is breached, and no payout
@@ -142,7 +142,7 @@ ORE's catalogue shows a long double no-touch:
 </FxDoubleTouchOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doubletouchoption.tex][fx_doubletouchoption.tex]],
 listing =FX Double Touch Option data= (optional elements omitted).
 
 The single-level form is the [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch Option]].
@@ -154,6 +154,6 @@ The single-level form is the [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_doubletouchoption.tex][fx_doubletouchoption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_doubletouchoption.org
+++ b/doc/knowledge/domain/fx_doubletouchoption.org
@@ -1,0 +1,156 @@
+:PROPERTIES:
+:ID: 7BA83993-32A7-4090-A6A9-A07AA3AF2B1D
+:END:
+#+title: FX Double Touch Option
+#+description: An FX option paying on one or two spot touches before expiry; ORE's FxDoubleTouchOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_doubletouchoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX double touch option is the touch product with two levels. It
+pays a fixed amount depending on whether a rate touches either level.
+ORE models it with the trade type =FxDoubleTouchOption=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An FX double touch option combines two continuously monitored
+barriers with a cash-or-nothing digital underlying. It pays a fixed
+amount or zero, depending on whether the spot rate reaches one of the
+levels. A knock-in, or double one-touch, pays if a barrier is
+breached. A knock-out, or double no-touch, pays if neither is
+breached. Payout at expiry is the only supported mode. No rebates are
+supported.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product has two continuously monitored barriers with a
+Cash-or-Nothing digital underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+
+ORE states the payoff condition as follows:
+
+#+begin_quote
+A FX Double Touch option pays either a fixed predetermined payoff
+amount or zero (Cash-or-Nothing) depending upon an FX spot rate
+reaching one of the pre-set barrier levels.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+
+ORE also states the two forms. A knock-in, or double one-touch, has a
+fixed payout if one of the barriers is breached, and no payout
+otherwise. A knock-out, or double no-touch, has no payout if one of
+the barriers is breached, and a fixed payout otherwise. The buyer pays
+a premium to the seller.
+
+** In plain terms
+
+An FX double touch option is a bet on a corridor. One side bets that
+the rate touches either wall before expiry. The other side bets that
+it never does. The payout is fixed. There is no middle ground.
+
+** How it works in ORE
+
+The =FxDoubleTouchOptionData= node includes one =OptionData= node and
+one =BarrierData= node. The barrier =Type= is =KnockOut= or
+=KnockIn=. =Levels= holds the two levels. The =OptionType= can be
+omitted. =PayOffAtExpiry= selects the payout timing. Only payout at
+expiry is currently supported, for both knock-out and knock-in
+barriers. =PayoffAmount= and =PayoffCurrency= set the fixed payout.
+=ForeignCurrency= and =DomesticCurrency= name the rate.
+=StartDate= sets the monitoring start, with the =Calendar= and
+=FXIndex= naming the fixing source.
+
+ORE notes that the current implementation supports FX double touch
+options with payout at expiry only. No rebates are supported.
+
+** Mathematical notes
+
+The value is the probability of the touch condition, discounted, times
+the fixed payout. A knock-in pays when the rate breaches either level
+at any time before expiry. A knock-out pays when it breaches neither.
+The probability of touching either level rises with volatility and
+with time. With payout at expiry, the timing of the touch does not
+change the payout date.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its position inside the corridor sets the state.
+- The volatility of the pair. It drives the touch probability.
+- The interest rates in the two currencies.
+- The two barrier levels and the fixed payout.
+- The payoff currency and the fixing source.
+
+A double no-touch loses value as spot approaches either level. A
+double one-touch gains. Near the levels the delta and vega change
+direction.
+
+** How the profile ages (dynamic sensitivities)
+
+The two levels are monitored continuously. A one-touch can be decided
+at any moment, though the payout waits for expiry. A no-touch stays
+alive while spot stays inside the corridor. As expiry approaches, the
+remaining time to touch shrinks. At expiry the payout settles and the
+trade stops.
+
+** Why a customer would want it
+
+A customer who expects the rate to stay in a range sells a double
+no-touch and collects the premium. A customer who expects a breakout
+buys a double one-touch. In ORE Studio a customer books FX double
+touch options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long double no-touch:
+
+#+begin_example
+<FxDoubleTouchOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <PayOffAtExpiry>true</PayOffAtExpiry>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>KnockOut</Type>
+    <Levels>
+      <Level>1.1</Level>
+      <Level>1.2</Level>
+    </Levels>
+  </BarrierData>
+  <ForeignCurrency>EUR</ForeignCurrency>
+  <DomesticCurrency>USD</DomesticCurrency>
+  <PayoffCurrency>USD</PayoffCurrency>
+  <PayoffAmount>100000</PayoffAmount>
+  <StartDate>2019-01-25</StartDate>
+  <FXIndex>FX-ECB-EUR-USD</FXIndex>
+  <Calendar>TARGET</Calendar>
+</FxDoubleTouchOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=,
+listing =FX Double Touch Option data= (optional elements omitted).
+
+The single-level form is the [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_doubletouchoption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_doubletouchoption.org
+++ b/doc/knowledge/domain/fx_doubletouchoption.org
@@ -149,6 +149,9 @@ The single-level form is the [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/fx_europeanbarrieroption.org
+++ b/doc/knowledge/domain/fx_europeanbarrieroption.org
@@ -34,7 +34,7 @@ obligation, to exchange a set amount of one currency for another, at a
 predetermined exchange rate, at one predetermined time in the future.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex][fx_europeanbarrieroption.tex]].
 
 ORE states that this right may be withdrawn depending upon an FX spot
 rate reaching a predetermined barrier level at the predetermined
@@ -55,7 +55,7 @@ A knock-out option starts its life active, but ceases to exist/becomes
 inactive, if the barrier is reached at expiry.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex][fx_europeanbarrieroption.tex]].
 
 ** In plain terms
 
@@ -139,7 +139,7 @@ and a rebate:
 </FxEuropeanBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex][fx_europeanbarrieroption.tex]],
 listing =FX European Barrier Option data= (optional elements omitted).
 
 The continuously monitored form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]].
@@ -150,6 +150,6 @@ The continuously monitored form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex][fx_europeanbarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_europeanbarrieroption.org
+++ b/doc/knowledge/domain/fx_europeanbarrieroption.org
@@ -1,0 +1,152 @@
+:PROPERTIES:
+:ID: 4BAF88FA-7FDF-4B01-9A52-7AAE733A02B5
+:END:
+#+title: FX European Barrier Option
+#+description: An FX European barrier option; ORE's FxEuropeanBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_europeanbarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX European barrier option checks its barrier once, at expiry. The
+monitoring is European rather than continuous. ORE models it with the
+trade type =FxEuropeanBarrierOption=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX European barrier option is a barrier option whose underlying is
+monitored only at expiry, with a single barrier. The buyer holds the
+right to exchange one currency for another at a set rate. The right
+may be withdrawn if the spot rate reaches the barrier at expiry.
+Settlement is cash or physical. The four main barrier types apply.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A FX European Barrier option gives the buyer the right, but not the
+obligation, to exchange a set amount of one currency for another, at a
+predetermined exchange rate, at one predetermined time in the future.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+
+ORE states that this right may be withdrawn depending upon an FX spot
+rate reaching a predetermined barrier level at the predetermined
+time. The underlying is monitored only at expiry, with a single
+barrier. For this right the buyer pays a premium to the seller.
+Settlement can be either cash or physical delivery.
+
+ORE defines the two life modes at expiry as follows:
+
+#+begin_quote
+A knock-in option is a barrier option that only comes into
+existence/becomes active when the FX spot rate reaches the barrier
+level at expiry.
+#+end_quote
+
+#+begin_quote
+A knock-out option starts its life active, but ceases to exist/becomes
+inactive, if the barrier is reached at expiry.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+
+** In plain terms
+
+An FX European barrier option is a vanilla option with an expiry-day
+condition. The barrier matters only at the end. If the rate sits past
+the level at expiry, the option switches on or off. During the life
+of the option, the barrier does not react.
+
+** How it works in ORE
+
+The =FxEuropeanBarrierOptionData= node includes one =OptionData= node
+and one =BarrierData= node. The barrier level is quoted as the amount
+in =SoldCurrency= per unit =BoughtCurrency=. The barrier =Type=
+selects one of the four main types. =Levels= holds the level, and
+=Rebate= the cash rebate on inactive expiry. The bought and sold
+currencies and amounts set the underlying exchange.
+
+** Mathematical notes
+
+A European barrier option prices against the terminal spot
+distribution, not the path. The barrier event and the expiry fixing
+are the same observation. The value is the vanilla option adjusted by
+the probability that the terminal rate sits past the barrier. A cash
+rebate applies when the option expires inactive.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its position against the barrier at expiry sets
+  the state.
+- The volatility of the pair. It spreads the terminal rate around the
+  forward.
+- The interest rates in both currencies.
+- The strike, the barrier level, and the rebate.
+
+The absence of continuous monitoring removes the intraday touch risk.
+The barrier exposure lives at the expiry date. A knock-out loses value
+as the forward rate sits closer to the barrier at expiry.
+
+** How the profile ages (dynamic sensitivities)
+
+The option ages like a vanilla option for most of its life. The
+barrier sleeps until expiry. At expiry the fixing decides both the
+moneyness and the barrier state. The option settles in cash or by
+delivery, or expires with the rebate.
+
+** Why a customer would want it
+
+A customer who wants a cheaper vanilla hedge buys a European barrier
+option. The barrier check at expiry only suits a view on the terminal
+rate. In ORE Studio a customer books FX European barrier options to
+value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European call with an up-and-in barrier
+and a rebate:
+
+#+begin_example
+<FxEuropeanBarrierOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>UpAndIn</Type>
+    <Levels>
+      <Level>1.2</Level>
+    </Levels>
+    <Rebate>100000</Rebate>
+  </BarrierData>
+  <BoughtCurrency>EUR</BoughtCurrency>
+  <BoughtAmount>1000000</BoughtAmount>
+  <SoldCurrency>USD</SoldCurrency>
+  <SoldAmount>1100000</SoldAmount>
+</FxEuropeanBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=,
+listing =FX European Barrier Option data= (optional elements omitted).
+
+The continuously monitored form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_europeanbarrieroption.org
+++ b/doc/knowledge/domain/fx_europeanbarrieroption.org
@@ -146,6 +146,9 @@ The continuously monitored form is the [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_europeanbarrieroption.tex=.

--- a/doc/knowledge/domain/fx_forward.org
+++ b/doc/knowledge/domain/fx_forward.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: 47598B8D-0121-4989-9661-79A8E6D1A070
+:END:
+#+title: FX Forward
+#+description: An FX forward locks an exchange rate for a future currency exchange; ORE's FxForward product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_forward:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX forward is the simplest currency derivative. Two parties agree
+today on a rate at which they will exchange two currencies on a future
+date. ORE models it as the trade type =FxForward=. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX forward locks the exchange rate for a future exchange of one
+currency against another. No money changes hands at trade time. The
+rate is fixed at inception, and the settlement happens on the value
+date. A cash-settled forward, which ORE represents with
+=Settlement=Cash=, is the standard form of a non-deliverable forward.
+The value of the contract between trade date and value date moves with
+market FX rates. It also moves with the interest-rate differential of
+the two currencies.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An Fx Forward is a contract that locks in the FX rate for the exchange
+of a set amount of one currency for another at a predetermined time in
+the future. An Fx Forward does not involve any upfront payment.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=.
+
+** In plain terms
+
+Two parties agree to swap currencies on a future date. The rate is
+fixed today. Neither party pays anything now. On the agreed date they
+exchange the agreed amounts, or the difference in cash. The deal
+removes the uncertainty of what the rate will be later.
+
+** How it works in ORE
+
+The =FxForwardData= node names the two sides of the exchange:
+
+- =BoughtCurrency= and =BoughtAmount=. What the holder buys on the
+  value date.
+- =SoldCurrency= and =SoldAmount=. What the holder sells in return.
+- =ValueDate=. The exchange happens on this date. The agreed rate
+  applies then.
+- =Settlement=. =Physical= delivers both currencies. =Cash= settles the
+  difference in one currency. ORE represents a non-deliverable forward
+  as a cash-settled forward.
+- =SettlementData=. The settlement currency, the FX fixing index, and
+  the payment date. These apply when settlement is cash.
+
+The value date follows the [[id:267DD5E8-F095-47C1-B42B-733565306776][FX spot date conventions]] of the pair.
+Restricted currencies use the [[id:CD3E82C6-AE56-4D06-B949-0B3A5CE7A5FC][non-deliverable]] form. Only the
+difference changes hands there.
+
+** Mathematical notes
+
+The forward rate derives from the spot rate and the interest-rate
+differential of the two currencies. The relation is
+[[id:49687AD7-396A-4CD8-B96B-B3F6675C9779][covered interest parity]]. The difference between forward and spot is the
+forward points. They shrink as the value date approaches. A forward is
+a linear product. Its value is proportional to the move in the
+underlying FX rate, with no optionality.
+
+** What moves its value (static sensitivities)
+
+- Spot FX. The dominant driver. The value changes nearly one-for-one
+  with the spot move, scaled by the amounts.
+- Interest rates. They act through the forward points. A rise in the
+  bought currency's rates, relative to the sold currency's, moves the
+  value in the opposite direction.
+- Settlement conventions. Cash settlement adds a small sensitivity to
+  the fixing index and the settlement date.
+
+The sign of the sensitivity depends on which currency is bought. A
+holder buying EUR against USD gains when EUR strengthens.
+
+** How the profile ages (dynamic sensitivities)
+
+Between trade date and value date the contract value fluctuates with
+the market. ORE's own words:
+
+#+begin_quote
+Before the ValueDate, the FxForward contract's value fluctuates with
+market FX rates. At the ValueDate, the settlement becomes
+deterministic.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=.
+
+After the value date, no market risk remains. Only the settlement and
+any payment-lag exposure are left.
+
+** Why a customer would want it
+
+A corporate that will pay or receive foreign currency locks the rate
+now and removes budget uncertainty. A bank hedges its own currency
+positions or quotes forwards to clients. A cash-settled forward gives
+the same hedge where the currency cannot be delivered, or where the
+client must not hold it. Arbitrageurs trade the forward against spot
+and deposits when covered interest parity breaks.
+
+** Example
+
+ORE's own catalogue shows the trade data node:
+
+#+begin_example
+<FxForwardData>
+    <ValueDate>2023-04-09</ValueDate>
+    <BoughtCurrency>EUR</BoughtCurrency>
+    <BoughtAmount>1000000</BoughtAmount>
+    <SoldCurrency>USD</SoldCurrency>
+    <SoldAmount>1500000</SoldAmount>
+    <Settlement>Physical</Settlement>
+</FxForwardData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=,
+listing =FX Forward data= (settlement details omitted).
+
+A cash-settled forward example sits in the ORE trade corpus at
+=assets/test_data/golden_dataset/Products/Example_Trades/FX_Forward.xml=.
+Native ORE example portfolios with FX forwards sit under
+=external/ore/examples/Exposure/Input/portfolio_fx.xml=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
+  definition.
+- [[https://en.wikipedia.org/wiki/Non-deliverable_forward][Wikipedia: Non-deliverable forward]]. This covers the cash-settled
+  variant.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fxforward.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_forward.org
+++ b/doc/knowledge/domain/fx_forward.org
@@ -137,6 +137,9 @@ Native ORE example portfolios with FX forwards sit under
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Forward_contract][Wikipedia: Forward contract]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Non-deliverable_forward][Wikipedia: Non-deliverable forward]]. This covers the cash-settled

--- a/doc/knowledge/domain/fx_forward.org
+++ b/doc/knowledge/domain/fx_forward.org
@@ -37,7 +37,7 @@ of a set amount of one currency for another at a predetermined time in
 the future. An Fx Forward does not involve any upfront payment.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxforward.tex][fxforward.tex]].
 
 ** In plain terms
 
@@ -98,7 +98,7 @@ market FX rates. At the ValueDate, the settlement becomes
 deterministic.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxforward.tex][fxforward.tex]].
 
 After the value date, no market risk remains. Only the settlement and
 any payment-lag exposure are left.
@@ -127,7 +127,7 @@ ORE's own catalogue shows the trade data node:
 </FxForwardData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxforward.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxforward.tex][fxforward.tex]],
 listing =FX Forward data= (settlement details omitted).
 
 A cash-settled forward example sits in the ORE trade corpus at
@@ -144,6 +144,6 @@ Native ORE example portfolios with FX forwards sit under
   definition.
 - [[https://en.wikipedia.org/wiki/Non-deliverable_forward][Wikipedia: Non-deliverable forward]]. This covers the cash-settled
   variant.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fxforward.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxforward.tex][fxforward.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_kikobarrieroption.org
+++ b/doc/knowledge/domain/fx_kikobarrieroption.org
@@ -36,7 +36,7 @@ once the knock-in barrier is hit the trade becomes a single barrier
 knock-out trade.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_kikobarrieroption.tex][fx_kikobarrieroption.tex]].
 
 ORE states the exercise condition as follows:
 
@@ -45,7 +45,7 @@ The KIKO option can only be exercised if the knock-out barrier is
 never touched and the knock-in barrier is touched at least once.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_kikobarrieroption.tex][fx_kikobarrieroption.tex]].
 
 ORE notes that the barriers can be any of the four main barrier types.
 One of the barriers must be a knock-in and the other a knock-out.
@@ -140,7 +140,7 @@ down-and-out barrier:
 </FxKIKOBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_kikobarrieroption.tex][fx_kikobarrieroption.tex]],
 listing =FX KIKO Barrier Option data= (optional elements omitted).
 
 The two-level form without mixed types is the
@@ -152,6 +152,6 @@ The two-level form without mixed types is the
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_kikobarrieroption.tex][fx_kikobarrieroption.tex]].
   The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_kikobarrieroption.org
+++ b/doc/knowledge/domain/fx_kikobarrieroption.org
@@ -148,6 +148,9 @@ The two-level form without mixed types is the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.

--- a/doc/knowledge/domain/fx_kikobarrieroption.org
+++ b/doc/knowledge/domain/fx_kikobarrieroption.org
@@ -1,0 +1,154 @@
+:PROPERTIES:
+:ID: B6A26725-EC1A-482D-A920-3CAB8834ED6D
+:END:
+#+title: FX KIKO Barrier Option
+#+description: A knock-in knock-out FX barrier option; ORE's FxKIKOBarrierOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_kikobarrieroption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX KIKO barrier option pairs one knock-in barrier with one
+knock-out barrier. It is the hybrid of the FX barrier family. ORE
+models it with the trade type =FxKIKOBarrierOption=. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX KIKO barrier option carries both a knock-out and a knock-in
+barrier. The knock-out barrier can happen at any time. Once the
+knock-in barrier is hit, the trade becomes a single-barrier
+knock-out trade. The option can be exercised only if the knock-out
+barrier is never touched and the knock-in barrier is touched at least
+once. One barrier must be a knock-in and the other a knock-out.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An FX KIKO Barrier option is an option with both a knock-out and a
+knock-in barrier. The knock-out barrier can happen at any time, and
+once the knock-in barrier is hit the trade becomes a single barrier
+knock-out trade.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+
+ORE states the exercise condition as follows:
+
+#+begin_quote
+The KIKO option can only be exercised if the knock-out barrier is
+never touched and the knock-in barrier is touched at least once.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+
+ORE notes that the barriers can be any of the four main barrier types.
+One of the barriers must be a knock-in and the other a knock-out.
+
+** In plain terms
+
+An FX KIKO option needs both a touch and a miss. The rate must touch
+one level to arm the option. The rate must never touch the other
+level, or the option dies. Two conditions, one payout.
+
+** How it works in ORE
+
+The =FxKIKOBarrierOptionData= node includes one =OptionData= node and
+two =BarrierData= nodes, wrapped in a =Barriers= node. One barrier
+data node names the knock-in, the other the knock-out. The strike rate
+and the barrier levels are expressed as the amount in =SoldCurrency=
+per unit =BoughtCurrency=. The bought and sold currencies and amounts
+set the underlying exchange.
+
+** Mathematical notes
+
+The value is the vanilla payoff conditioned on two path events. The
+knock-in must occur at least once. The knock-out must never occur.
+Both barriers are continuously monitored. The joint probability of
+the two events prices the option.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its position between the two barriers sets the
+  state.
+- The volatility of the pair. It drives both touch probabilities.
+- The interest rates in both currencies.
+- The strike and the two barrier levels.
+
+A spot move toward the knock-out level destroys value. A move toward
+the knock-in level creates it. Near either level the exposure to spot
+and volatility changes direction.
+
+** How the profile ages (dynamic sensitivities)
+
+The knock-out barrier is monitored continuously. The knock-in barrier
+waits for its first touch. Once the knock-in fires, the trade becomes
+a single-barrier knock-out trade. If the knock-out fires first, the
+trade dies. At expiry the survivor settles in the money or expires.
+
+** Why a customer would want it
+
+A customer sells a KIKO to fund a cheap hedge with a tight range view.
+The knock-in lowers the premium; the knock-out caps the payout. KIKO
+structures are common in corporate FX. In ORE Studio a customer books
+FX KIKO barrier options to value them and run sensitivities on the ORE
+engine.
+
+** Example
+
+ORE's catalogue shows a long European call with an up-and-in and a
+down-and-out barrier:
+
+#+begin_example
+<FxKIKOBarrierOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <Barriers>
+    <BarrierData>
+      <Type>UpAndIn</Type>
+      <Levels>
+        <Level>1.2</Level>
+      </Levels>
+    </BarrierData>
+    <BarrierData>
+      <Type>DownAndOut</Type>
+      <Levels>
+        <Level>1.2</Level>
+      </Levels>
+    </BarrierData>
+  </Barriers>
+  <StartDate>2019-01-25</StartDate>
+  <Calendar>TARGET</Calendar>
+  <FXIndex>FX-ECB-EUR-USD</FXIndex>
+  <BoughtCurrency>EUR</BoughtCurrency>
+  <BoughtAmount>1000000</BoughtAmount>
+  <SoldCurrency>USD</SoldCurrency>
+  <SoldAmount>1100000</SoldAmount>
+</FxKIKOBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=,
+listing =FX KIKO Barrier Option data= (optional elements omitted).
+
+The two-level form without mixed types is the
+[[id:0AA6F04D-C049-43D5-8307-82A9562E2883][FX Double Barrier Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_kikobarrieroption.tex=.
+  The upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_touchoption.org
+++ b/doc/knowledge/domain/fx_touchoption.org
@@ -142,6 +142,9 @@ The two-level form is the [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double T
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/fx_touchoption.org
+++ b/doc/knowledge/domain/fx_touchoption.org
@@ -34,7 +34,7 @@ This product has a continuously monitored single barrier with a
 Cash-or-Nothing digital underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_touchoption.tex][fx_touchoption.tex]].
 
 ORE states the payoff condition as follows:
 
@@ -44,7 +44,7 @@ amount or zero (Cash-or-Nothing) depending upon an FX spot rate
 reaching a pre-set barrier level.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_touchoption.tex][fx_touchoption.tex]].
 
 ORE also states the two forms. A knock-in, or one-touch, has a fixed
 payout if the barrier is breached, and no payout otherwise. The
@@ -135,7 +135,7 @@ ORE's catalogue shows a long no-touch on dollar-yen:
 </FxTouchOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_touchoption.tex][fx_touchoption.tex]],
 listing =FX Touch Option data= (optional elements omitted).
 
 The two-level form is the [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double Touch Option]].
@@ -147,6 +147,6 @@ The two-level form is the [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double T
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fx_touchoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fx_touchoption.tex][fx_touchoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fx_touchoption.org
+++ b/doc/knowledge/domain/fx_touchoption.org
@@ -1,0 +1,149 @@
+:PROPERTIES:
+:ID: EA6E4A7A-6229-4F8C-93C5-426D1E4CB496
+:END:
+#+title: FX Touch Option
+#+description: An FX option paying when spot touches a level before expiry; ORE's FxTouchOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fx_touchoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX touch option is a pure bet on a rate touching a level. It has no
+strike optionality beyond that event. ORE models it with the trade
+type =FxTouchOption=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+An FX touch option combines a continuously monitored single barrier
+with a cash-or-nothing digital underlying. At expiry it pays a fixed
+amount or zero, depending on whether the spot rate reached the
+barrier. The four main barrier types apply. A knock-in, or one-touch,
+pays if the barrier is breached. A knock-out, or no-touch, pays if it
+is not. No rebates are supported.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+This product has a continuously monitored single barrier with a
+Cash-or-Nothing digital underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=.
+
+ORE states the payoff condition as follows:
+
+#+begin_quote
+At expiry a FX Touch Option pays either a fixed predetermined payoff
+amount or zero (Cash-or-Nothing) depending upon an FX spot rate
+reaching a pre-set barrier level.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=.
+
+ORE also states the two forms. A knock-in, or one-touch, has a fixed
+payout if the barrier is breached, and no payout otherwise. The
+payout can be at expiry or at hit. A knock-out, or no-touch, has no
+payout if the barrier is breached, and a fixed payout at expiry
+otherwise. The buyer pays a premium to the seller.
+
+** In plain terms
+
+An FX touch option is a bet on a single touch. One side bets that the
+rate touches a level before expiry. The other side bets that it never
+does. The payout is fixed. The level, not the strike, is the whole
+game.
+
+** How it works in ORE
+
+The =FxTouchOptionData= node includes one =OptionData= node and one
+=BarrierData= node. The =OptionType= is not required. It is inferred
+from the barrier type, call for an up barrier and put for a down
+barrier. The barrier =Type= is one of the four main types. =Levels=
+holds the level. =PayoffAmount= and =PayoffCurrency= set the fixed
+payout. =ForeignCurrency= and =DomesticCurrency= name the rate.
+=StartDate= sets the monitoring start, with the =Calendar= and
+=FXIndex= naming the fixing source.
+
+** Mathematical notes
+
+The value is the probability of the touch event, discounted, times the
+fixed payout. A one-touch pays when the rate breaches the barrier at
+any time before expiry. A no-touch pays when it never breaches. The
+touch probability rises with volatility and with time. A payout at
+hit settles earlier than a payout at expiry.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. Its distance from the barrier sets the state.
+- The volatility of the pair. It drives the touch probability.
+- The interest rates in the two currencies.
+- The barrier level and the fixed payout.
+- The payout timing, at expiry or at hit.
+
+A no-touch loses value as spot approaches the barrier. A one-touch
+gains. Near the barrier the delta and vega change direction.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier is monitored continuously. A one-touch can be decided at
+any moment, with the payout at hit or at expiry. A no-touch stays
+alive while spot stays away from the level. As expiry approaches, the
+remaining time to touch shrinks. At expiry the payout settles and the
+trade stops.
+
+** Why a customer would want it
+
+A customer who expects the rate to stay below a level sells a
+no-touch and collects the premium. A customer who expects a move buys
+a one-touch. The products express a pure range view. In ORE Studio a
+customer books FX touch options to value them and run sensitivities on
+the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long no-touch on dollar-yen:
+
+#+begin_example
+<FxTouchOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <PayOffAtExpiry>true</PayOffAtExpiry>
+    <ExerciseDates>
+      <ExerciseDate>2021-12-14</ExerciseDate>
+    </ExerciseDates>
+    ...
+  </OptionData>
+  <BarrierData>
+    <Type>DownAndOut</Type>
+    <Levels>
+      <Level>0.009</Level>
+    </Levels>
+  </BarrierData>
+  <ForeignCurrency>JPY</ForeignCurrency>
+  <DomesticCurrency>USD</DomesticCurrency>
+  <PayoffCurrency>USD</PayoffCurrency>
+  <PayoffAmount>100000</PayoffAmount>
+  <StartDate>2019-01-25</StartDate>
+  <FXIndex>FX-TR20H-USD-JPY</FXIndex>
+  <Calendar>NYB,TKB</Calendar>
+</FxTouchOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fx_touchoption.tex=,
+listing =FX Touch Option data= (optional elements omitted).
+
+The two-level form is the [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double Touch Option]].
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fx_touchoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxoption.org
+++ b/doc/knowledge/domain/fxoption.org
@@ -1,0 +1,145 @@
+:PROPERTIES:
+:ID: 199AB340-A254-40A9-8CBE-FBABB17FF51F
+:END:
+#+title: FX Option
+#+description: Vanilla FX optionality: the right to exchange currencies at a set rate; ORE's FxOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fxoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+A European or American FX option is the vanilla option of the FX
+family. It is the underlying of the FX barrier and exotic products.
+ORE models it with the trade type =FxOption=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX option gives the buyer the right, not the obligation, to
+exchange a set amount of one currency for another at a predetermined
+exchange rate. A European option can be exercised at one time in the
+future. An American option can be exercised any time up to expiry, but
+once only. The buyer pays a premium. Settlement is cash or physical.
+The trade data carries one =OptionData= node plus the currency pair.
+
+* Detail
+
+** What it is
+
+ORE defines the European form as follows:
+
+#+begin_quote
+A European FX option gives the buyer the right, but not the
+obligation, to exchange a set amount of one currency for another, at a
+predetermined exchange rate, at one predetermined time in the future.
+For this right the buyer pays a premium to the seller. Settlement can
+be either cash or physical delivery.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=.
+
+ORE defines the American form as follows:
+
+#+begin_quote
+An American FX option gives the buyer the right, but not the
+obligation, to exchange a set amount of one currency for another, at a
+predetermined exchange rate, at any time during the life of the option
+up until the expiration date. The right to exchange of one currency
+for another can only be exercised once. For this right the buyer pays
+a premium to the seller.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=.
+
+** In plain terms
+
+An FX option is a ticket to a future exchange rate. The buyer pays a
+premium today. If the rate moves in the buyer's favour, the option is
+used. If not, it expires and only the premium is lost.
+
+** How it works in ORE
+
+The =FxOptionData= node includes exactly one =OptionData= node plus
+elements specific to the option. For a put, the bought and sold
+currencies and amounts are switched compared to the trade data. A
+holder of a EUR-bought USD-sold call has the right to buy EUR using
+USD. The put counterpart has the right to buy USD using EUR.
+=Settlement= selects cash or physical delivery. =PayOffAtExpiry=
+selects payoff at expiry or at exercise, which matters for American
+options. =AutomaticExercise= handles an option whose expiry date has
+passed while its payment date still lies ahead.
+
+** Mathematical notes
+
+A call on CCY1 per CCY2 pays the difference between the rate at
+exercise and the strike, times the quantity, when positive. A put pays
+the reverse. The value prices off the FX spot, the interest rates in
+both currencies, and the volatility surface. An American option adds
+the value of early exercise.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. It sets the moneyness.
+- The volatility of the currency pair. It drives the time value.
+- The interest rates in both currencies.
+- The strike, the amounts, and the exercise style.
+- The settlement mode and the premium terms.
+
+A call gains when the rate rises. A put gains when it falls.
+Volatility raises the value of both.
+
+** How the profile ages (dynamic sensitivities)
+
+The option loses time value as expiry approaches. The moneyness
+decides its fate at the end. An American option can be exercised early
+when that pays. After exercise the payoff settles, at exercise or at
+expiry. After settlement the trade stops.
+
+** Why a customer would want it
+
+An importer buys a call on the currency it pays. An exporter buys a
+put on the currency it earns. Both keep the upside of a favourable
+rate. The vanilla option is also the underlying of the FX exotic
+family. In ORE Studio a customer books FX options to value them and
+run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European call:
+
+#+begin_example
+<FxOptionData>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <OptionType>Call</OptionType>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <PayOffAtExpiry>false</PayOffAtExpiry>
+    <ExerciseDates>
+      <ExerciseDate>2026-03-01</ExerciseDate>
+    </ExerciseDates>
+    <Premiums>
+      <Premium>
+        <Amount>10900</Amount>
+        <Currency>EUR</Currency>
+        <PayDate>2020-03-01</PayDate>
+      </Premium>
+    </Premiums>
+  </OptionData>
+  <BoughtCurrency>EUR</BoughtCurrency>
+  <BoughtAmount>1000000</BoughtAmount>
+  <SoldCurrency>USD</SoldCurrency>
+  <SoldAmount>1700000</SoldAmount>
+</FxOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=,
+listing =FX Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Foreign_exchange_option][Wikipedia: Foreign exchange option]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fxoption.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxoption.org
+++ b/doc/knowledge/domain/fxoption.org
@@ -36,7 +36,7 @@ For this right the buyer pays a premium to the seller. Settlement can
 be either cash or physical delivery.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxoption.tex][fxoption.tex]].
 
 ORE defines the American form as follows:
 
@@ -49,7 +49,7 @@ for another can only be exercised once. For this right the buyer pays
 a premium to the seller.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxoption.tex][fxoption.tex]].
 
 ** In plain terms
 
@@ -133,7 +133,7 @@ ORE's catalogue shows a long European call:
 </FxOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxoption.tex][fxoption.tex]],
 listing =FX Option data=.
 
 * See also
@@ -143,6 +143,6 @@ listing =FX Option data=.
 
 - [[https://en.wikipedia.org/wiki/Foreign_exchange_option][Wikipedia: Foreign exchange option]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fxoption.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxoption.tex][fxoption.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxoption.org
+++ b/doc/knowledge/domain/fxoption.org
@@ -138,6 +138,9 @@ listing =FX Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Foreign_exchange_option][Wikipedia: Foreign exchange option]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/fxswap.org
+++ b/doc/knowledge/domain/fxswap.org
@@ -37,7 +37,7 @@ uses the FX spot rate, whereas the exchange at the end uses the FX
 forward rate at the start.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxswap.tex][fxswap.tex]].
 
 ** In plain terms
 
@@ -114,7 +114,7 @@ ORE's catalogue shows a euro-dollar swap:
 </FxSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxswap.tex][fxswap.tex]],
 listing =FX Swap data=.
 
 * See also
@@ -124,6 +124,6 @@ listing =FX Swap data=.
 
 - [[https://en.wikipedia.org/wiki/Foreign_exchange_swap][Wikipedia: Foreign exchange swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fxswap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxswap.tex][fxswap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxswap.org
+++ b/doc/knowledge/domain/fxswap.org
@@ -1,0 +1,126 @@
+:PROPERTIES:
+:ID: E9A214DE-AD39-4128-9EDB-106C4A606B90
+:END:
+#+title: FX Swap
+#+description: An exchange of two currencies at spot and at a forward date; ORE's FxSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fxswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX swap is the spot-forward pair of the FX family. Two parties
+exchange currencies now and reverse the exchange later. ORE models it
+with the trade type =FxSwap=. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+An FX swap exchanges a set amount of one currency for another at the
+start of the contract, then reverses the exchange at the end. The
+start exchange uses the FX spot rate. The end exchange uses the FX
+forward rate quoted at the start. The trade data names the near and
+far dates and the amounts. Settlement can be cash or physical. The
+value moves with spot and the forward points.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An FX Swap is a contract that involves the exchange of a set amount of
+one currency for another at the start of the contract, and then the
+reverse exchange at the end of the contract. The exchange at the start
+uses the FX spot rate, whereas the exchange at the end uses the FX
+forward rate at the start.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxswap.tex=.
+
+** In plain terms
+
+An FX swap is a spot trade and a forward trade in one contract. One
+side buys a currency today and sells it back later. The near exchange
+fixes the amount of currency delivered now. The far exchange fixes the
+amount delivered at the end. Banks use the product to move liquidity
+between currencies.
+
+** How it works in ORE
+
+The =FxSwapData= node is the trade data container. It holds no
+sub-nodes. The =NearDate= names the first exchange, the =FarDate= the
+final one. The near leg names the bought and sold currencies and
+amounts. The far leg names the bought and sold amounts; its
+currencies mirror the near leg. =Settlement= selects cash or physical
+delivery. A non-deliverable FX swap is a cash-settled swap. The
+settlement type does not impact pricing in ORE.
+
+ORE notes that FX swaps also cover precious metals swaps, with
+currencies XAU, XAG, XPT, and XPD, and cryptocurrency swaps.
+
+** Mathematical notes
+
+The near leg settles at the spot rate. The far leg settles at the
+forward rate implied at trade time. The swap value combines the two
+legs as present values in one base currency. The forward points, the
+difference between forward and spot, price the roll. An FX swap
+starting today is close to a collateralised loan of one currency
+against the other.
+
+** What moves its value (static sensitivities)
+
+- The FX spot rate. It drives both legs.
+- The forward points of the currency pair.
+- The discount rates in both currencies.
+- The near and far amounts.
+- The distance between the near and far dates.
+
+The two legs offset most of the spot exposure. What remains is the
+forward exposure between the near and far legs. A swap whose legs
+are balanced is mainly sensitive to the forward points.
+
+** How the profile ages (dynamic sensitivities)
+
+Before the near date the trade carries both exchanges. At the near
+date the first exchange settles. What remains is a single forward
+exchange to the far date. From then on the position ages like an
+[[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]]. At the far date the final exchange settles and the trade
+stops.
+
+** Why a customer would want it
+
+A treasurer rolls a maturing forward into a new one. A bank moves
+surplus liquidity from one currency to another. A trader takes a view
+on forward points without spot risk. In ORE Studio a customer books FX
+swaps to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a euro-dollar swap:
+
+#+begin_example
+<FxSwapData>
+  <NearDate>2018-09-01</NearDate>
+  <NearBoughtCurrency>EUR</NearBoughtCurrency>
+  <NearBoughtAmount>1000000</NearBoughtAmount>
+  <NearSoldCurrency>USD</NearSoldCurrency>
+  <NearSoldAmount>1140000</NearSoldAmount>
+  <FarDate>2028-09-01</FarDate>
+  <FarBoughtAmount>1300000</FarBoughtAmount>
+  <FarSoldAmount>1000000</FarSoldAmount>
+  <Settlement>Cash</Settlement>
+</FxSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxswap.tex=,
+listing =FX Swap data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Foreign_exchange_swap][Wikipedia: Foreign exchange swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fxswap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxswap.org
+++ b/doc/knowledge/domain/fxswap.org
@@ -119,6 +119,9 @@ listing =FX Swap data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Foreign_exchange_swap][Wikipedia: Foreign exchange swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/fxvarianceswap.org
+++ b/doc/knowledge/domain/fxvarianceswap.org
@@ -39,7 +39,7 @@ level (the strike) for the actual amount of variance realized over an
 observation period.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxvarianceswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxvarianceswap.tex][fxvarianceswap.tex]].
 
 ORE notes that the strike is typically set at ATM so the swap
 initially has zero value. If the subsequent realised volatility is
@@ -136,7 +136,7 @@ ORE's catalogue shows a long variance swap on euro-yen:
 </FxVarianceSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxvarianceswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxvarianceswap.tex][fxvarianceswap.tex]],
 listing =Variance Swap data=.
 
 * See also
@@ -145,6 +145,6 @@ listing =Variance Swap data=.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/fxvarianceswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxvarianceswap.tex][fxvarianceswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxvarianceswap.org
+++ b/doc/knowledge/domain/fxvarianceswap.org
@@ -1,0 +1,147 @@
+:PROPERTIES:
+:ID: 7A2186FB-33C3-4916-B62C-A14468EE713F
+:END:
+#+title: FX Variance Swap
+#+description: An FX derivative on realised variance or volatility; ORE's FxVarianceSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:fxvarianceswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An FX variance swap trades the volatility of an exchange rate
+directly. Its payoff depends on how much the rate moves, not on where
+it ends. ORE models it with the trade type =FxVarianceSwap=. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+An FX variance swap depends on the volatility of an underlying FX
+rate. The counterparties exchange a pre-agreed variance level, the
+strike, for the variance actually realised over an observation period.
+The strike is typically set at the money so the swap starts at zero
+value. The variance form pays on squared volatility. The volatility
+form pays on volatility. Only vanilla variance swaps are supported by
+this trade type.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An FX Variance Swap has a payoff, similar to an Equity Variance
+Swap's payoff, that depends on the volatility of an underlying FX
+rate. The swap counterparties agree to exchange a pre-agreed variance
+level (the strike) for the actual amount of variance realized over an
+observation period.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxvarianceswap.tex=.
+
+ORE notes that the strike is typically set at ATM so the swap
+initially has zero value. If the subsequent realised volatility is
+above the strike level, the buyer of a variance swap, who is long
+volatility, has a positive NPV. The seller, who is short volatility,
+has a negative NPV.
+
+** In plain terms
+
+An FX variance swap is a bet on movement, not direction. One side
+pays the realised variance of an exchange rate over the life of the
+swap. The other side pays a fixed variance agreed at trade time. If
+the rate moves more than expected, the variance buyer gains.
+
+** How it works in ORE
+
+The =FxVarianceSwapData= node carries the swap terms. =StartDate= and
+=EndDate= frame the observation period. =Currency= is the bought
+currency. =Name=, or the =Underlying= node, names the currency pair.
+=LongShort= sets the direction. =Strike= is the volatility strike,
+quoted absolutely, not as a percent. If the swap was struck in terms
+of variance, the square root of that variance is used here.
+=Notional= is the vega notional, the notional in volatility units.
+=Calendar= joins the calendars of the two currencies.
+=MomentType= distinguishes a volatility or variance payoff.
+=Volatility= or =Variance=, with variance the default.
+
+ORE notes that only vanilla variance swaps are supported by this
+trade type. Exotic variance swaps are supported by the scripted trade
+mechanism. FX variance and volatility swaps also cover precious
+metals, with currencies XAU, XAG, XPT, and XPD, and
+cryptocurrencies.
+
+** Mathematical notes
+
+ORE states the variance payoff as follows:
+
+Payoff = N x (RealisedVol^2 - K^2)
+
+N is the variance notional, determined as the vega notional divided
+by 2K. The realised volatility is annualised from the squared daily
+log returns over the observation period. The volatility swap payoff
+is closely related:
+
+Payoff = N x (RealisedVol - K)
+
+** What moves its value (static sensitivities)
+
+- The implied volatility of the FX pair. It prices the variance
+  strike.
+- The realised path of daily returns. It settles the payoff.
+- The vega notional and the strike.
+- The observation schedule and the annualisation convention.
+- The discount rate of the settlement currency.
+
+A long variance position gains when realised movement exceeds the
+strike. It gains from jumps in either direction. Direction of the
+rate itself does not drive the payoff.
+
+** How the profile ages (dynamic sensitivities)
+
+Each day adds one return to the realised variance. Early in life the
+realised part is small and the trade behaves like a forward on
+implied variance. Late in life the realised variance dominates and
+the payoff locks in. At maturity the final variance settles and the
+swap stops.
+
+** Why a customer would want it
+
+A customer with FX exposure wants protection on the volatility of the
+rate. A trader takes a view that FX volatility is cheap or rich.
+Variance swaps isolate that view from direction. In ORE Studio a
+customer books FX variance swaps to value them and run sensitivities
+on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long variance swap on euro-yen:
+
+#+begin_example
+<FxVarianceSwapData>
+  <StartDate>2018-05-10</StartDate>
+  <EndDate>2018-11-12</EndDate>
+  <Currency>EUR</Currency>
+  <Underlying>
+    <Type>FX</Type>
+    <Name>ECB-EUR-JPY</Name>
+  </Underlying>
+  <LongShort>Long</LongShort>
+  <Strike>0.05</Strike>
+  <Notional>200000</Notional>
+  <Calendar>EUR</Calendar>
+  <MomentType>Variance</MomentType>
+</FxVarianceSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/fxvarianceswap.tex=,
+listing =Variance Swap data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/fxvarianceswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/fxvarianceswap.org
+++ b/doc/knowledge/domain/fxvarianceswap.org
@@ -141,6 +141,9 @@ listing =Variance Swap data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Variance_swap][Wikipedia: Variance swap]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/fxvarianceswap.tex=. The

--- a/doc/knowledge/domain/generic_barrieroption.org
+++ b/doc/knowledge/domain/generic_barrieroption.org
@@ -38,7 +38,7 @@ payoff at maturity can be made conditional on (single) European
 Knock-In or Knock-Out barrier condition ("Transatlantic Barrier").
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 ORE describes the American barriers:
 
@@ -48,7 +48,7 @@ conditions can be defined that are monitored on a defined schedule,
 e.g. a daily schedule between a monitoring start and end date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 ORE states the knock-in and knock-out logic:
 
@@ -58,13 +58,13 @@ The different barrier types are "UpAndIn", "UpAndOut", "DownAndIn",
 payoff is only activated if at least one Knock-In barrier is touched.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 #+begin_quote
 An option that is knocked out, can not knock in again.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 ** In plain terms
 
@@ -89,7 +89,7 @@ and an associated node FxGenericBarrierOptionData,
 EquityGenericBarrierOptionData, CommodityGenericBarrierOptionData.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 A generic barrier option has one or multiple underlyings. The single
 =Underlying= node names one underlying. The =Underlyings= node is the
@@ -138,7 +138,7 @@ or "atExpiry" (i.e. on the settlement date associated to the expiry
 date of the underlying option).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 For knock-in barriers, or a mixed set, only one rebate amount can be
 defined, paid at expiry. ORE describes the Transatlantic rebate as
@@ -150,7 +150,7 @@ specified that is paid when the American barriers do not deactivate
 the underlying option, but the additional Transatlantic Barrier does.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 =StrictComparison= tunes the barrier checks: the value 0 uses
 less-or-equal and greater-or-equal comparisons for knock-in barriers
@@ -167,7 +167,7 @@ KoAfterKi: The option can only knock out after a Knock-In
 KoBeforeKi: The option can only knock out before a Knock-In
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
 
 =TransatlanticBarrier= is optional. It holds one BarrierData block
 with one level per underlying, or the matching number of blocks with
@@ -294,7 +294,7 @@ Transatlantic up-and-out at 1.3:
 </FxGenericBarrierOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]],
 listing =Generic Barrier Option data (FX Underlying)=. The catalogue
 also shows the multi-asset form with two FX underlyings and one
 barrier level per underlying.
@@ -304,7 +304,7 @@ barrier level per underlying.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/generic_barrieroption.tex][generic_barrieroption.tex]].
   The upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/generic_barrieroption.org
+++ b/doc/knowledge/domain/generic_barrieroption.org
@@ -301,6 +301,9 @@ barrier level per underlying.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
   The upstream project is

--- a/doc/knowledge/domain/generic_barrieroption.org
+++ b/doc/knowledge/domain/generic_barrieroption.org
@@ -1,0 +1,307 @@
+:PROPERTIES:
+:ID: 2C172183-1513-45EC-9A42-F0F3AB0E1F56
+:END:
+#+title: Generic Barrier Option
+#+description: A vanilla, asset-or-nothing or cash-or-nothing option with American and expiry barriers; ORE's Generic Barrier Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:generic_barrieroption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A generic barrier option pays a European payoff at maturity, made
+conditional on American barriers and on a single European barrier at
+expiry. ORE prices it on FX, equity and commodity underlyings, single
+or multiple. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+The product pays a vanilla call or put, an asset-or-nothing or a
+cash-or-nothing payoff at maturity. American knock-in and knock-out
+barriers are monitored on a defined schedule. An option that knocks
+out cannot knock in again. A knock-out before a knock-in, and the
+reverse, are separate sub-types. A Transatlantic Barrier adds one
+European barrier check at expiry. Rebates can compensate the holder
+when the barriers deactivate the option.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+Generic Barrier Options pay a (European) vanilla call / put, an
+asset or nothing or a cash or nothing payoff at their maturity. The
+payoff at maturity can be made conditional on (single) European
+Knock-In or Knock-Out barrier condition ("Transatlantic Barrier").
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+ORE describes the American barriers:
+
+#+begin_quote
+In addition, a number of American Knock-In and Knock-Out barrier
+conditions can be defined that are monitored on a defined schedule,
+e.g. a daily schedule between a monitoring start and end date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+ORE states the knock-in and knock-out logic:
+
+#+begin_quote
+The different barrier types are "UpAndIn", "UpAndOut", "DownAndIn",
+"DownAndOut". If at least one Knock-In barrier is defined, the final
+payoff is only activated if at least one Knock-In barrier is touched.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+#+begin_quote
+An option that is knocked out, can not knock in again.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+** In plain terms
+
+A generic barrier option is a customisable barrier package on one
+payoff. The payoff can be a plain call or put, the asset itself, or a
+fixed cash amount. Several American barriers can watch the underlying
+on a schedule, each able to knock the option in or out. Once knocked
+out, the option stays dead. The timing rules decide whether a
+knock-out can happen before or only after a knock-in. A final
+European barrier adds one more condition at expiry. Rebates soften
+the loss when a barrier kills the option.
+
+** How it works in ORE
+
+ORE introduces the trade types:
+
+#+begin_quote
+Generic Barrier Options are defined using one of the trade types
+FxGenericBarrierOption, EquityGenericBarrierOption,
+CommodityGenericBarrierOption depending on the underlying asset class
+and an associated node FxGenericBarrierOptionData,
+EquityGenericBarrierOptionData, CommodityGenericBarrierOptionData.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+A generic barrier option has one or multiple underlyings. The single
+=Underlying= node names one underlying. The =Underlyings= node is the
+alternative form, present when several underlyings are used, and only
+one of the two can be present. In the multi-underlying case every
+barrier must provide one level per underlying. For FX underlyings the
+currency order defines the observed value: for EUR-USD the domestic
+currency is USD and the observed value is USD per EUR, while for
+USD-EUR the roles are reversed.
+
+=PayCurrency= is the payment currency. It is usually the domestic
+currency for an FX underlying, and the equity or commodity currency
+for those types. Quanto payoffs are allowed: the foreign currency
+for FX, or a third currency, or a currency different from the equity
+or commodity currency.
+
+=OptionData= carries the option description. =LongShort= takes =Long=
+or =Short=. =PayoffType= selects =Vanilla=, =AssetOrNothing= or
+=CashOrNothing=. =OptionType= is required for the vanilla payoff and
+takes =Call= or =Put=. =ExerciseDate= is the exercise date. A
+=Premiums= node is optional and holds premiums paid unconditionally.
+=SettlementDate= is optional and used unadjusted as given. Instead of
+it, a settlement lag, convention and calendar can be given relative
+to the exercise date; the two specifications exclude each other. The
+lag defaults to =0D=, the calendar to the underlying calendar, and
+the convention to =Following=. =Quantity= is the option quantity,
+required for the vanilla and asset-or-nothing payoffs; for FX it is
+the amount in foreign currency. =Strike= is required for the vanilla
+payoff. =Amount= is required for the cash-or-nothing payoff.
+
+=Barriers= holds the barrier definition. Its =ScheduleData= node is
+the observation schedule; alternatively a daily schedule with respect
+to the underlying calendar comes from =StartDate= and =EndDate=.
+Each =BarrierData= block defines one barrier with its =Type=, one
+=Levels= entry, and the rebate terms. =Rebate= defaults to zero.
+=RebateCurrency= defaults to =PayCurrency=. =RebatePayTime= takes
+=atExpiry= or =atHit=; only =atExpiry= is allowed for knock-in
+barriers. ORE describes the timing choice for knock-out barriers:
+
+#+begin_quote
+If only Knock-Out barriers are defined, one can associate different
+rebate amounts to each of the barriers. Once the option knocks out at
+a barrier, the associated amount is paid. Furthermore, the timing of
+the payment can be "atHit" (i.e. immediately when the barrier is hit)
+or "atExpiry" (i.e. on the settlement date associated to the expiry
+date of the underlying option).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+For knock-in barriers, or a mixed set, only one rebate amount can be
+defined, paid at expiry. ORE describes the Transatlantic rebate as
+follows:
+
+#+begin_quote
+In both cases a separate Transatlantic Barrier Rebate amount can be
+specified that is paid when the American barriers do not deactivate
+the underlying option, but the additional Transatlantic Barrier does.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+=StrictComparison= tunes the barrier checks: the value 0 uses
+less-or-equal and greater-or-equal comparisons for knock-in barriers
+and strict comparisons for knock-out barriers; 1 uses strict
+comparisons for both; 2 uses less-or-equal and greater-or-equal for
+both. The value defaults to 0.
+
+=KikoType= is required when both knock-in and knock-out barriers are
+defined. ORE lists its values:
+
+#+begin_quote
+KoAlways: The option can knock out any time in the monitoring period
+KoAfterKi: The option can only knock out after a Knock-In
+KoBeforeKi: The option can only knock out before a Knock-In
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+
+=TransatlanticBarrier= is optional. It holds one BarrierData block
+with one level per underlying, or the matching number of blocks with
+one level each. Its type, level, strict comparison and rebate are the
+relevant fields. The rebate is paid when there is no knock-out from
+the American barriers and no payoff from the Transatlantic barrier.
+
+** Mathematical notes
+
+ORE states the payoff types with S the underlying value and K the
+strike. The vanilla payoff is the positive part of S minus K for a
+call, or of K minus S for a put, paid in the pay currency. The
+asset-or-nothing payoff pays S in the pay currency. The
+cash-or-nothing payoff pays the fixed amount in the pay currency.
+
+The American barriers scale the payoff. A knock-out barrier zeroes it
+when touched on the monitoring schedule; a knock-in barrier activates
+it when touched. The sub-type rules order the knock-out relative to a
+knock-in. The Transatlantic barrier applies the same in-or-out logic
+in a single check at expiry. The rebates pay the associated amounts
+at the barrier hit or at expiry, per the =RebatePayTime= setting.
+
+** What moves its value (static sensitivities)
+
+- The underlying value at expiry. It drives the payoff and the
+  Transatlantic barrier.
+- The path of the underlying over the monitoring schedule. It drives
+  the American barriers.
+- The volatility of the underlying.
+- The correlation between underlyings, in the multi-asset form.
+- The barrier levels, types and the =KikoType= ordering.
+- The payoff type and its parameters: strike, amount, quantity.
+- The rebate amounts and their payment timing.
+- The interest rates that discount the payoffs and rebates.
+
+** How the profile ages (dynamic sensitivities)
+
+Each date of the monitoring schedule checks the American barriers. A
+knock-out can end the option at any monitored point, subject to the
+=KikoType= ordering. A knock-in can activate a dormant payoff. The
+Transatlantic barrier is decided once, at expiry, together with the
+payoff. Rebates fall due at the barrier hit or at expiry, per their
+payment time. The settlement date then settles the payoff.
+
+** Why a customer would want it
+
+A generic barrier option assembles several barrier features in one
+trade. The buyer can combine American windows, a European barrier at
+expiry, sub-type ordering and rebates in one contract. The structure
+serves structured products that need precise barrier timing and
+protection against barrier losses. In ORE Studio a customer books
+generic barrier options to value them and run sensitivities on the
+ORE engine.
+
+** Example
+
+ORE's catalogue shows a long vanilla call on EUR-USD struck at 1.2
+with a full barrier structure. The trade monitors a down-and-out at
+1.1 and an up-and-in at 1.3 daily until expiry, and adds a
+Transatlantic up-and-out at 1.3:
+
+#+begin_example
+<FxGenericBarrierOptionData>
+  <Underlying>
+    <Type>FX</Type>
+    <Name>ECB-EUR-USD</Name>
+  </Underlying>
+  <PayCurrency>USD</PayCurrency>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <PayoffType>Vanilla</PayoffType>
+    <OptionType>Call</OptionType>
+    <ExerciseDates>
+      <ExerciseDate>2023-06-06</ExerciseDate>
+    </ExerciseDates>
+  </OptionData>
+  <SettlementDate>2023-06-08</SettlementDate>
+  <Quantity>100000000</Quantity>
+  <Strike>1.2</Strike>
+  <Barriers>
+    <ScheduleData>
+      <Rules>
+        <StartDate>2021-07-10</StartDate>
+        <EndDate>2023-06-06</EndDate>
+        <Tenor>1D</Tenor>
+        <Calendar>TGT,US</Calendar>
+        <Convention>F</Convention>
+        <TermConvention>F</TermConvention>
+        <Rule>Forward</Rule>
+      </Rules>
+    </ScheduleData>
+    <BarrierData>
+      <Type>DownAndOut</Type>
+      <Levels>
+        <Level>1.1</Level>
+      </Levels>
+      <Rebate>1000000</Rebate>
+      <RebateCurrency>USD</RebateCurrency>
+      <RebatePayTime>atExpiry</RebatePayTime>
+      <StrictComparison>1</StrictComparison>
+    </BarrierData>
+    <BarrierData>
+      <Type>UpAndIn</Type>
+      <Levels>
+        <Level>1.3</Level>
+      </Levels>
+      <Rebate>1000000</Rebate>
+      <RebateCurrency>USD</RebateCurrency>
+      <RebatePayTime>atExpiry</RebatePayTime>
+    </BarrierData>
+    <KikoType>KoAfterKi</KikoType>
+  </Barriers>
+  <TransatlanticBarrier>
+    <BarrierData>
+      <Type>UpAndOut</Type>
+      <Levels>
+        <Level>1.3</Level>
+      </Levels>
+      <Rebate>2000000</Rebate>
+      <RebateCurrency>USD</RebateCurrency>
+      <StrictComparison>1</StrictComparison>
+    </BarrierData>
+  </TransatlanticBarrier>
+</FxGenericBarrierOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/generic_barrieroption.tex=,
+listing =Generic Barrier Option data (FX Underlying)=. The catalogue
+also shows the multi-asset form with two FX underlyings and one
+barrier level per underlying.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/generic_barrieroption.tex=.
+  The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/genericscriptedproducts.org
+++ b/doc/knowledge/domain/genericscriptedproducts.org
@@ -39,7 +39,7 @@ across five of the six asset classes covered in ORE, just by way of
 defining the payoff script.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/genericscriptedproducts.tex][genericscriptedproducts.tex]].
 
 ORE states where the script lives:
 
@@ -48,7 +48,7 @@ The payoff script can be embedded into the trade XML or can be placed
 into a separate script library.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/genericscriptedproducts.tex][genericscriptedproducts.tex]].
 
 ** In plain terms
 
@@ -112,7 +112,7 @@ long call on the realised variance of the S&P 500 as a scripted
 variance option trade with its =VarianceOption= script. Both listings
 are reproduced in the corresponding knowledge notes.
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/genericscriptedproducts.tex][genericscriptedproducts.tex]],
 which points at the sections =Rainbow Option= and =Exotic Variance and
 Volatility Derivatives=.
 
@@ -121,9 +121,9 @@ Volatility Derivatives=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
   which inputs
-  =Docs/UserGuide/tradedata/genericscriptedproducts.tex=. The
+  [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/genericscriptedproducts.tex][genericscriptedproducts.tex]]. The
   upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].
 - Knowledge notes =Rainbow Options= and =Exotic Variance and

--- a/doc/knowledge/domain/genericscriptedproducts.org
+++ b/doc/knowledge/domain/genericscriptedproducts.org
@@ -118,6 +118,9 @@ Volatility Derivatives=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs
   =Docs/UserGuide/tradedata/genericscriptedproducts.tex=. The

--- a/doc/knowledge/domain/genericscriptedproducts.org
+++ b/doc/knowledge/domain/genericscriptedproducts.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: 2F5B28D9-9AB7-401E-8EF3-612712F626C1
+:END:
+#+title: Generic Scripted Products
+#+description: The scripted trade module and its flexible payoff scripts; ORE's Generic Scripted Products section.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:genericscriptedproducts:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+ORE's product catalogue describes one module that prices an open
+family of payoffs from user-defined scripts: the Scripted Trade
+module. ORE calls the section Generic Scripted Products. Many
+products in the catalogue run on this module under the surface. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A scripted trade defines its payoff in a small script language
+instead of picking one product from a fixed list. The script reads
+the trade's data node and writes the option legs. The payoff script
+can ride inside the trade XML or sit in a script library. The module
+covers five of the six ORE asset classes. ORE wraps the module inside
+classic-looking trade types in several product sections, and shows
+the raw scripted input format in the rainbow option and exotic
+variance sections.
+
+* Detail
+
+** What it is
+
+ORE describes the module as follows:
+
+#+begin_quote
+The Scripted Trade module allows flexible definition of new payoffs
+across five of the six asset classes covered in ORE, just by way of
+defining the payoff script.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=.
+
+ORE states where the script lives:
+
+#+begin_quote
+The payoff script can be embedded into the trade XML or can be placed
+into a separate script library.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=.
+
+** In plain terms
+
+A scripted trade is a payoff written as a program. The program names
+the market quantities it needs and produces the payments. A new
+product is a new script. No C++ code and no new trade type is needed.
+The rest of the ORE machinery, the pricing, the curves, the
+sensitivities, treats the result as a normal trade.
+
+** How it works in ORE
+
+The catalogue text explains where the two input formats appear. The
+products in the catalogue sections from the double digital option to
+the target redemption forward are internally scripted trades. ORE
+wraps them in their own trade types and data containers, so the trade
+XML looks classic. The rainbow option section and the exotic variance
+and volatility section show the generic scripted trade input format
+in full. ORE prices each variation with its own payoff script, and
+the catalogue lists the scripts. The two families are documented as
+separate knowledge notes: =Rainbow Options= and =Exotic Variance and
+Volatility Derivatives=.
+
+** Mathematical notes
+
+There are no formulas in this section of the catalogue. Each scripted
+product carries its own mathematics inside its payoff script. The
+scripts compute prices and returns from the data node fields, combine
+them, and write option legs. The script language handles conditions,
+loops, schedules and payoffs. See the knowledge notes for the two
+scripted families for their payoff mathematics.
+
+** What moves its value (static sensitivities)
+
+A scripted payoff's value follows its script inputs: the market
+levels it reads, the volatilities of its underlyings, the
+correlations between them, and the rates that discount the payout.
+The concrete drivers differ per product.
+
+** How the profile ages (dynamic sensitivities)
+
+A scripted payoff ages by its schedule. Observation dates fix the
+levels the script reads. Barrier and trigger conditions are checked
+on their dates. The payoff settles on the settlement date the script
+writes. The concrete timing differs per product.
+
+** Why a customer would want it
+
+The module lets a desk express a new payoff without waiting for a
+software release. In ORE Studio a customer books scripted products to
+value them and run sensitivities on the ORE engine, with the same
+support the fixed product set gets.
+
+** Example
+
+This catalogue section holds no trade listing of its own. It points
+at the scripted examples in the two family sections. The rainbow
+option section shows the best of asset or cash option on the S&P 500
+and the Euro Stoxx 50, in the traditional container and as a scripted
+trade with its full payoff script. The exotic variance section shows a
+long call on the realised variance of the S&P 500 as a scripted
+variance option trade with its =VarianceOption= script. Both listings
+are reproduced in the corresponding knowledge notes.
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/genericscriptedproducts.tex=,
+which points at the sections =Rainbow Option= and =Exotic Variance and
+Volatility Derivatives=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs
+  =Docs/UserGuide/tradedata/genericscriptedproducts.tex=. The
+  upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].
+- Knowledge notes =Rainbow Options= and =Exotic Variance and
+  Volatility Derivatives=, the two scripted families this section
+  introduces.

--- a/doc/knowledge/domain/indexcds.org
+++ b/doc/knowledge/domain/indexcds.org
@@ -137,6 +137,9 @@ contract.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This note follows its
   general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/indexcds.org
+++ b/doc/knowledge/domain/indexcds.org
@@ -1,0 +1,144 @@
+:PROPERTIES:
+:ID: FB662CB6-F6E7-4BD5-8616-CC767D60E8C6
+:END:
+#+title: Index Credit Default Swap
+#+description: A credit default swap on an index of reference entities; ORE's IndexCreditDefaultSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:indexcds:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An index credit default swap trades protection on a basket of names
+as one contract. ORE models it with the trade type
+=IndexCreditDefaultSwap=. This note records the domain grounding, as
+ORE documents it in its product catalogue.
+
+* Summary
+
+An index CDS is a credit default swap on an index of reference
+entities, such as CDX or iTraxx. It pays a running premium and settles
+the losses of defaulted constituents. The premium leg uses the
+unfactored notional, which ignores defaults. The factored notional
+shrinks as constituents default. A standard index takes its
+constituents from the credit curve. A bespoke basket names its own
+constituents in a =BasketData= node. The product trades portfolio
+credit risk in one instrument.
+
+* Detail
+
+** What it is
+
+ORE defines the input form as follows:
+
+#+begin_quote
+An index credit default swap (trade type IndexCreditDefaultSwap) is
+set up using an IndexCreditDefaultSwapData block
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcds.tex=.
+The block also includes =LegData= and =BasketData= trade component
+sub-nodes.
+
+** In plain terms
+
+An index CDS is insurance on a whole group of borrowers at once. One
+premium covers the basket. If one borrower defaults, the seller pays
+that borrower's loss. The premium base and the protection base shrink
+as defaults happen.
+
+** How it works in ORE
+
+The =LegData= sub-node is a fixed leg and holds the recurring premium.
+Payer true means the trade buys protection. Payer false means it sells
+protection. The notional on the fixed leg is the unfactored notional,
+which excludes any defaults. ORE contrasts it with two other notions.
+The trade date notional is reduced by defaults between series
+inception and the trade date. The current notional, also called the
+factored notional, is reduced by defaults up to the current evaluation
+date.
+
+The =BasketData= sub-node is optional. It specifies the constituent
+reference entities of the index and is intended for non-standard
+indices that need a bespoke basket. When it is omitted, the index
+constituents come from the =CreditCurveId= element in the trade data.
+
+** Mathematical notes
+
+The premium leg is a risky annuity on the unfactored notional. The
+protection leg pays the loss of each defaulted constituent, the
+notional minus its recovery, from the factored base. The mechanics
+follow the single-name [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]], applied name by
+name to the basket.
+
+** What moves its value (static sensitivities)
+
+- The index credit curve. It prices the basket and its defaults. A
+  spread widening raises the value of bought protection.
+- The discount curve of the premium currency.
+- The composition of the index. Constituent weights and recoveries
+  shape the loss distribution.
+- The premium and any upfront fee. They fix the running cost.
+
+A protection buyer gains when the index worsens. A seller gains when
+it improves.
+
+** How the profile ages (dynamic sensitivities)
+
+Each default of a constituent settles its loss and reduces the
+factored notional. The running premium keeps paying on the unfactored
+base. The protection window shortens as the trade runs. Near
+maturity, only near-term defaults matter. At maturity the trade stops
+with the surviving basket.
+
+** Why a customer would want it
+
+A bank hedges a portfolio of credit exposures with one index trade
+instead of many single-name CDS. An investor sells protection on an
+index to earn the portfolio premium. The product prices and trades
+more cheaply than a bespoke basket. In ORE Studio a customer books
+index CDS to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an index trade with its basket:
+
+#+begin_example
+<IndexCreditDefaultSwapData>
+  <CreditCurveId>RED:2I65BRHH6</CreditCurveId>
+  <SettlesAccrual>Y</SettlesAccrual>
+  <ProtectionPaymentTime>atDefault</ProtectionPaymentTime>
+  <ProtectionStart>20160206</ProtectionStart>
+  <UpfrontDate>20160208</UpfrontDate>
+  <UpfrontFee>0.0</UpfrontFee>
+  <LegData>
+    <LegType>Fixed</LegType>
+    <Payer>false</Payer>
+    ...
+  </LegData>
+  <BasketData>
+    <Name>
+      <IssuerId>CPTY_1</IssuerId>
+      <CreditCurveId>RED:</CreditCurveId>
+      <Notional>100000.0</Notional>
+      <Currency>USD</Currency>
+    </Name>
+    ...
+  </BasketData>
+</IndexCreditDefaultSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcds.tex=,
+listing =Index CreditDefaultSwap Data= (constituents abbreviated).
+
+The single-name form is the [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]]. The
+[[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] trades the right to enter this
+contract.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This note follows its
+  general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/indexcds.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/indexcds.org
+++ b/doc/knowledge/domain/indexcds.org
@@ -36,7 +36,7 @@ An index credit default swap (trade type IndexCreditDefaultSwap) is
 set up using an IndexCreditDefaultSwapData block
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcds.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcds.tex][indexcds.tex]].
 The block also includes =LegData= and =BasketData= trade component
 sub-nodes.
 
@@ -128,7 +128,7 @@ ORE's catalogue shows an index trade with its basket:
 </IndexCreditDefaultSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcds.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcds.tex][indexcds.tex]],
 listing =Index CreditDefaultSwap Data= (constituents abbreviated).
 
 The single-name form is the [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]]. The
@@ -142,6 +142,6 @@ contract.
 
 - [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This note follows its
   general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/indexcds.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcds.tex][indexcds.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/indexcdsoption.org
+++ b/doc/knowledge/domain/indexcdsoption.org
@@ -138,6 +138,9 @@ listing =IndexCreditDefaultSwapOption Data= (underlying abbreviated).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This covers the
   underlying product.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/indexcdsoption.org
+++ b/doc/knowledge/domain/indexcdsoption.org
@@ -1,0 +1,145 @@
+:PROPERTIES:
+:ID: 6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58
+:END:
+#+title: Index Credit Default Swap Option
+#+description: An option to enter an index CDS at a strike; ORE's IndexCreditDefaultSwapOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:indexcdsoption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+An index CDS option is the right to enter an index credit default swap
+at a set strike. ORE models it with the trade type
+=IndexCreditDefaultSwapOption=. This note records the domain
+grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+An index CDS option gives the right to buy or sell protection on a
+credit index at a strike spread or strike price. The option is usually
+European and exercises on one date. The exercise starts an index CDS
+at the strike terms. The option can carry front end protection, or
+knock out if the index defaults before expiry. The product adds
+optionality to the index CDS family.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+An index CDS option, trade type IndexCreditDefaultSwapOption, is an
+option to enter into an index CDS at a specified strike spread or
+strike price.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=.
+
+** In plain terms
+
+An index CDS option is an option on insurance premia. The buyer pays a
+premium for the right to buy or sell index protection later at a rate
+set today. If the market moves in the buyer's favour, the option is
+exercised. Otherwise it expires worthless.
+
+** How it works in ORE
+
+The trade data names the underlying index CDS and the option terms.
+The =OptionData= node holds the usual option mechanics, long or short,
+exercise style, and settlement. The =Strike= and =StrikeType= set the
+level, as a spread or as a price. The underlying
+=IndexCreditDefaultSwapData= node describes the index CDS that the
+exercise starts.
+
+The =IndexTerm= node gives the term of the underlying index CDS, such
+as 5Y or 10Y. ORE uses it to find the right volatility surface. With
+no =IndexTerm=, the market is searched for a surface named after the
+credit curve of the index series. With one, the surface name carries a
+suffix such as =CDXHYS34V1-5Y=. Different terms of one series can then
+use different volatility structures.
+
+ORE describes the credit mechanics as follows:
+
+#+begin_quote
+CDS Options can come with or without front end protection, i.e. the
+protection seller may either have to pay the contract notional if
+default happens before option expiry, or not (knock out).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=.
+
+** Mathematical notes
+
+An option on an index CDS prices off a CDS volatility surface. At
+expiry, the option is worth the difference between the market
+protection value and the strike protection value. Options on credit
+indices include any defaulted entities in the intrinsic value when
+exercised, per ORE's payoff description. Options on single credits are
+extinguished upon default without cash flows other than the upfront
+premium.
+
+** What moves its value (static sensitivities)
+
+- The CDS volatility surface of the index term. It drives the option
+  value.
+- The index credit curve. It sets the level of the underlying
+  protection.
+- The strike spread or price. It fixes the exercise terms.
+- The discount curve of the premium currency.
+- The composition of the index and its defaults before expiry.
+
+A payer of protection gains when the index worsens. A receiver gains
+when it improves. Volatility raises the value of both sides.
+
+** How the profile ages (dynamic sensitivities)
+
+The option loses time value as expiry approaches. A default in the
+index before expiry settles through the front-end protection terms, or
+knocks the option out. At expiry, a European option exercises into the
+index CDS or expires. After exercise, the trade ages like the
+underlying [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]].
+
+** Why a customer would want it
+
+A bank buys index CDS options to cap the cost of future protection. A
+dealer sells them to earn the option premium and to express views on
+credit volatility. The product hedges spread moves without committing
+to the running premium. In ORE Studio a customer books index CDS
+options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long European option on a 5Y index:
+
+#+begin_example
+<IndexCreditDefaultSwapOptionData>
+  <IndexTerm>5Y</IndexTerm>
+  <OptionData>
+    <LongShort>Long</LongShort>
+    <Style>European</Style>
+    <Settlement>Cash</Settlement>
+    <PayOffAtExpiry>false</PayOffAtExpiry>
+    <ExerciseDates>
+      <ExerciseDate>2023-05-09</ExerciseDate>
+    </ExerciseDates>
+  </OptionData>
+  <IndexCreditDefaultSwapData>
+    ...
+  </IndexCreditDefaultSwapData>
+  <Strike>1.063</Strike>
+  <StrikeType>Price</StrikeType>
+</IndexCreditDefaultSwapOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=,
+listing =IndexCreditDefaultSwapOption Data= (underlying abbreviated).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This covers the
+  underlying product.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/indexcdsoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/indexcdsoption.org
+++ b/doc/knowledge/domain/indexcdsoption.org
@@ -35,7 +35,7 @@ option to enter into an index CDS at a specified strike spread or
 strike price.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcdsoption.tex][indexcdsoption.tex]].
 
 ** In plain terms
 
@@ -68,7 +68,7 @@ protection seller may either have to pay the contract notional if
 default happens before option expiry, or not (knock out).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcdsoption.tex][indexcdsoption.tex]].
 
 ** Mathematical notes
 
@@ -133,7 +133,7 @@ ORE's catalogue shows a long European option on a 5Y index:
 </IndexCreditDefaultSwapOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/indexcdsoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcdsoption.tex][indexcdsoption.tex]],
 listing =IndexCreditDefaultSwapOption Data= (underlying abbreviated).
 
 * See also
@@ -143,6 +143,6 @@ listing =IndexCreditDefaultSwapOption Data= (underlying abbreviated).
 
 - [[https://en.wikipedia.org/wiki/Credit_default_swap_index][Wikipedia: Credit default swap index]]. This covers the
   underlying product.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/indexcdsoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/indexcdsoption.tex][indexcdsoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/knockoutswap.org
+++ b/doc/knowledge/domain/knockoutswap.org
@@ -1,0 +1,153 @@
+:PROPERTIES:
+:ID: 37689AC9-DBA5-41AA-866E-19522F733D2E
+:END:
+#+title: Knock Out Swap
+#+description: A swap that terminates when a rate fixing breaches a barrier; ORE's KnockOutSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:knockoutswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A knock out swap terminates when a floating index fixing crosses a
+barrier level. The swap is otherwise a vanilla fixed-versus-floating
+swap. ORE models it with the trade type =KnockOutSwap=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A knock out swap is a vanilla fixed-versus-floating interest rate
+swap. It terminates when the float index fixing is above an up-and-
+out barrier or below a down-and-out barrier. The barrier is monitored
+on all floating leg fixing dates on or after the barrier start date.
+ORE requires exactly one =BarrierData= node and exactly two legs, one
+fixed and one floating.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Knock Out Swap refers to a vanilla fixed vs. float Interest Rate
+Swap that terminates when the float index fixing is above ("up and
+out") or below ("down and out") a given barrier level.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=.
+
+ORE states the mechanics as follows:
+
+#+begin_quote
+A Knock Out Swap is a Swap with one Fixed and one Floating leg, where
+the Swap is terminated if the Floating leg Index hits a barrier. The
+barrier is monitored on all floating leg fixing dates after the
+BarrierStartDate.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=.
+
+** In plain terms
+
+A knock out swap is a normal swap with a tripwire. If the floating
+rate fixing crosses the barrier on a fixing date, the swap ends. The
+tripwire removes all remaining payments. Otherwise the swap runs to
+maturity like any other.
+
+** How it works in ORE
+
+A knock out swap uses the trade type =KnockOutSwap= and a
+=KnockOutSwapData= block. It must have one =BarrierData= node and two
+legs, one fixed and one floating. The =BarrierData= node carries a
+=Type= of =UpAndOut= or =DownAndOut=. =Levels= holds exactly one
+barrier level. The optional =StrictComparison= element takes 0 or 1
+and defaults to 0. The value 0 checks out-barriers with =<= and =>=.
+The value 1 checks out-barriers with strict < and >. =BarrierStartDate=
+names the date from which the barrier is monitored. The barrier is
+monitored on all floating leg fixing dates that fall on or after that
+date.
+
+** Mathematical notes
+
+The product is a vanilla swap with a barrier condition. The value is
+the swap value minus the value of the remaining payments in the
+states where the barrier is hit. Each floating fixing date is a test
+once monitoring has started. For an up-and-out swap, a fixing above
+the level ends the trade. For a down-and-out swap, a fixing below the
+level ends it. The strictness of the comparison decides whether a
+fixing exactly at the level counts.
+
+** What moves its value (static sensitivities)
+
+- The level of the floating index against the barrier.
+- The swap rate levels of the fixed and floating legs.
+- The volatility of the floating index. It drives the chance of
+  breach.
+- The barrier level and the strictness of the comparison.
+- The barrier start date and the fixing schedule.
+
+The chance of breach rises as the index fixing nears the barrier.
+Close to the level the trade is most sensitive to the index and to
+volatility.
+
+** How the profile ages (dynamic sensitivities)
+
+The swap runs like a vanilla swap before the barrier start date.
+From that date each floating fixing is a test. A breach ends the swap
+at once. No further payments occur after the breach. If no fixing
+breaches, the swap runs to maturity and ages like a plain vanilla
+swap.
+
+** Why a customer would want it
+
+A customer can cap the life of a swap with a knock out feature. An
+up-and-out swap suits a view that rates stay below the level. If
+rates spike, the swap ends and the exposure with it. The barrier
+feature can also cheapen the swap against a vanilla one. In ORE
+Studio a customer books knock out swaps to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an up-and-out knock out swap. The trade ends
+when a floating fixing rises above 5 percent:
+
+#+begin_example
+<Trade id="194837232">
+  <TradeType>KnockOutSwap</TradeType>
+  <Envelope>...</Envelope>
+  <KnockOutSwapData>
+    <!-- BarrierData and BarrierStartDate specify the knock out terms -->
+    <BarrierData>
+      <Type>UpAndOut</Type>
+      <Levels>
+        <Level>0.05</Level>
+      </Levels>
+    </BarrierData>
+    <BarrierStartDate>2024-10-01</BarrierStartDate>
+    <!-- we require exactly one Floating and one Fixed Leg -->
+    <LegData>
+      <LegType>Floating</LegType>
+      ...
+    </LegData>
+    <LegData>
+      <LegType>Fixed</LegType>
+      ...
+    </LegData>
+  </KnockOutSwapData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=,
+listing =Knock Out Swap=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/knockoutswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/knockoutswap.org
+++ b/doc/knowledge/domain/knockoutswap.org
@@ -145,6 +145,9 @@ listing =Knock Out Swap=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.

--- a/doc/knowledge/domain/knockoutswap.org
+++ b/doc/knowledge/domain/knockoutswap.org
@@ -36,7 +36,7 @@ Swap that terminates when the float index fixing is above ("up and
 out") or below ("down and out") a given barrier level.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/knockoutswap.tex][knockoutswap.tex]].
 
 ORE states the mechanics as follows:
 
@@ -47,7 +47,7 @@ barrier is monitored on all floating leg fixing dates after the
 BarrierStartDate.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/knockoutswap.tex][knockoutswap.tex]].
 
 ** In plain terms
 
@@ -140,7 +140,7 @@ when a floating fixing rises above 5 percent:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/knockoutswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/knockoutswap.tex][knockoutswap.tex]],
 listing =Knock Out Swap=.
 
 * See also
@@ -151,6 +151,6 @@ listing =Knock Out Swap=.
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Barrier_option][Wikipedia: Barrier option]]. This places the barrier condition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/knockoutswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/knockoutswap.tex][knockoutswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/ore_advance_calendar_convention.org
+++ b/doc/knowledge/domain/ore_advance_calendar_convention.org
@@ -48,7 +48,7 @@ bootstrapping for FX-forward-implied points
 documents the fallback behaviour for FX forwards explicitly: "For cash
 settlement and if a FXIndex is specified defaults to the fx convention
 (field 'AdvanceCalendar') if left blank or omitted, otherwise to
-NullCalendar (no holidays)" (=Docs/UserGuide/tradedata/fxforward.tex=).
+NullCalendar (no holidays)" ([[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/fxforward.tex][fxforward.tex]]).
 
 ** XML example
 

--- a/doc/knowledge/domain/performanceoption_01.org
+++ b/doc/knowledge/domain/performanceoption_01.org
@@ -201,6 +201,9 @@ listing =Performance Option Type 01 data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/performanceoption_01.tex=.
   The upstream project is

--- a/doc/knowledge/domain/performanceoption_01.org
+++ b/doc/knowledge/domain/performanceoption_01.org
@@ -46,7 +46,7 @@ The above payoff includes the strike in the performance calculation.
 There is another variant with excluded strike and payoff:
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/performanceoption_01.tex][performanceoption_01.tex]].
 
 ** In plain terms
 
@@ -71,7 +71,7 @@ The participation rate. Allowable values are non-negative numbers.
 Usually the value will be between 0 and 1.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/performanceoption_01.tex][performanceoption_01.tex]].
 
 =ValuationDate= is the valuation date and =SettlementDate= the
 settlement date. =Underlyings= holds the underlyings of the option,
@@ -90,7 +90,7 @@ the underlying basket (see the product description for more details).
 Allowable values are numbers.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/performanceoption_01.tex][performanceoption_01.tex]].
 
 =StrikeIncluded= is optional. When true, the strike is included in
 the performance calculation of each underlying; this is also the
@@ -196,7 +196,7 @@ calculation:
 </PerformanceOption01Data>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/performanceoption_01.tex][performanceoption_01.tex]],
 listing =Performance Option Type 01 data=.
 
 * See also
@@ -204,7 +204,7 @@ listing =Performance Option Type 01 data=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/performanceoption_01.tex][performanceoption_01.tex]].
   The upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/performanceoption_01.org
+++ b/doc/knowledge/domain/performanceoption_01.org
@@ -1,0 +1,207 @@
+:PROPERTIES:
+:ID: AEB7149D-EE91-4912-A663-D7A0261B87A0
+:END:
+#+title: Performance Option Type 01
+#+description: An option paying a performance return against a strike; ORE's Performance Option Type 01 product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:performanceoption_01:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A performance option of type 01 pays the average performance of an
+underlying basket against an option strike, scaled by a notional and
+a participation rate. ORE prices it on equity, FX and commodity
+underlyings. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+The product is characterised by a notional, a participation rate, one
+valuation date with a settlement date, a basket of underlyings with
+weights, an initial strike price per underlying, and an option
+strike. On the valuation date the average performance of the basket
+is computed and floored at zero. The option holder receives the
+notional times the participation rate times that performance on the
+settlement date. The option strike can sit inside the performance
+calculation of each underlying, or outside it.
+
+* Detail
+
+** What it is
+
+The performance option of type 01 is characterised by its data: a
+notional amount, a participation rate, one valuation date and one
+settlement date, a number of underlyings with weights, initial strike
+prices for the underlyings, and an option strike. On the valuation
+date the average performance of the underlying basket is computed.
+The option holder receives the notional times the participation rate
+times the computed performance on the settlement date. The
+underlyings can be equity, FX or commodity underlyings.
+
+ORE distinguishes the two strike treatments as follows:
+
+#+begin_quote
+The above payoff includes the strike in the performance calculation.
+There is another variant with excluded strike and payoff:
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+
+** In plain terms
+
+A performance option is a call on the average performance of a
+basket. Each asset in the basket is measured from its own initial
+strike price. The weighted average of these performances is compared
+with an option strike. The buyer receives a share of the positive
+part of the result, scaled by a participation rate. The structure
+pays only when the basket as a whole beats the option strike. The
+choice of strike treatment changes where the option strike enters the
+calculation.
+
+** How it works in ORE
+
+The catalogue shows the trade data container =PerformanceOption01Data=
+for the =PerformanceOption_01= trade type. =NotionalAmount= is the
+notional amount of the option. =ParticipationRate= is the
+participation rate:
+
+#+begin_quote
+The participation rate. Allowable values are non-negative numbers.
+Usually the value will be between 0 and 1.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+
+=ValuationDate= is the valuation date and =SettlementDate= the
+settlement date. =Underlyings= holds the underlyings of the option,
+each with its =Weight=. =StrikePrices= holds the initial strike price
+of each underlying. For an FX underlying it is the number of units of
+=CCY2= per unit of =CCY1=; for an equity underlying it is the equity
+price in the equity currency; for a commodity underlying it is the
+commodity price as quoted for the commodity.
+
+=Strike= is the option strike, expressed in terms of the performance
+of the underlying basket. ORE describes it as follows:
+
+#+begin_quote
+The option strike. This is expressed in terms of the performance of
+the underlying basket (see the product description for more details).
+Allowable values are numbers.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+
+=StrikeIncluded= is optional. When true, the strike is included in
+the performance calculation of each underlying; this is also the
+default when the flag is not given. When false, the strike is
+excluded and applies to the basket performance as a whole.
+=Position= takes =Long= or =Short=. =PayCcy= is the payment currency
+of the option.
+
+** Mathematical notes
+
+ORE computes the performance P on the valuation date from the
+weighted sum of the underlying performances. In the included form the
+option strike enters each underlying's term:
+
+P = max( sum over i of w-i x (U-i(V) / s-i - K), 0 ).
+
+In the excluded form the option strike applies once, after the
+weighted sum:
+
+P = max( [ sum over i of w-i x U-i(V) / s-i ] - K, 0 ).
+
+The performance is floored at zero in both forms. The option holder
+receives the notional N times the participation rate q times P on the
+settlement date S.
+
+** What moves its value (static sensitivities)
+
+- The levels of the basket underlyings on the valuation date. They
+  drive the basket performance.
+- The initial strike prices, which anchor each underlying's return.
+- The weights of the underlyings.
+- The option strike, and the choice of strike treatment.
+- The participation rate.
+- The volatility of each underlying and the correlation between
+  them. They set the dispersion of the basket performance.
+- The interest rates that discount the payout from the settlement
+  date.
+
+** How the profile ages (dynamic sensitivities)
+
+The trade has one valuation date. Until then the basket underlyings
+diffuse and the option value tracks the expected floored basket
+performance. On the valuation date the underlyings fix and the
+performance is computed under the selected strike treatment. The
+payout settles shortly after on the settlement date.
+
+** Why a customer would want it
+
+A performance option buys participation in the average performance of
+a basket, with a floor at zero. The buyer keeps the upside of a
+collection of assets while the option strike sets the performance
+hurdle. Banks use it to give clients diversified participation in a
+basket of currencies or markets. In ORE Studio a customer books
+performance options of type 01 to value them and run sensitivities on
+the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long performance option on a basket of
+Scandinavian and Swiss currencies against the euro. The basket lists
+CHF-EUR at 34%, NOK-EUR at 32%, and SEK-EUR twice, at 24% and 10%.
+The option strike of 1.15 is included in the performance
+calculation:
+
+#+begin_example
+<PerformanceOption01Data>
+  <NotionalAmount>12500000</NotionalAmount>
+  <ParticipationRate>0.9</ParticipationRate>
+  <ValuationDate>2022-05-03</ValuationDate>
+  <SettlementDate>2022-05-05</SettlementDate>
+  <Underlyings>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-CHF-EUR</Name>
+      <Weight>0.34</Weight>
+    </Underlying>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-NOK-EUR</Name>
+      <Weight>0.32</Weight>
+    </Underlying>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-SEK-EUR</Name>
+      <Weight>0.24</Weight>
+    </Underlying>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-SEK-EUR</Name>
+      <Weight>0.10</Weight>
+    </Underlying>
+  </Underlyings>
+  <StrikePrices>
+    <StrikePrice>0.910002</StrikePrice>
+    <StrikePrice>0.097192</StrikePrice>
+    <StrikePrice>0.096085</StrikePrice>
+    <StrikePrice>0.035032</StrikePrice>
+  </StrikePrices>
+  <Strike>1.15</Strike>
+  <StrikeIncluded>true</StrikeIncluded>
+  <Position>Long</Position>
+  <PayCcy>EUR</PayCcy>
+</PerformanceOption01Data>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/performanceoption_01.tex=,
+listing =Performance Option Type 01 data=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/performanceoption_01.tex=.
+  The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/products_by_asset_class.org
+++ b/doc/knowledge/domain/products_by_asset_class.org
@@ -1,0 +1,304 @@
+:PROPERTIES:
+:ID: C5C95B29-2EF9-4DFC-9E04-428C41C1925D
+:END:
+#+title: ORE Products by Asset Class
+#+description: Entry page for the ORE product knowledge notes, grouped by asset class.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:products_by_asset_class:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+This page is the entry point to the ORE product knowledge notes. The notes
+document the ORE product set as ORE's User Guide describes it, one note per
+product section of the products catalogue. Each note pairs the official ORE
+description with domain grounding, light mathematics and an ORE example. This
+page groups the notes by asset class. The alphabetical run of all product
+notes lives in the Knowledge hub, in the Products section.
+
+* Interest rate derivatives
+
+ORE's rates catalogue covers the swap family, caps and floors, digitals, and
+the amortising and barrier structures.
+
+- [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — An
+amortising swap that follows the prepayments of a reference security; ORE's
+BalanceGuaranteedSwap product.
+- [[id:0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE][Callable Swap]] — A swap one
+party can cancel on set dates; ORE's CallableSwap product.
+- [[id:3DCC5F43-9728-4E67-8720-AE307E780CBF][Cap/Floor]] — A strip of interest
+rate caplets or floorlets bounding a floating leg; ORE's CapFloor product.
+- [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — A swap with an
+option to cut the notional toward a lower bound; ORE's FlexiSwap product.
+- [[id:11714B3F-A790-4797-BE01-41426289E7C7][Forward Rate Agreement]] — A
+single-period lock on a future interest rate; ORE's ForwardRateAgreement
+product.
+- [[id:37689AC9-DBA5-41AA-866E-19522F733D2E][Knock Out Swap]] — A swap that
+terminates when a rate fixing breaches a barrier; ORE's KnockOutSwap product.
+- [[id:94B1DBE3-33AB-44F5-B9F1-B71E34A58123][Rate Digital Option]] — A fixed-
+payout option on an interest rate fixing; ORE's RateDigitalOption product.
+- [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]] — An interest rate swap
+exchanges streams of interest payments between two parties on a notional;
+ORE's swap family.
+- [[id:FCC37EB3-D654-4333-B110-3BF4AFA3A237][Swaption]] — An option to enter
+an interest rate swap; ORE's Swaption product.
+- [[id:D0F2BDFE-AA84-4472-86E5-AB273E1A8EEC][Zero Coupon Swap]] — An interest
+rate swap whose zero-coupon leg pays one final amount at maturity; ORE's
+ZeroCouponSwap product.
+
+* FX derivatives
+
+ORE's FX catalogue covers forwards, swaps and options, the barrier and touch
+exotics, and the variance swap.
+
+- [[id:9C395333-73C7-401D-9E71-5333E1645E1A][FX Asian Option]] — An FX option
+on an averaged exchange rate; ORE's FxAsianOption product.
+- [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]] — An FX
+option with a single barrier; ORE's FxBarrierOption product.
+- [[id:8668F997-2609-47C6-BF5C-EE35F21405EE][FX Digital Barrier Option]] — An
+FX digital option combined with a barrier; ORE's FxDigitalBarrierOption
+product.
+- [[id:C880CEB4-4FB7-41AA-8A4A-A650B6FC388C][FX Digital Option]] — An FX
+option paying a fixed amount when the rate settles; ORE's FxDigitalOption
+product.
+- [[id:0AA6F04D-C049-43D5-8307-82A9562E2883][FX Double Barrier Option]] — An
+FX option with two barriers around the strike; ORE's FxDoubleBarrierOption
+product.
+- [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double Touch Option]] — An FX
+option paying on one or two spot touches before expiry; ORE's
+FxDoubleTouchOption product.
+- [[id:4BAF88FA-7FDF-4B01-9A52-7AAE733A02B5][FX European Barrier Option]] — An
+FX European barrier option; ORE's FxEuropeanBarrierOption product.
+- [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — An FX forward
+locks an exchange rate for a future currency exchange; ORE's FxForward
+product.
+- [[id:B6A26725-EC1A-482D-A920-3CAB8834ED6D][FX KIKO Barrier Option]] — A
+knock-in knock-out FX barrier option; ORE's FxKIKOBarrierOption product.
+- [[id:199AB340-A254-40A9-8CBE-FBABB17FF51F][FX Option]] — Vanilla FX
+optionality: the right to exchange currencies at a set rate; ORE's FxOption
+product.
+- [[id:E9A214DE-AD39-4128-9EDB-106C4A606B90][FX Swap]] — An exchange of two
+currencies at spot and at a forward date; ORE's FxSwap product.
+- [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch Option]] — An FX option
+paying when spot touches a level before expiry; ORE's FxTouchOption product.
+- [[id:7A2186FB-33C3-4916-B62C-A14468EE713F][FX Variance Swap]] — An FX
+derivative on realised variance or volatility; ORE's FxVarianceSwap product.
+
+* Inflation derivatives
+
+ORE prices inflation swaps in the CPI-linked and year-on-year forms.
+
+- [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — An inflation swap
+whose CPI-linked leg pays a real rate scaled by index changes.
+- [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] —
+An inflation swap whose leg pays the annual change of an inflation index;
+ORE's YY leg.
+
+* Equity derivatives
+
+ORE's equity catalogue covers the cash products, swaps and variance, the
+option exotics from Asian to cliquet, and outperformance.
+
+- [[id:90BB6829-31EC-4C86-BE17-FDABF670DDB6][Equity Asian Option]] — An Asian
+option on the average equity price; ORE's EquityAsianOption product.
+- [[id:E9DCA7FE-1680-435D-BAD3-956E809BD71C][Equity Auto Delta Hedged Option]]
+— Batches of European equity options with an embedded delta-hedging strategy;
+ORE's EquityAutoDeltaHedgedOption product.
+- [[id:80C9B215-EBBA-4367-902B-C0687C0E43E8][Equity Barrier Option]] — A
+barrier option on an equity price; ORE's EquityBarrierOption product.
+- [[id:F3398C7E-E978-45C4-94AA-6EBB6DA98EC9][Equity Cliquet Option]] — A
+series of forward-start equity options with local and global caps; ORE's
+EquityCliquetOption product.
+- [[id:FCD38489-372D-4CD4-9A8A-DB0A332DE26E][Equity Digital Option]] — A cash-
+or-nothing digital option on an equity; ORE's EquityDigitalOption product.
+- [[id:06615BB7-3A1C-407D-8745-010DB52BD053][Equity Double Barrier Option]] —
+A double barrier option on an equity price; ORE's EquityDoubleBarrierOption
+product.
+- [[id:44BB5D47-C9CF-4E77-A4A9-50F14044A535][Equity Double Touch Option]] — A
+cash-or-nothing double touch option on an equity; ORE's
+EquityDoubleTouchOption product.
+- [[id:0415E392-7423-411F-A83B-C791E6BE3078][Equity European Barrier Option]]
+— A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption
+product.
+- [[id:D60CBEE4-AE5C-421B-AAEF-5E56DC75A662][Equity Forward]] — An agreement
+to buy or sell shares at a future price; ORE's EquityForward product.
+- [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equity Futures Option]] — An
+option on an equity future contract; ORE's EquityFutureOption product.
+- [[id:803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1][Equity Option]] — An option to
+buy or sell shares at a strike price; ORE's EquityOption product.
+- [[id:643843A9-B265-49B3-85BA-0E2F261DE7A9][Equity Option Position]] — A
+position in a single equity option or a weighted option basket; ORE's
+EquityOptionPosition product.
+- [[id:9033DF60-3AD6-45FB-9DF7-1094D9B489FF][Equity Outperformance Option]] —
+An option paying the outperformance of one asset over another; ORE's Equity
+Outperformance Option product.
+- [[id:0AE749B3-E51A-4036-8561-622F5EE69C02][Equity Position]] — A position in
+a single equity or a weighted equity basket; ORE's EquityPosition product.
+- [[id:D45F8289-3F31-462F-9C98-460CE820F75F][Equity Swap]] — A swap of an
+equity return against a fixed or floating leg; ORE's EquitySwap product.
+- [[id:45585B0A-31A1-49D9-9CF3-A5C240F9607D][Equity Touch Option]] — A cash-
+or-nothing one-touch option on an equity; ORE's EquityTouchOption product.
+- [[id:D69C0964-9F15-43BC-8A13-66ECED718BED][Equity Variance Swap]] — A swap
+of realised equity variance against a volatility strike; ORE's
+EquityVarianceSwap product.
+
+* Credit derivatives
+
+ORE prices single-name and index protection, options on index protection, and
+the structured and linked credit forms.
+
+- [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] — A CDS
+trades protection on a reference entity's default; ORE's CreditDefaultSwap
+product.
+- [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — A swap
+with payments contingent on credit events of a reference; ORE's
+CreditLinkedSwap product.
+- [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — A
+credit default swap on an index of reference entities; ORE's
+IndexCreditDefaultSwap product.
+- [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap
+Option]] — An option to enter an index CDS at a strike; ORE's
+IndexCreditDefaultSwapOption product.
+- [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] —
+Credit protection on a counterparty's default on an underlying swap; ORE's RPA
+product.
+- [[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]] — A tranched
+basket credit derivative; ORE's SyntheticCDO product.
+
+* Commodity derivatives
+
+ORE covers commodity forwards, swaps and options, with Asian, strip, swaption,
+variance and position forms.
+
+- [[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]]
+— An Asian option on daily commodity price fixings; ORE's
+CommodityAveragePriceOption product.
+- [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]] — An
+agreement to buy or sell a commodity at a set price later; ORE's
+CommodityForward product.
+- [[id:EC6DB3A0-4B34-4CD2-A3B7-ED004F3FA1B8][Commodity Option]] — A European
+or American option on a commodity; ORE's CommodityOption product.
+- [[id:48305B53-26C5-474D-8AA2-0DC425F96E3B][Commodity Option Strip]] — A
+strip of commodity APOs or European options over periods; ORE's
+CommodityOptionStrip product.
+- [[id:8B992141-85D3-4480-ABAF-9E2BD1BEB01B][Commodity Position]] — A position
+in a commodity or weighted commodity basket; ORE's CommodityPosition product.
+- [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]] — Floating
+commodity prices against a fixed price; ORE's CommoditySwap and basis swap
+forms.
+- [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] — A European
+option on a forward-starting commodity swap; ORE's CommoditySwaption product.
+- [[id:1989F85A-42F8-4894-8982-AC34D19B0351][Commodity Variance Swap]] — A
+swap on commodity volatility or variance; ORE's CommodityVarianceSwap product.
+
+* Bonds and cash
+
+The bond catalogue runs from the cash bond to its position, forward, future,
+repo, option and total-return forms, with cash positions.
+
+- [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — A bond is a tradable
+debt instrument paying scheduled interest and principal; ORE's Bond product.
+- [[id:C00D82F7-942F-4270-AB9F-D0C31F0881A9][Bond Forward (Reference Data)]] —
+A forward contract on a bond with the underlying set by reference data; ORE's
+ForwardBond product.
+- [[id:B50027E5-44CD-49FA-B4DF-1177E321F156][Bond Future]] — A contract to buy
+or sell an underlying bond at expiry at an agreed price; ORE's BondFuture
+product.
+- [[id:52C1431E-517D-40EC-AE9F-838F040A4103][Bond Option]] — A right to buy or
+sell a given bond at a fixed price; ORE's BondOption product.
+- [[id:0E145E20-C296-4D0F-B26C-2CC5EAA22F3B][Bond Option (Reference Data)]] —
+A bond option with the underlying bond set by reference data; ORE's BondOption
+product.
+- [[id:531499CE-C843-4178-8F89-CA901B1BA9AE][Bond Position]] — A position in a
+weighted basket of underlying bonds; ORE's BondPosition product.
+- [[id:C96BBC70-71C1-442A-97FF-CCD596C193DB][Bond Repo]] — A cash borrowing
+with a bond posted as collateral; ORE's BondRepo product.
+- [[id:0727A454-AB7F-4202-A3A8-A4A183683566][Bond Total Return Swap]] — A swap
+paying the total return of a bond against a funding leg; ORE's BondTRS
+product.
+- [[id:940CB31A-BD50-45D6-98AC-4B0D53973825][Cash Position]] — An amount of
+cash in a currency; ORE's CashPosition product.
+- [[id:8CCD37D5-1D16-4972-8582-13595E62381C][Forward Bond]] — A forward
+contract to buy or sell an underlying bond at a future date; ORE's ForwardBond
+product.
+
+* Multi-asset derivatives and scripted products
+
+ORE catalogues payoffs that accept FX, equity or commodity underlyings,
+several of them in any combination, and prices the compiled forms through its
+scripted trade module.
+
+- [[id:6B186A8F-B261-40A4-B950-932AB735AE95][Accumulator]] — A forward
+purchase of an asset in daily instalments within a price range; ORE's
+accumulator products.
+- [[id:6B1D0C78-0CAF-4A1C-BA34-56FB07C4F107][Autocallable Type 01]] — A
+structured option that pays accumulated amounts and redeems early below a
+trigger level; ORE's Autocallable Type 01 product.
+- [[id:00DE9B53-9E4F-4FD4-A5E9-BE00B0956710][Basket Option]] — An option on a
+basket of underlying assets; ORE's BasketOption product.
+- [[id:18891481-BBFE-4731-A677-DB66400A724C][Best Entry Option]] — An option
+whose payoff uses the best observed entry level of the underlying; ORE's Best
+Entry Option product.
+- [[id:E63E99AD-6C5E-446B-BE14-57A8D9042AFD][Double Digital Option]] — A
+binary option paying a fixed amount when two underlyings are simultaneously in
+the money; ORE's Double Digital Option product.
+- [[id:F0727CDB-4696-4C25-BFF5-AF0D302B5A71][European Option Contingent on a
+Barrier]] — A plain vanilla European option whose payoff depends on a barrier
+on another underlying; ORE's EuropeanOptionBarrier product.
+- [[id:D3DF8CDD-2BD9-44BC-B805-D06C8A6C2074][Exotic Variance and Volatility
+Derivatives]] — Variance and volatility swaps and options with barriers,
+corridors, baskets and optionality; ORE's exotic variance product family.
+- [[id:90DDE9BB-770F-4337-AF0E-69698AF2A2A1][Extended Accumulator]] — An
+accumulator that can extend past a barrier decision date; ORE's
+ExtendedAccumulator product.
+- [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] — A
+vanilla, asset-or-nothing or cash-or-nothing option with American and expiry
+barriers; ORE's Generic Barrier Option product.
+- [[id:2F5B28D9-9AB7-401E-8EF3-612712F626C1][Generic Scripted Products]] — The
+scripted trade module and its flexible payoff scripts; ORE's Generic Scripted
+Products section.
+- [[id:AEB7149D-EE91-4912-A663-D7A0261B87A0][Performance Option Type 01]] — An
+option paying a performance return against a strike; ORE's Performance Option
+Type 01 product.
+- [[id:E5C8CE52-C382-4523-8BB9-1A3698ABB0BF][Rainbow Options]] — European
+options on the best or worst of a range of assets; ORE's Rainbow Options
+product family.
+- [[id:18E6A88B-6F6E-488F-91B2-B6106C43AF73][Strike Resettable Option]] — An
+option whose strike resets when the underlying reaches a level; ORE's Strike
+Resettable Option product.
+- [[id:808C159F-5852-45AD-AE49-B7A4488513CC][Target Redemption Forward]] — A
+forward series that redeems early at a target profit; ORE's TaRF product.
+- [[id:5368EC07-71E8-4906-B897-AA41A57CE0FA][Total Return Swap]] — A swap
+paying the total return of an asset against a funding leg; ORE's generic TRS
+product.
+- [[id:59A56773-6E82-421A-8E64-AA54D46489D4][Window Barrier Option]] — An
+option with a barrier active only inside a time window; ORE's Window Barrier
+Option product.
+- [[id:428BA744-B3D3-486C-A3BF-39E59C6EC11F][Worst Of Basket Swap]] — A swap
+whose coupon references the worst performing asset in a basket; ORE's
+WorstOfBasketSwap product.
+
+* Hybrid and composite trades
+
+ORE prices bond structures with embedded equity and credit features, and
+bundles component trades into one composite trade.
+
+- [[id:DBC183E7-9AB4-481A-8A27-A70966EE4D48][Ascot]] — An American-style
+option to buy back a convertible bond; ORE's Ascot product.
+- [[id:4E78B88B-432F-445D-9FEA-9DBE80718DBF][Callable Bond]] — A bond with
+issuer call and investor put rights; ORE's CallableBond product.
+- [[id:F8341BB7-33FE-4441-8C2D-56B8DDDCA91C][Collateral Bond Obligation]] — A
+tranched securitisation of a portfolio of corporate bonds or loans; ORE's CBO
+product.
+- [[id:2D1B9342-FC33-49DF-8F23-5B2248968156][Composite Trade]] — A hybrid
+position bundling multiple component trades; ORE's CompositeTrade product.
+- [[id:F5D8E0C4-EC67-4210-AF1C-B664246810C9][Convertible Bond]] — A bond that
+converts into a prespecified number of shares; ORE's ConvertibleBond product.
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all
+knowledge notes, with the alphabetical product run.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=, which
+inputs the product sections. The upstream project is
+[[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/products_by_asset_class.org
+++ b/doc/knowledge/domain/products_by_asset_class.org
@@ -21,206 +21,121 @@ notes lives in the Knowledge hub, in the Products section.
 ORE's rates catalogue covers the swap family, caps and floors, digitals, and
 the amortising and barrier structures.
 
-- [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — An
-amortising swap that follows the prepayments of a reference security; ORE's
-BalanceGuaranteedSwap product.
-- [[id:0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE][Callable Swap]] — A swap one
-party can cancel on set dates; ORE's CallableSwap product.
-- [[id:3DCC5F43-9728-4E67-8720-AE307E780CBF][Cap/Floor]] — A strip of interest
-rate caplets or floorlets bounding a floating leg; ORE's CapFloor product.
-- [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — A swap with an
-option to cut the notional toward a lower bound; ORE's FlexiSwap product.
-- [[id:11714B3F-A790-4797-BE01-41426289E7C7][Forward Rate Agreement]] — A
-single-period lock on a future interest rate; ORE's ForwardRateAgreement
-product.
-- [[id:37689AC9-DBA5-41AA-866E-19522F733D2E][Knock Out Swap]] — A swap that
-terminates when a rate fixing breaches a barrier; ORE's KnockOutSwap product.
-- [[id:94B1DBE3-33AB-44F5-B9F1-B71E34A58123][Rate Digital Option]] — A fixed-
-payout option on an interest rate fixing; ORE's RateDigitalOption product.
-- [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]] — An interest rate swap
-exchanges streams of interest payments between two parties on a notional;
-ORE's swap family.
-- [[id:FCC37EB3-D654-4333-B110-3BF4AFA3A237][Swaption]] — An option to enter
-an interest rate swap; ORE's Swaption product.
-- [[id:D0F2BDFE-AA84-4472-86E5-AB273E1A8EEC][Zero Coupon Swap]] — An interest
-rate swap whose zero-coupon leg pays one final amount at maturity; ORE's
-ZeroCouponSwap product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/balanceguaranteedswap.html][Balance Guaranteed Swap]] | An amortising swap that follows the prepayments of a reference security; ORE's BalanceGuaranteedSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/callableswap.html][Callable Swap]] | A swap one party can cancel on set dates; ORE's CallableSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/capfloor.html][Cap/Floor]] | A strip of interest rate caplets or floorlets bounding a floating leg; ORE's CapFloor product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/flexiswap.html][Flexi Swap]] | A swap with an option to cut the notional toward a lower bound; ORE's FlexiSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/forwardrateagreement.html][Forward Rate Agreement]] | A single-period lock on a future interest rate; ORE's ForwardRateAgreement product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/knockoutswap.html][Knock Out Swap]] | A swap that terminates when a rate fixing breaches a barrier; ORE's KnockOutSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/ratedigitaloption.html][Rate Digital Option]] | A fixed-payout option on an interest rate fixing; ORE's RateDigitalOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/swap.html][Swap]] | An interest rate swap exchanges streams of interest payments between two parties on a notional; ORE's swap family. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/swaption.html][Swaption]] | An option to enter an interest rate swap; ORE's Swaption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/zerocouponswap.html][Zero Coupon Swap]] | An interest rate swap whose zero-coupon leg pays one final amount at maturity; ORE's ZeroCouponSwap product. |
 
 * FX derivatives
 
 ORE's FX catalogue covers forwards, swaps and options, the barrier and touch
 exotics, and the variance swap.
 
-- [[id:9C395333-73C7-401D-9E71-5333E1645E1A][FX Asian Option]] — An FX option
-on an averaged exchange rate; ORE's FxAsianOption product.
-- [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]] — An FX
-option with a single barrier; ORE's FxBarrierOption product.
-- [[id:8668F997-2609-47C6-BF5C-EE35F21405EE][FX Digital Barrier Option]] — An
-FX digital option combined with a barrier; ORE's FxDigitalBarrierOption
-product.
-- [[id:C880CEB4-4FB7-41AA-8A4A-A650B6FC388C][FX Digital Option]] — An FX
-option paying a fixed amount when the rate settles; ORE's FxDigitalOption
-product.
-- [[id:0AA6F04D-C049-43D5-8307-82A9562E2883][FX Double Barrier Option]] — An
-FX option with two barriers around the strike; ORE's FxDoubleBarrierOption
-product.
-- [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double Touch Option]] — An FX
-option paying on one or two spot touches before expiry; ORE's
-FxDoubleTouchOption product.
-- [[id:4BAF88FA-7FDF-4B01-9A52-7AAE733A02B5][FX European Barrier Option]] — An
-FX European barrier option; ORE's FxEuropeanBarrierOption product.
-- [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — An FX forward
-locks an exchange rate for a future currency exchange; ORE's FxForward
-product.
-- [[id:B6A26725-EC1A-482D-A920-3CAB8834ED6D][FX KIKO Barrier Option]] — A
-knock-in knock-out FX barrier option; ORE's FxKIKOBarrierOption product.
-- [[id:199AB340-A254-40A9-8CBE-FBABB17FF51F][FX Option]] — Vanilla FX
-optionality: the right to exchange currencies at a set rate; ORE's FxOption
-product.
-- [[id:E9A214DE-AD39-4128-9EDB-106C4A606B90][FX Swap]] — An exchange of two
-currencies at spot and at a forward date; ORE's FxSwap product.
-- [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch Option]] — An FX option
-paying when spot touches a level before expiry; ORE's FxTouchOption product.
-- [[id:7A2186FB-33C3-4916-B62C-A14468EE713F][FX Variance Swap]] — An FX
-derivative on realised variance or volatility; ORE's FxVarianceSwap product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_asianoption.html][FX Asian Option]] | An FX option on an averaged exchange rate; ORE's FxAsianOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_barrieroption.html][FX Barrier Option]] | An FX option with a single barrier; ORE's FxBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_digitalbarrieroption.html][FX Digital Barrier Option]] | An FX digital option combined with a barrier; ORE's FxDigitalBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_digitaloption.html][FX Digital Option]] | An FX option paying a fixed amount when the rate settles; ORE's FxDigitalOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_doublebarrieroption.html][FX Double Barrier Option]] | An FX option with two barriers around the strike; ORE's FxDoubleBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_doubletouchoption.html][FX Double Touch Option]] | An FX option paying on one or two spot touches before expiry; ORE's FxDoubleTouchOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_europeanbarrieroption.html][FX European Barrier Option]] | An FX European barrier option; ORE's FxEuropeanBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_forward.html][FX Forward]] | An FX forward locks an exchange rate for a future currency exchange; ORE's FxForward product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_kikobarrieroption.html][FX KIKO Barrier Option]] | A knock-in knock-out FX barrier option; ORE's FxKIKOBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fxoption.html][FX Option]] | Vanilla FX optionality: the right to exchange currencies at a set rate; ORE's FxOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fxswap.html][FX Swap]] | An exchange of two currencies at spot and at a forward date; ORE's FxSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fx_touchoption.html][FX Touch Option]] | An FX option paying when spot touches a level before expiry; ORE's FxTouchOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/fxvarianceswap.html][FX Variance Swap]] | An FX derivative on realised variance or volatility; ORE's FxVarianceSwap product. |
 
 * Inflation derivatives
 
 ORE prices inflation swaps in the CPI-linked and year-on-year forms.
 
-- [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — An inflation swap
-whose CPI-linked leg pays a real rate scaled by index changes.
-- [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] —
-An inflation swap whose leg pays the annual change of an inflation index;
-ORE's YY leg.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/cpiswap.html][CPI Swap]] | An inflation swap whose CPI-linked leg pays a real rate scaled by index changes. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/yyswap.html][Year-on-Year Inflation Swap]] | An inflation swap whose leg pays the annual change of an inflation index; ORE's YY leg. |
 
 * Equity derivatives
 
 ORE's equity catalogue covers the cash products, swaps and variance, the
 option exotics from Asian to cliquet, and outperformance.
 
-- [[id:90BB6829-31EC-4C86-BE17-FDABF670DDB6][Equity Asian Option]] — An Asian
-option on the average equity price; ORE's EquityAsianOption product.
-- [[id:E9DCA7FE-1680-435D-BAD3-956E809BD71C][Equity Auto Delta Hedged Option]]
-— Batches of European equity options with an embedded delta-hedging strategy;
-ORE's EquityAutoDeltaHedgedOption product.
-- [[id:80C9B215-EBBA-4367-902B-C0687C0E43E8][Equity Barrier Option]] — A
-barrier option on an equity price; ORE's EquityBarrierOption product.
-- [[id:F3398C7E-E978-45C4-94AA-6EBB6DA98EC9][Equity Cliquet Option]] — A
-series of forward-start equity options with local and global caps; ORE's
-EquityCliquetOption product.
-- [[id:FCD38489-372D-4CD4-9A8A-DB0A332DE26E][Equity Digital Option]] — A cash-
-or-nothing digital option on an equity; ORE's EquityDigitalOption product.
-- [[id:06615BB7-3A1C-407D-8745-010DB52BD053][Equity Double Barrier Option]] —
-A double barrier option on an equity price; ORE's EquityDoubleBarrierOption
-product.
-- [[id:44BB5D47-C9CF-4E77-A4A9-50F14044A535][Equity Double Touch Option]] — A
-cash-or-nothing double touch option on an equity; ORE's
-EquityDoubleTouchOption product.
-- [[id:0415E392-7423-411F-A83B-C791E6BE3078][Equity European Barrier Option]]
-— A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption
-product.
-- [[id:D60CBEE4-AE5C-421B-AAEF-5E56DC75A662][Equity Forward]] — An agreement
-to buy or sell shares at a future price; ORE's EquityForward product.
-- [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equity Futures Option]] — An
-option on an equity future contract; ORE's EquityFutureOption product.
-- [[id:803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1][Equity Option]] — An option to
-buy or sell shares at a strike price; ORE's EquityOption product.
-- [[id:643843A9-B265-49B3-85BA-0E2F261DE7A9][Equity Option Position]] — A
-position in a single equity option or a weighted option basket; ORE's
-EquityOptionPosition product.
-- [[id:9033DF60-3AD6-45FB-9DF7-1094D9B489FF][Equity Outperformance Option]] —
-An option paying the outperformance of one asset over another; ORE's Equity
-Outperformance Option product.
-- [[id:0AE749B3-E51A-4036-8561-622F5EE69C02][Equity Position]] — A position in
-a single equity or a weighted equity basket; ORE's EquityPosition product.
-- [[id:D45F8289-3F31-462F-9C98-460CE820F75F][Equity Swap]] — A swap of an
-equity return against a fixed or floating leg; ORE's EquitySwap product.
-- [[id:45585B0A-31A1-49D9-9CF3-A5C240F9607D][Equity Touch Option]] — A cash-
-or-nothing one-touch option on an equity; ORE's EquityTouchOption product.
-- [[id:D69C0964-9F15-43BC-8A13-66ECED718BED][Equity Variance Swap]] — A swap
-of realised equity variance against a volatility strike; ORE's
-EquityVarianceSwap product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_asianoption.html][Equity Asian Option]] | An Asian option on the average equity price; ORE's EquityAsianOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityautodeltahedgedoption.html][Equity Auto Delta Hedged Option]] | — Batches of European equity options with an embedded delta-hedging strategy; ORE's EquityAutoDeltaHedgedOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_barrieroption.html][Equity Barrier Option]] | A barrier option on an equity price; ORE's EquityBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equitycliquetoption.html][Equity Cliquet Option]] | A series of forward-start equity options with local and global caps; ORE's EquityCliquetOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_digitaloption.html][Equity Digital Option]] | A cash-or-nothing digital option on an equity; ORE's EquityDigitalOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_doublebarrieroption.html][Equity Double Barrier Option]] | A double barrier option on an equity price; ORE's EquityDoubleBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_doubletouchoption.html][Equity Double Touch Option]] | A cash-or-nothing double touch option on an equity; ORE's EquityDoubleTouchOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_europeanbarrieroption.html][Equity European Barrier Option]] | — A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityforward.html][Equity Forward]] | An agreement to buy or sell shares at a future price; ORE's EquityForward product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityfuturesoption.html][Equity Futures Option]] | An option on an equity future contract; ORE's EquityFutureOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityoption.html][Equity Option]] | An option to buy or sell shares at a strike price; ORE's EquityOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityoptionposition.html][Equity Option Position]] | A position in a single equity option or a weighted option basket; ORE's EquityOptionPosition product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_outperformance.html][Equity Outperformance Option]] | An option paying the outperformance of one asset over another; ORE's Equity Outperformance Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityposition.html][Equity Position]] | A position in a single equity or a weighted equity basket; ORE's EquityPosition product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityswap.html][Equity Swap]] | A swap of an equity return against a fixed or floating leg; ORE's EquitySwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_touchoption.html][Equity Touch Option]] | A cash-or-nothing one-touch option on an equity; ORE's EquityTouchOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityvarianceswap.html][Equity Variance Swap]] | A swap of realised equity variance against a volatility strike; ORE's EquityVarianceSwap product. |
 
 * Credit derivatives
 
 ORE prices single-name and index protection, options on index protection, and
 the structured and linked credit forms.
 
-- [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] — A CDS
-trades protection on a reference entity's default; ORE's CreditDefaultSwap
-product.
-- [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — A swap
-with payments contingent on credit events of a reference; ORE's
-CreditLinkedSwap product.
-- [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — A
-credit default swap on an index of reference entities; ORE's
-IndexCreditDefaultSwap product.
-- [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap
-Option]] — An option to enter an index CDS at a strike; ORE's
-IndexCreditDefaultSwapOption product.
-- [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] —
-Credit protection on a counterparty's default on an underlying swap; ORE's RPA
-product.
-- [[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]] — A tranched
-basket credit derivative; ORE's SyntheticCDO product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/creditdefaultswap.html][Credit Default Swap]] | A CDS trades protection on a reference entity's default; ORE's CreditDefaultSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/creditlinkedswap.html][Credit Linked Swap]] | A swap with payments contingent on credit events of a reference; ORE's CreditLinkedSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/indexcds.html][Index Credit Default Swap]] | A credit default swap on an index of reference entities; ORE's IndexCreditDefaultSwap product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/indexcdsoption.html][Index Credit Default Swap Option]] | An option to enter an index CDS at a strike; ORE's IndexCreditDefaultSwapOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/rpa.html][Risk Participation Agreement]] | Credit protection on a counterparty's default on an underlying swap; ORE's RPA product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/syntheticcdo.html][Synthetic CDO]] | A tranched basket credit derivative; ORE's SyntheticCDO product. |
 
 * Commodity derivatives
 
 ORE covers commodity forwards, swaps and options, with Asian, strip, swaption,
 variance and position forms.
 
-- [[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]]
-— An Asian option on daily commodity price fixings; ORE's
-CommodityAveragePriceOption product.
-- [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]] — An
-agreement to buy or sell a commodity at a set price later; ORE's
-CommodityForward product.
-- [[id:EC6DB3A0-4B34-4CD2-A3B7-ED004F3FA1B8][Commodity Option]] — A European
-or American option on a commodity; ORE's CommodityOption product.
-- [[id:48305B53-26C5-474D-8AA2-0DC425F96E3B][Commodity Option Strip]] — A
-strip of commodity APOs or European options over periods; ORE's
-CommodityOptionStrip product.
-- [[id:8B992141-85D3-4480-ABAF-9E2BD1BEB01B][Commodity Position]] — A position
-in a commodity or weighted commodity basket; ORE's CommodityPosition product.
-- [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]] — Floating
-commodity prices against a fixed price; ORE's CommoditySwap and basis swap
-forms.
-- [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] — A European
-option on a forward-starting commodity swap; ORE's CommoditySwaption product.
-- [[id:1989F85A-42F8-4894-8982-AC34D19B0351][Commodity Variance Swap]] — A
-swap on commodity volatility or variance; ORE's CommodityVarianceSwap product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityapo.html][Commodity Average Price Option]] | — An Asian option on daily commodity price fixings; ORE's CommodityAveragePriceOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityforward.html][Commodity Forward]] | An agreement to buy or sell a commodity at a set price later; ORE's CommodityForward product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityoption.html][Commodity Option]] | A European or American option on a commodity; ORE's CommodityOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityoptionstrip.html][Commodity Option Strip]] | A strip of commodity APOs or European options over periods; ORE's CommodityOptionStrip product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityposition.html][Commodity Position]] | A position in a commodity or weighted commodity basket; ORE's CommodityPosition product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityswap.html][Commodity Swap]] | Floating commodity prices against a fixed price; ORE's CommoditySwap and basis swap forms. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityswaption.html][Commodity Swaption]] | A European option on a forward-starting commodity swap; ORE's CommoditySwaption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityvarianceswap.html][Commodity Variance Swap]] | A swap on commodity volatility or variance; ORE's CommodityVarianceSwap product. |
 
 * Bonds and cash
 
 The bond catalogue runs from the cash bond to its position, forward, future,
 repo, option and total-return forms, with cash positions.
 
-- [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — A bond is a tradable
-debt instrument paying scheduled interest and principal; ORE's Bond product.
-- [[id:C00D82F7-942F-4270-AB9F-D0C31F0881A9][Bond Forward (Reference Data)]] —
-A forward contract on a bond with the underlying set by reference data; ORE's
-ForwardBond product.
-- [[id:B50027E5-44CD-49FA-B4DF-1177E321F156][Bond Future]] — A contract to buy
-or sell an underlying bond at expiry at an agreed price; ORE's BondFuture
-product.
-- [[id:52C1431E-517D-40EC-AE9F-838F040A4103][Bond Option]] — A right to buy or
-sell a given bond at a fixed price; ORE's BondOption product.
-- [[id:0E145E20-C296-4D0F-B26C-2CC5EAA22F3B][Bond Option (Reference Data)]] —
-A bond option with the underlying bond set by reference data; ORE's BondOption
-product.
-- [[id:531499CE-C843-4178-8F89-CA901B1BA9AE][Bond Position]] — A position in a
-weighted basket of underlying bonds; ORE's BondPosition product.
-- [[id:C96BBC70-71C1-442A-97FF-CCD596C193DB][Bond Repo]] — A cash borrowing
-with a bond posted as collateral; ORE's BondRepo product.
-- [[id:0727A454-AB7F-4202-A3A8-A4A183683566][Bond Total Return Swap]] — A swap
-paying the total return of a bond against a funding leg; ORE's BondTRS
-product.
-- [[id:940CB31A-BD50-45D6-98AC-4B0D53973825][Cash Position]] — An amount of
-cash in a currency; ORE's CashPosition product.
-- [[id:8CCD37D5-1D16-4972-8582-13595E62381C][Forward Bond]] — A forward
-contract to buy or sell an underlying bond at a future date; ORE's ForwardBond
-product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bond.html][Bond]] | A bond is a tradable debt instrument paying scheduled interest and principal; ORE's Bond product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondforward_refdata.html][Bond Forward (Reference Data)]] | A forward contract on a bond with the underlying set by reference data; ORE's ForwardBond product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondfuture.html][Bond Future]] | A contract to buy or sell an underlying bond at expiry at an agreed price; ORE's BondFuture product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondoption.html][Bond Option]] | A right to buy or sell a given bond at a fixed price; ORE's BondOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondoption_refdata.html][Bond Option (Reference Data)]] | A bond option with the underlying bond set by reference data; ORE's BondOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondposition.html][Bond Position]] | A position in a weighted basket of underlying bonds; ORE's BondPosition product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondrepo.html][Bond Repo]] | A cash borrowing with a bond posted as collateral; ORE's BondRepo product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bondtotalreturnswap.html][Bond Total Return Swap]] | A swap paying the total return of a bond against a funding leg; ORE's BondTRS product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/cashposition.html][Cash Position]] | An amount of cash in a currency; ORE's CashPosition product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/forwardbond.html][Forward Bond]] | A forward contract to buy or sell an underlying bond at a future date; ORE's ForwardBond product. |
 
 * Multi-asset derivatives and scripted products
 
@@ -228,77 +143,43 @@ ORE catalogues payoffs that accept FX, equity or commodity underlyings,
 several of them in any combination, and prices the compiled forms through its
 scripted trade module.
 
-- [[id:6B186A8F-B261-40A4-B950-932AB735AE95][Accumulator]] — A forward
-purchase of an asset in daily instalments within a price range; ORE's
-accumulator products.
-- [[id:6B1D0C78-0CAF-4A1C-BA34-56FB07C4F107][Autocallable Type 01]] — A
-structured option that pays accumulated amounts and redeems early below a
-trigger level; ORE's Autocallable Type 01 product.
-- [[id:00DE9B53-9E4F-4FD4-A5E9-BE00B0956710][Basket Option]] — An option on a
-basket of underlying assets; ORE's BasketOption product.
-- [[id:18891481-BBFE-4731-A677-DB66400A724C][Best Entry Option]] — An option
-whose payoff uses the best observed entry level of the underlying; ORE's Best
-Entry Option product.
-- [[id:E63E99AD-6C5E-446B-BE14-57A8D9042AFD][Double Digital Option]] — A
-binary option paying a fixed amount when two underlyings are simultaneously in
-the money; ORE's Double Digital Option product.
-- [[id:F0727CDB-4696-4C25-BFF5-AF0D302B5A71][European Option Contingent on a
-Barrier]] — A plain vanilla European option whose payoff depends on a barrier
-on another underlying; ORE's EuropeanOptionBarrier product.
-- [[id:D3DF8CDD-2BD9-44BC-B805-D06C8A6C2074][Exotic Variance and Volatility
-Derivatives]] — Variance and volatility swaps and options with barriers,
-corridors, baskets and optionality; ORE's exotic variance product family.
-- [[id:90DDE9BB-770F-4337-AF0E-69698AF2A2A1][Extended Accumulator]] — An
-accumulator that can extend past a barrier decision date; ORE's
-ExtendedAccumulator product.
-- [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] — A
-vanilla, asset-or-nothing or cash-or-nothing option with American and expiry
-barriers; ORE's Generic Barrier Option product.
-- [[id:2F5B28D9-9AB7-401E-8EF3-612712F626C1][Generic Scripted Products]] — The
-scripted trade module and its flexible payoff scripts; ORE's Generic Scripted
-Products section.
-- [[id:AEB7149D-EE91-4912-A663-D7A0261B87A0][Performance Option Type 01]] — An
-option paying a performance return against a strike; ORE's Performance Option
-Type 01 product.
-- [[id:E5C8CE52-C382-4523-8BB9-1A3698ABB0BF][Rainbow Options]] — European
-options on the best or worst of a range of assets; ORE's Rainbow Options
-product family.
-- [[id:18E6A88B-6F6E-488F-91B2-B6106C43AF73][Strike Resettable Option]] — An
-option whose strike resets when the underlying reaches a level; ORE's Strike
-Resettable Option product.
-- [[id:808C159F-5852-45AD-AE49-B7A4488513CC][Target Redemption Forward]] — A
-forward series that redeems early at a target profit; ORE's TaRF product.
-- [[id:5368EC07-71E8-4906-B897-AA41A57CE0FA][Total Return Swap]] — A swap
-paying the total return of an asset against a funding leg; ORE's generic TRS
-product.
-- [[id:59A56773-6E82-421A-8E64-AA54D46489D4][Window Barrier Option]] — An
-option with a barrier active only inside a time window; ORE's Window Barrier
-Option product.
-- [[id:428BA744-B3D3-486C-A3BF-39E59C6EC11F][Worst Of Basket Swap]] — A swap
-whose coupon references the worst performing asset in a basket; ORE's
-WorstOfBasketSwap product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/accumulator.html][Accumulator]] | A forward purchase of an asset in daily instalments within a price range; ORE's accumulator products. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/autocallable_01.html][Autocallable Type 01]] | A structured option that pays accumulated amounts and redeems early below a trigger level; ORE's Autocallable Type 01 product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/basketoption.html][Basket Option]] | An option on a basket of underlying assets; ORE's BasketOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/bestentryoption.html][Best Entry Option]] | An option whose payoff uses the best observed entry level of the underlying; ORE's Best Entry Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/doubledigitaloption.html][Double Digital Option]] | A binary option paying a fixed amount when two underlyings are simultaneously in the money; ORE's Double Digital Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/europeanoptioncontingentonabarrier.html][European Option Contingent on a Barrier]] | A plain vanilla European option whose payoff depends on a barrier on another underlying; ORE's EuropeanOptionBarrier product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/var_and_vol_derivatives.html][Exotic Variance and Volatility Derivatives]] | Variance and volatility swaps and options with barriers, corridors, baskets and optionality; ORE's exotic variance product family. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/extendedaccumulator.html][Extended Accumulator]] | An accumulator that can extend past a barrier decision date; ORE's ExtendedAccumulator product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/generic_barrieroption.html][Generic Barrier Option]] | A vanilla, asset-or-nothing or cash-or-nothing option with American and expiry barriers; ORE's Generic Barrier Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/genericscriptedproducts.html][Generic Scripted Products]] | The scripted trade module and its flexible payoff scripts; ORE's Generic Scripted Products section. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/performanceoption_01.html][Performance Option Type 01]] | An option paying a performance return against a strike; ORE's Performance Option Type 01 product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/rainbow_option.html][Rainbow Options]] | European options on the best or worst of a range of assets; ORE's Rainbow Options product family. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/strikeresettableoption.html][Strike Resettable Option]] | An option whose strike resets when the underlying reaches a level; ORE's Strike Resettable Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/tarf.html][Target Redemption Forward]] | A forward series that redeems early at a target profit; ORE's TaRF product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/totalreturnswap.html][Total Return Swap]] | A swap paying the total return of an asset against a funding leg; ORE's generic TRS product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/window_barrieroption.html][Window Barrier Option]] | An option with a barrier active only inside a time window; ORE's Window Barrier Option product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/worstofbasketswap.html][Worst Of Basket Swap]] | A swap whose coupon references the worst performing asset in a basket; ORE's WorstOfBasketSwap product. |
 
 * Hybrid and composite trades
 
 ORE prices bond structures with embedded equity and credit features, and
 bundles component trades into one composite trade.
 
-- [[id:DBC183E7-9AB4-481A-8A27-A70966EE4D48][Ascot]] — An American-style
-option to buy back a convertible bond; ORE's Ascot product.
-- [[id:4E78B88B-432F-445D-9FEA-9DBE80718DBF][Callable Bond]] — A bond with
-issuer call and investor put rights; ORE's CallableBond product.
-- [[id:F8341BB7-33FE-4441-8C2D-56B8DDDCA91C][Collateral Bond Obligation]] — A
-tranched securitisation of a portfolio of corporate bonds or loans; ORE's CBO
-product.
-- [[id:2D1B9342-FC33-49DF-8F23-5B2248968156][Composite Trade]] — A hybrid
-position bundling multiple component trades; ORE's CompositeTrade product.
-- [[id:F5D8E0C4-EC67-4210-AF1C-B664246810C9][Convertible Bond]] — A bond that
-converts into a prespecified number of shares; ORE's ConvertibleBond product.
+| Product | Description |
+|---------+-------------|
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/ascot.html][Ascot]] | An American-style option to buy back a convertible bond; ORE's Ascot product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/callablebond.html][Callable Bond]] | A bond with issuer call and investor put rights; ORE's CallableBond product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/cbodata.html][Collateral Bond Obligation]] | A tranched securitisation of a portfolio of corporate bonds or loans; ORE's CBO product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/compositetrade.html][Composite Trade]] | A hybrid position bundling multiple component trades; ORE's CompositeTrade product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/convertiblebond.html][Convertible Bond]] | A bond that converts into a prespecified number of shares; ORE's ConvertibleBond product. |
 
 * See also
 
-- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all
-knowledge notes, with the alphabetical product run.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=, which
-inputs the product sections. The upstream project is
-[[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].
+- [[http://192.168.1.172:21404/OreStudio/doc/knowledge/knowledge.html][Knowledge]] — the hub of all knowledge notes, with the
+  alphabetical product run.
+- ORE User Guide, Products catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]], which
+  inputs the product sections. The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/products_by_asset_class.org
+++ b/doc/knowledge/domain/products_by_asset_class.org
@@ -72,13 +72,13 @@ option exotics from Asian to cliquet, and outperformance.
 | Product | Description |
 |---------+-------------|
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_asianoption.html][Equity Asian Option]] | An Asian option on the average equity price; ORE's EquityAsianOption product. |
-| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityautodeltahedgedoption.html][Equity Auto Delta Hedged Option]] | — Batches of European equity options with an embedded delta-hedging strategy; ORE's EquityAutoDeltaHedgedOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityautodeltahedgedoption.html][Equity Auto Delta Hedged Option]] | Batches of European equity options with an embedded delta-hedging strategy; ORE's EquityAutoDeltaHedgedOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_barrieroption.html][Equity Barrier Option]] | A barrier option on an equity price; ORE's EquityBarrierOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equitycliquetoption.html][Equity Cliquet Option]] | A series of forward-start equity options with local and global caps; ORE's EquityCliquetOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_digitaloption.html][Equity Digital Option]] | A cash-or-nothing digital option on an equity; ORE's EquityDigitalOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_doublebarrieroption.html][Equity Double Barrier Option]] | A double barrier option on an equity price; ORE's EquityDoubleBarrierOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_doubletouchoption.html][Equity Double Touch Option]] | A cash-or-nothing double touch option on an equity; ORE's EquityDoubleTouchOption product. |
-| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_europeanbarrieroption.html][Equity European Barrier Option]] | — A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/eq_europeanbarrieroption.html][Equity European Barrier Option]] | A barrier option monitored once at expiry; ORE's EquityEuropeanBarrierOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityforward.html][Equity Forward]] | An agreement to buy or sell shares at a future price; ORE's EquityForward product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityfuturesoption.html][Equity Futures Option]] | An option on an equity future contract; ORE's EquityFutureOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/equityoption.html][Equity Option]] | An option to buy or sell shares at a strike price; ORE's EquityOption product. |
@@ -110,7 +110,7 @@ variance and position forms.
 
 | Product | Description |
 |---------+-------------|
-| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityapo.html][Commodity Average Price Option]] | — An Asian option on daily commodity price fixings; ORE's CommodityAveragePriceOption product. |
+| [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityapo.html][Commodity Average Price Option]] | An Asian option on daily commodity price fixings; ORE's CommodityAveragePriceOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityforward.html][Commodity Forward]] | An agreement to buy or sell a commodity at a set price later; ORE's CommodityForward product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityoption.html][Commodity Option]] | A European or American option on a commodity; ORE's CommodityOption product. |
 | [[http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/commodityoptionstrip.html][Commodity Option Strip]] | A strip of commodity APOs or European options over periods; ORE's CommodityOptionStrip product. |

--- a/doc/knowledge/domain/rainbow_option.org
+++ b/doc/knowledge/domain/rainbow_option.org
@@ -44,7 +44,7 @@ trades, refer to the scripted trade documentation in
 ore/Docs/ScriptedTrade for an introduction of the latter.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rainbow_option.tex][rainbow_option.tex]].
 
 ORE scopes the asset classes and their trade types:
 
@@ -56,14 +56,14 @@ FxRainbowOption / FxRainbowOptionData
 CommodityRainbowOption / CommodityRainbowOptionData
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rainbow_option.tex][rainbow_option.tex]].
 
 #+begin_quote
 Trade input and the associated payoff script are described in the
 following for 12 supported Rainbow Option variations.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rainbow_option.tex][rainbow_option.tex]].
 
 ** In plain terms
 
@@ -277,7 +277,7 @@ Option = LongShort * Notional * PAY(bestPrice, Expiry, Settlement, PayCcy);
 currentNotional = Notional * Strike;
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rainbow_option.tex][rainbow_option.tex]],
 listing =Payoff script for a BestOfAssetOrCashRainbowOption=. The
 trade listing above it shows the same option in the traditional
 container, with a notional of 1 and a strike of 2000. The same trade
@@ -289,7 +289,7 @@ node and typed fields.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/rainbow_option.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rainbow_option.tex][rainbow_option.tex]]. The
   upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/rainbow_option.org
+++ b/doc/knowledge/domain/rainbow_option.org
@@ -1,0 +1,292 @@
+:PROPERTIES:
+:ID: E5C8CE52-C382-4523-8BB9-1A3698ABB0BF
+:END:
+#+title: Rainbow Options
+#+description: European options on the best or worst of a range of assets; ORE's Rainbow Options product family.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:rainbow_option:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+Rainbow options are European calls or puts on the maximum or minimum
+of a range of assets. ORE documents the family in one catalogue
+section with sixteen variations, each with its own payoff script.
+This note records the domain grounding, as ORE documents it in its
+product catalogue.
+
+* Summary
+
+A rainbow option looks at several assets at once and pays off the
+best or the worst of them. The core forms pay the best or worst of
+the weighted asset values against a cash alternative, or a call or a
+put on the maximum or the minimum of the weighted assets. The call
+spread forms sort the assets by performance, weight them by rank and
+apply a floor and a cap. One form adds a knock-in barrier, another
+averages the assets first. Nine worst performance forms complete the
+family. ORE prices the family on equity, FX and commodity
+underlyings, in a traditional container or as scripted trades.
+
+* Detail
+
+** What it is
+
+ORE's catalogue defines rainbow options as European calls or puts on
+the maximum or minimum of a range of assets, with constant weights
+per asset. The catalogue opens with a payoff table of the core forms:
+the best of the weighted assets or cash, the worst of the weighted
+assets or cash, and calls or puts on the maximum or minimum of the
+weighted assets. ORE states the two input representations as follows:
+
+#+begin_quote
+Rainbow Options are represented as traditional trades or scripted
+trades, refer to the scripted trade documentation in
+ore/Docs/ScriptedTrade for an introduction of the latter.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+
+ORE scopes the asset classes and their trade types:
+
+#+begin_quote
+The supported underlying types are Equity, Fx or Commodity resulting
+in corresponding trade types and trade data container names
+EquityRainbowOption / EquityRainbowOptionData
+FxRainbowOption / FxRainbowOptionData
+CommodityRainbowOption / CommodityRainbowOptionData
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+
+#+begin_quote
+Trade input and the associated payoff script are described in the
+following for 12 supported Rainbow Option variations.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=.
+
+** In plain terms
+
+A rainbow option is a bet on the spread across several markets. One
+form pays the best market at the end, with a cash floor. Another pays
+the worst market, with a cash ceiling. Call and put forms buy or sell
+the maximum or the minimum of the group. The spread forms rank the
+markets by their performance, weight the ranks and pay the capped
+result above a floor. A barrier version only pays when one market has
+knocked the structure in. An Asian version looks at average levels
+instead of one final look. The worst performance forms pay the drop
+of the weakest market, with a reduced loss share below par.
+
+** How it works in ORE
+
+The catalogue's variations are:
+
+- Best Of Asset Or Cash Rainbow Option, script
+  =BestOfAssetOrCashRainbowOption=. It pays the greater of the
+  strike and the best weighted asset value at expiry.
+- Worst Of Asset Or Cash Rainbow Option, script
+  =WorstOfAssetOrCashRainbowOption=. It pays the lesser of the
+  strike and the worst weighted asset value at expiry.
+- Put/Call on Max Rainbow Option, script =MaxRainbowOption=. It pays
+  a call or put on the maximum of the weighted asset values against
+  the strike.
+- Put/Call on Min Rainbow Option, script =MinRainbowOption=. It pays
+  a call or put on the minimum of the weighted asset values against
+  the strike.
+- European Rainbow Call Spread Option, script
+  =EuropeanRainbowCallSpreadOption=. It ranks the asset performances,
+  weights them from best to worst, and pays the notional times the
+  capped and floored return.
+- Rainbow Call Spread Barrier Option, script
+  =RainbowCallSpreadBarrierOption=. It adds a knock-in barrier to the
+  call spread, observed on a schedule or at expiry.
+- Asian Rainbow Call Spread Option, script
+  =AsianRainbowCallSpreadOption=. It averages each asset over its
+  averaging dates before the ranking.
+- Worst Performance Rainbow Option 01 through 09, scripts
+  =WorstPerformanceRainbowOption01= through 09. They extend the
+  worst performance structure with further parameters, each variant
+  with its own script.
+
+The first four variations exist in a traditional form. The trade is
+one of =EquityRainbowOption=, =FxRainbowOption= or
+=CommodityRainbowOption= with the matching data node. In the example
+below the option on the best of two equity indices uses
+=EquityRainbowOptionData=. The node carries =Currency=, the pay
+currency; =Notional=, the quantity for equity and commodity
+underlyings or the foreign amount for an FX underlying; =Strike=,
+the cash level of the payoff; =Underlyings=, the basket with one
+=Weight= per underlying; and =OptionData=. The =OptionData= node
+carries the long or short flag, the payoff type, which must name the
+variation, and exactly one exercise date. =Settlement= is the
+settlement date, optional and defaulting to the exercise date.
+
+The call spread and worst performance variations exist only as
+scripted trades. Every variation has a data node under the
+=ScriptedTrade= trade type, named after the variation, with typed
+fields. List fields such as =Underlyings= and =Weights= hold their
+values under repeated =Value= elements, in the same order. Each data
+node names its payoff script, and the catalogue lists the script in
+full. =PayCcy= is the payment currency. For FX the underlying name
+has the form =FX-SOURCE-CCY1-CCY2= and =PayCcy= should be =CCY2=.
+Choosing =CCY1=, or the underlying currency for equity and commodity
+underlyings, produces a quanto payoff.
+
+** Mathematical notes
+
+ORE writes the prices of the n assets at expiry as S-1 to S-n, their
+initial prices with a zero superscript, and constant weights w-1 to
+w-n. A plus-one omega marks a call and a minus-one omega marks a put.
+
+The core payoffs of the payoff table are:
+
+- Best of asset or cash: the maximum of the weighted asset values
+  and the cash level K, that is max(w-1 S-1, ..., w-n S-n, K).
+- Worst of asset or cash: the minimum of the weighted asset values
+  and the cash level K.
+- Call or put on the maximum: the positive part of omega times the
+  maximum of the weighted asset values minus K.
+- Call or put on the minimum: the same form on the minimum of the
+  weighted asset values.
+
+The European rainbow call spread ranks each asset's performance, the
+ratio of its price at expiry to its initial strike. The return is
+the weighted sum of the ranked performances, with the weights applied
+from the best performer to the worst. The payout is the notional
+times the return minus one, floored at the floor and capped at the
+cap. The barrier version strikes the return at a strike instead of
+one, applies a gearing multiplier, and multiplies the payout by a
+knock-in indicator. The knock-in fires when any asset's performance
+touches the barrier level; a Bermudan flag chooses observation on a
+schedule, and the alternative checks once at expiry. The Asian
+version replaces each asset's final price by its average over the
+averaging dates, then applies the same ranking, floor and cap.
+
+The worst performance option 01 observes the basket once, on the
+observation date. The worst performance is the minimum over the
+assets of the final price over the initial price. The payout is the
+quantity times the worst performance minus one. When the worst
+performance is below one, the payout is scaled by the payoff
+multiplier, which reduces the loss share. The option value is the
+long-short signed difference between the payoff, settled on the
+settlement date, and the premium, paid on the premium date. The
+variants 02 to 09 extend this core: 02 adds a floor; 03 and 04 add a
+strike, a cap, a floor and a Bermudan barrier with level and
+schedule; 05 adds a put or call flag with a barrier type and level;
+06 adds strike prices, barrier levels, knock-in prices and a bonus
+coupon; 07 adds two fixed rates with a day count fraction, strike
+prices and trigger levels over determination dates; 08 is a call or
+put on the worst performance against strike prices; 09 adds
+knock-out levels on barrier dates to that form.
+
+** What moves its value (static sensitivities)
+
+- The levels of the underlyings at expiry, or on their averaging
+  dates.
+- The weights of the underlyings, and the rank order in the spread
+  forms.
+- The initial prices and initial strikes, which anchor the
+  performances.
+- The cash level or strike, the floor, the cap and the gearing.
+- The barrier level and the barrier style of the barrier form.
+- The volatility of each underlying and the correlation between
+  them. Both shape the spread of the best and worst performers.
+- The payoff multiplier of the worst performance forms.
+- The interest rates that discount the payoff and the premium.
+
+** How the profile ages (dynamic sensitivities)
+
+The averaging forms fix their asset levels on each averaging date. A
+barrier form watches its schedule until a knock-in fires. The expiry
+date decides the terminal levels, the ranking and the payoff
+branch. The worst performance forms fix the basket on their
+observation date. The settlement date settles the payoff, and the
+premium date settles the premium.
+
+** Why a customer would want it
+
+A rainbow option prices a view on several assets with one payoff. The
+best of forms buy the strongest market with a cash floor. The worst
+performance forms give access to a diversified basket at a lower
+cost, with a capped loss share. The spread forms pay the spread of
+the ranked field. Banks use the family in structured notes that
+reference a basket of indices. In ORE Studio a customer books rainbow
+options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows the best of asset or cash form on two equity
+indices. The trade compares the S&P 500 and the Euro Stoxx 50 at
+expiry and pays the better weighted level, but at least the strike of
+2000. The S&P index is quoted in USD, the Euro Stoxx index carries
+its EUR currency, and the pay currency is USD:
+
+#+begin_example
+<Trade id="BestOfAssetOrCashRainbowOption#1">
+  <TradeType>EquityRainbowOption</TradeType>
+  <Envelope>
+    <CounterParty>CPTY_A</CounterParty>
+    <NettingSetId>CPTY_A</NettingSetId>
+    <AdditionalFields/>
+  </Envelope>
+  <EquityRainbowOptionData>
+    <Currency>USD</Currency>
+    <Notional>1</Notional>
+    <Strike>2000</Strike>
+    <Underlyings>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>RIC:.SPX</Name>
+        <Weight>1.0</Weight>
+      </Underlying>
+      <Underlying>
+        <Type>Equity</Type>
+        <Name>RIC:.STOXX50E</Name>
+        <Currency>EUR</Currency>
+        <Weight>1.0</Weight>
+      </Underlying>
+    </Underlyings>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <PayoffType>BestOfAssetOrCash</PayoffType>
+      <ExerciseDates>
+        <ExerciseDate>2020-02-15</ExerciseDate>
+      </ExerciseDates>
+    </OptionData>
+    <Settlement>2020-02-20</Settlement>
+  </EquityRainbowOptionData>
+</Trade>
+#+end_example
+
+ORE prices the payoff with the =BestOfAssetOrCashRainbowOption=
+script. The script starts the best price at the strike, scans the
+basket and keeps the highest weighted price, then pays the long or
+short signed notional times that level on the settlement date:
+
+#+begin_example
+REQUIRE SIZE(Underlyings) == SIZE(Weights);
+NUMBER u, thisPrice, bestPrice, Payoff, currentNotional;
+bestPrice = Strike;
+FOR u IN (1, SIZE(Underlyings)) DO
+    thisPrice = Underlyings[u](Expiry) * Weights[u];
+    IF thisPrice > bestPrice THEN
+        bestPrice = thisPrice;
+    END;
+END;
+Option = LongShort * Notional * PAY(bestPrice, Expiry, Settlement, PayCcy);
+currentNotional = Notional * Strike;
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rainbow_option.tex=,
+listing =Payoff script for a BestOfAssetOrCashRainbowOption=. The
+trade listing above it shows the same option in the traditional
+container, with a notional of 1 and a strike of 2000. The same trade
+exists as a scripted trade with a =BestOfAssetOrCashRainbowOptionData=
+node and typed fields.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/rainbow_option.tex=. The
+  upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/rainbow_option.org
+++ b/doc/knowledge/domain/rainbow_option.org
@@ -286,6 +286,9 @@ node and typed fields.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/rainbow_option.tex=. The
   upstream project is

--- a/doc/knowledge/domain/ratedigitaloption.org
+++ b/doc/knowledge/domain/ratedigitaloption.org
@@ -1,0 +1,133 @@
+:PROPERTIES:
+:ID: 94B1DBE3-33AB-44F5-B9F1-B71E34A58123
+:END:
+#+title: Rate Digital Option
+#+description: A fixed-payout option on an interest rate fixing; ORE's RateDigitalOption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:ratedigitaloption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A rate digital option pays a fixed cash amount when a rate fixing is
+above or below a strike. The payout is decided by one fixing date.
+ORE models it with the trade type =RateDigitalOption=. This note
+records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+A rate digital option is a European cash-or-nothing option on an
+interest rate fixing. It pays a fixed cash amount if the fixing on
+the fixing date is above the strike, a call, or below the strike, a
+put. The payout is decided by the fixing on the fixing date. ORE
+notes the trade type is useful for hedging or replicating Range
+Accrual coupons. Each daily observation of such a coupon decomposes
+into a digital option on the rate.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Rate Digital Option is a European cash-or-nothing option on an
+interest rate fixing. It pays a fixed cash amount if the underlying
+rate index fixing on the fixing date is above the strike (Call) or
+below the strike (Put). This trade type is useful for hedging or
+replicating Range Accrual coupons, where each daily observation can
+be decomposed into a digital option on the rate.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ratedigitaloption.tex=.
+
+The payout direction follows the option type. A call pays when the
+rate fixing is above the strike. A put pays when the rate fixing is
+below the strike.
+
+** In plain terms
+
+A rate digital is a binary bet on a rate. The rate either beats the
+level or it does not. The payout is fixed in advance. There is no
+graduated payoff.
+
+** How it works in ORE
+
+The =RateDigitalOptionData= node is the trade data container for the
+=RateDigitalOption= trade type. It includes one =OptionData= sub-node
+plus elements specific to the product. =LongShort= sets the
+direction. =OptionType= names the condition, call or put.
+=ExerciseDates= holds the single European exercise date. =Index=
+names the underlying rate, for example EUR-EURIBOR-6M. =Strike= sets
+the level in decimal form. =PayoffAmount= and =PayoffCurrency= set
+the fixed payout. =FixingDate= is when the index fixes.
+=PaymentDate= is when the payout settles.
+
+** Mathematical notes
+
+The payout is a fixed cash amount conditional on one event. A call
+pays if the fixing is above the strike. A put pays if the fixing is
+below the strike. The value is the payout times the discounted
+probability of the event under the pricing measure. A digital behaves
+like the limit of a tight call or put spread. Near the strike its
+sensitivity to the rate and to volatility is at its peak.
+
+** What moves its value (static sensitivities)
+
+- The forward level of the reference rate against the strike.
+- The volatility of the reference index.
+- The discount rate to the payment date.
+- The gap between the fixing date and the payment date.
+- The payout amount and its currency.
+
+Far from the strike the value saturates. Deep in the money the
+payout is near certain. Deep out of the money it is near zero.
+
+** How the profile ages (dynamic sensitivities)
+
+Until the fixing, the trade prices the probability of the payout. The
+fixing date decides the outcome. After the fixing the payoff is
+known. Only the discount to the payment date remains. At the payment
+date the cash settles and the trade stops.
+
+** Why a customer would want it
+
+A customer uses the product to hedge Range Accrual coupons. Each
+daily observation of such a coupon is a digital on the rate. A trader
+expresses a cheap binary view on a rate level. In ORE Studio a
+customer books rate digital options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long call digital on euro six-month Euribor.
+It pays 10000 euros if the fixing is above 2 percent:
+
+#+begin_example
+<RateDigitalOptionData>
+      <OptionData>
+        <LongShort>Long</LongShort>
+        <OptionType>Call</OptionType>
+        <ExerciseDates>
+          <ExerciseDate>2027-06-20</ExerciseDate>
+        </ExerciseDates>
+      </OptionData>
+      <Index>EUR-EURIBOR-6M</Index>
+      <Strike>0.02</Strike>
+      <PayoffAmount>10000.0</PayoffAmount>
+      <PayoffCurrency>EUR</PayoffCurrency>
+      <FixingDate>2027-06-18</FixingDate>
+      <PaymentDate>2027-06-20</PaymentDate>
+</RateDigitalOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ratedigitaloption.tex=,
+listing =Rate Digital Option data=.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/ratedigitaloption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/ratedigitaloption.org
+++ b/doc/knowledge/domain/ratedigitaloption.org
@@ -127,6 +127,9 @@ listing =Rate Digital Option data=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/ratedigitaloption.tex=. The

--- a/doc/knowledge/domain/ratedigitaloption.org
+++ b/doc/knowledge/domain/ratedigitaloption.org
@@ -40,7 +40,7 @@ replicating Range Accrual coupons, where each daily observation can
 be decomposed into a digital option on the rate.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ratedigitaloption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ratedigitaloption.tex][ratedigitaloption.tex]].
 
 The payout direction follows the option type. A call pays when the
 rate fixing is above the strike. A put pays when the rate fixing is
@@ -122,7 +122,7 @@ It pays 10000 euros if the fixing is above 2 percent:
 </RateDigitalOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/ratedigitaloption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ratedigitaloption.tex][ratedigitaloption.tex]],
 listing =Rate Digital Option data=.
 
 * See also
@@ -131,6 +131,6 @@ listing =Rate Digital Option data=.
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Binary_option][Wikipedia: Binary option]]. This places the fixed payout concept.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/ratedigitaloption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/ratedigitaloption.tex][ratedigitaloption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/rpa.org
+++ b/doc/knowledge/domain/rpa.org
@@ -35,7 +35,7 @@ A RPA is a credit derivative between two counterparties. The
 protection buyer pays a premium to the protection seller.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rpa.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rpa.tex][rpa.tex]].
 
 In return, the seller agrees to pay a percentage share of the
 liabilities of a referenced underlying swap transaction. The share is
@@ -139,7 +139,7 @@ ORE's catalogue shows a trade with an 80 percent participation rate:
 </RiskParticipationAgreementData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rpa.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rpa.tex][rpa.tex]],
 listing =RiskParticipationAgreement Data= (underlying abbreviated).
 
 The example pays a one-off fee of 91171.72 EUR for protection on a
@@ -153,6 +153,6 @@ The example pays a one-off fee of 91171.72 EUR for protection on a
 
 - [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
   credit derivative family.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/rpa.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/rpa.tex][rpa.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/rpa.org
+++ b/doc/knowledge/domain/rpa.org
@@ -1,0 +1,155 @@
+:PROPERTIES:
+:ID: 95005252-270D-44DE-8A26-C61CE5D860E0
+:END:
+#+title: Risk Participation Agreement
+#+description: Credit protection on a counterparty's default on an underlying swap; ORE's RPA product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:rpa:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A risk participation agreement protects the credit of a swap
+counterparty. ORE models it with the trade type
+=RiskParticipationAgreement=. This note records the domain grounding,
+as ORE documents it in its product catalogue.
+
+* Summary
+
+A risk participation agreement (RPA) is a credit derivative between
+two counterparties. The protection buyer pays a premium. In return,
+the seller covers a share of the liabilities of an underlying swap
+when its payer defaults. The share is the participation rate. The
+protection runs for a defined period, often the life of the underlying
+swap. The premium can be one upfront payment or a series. The product
+transfers the credit risk of a derivative exposure.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A RPA is a credit derivative between two counterparties. The
+protection buyer pays a premium to the protection seller.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rpa.tex=.
+
+In return, the seller agrees to pay a percentage share of the
+liabilities of a referenced underlying swap transaction. The share is
+the participation rate. The liabilities fall on one counterparty of
+that transaction, the reference entity, in case of its default. The
+protection is granted for a defined period, which often coincides with
+the lifetime of the underlying swap. In case of a credit event,
+premiums due after the event are cancelled.
+
+** In plain terms
+
+An RPA is insurance on a swap counterparty. One bank enters a swap
+with a client and wants protection if the client defaults. Another
+party takes a share of that credit risk for a fee. The client's swap
+itself stays untouched.
+
+** How it works in ORE
+
+The trade uses a =RiskParticipationAgreementData= block. It holds a
+=ParticipationRate= and the protection window, from =ProtectionStart=
+to =ProtectionEnd=. The =CreditCurveId= names the reference entity.
+A =FixedRecoveryRate= makes the trade a fixed recovery RPA. A
+=ProtectionFee= block holds one or more legs for the fees paid by the
+protection buyer. An =Underlying= block carries the legs of the
+underlying swap, or the Treasury-Lock data that the contract
+references.
+
+The direction follows the premium leg. Payer true means protection is
+bought and the fee is paid. Payer false means protection is sold and
+the fee is received. If the reference entity defaults, the protection
+buyer receives the present value of the underlying if this value is
+positive. The underlying value is computed with the payer and receiver
+flags of its own legs.
+
+** Mathematical notes
+
+The protection is a credit product on the value of a swap. At default,
+the seller pays the positive present value of the underlying times
+the participation rate. The fee pays on the premium leg until the
+credit event or the end of the window. After a credit event, the
+remaining fee payments are cancelled.
+
+** What moves its value (static sensitivities)
+
+- The credit curve of the reference entity. It prices the default
+  risk.
+- The underlying swap. Its present value sets the protection amount,
+  so rates and other underlying risk factors move the trade.
+- The participation rate. It scales the exposure.
+- The fee structure, upfront or running.
+- The recovery assumption.
+
+A protection buyer gains when the reference entity's credit worsens.
+A seller gains when it improves. The trade carries a hybrid exposure,
+credit risk on a rates position.
+
+** How the profile ages (dynamic sensitivities)
+
+The protection window runs to its end date, often the maturity of the
+underlying swap. The underlying ages like the swap it covers, so its
+present value drifts with the market. A credit event settles the
+protection and cancels the remaining premiums. Without one, the trade
+runs to the end of the window and stops.
+
+** Why a customer would want it
+
+A bank shares the credit risk of its swap book without novating the
+trades. An insurer or another bank earns a fee for taking the risk.
+The product is a building block of counterparty credit management. In
+ORE Studio a customer books RPA to value them and run sensitivities on
+the ORE engine.
+
+** Example
+
+ORE's catalogue shows a trade with an 80 percent participation rate:
+
+#+begin_example
+<RiskParticipationAgreementData>
+  <ParticipationRate>0.8</ParticipationRate>
+  <ProtectionStart>2018-10-01</ProtectionStart>
+  <ProtectionEnd>2038-10-01</ProtectionEnd>
+  <CreditCurveId>RED:008CA0|SNRFOR|USD|MR14</CreditCurveId>
+  <IssuerId>CompanyXZY</IssuerId>
+  <SettlesAccrual>true</SettlesAccrual>
+  <FixedRecoveryRate>0.6</FixedRecoveryRate>
+  <ProtectionFee>
+    <LegData>
+      <LegType>Cashflow</LegType>
+      <Payer>true</Payer>
+      <Currency>EUR</Currency>
+      <CashflowData>
+        <Cashflow>
+          <Amount date="2018-10-03">91171.72</Amount>
+        </Cashflow>
+      </CashflowData>
+    </LegData>
+  </ProtectionFee>
+  <Underlying>
+    ...
+  </Underlying>
+</RiskParticipationAgreementData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/rpa.tex=,
+listing =RiskParticipationAgreement Data= (underlying abbreviated).
+
+The example pays a one-off fee of 91171.72 EUR for protection on a
+20-year window. The credit mechanics follow the
+[[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] family.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
+  credit derivative family.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/rpa.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/rpa.org
+++ b/doc/knowledge/domain/rpa.org
@@ -148,6 +148,9 @@ The example pays a one-off fee of 91171.72 EUR for protection on a
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Credit_derivative][Wikipedia: Credit derivative]]. This places the product in the
   credit derivative family.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/strikeresettableoption.org
+++ b/doc/knowledge/domain/strikeresettableoption.org
@@ -33,7 +33,7 @@ ORE defines the product as follows:
 The Strike Resettable Option is an option on a single underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/strikeresettableoption.tex][strikeresettableoption.tex]].
 
 The reset works on a trigger. When the underlying price reaches a
 certain level on an observation date, the strike of the option resets
@@ -49,7 +49,7 @@ class and an associated node FxStrikeResettableOptionData,
 EquityStrikeResettableOptionData, CommodityStrikeResettableOptionData.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/strikeresettableoption.tex][strikeresettableoption.tex]].
 
 ** In plain terms
 
@@ -81,7 +81,7 @@ occurs when the underlying value is below the TriggerPrice on any
 ObservationDates.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/strikeresettableoption.tex][strikeresettableoption.tex]].
 
 =TriggerType= takes the values =Up= or =Down=. =TriggerPrice= is the
 level of the underlying at which the trigger fires.
@@ -163,7 +163,7 @@ strike when the index trades above 4000:
 </EquityStrikeResettableOptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/strikeresettableoption.tex][strikeresettableoption.tex]],
 listing =Strike Resettable Option data (Equity Underlying)=.
 
 * See also
@@ -171,6 +171,6 @@ listing =Strike Resettable Option data (Equity Underlying)=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/strikeresettableoption.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/strikeresettableoption.tex][strikeresettableoption.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/strikeresettableoption.org
+++ b/doc/knowledge/domain/strikeresettableoption.org
@@ -168,6 +168,9 @@ listing =Strike Resettable Option data (Equity Underlying)=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/strikeresettableoption.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/strikeresettableoption.org
+++ b/doc/knowledge/domain/strikeresettableoption.org
@@ -1,0 +1,173 @@
+:PROPERTIES:
+:ID: 18E6A88B-6F6E-488F-91B2-B6106C43AF73
+:END:
+#+title: Strike Resettable Option
+#+description: An option whose strike resets when the underlying reaches a level; ORE's Strike Resettable Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:strikeresettableoption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A strike resettable option is an option whose strike can reset to a
+new level when the underlying reaches a set level on one of its
+observation dates. ORE offers it for FX, equity and commodity
+underlyings. This note records the domain grounding, as ORE documents
+it in its product catalogue.
+
+* Summary
+
+The option trades like a vanilla call or put on one underlying. A
+separate set of observation dates watches the underlying against a
+trigger price. When the underlying crosses the trigger, the strike
+resets to a new level. The payoff at expiry uses the reset strike.
+Without the trigger the payoff uses the initial strike.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+The Strike Resettable Option is an option on a single underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+
+The reset works on a trigger. When the underlying price reaches a
+certain level on an observation date, the strike of the option resets
+to a new strike.
+
+ORE names the trade types per asset class as follows:
+
+#+begin_quote
+Strike Resettable Options are defined using one of the trade types
+FxStrikeResettableOption, EquityStrikeResettableOption,
+CommodityStrikeResettableOption depending on the underlying asset
+class and an associated node FxStrikeResettableOptionData,
+EquityStrikeResettableOptionData, CommodityStrikeResettableOptionData.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+
+** In plain terms
+
+A strike resettable option is a vanilla option with a ratchet. The
+strike is not fixed for life. If the market reaches an agreed level
+on an agreed set of dates, the strike moves to a new agreed level.
+The expiry payoff uses whichever strike applies. The buyer pays a
+premium for the reset feature.
+
+** How it works in ORE
+
+=Underlying= defines the underlying. For FX the order of the
+currencies defines the observed value: for EUR-USD the domestic
+currency is USD and the observed value is dollars per euro, while for
+USD-EUR the domestic currency is EUR. =LongShort= says whether the
+payoff is computed for the holder or the seller of the option.
+=OptionType= says whether the option is a call or a put. =Currency=
+is the payment currency. =Strike= is the initial strike.
+=ResetStrike= is the strike used when the trigger has fired.
+=Quantity= scales the payoff. =Premium=, which defaults to zero, and
+=PremiumDate= record the option premium and its payment date.
+
+ORE describes the trigger mechanism as follows:
+
+#+begin_quote
+If Up, the trigger event occurs when the underlying value is above
+the TriggerPrice on any ObservationDates. If Down, the trigger event
+occurs when the underlying value is below the TriggerPrice on any
+ObservationDates.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=.
+
+=TriggerType= takes the values =Up= or =Down=. =TriggerPrice= is the
+level of the underlying at which the trigger fires.
+=ObservationDates= are the dates on which the underlying index level
+is observed for the reset. =ExpiryDate= is the date on which the
+option expires and the payoff is computed. =SettlementDate= is the
+date on which the payoff settles; ORE uses it unadjusted, as given.
+
+** Mathematical notes
+
+At expiry the payoff is the option payoff on the final index value.
+The mechanics follow the option type: a call pays when the final
+index is above the strike, a put when it is below. The quantity
+scales the payoff and the long-short direction flips it. When the
+reset event has fired, the payoff uses the reset strike. Otherwise it
+uses the initial strike. The final index value is the underlying
+index value on the expiry date.
+
+** What moves its value (static sensitivities)
+
+- The underlying price. It decides both the trigger and the final
+  payoff.
+- The volatility of the underlying. It drives the probability that
+  the trigger fires before expiry.
+- The distance between the trigger price and the reset strike.
+- The interest rates that discount the premium and the payoff.
+
+The reset makes the option path dependent in a binary way: the value
+splits into a triggered branch and an untriggered branch, each with
+its own strike.
+
+** How the profile ages (dynamic sensitivities)
+
+The trigger is observed on the observation dates, not continuously.
+Each observation can fire the reset. After the reset, the payoff at
+expiry uses the reset strike. Without the reset, the initial strike
+stands. On the expiry date the payoff is computed; the settlement
+date follows unadjusted.
+
+** Why a customer would want it
+
+The reset lets a customer change the strike of an option after the
+trade starts. This supports views on the market reaching a level and
+then reversing. In ORE Studio a customer books strike resettable
+options to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a put on the S&P 500 with a reset to a higher
+strike when the index trades above 4000:
+
+#+begin_example
+<EquityStrikeResettableOptionData>
+  <LongShort>Long</LongShort>
+  <OptionType>Put</OptionType>
+  <Currency>USD</Currency>
+  <Strike>3500</Strike>
+  <ResetStrike>3650</ResetStrike>
+  <Quantity>10000</Quantity>
+  <TriggerType>Up</TriggerType>
+  <TriggerPrice>4000</TriggerPrice>
+  <SettlementDate>2021-06-25</SettlementDate>
+  <ExpiryDate>2021-06-21</ExpiryDate>
+  <PremiumDate>2021-06-25</PremiumDate>
+  <Premium>100</Premium>
+  <Underlying>
+    <Type>Equity</Type>
+    <Name>RIC:.SPX</Name>
+  </Underlying>
+  <ObservationDates>
+    <Dates>
+      <Dates>
+        <Date>2021-04-26</Date>
+        <Date>2021-05-24</Date>
+        <Date>2021-06-21</Date>
+      </Dates>
+    </Dates>
+  </ObservationDates>
+</EquityStrikeResettableOptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/strikeresettableoption.tex=,
+listing =Strike Resettable Option data (Equity Underlying)=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/strikeresettableoption.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/swap.org
+++ b/doc/knowledge/domain/swap.org
@@ -1,0 +1,163 @@
+:PROPERTIES:
+:ID: 28DFC605-9F3D-470D-A45B-347EBA4B45B7
+:END:
+#+title: Swap
+#+description: An interest rate swap exchanges streams of interest payments between two parties on a notional; ORE's swap family.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:swap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A swap exchanges two streams of interest payments, its legs, on a
+notional that the parties never exchange. ORE's Swap trade type covers
+vanilla fixed-vs-floating, basis, OIS, BMA, and CMS structures. This
+note records the domain grounding for the whole family, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+An interest rate swap (IRS) is a bilateral contract. It exchanges a
+stream of interest payments for another stream, both computed on a
+notional amount in one currency. The notional itself is not exchanged.
+ORE models the family under the single trade type =Swap=. The common
+use is to transform the interest-rate exposure of an asset or a
+liability. [[id:13341B12-0393-4ECF-B392-CD68A4C0CDFB][Cash flows]] are the underlying building block of every leg.
+
+* Detail
+
+** What it is
+
+ORE defines the core instrument as follows:
+
+#+begin_quote
+An interest rate swap (IRS) is an agreement between two counterparties
+in which one stream of future interest payments (leg) is exchanged for
+another based on a specified notional amount.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swap.tex=.
+
+Two properties are common to the whole family. The notional per leg may
+be fixed, amortising, or accreting. The fixed rate or floating spread
+may vary over the life of the swap.
+
+** In plain terms
+
+Two parties agree to pay each other interest on the same pile of money
+for a set period. One pays a rate that is known in advance. The other
+pays a rate that is reset from the market over time. Only the
+difference between the two payments changes hands, usually
+periodically.
+
+** Variants inside the ORE Swap family
+
+- *Vanilla IRS*. One fixed leg against one floating leg. The floating
+  leg is benchmarked to an IBOR index of a given tenor.
+- *Single-currency basis swap*. Two floating legs. They are benchmarked
+  to two different IBOR indices, or to different tenors of one index.
+- *OIS*. At least one leg is benchmarked to an overnight index rate.
+  That is the rate for overnight unsecured bank lending. The overnight
+  leg compounds on a daily basis.
+- *BMA swap*. One leg is benchmarked to the US SIFMA municipal swap
+  index.
+- *CMS and CMB swaps*. One leg is benchmarked to a longer-maturity
+  market rate. CMS uses a swap rate. CMB uses a class of government
+  bond yields. A CMS leg may carry a cap, floor, or collar.
+
+ORE also models related structures as separate products in its
+catalogue. They are the ZeroCouponSwap, the CrossCurrencySwap, the
+CallableSwap, the FlexiSwap, the BalanceGuaranteedSwap, and the
+KnockOutSwap. Each gets its own product note in this set.
+
+** Mathematical notes
+
+The value of a swap is the difference between the present values of its
+two legs, discounted on the funding curve. A floating leg's expected
+payments come from the projection curve of its index. These two
+[[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][term structures]] are distinct. See
+[[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][funding and projection curves]]. A CMS leg adds convexity, because the
+index rate and the discount rate are correlated. A cap or floor on the
+leg prices off the interest-rate [[id:0CD30407-D67D-499C-B9AB-F268D05F40E4][volatility]] surface.
+
+** What moves its value (static sensitivities)
+
+- The discount curve. One basis point shifts of it give the DV01 of the
+  trade. Every leg is sensitive to it.
+- The projection curve of each floating index. It drives the expected
+  fixings.
+- The paid or received spread on each leg.
+- Index-convention details, such as day count, payment lag, or business
+  calendar.
+
+A vanilla receive-fixed swap gains value when rates fall. A pay-fixed
+swap gains value when rates rise. The size of the move scales with the
+notional and the remaining life of the trade.
+
+** How the profile ages (dynamic sensitivities)
+
+The value and risk profile evolve as the trade runs its schedule. Each
+fixing turns one unknown payment into a known one. The remaining risk
+migrates along the curve as time passes. An amortising notional shrinks
+the exposure on schedule. At maturity the swap has no residual market
+risk, only the last settlement.
+
+** Why a customer would want it
+
+A borrower with floating-rate debt pays fixed to remove rate risk. An
+investor with fixed coupons pays floating to transform them. Dealers
+quote swaps to manage their own rate books. OIS swaps are the primary
+market for funding rates. They are the anchors of discount-curve
+construction. In ORE Studio a customer books swaps to value them, run
+sensitivities, and feed XVA on the ORE engine.
+
+** Example
+
+A 20-year EUR fixed-vs-floating swap from the ORE trade corpus that ORE
+Studio keeps for its round-trip tests. The fixed leg is shown. The
+floating leg follows in the same file. Source:
+=assets/test_data/golden_dataset/Products/Example_Trades/IR_Swap_Vanilla.xml=.
+
+#+begin_example
+<Portfolio>
+  <Trade id="Swap_20y">
+    <TradeType>Swap</TradeType>
+    <Envelope>
+      <CounterParty>CPTY</CounterParty>
+      <NettingSetId>NS</NettingSetId>
+    </Envelope>
+    <SwapData>
+      <LegData>
+        <Payer>false</Payer>
+        <LegType>Fixed</LegType>
+        <Currency>EUR</Currency>
+        <PaymentConvention>MF</PaymentConvention>
+        <DayCounter>A360</DayCounter>
+        <Notionals>
+          <Notional>10000000</Notional>
+        </Notionals>
+        <ScheduleData>
+          <Rules>
+            <StartDate>2023-02-21</StartDate>
+            <EndDate>2043-02-21</EndDate>
+            <Tenor>1Y</Tenor>
+            <Calendar>TARGET</Calendar>
+            <Convention>MF</Convention>
+            <Rule>Forward</Rule>
+          </Rules>
+        </ScheduleData>
+      </LegData>
+#+end_example
+
+Native ORE example portfolios with swaps sit under
+=external/ore/examples/=. The Academy and AmericanMonteCarlo
+=Input/portfolio.xml= files both contain swaps.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- [[https://en.wikipedia.org/wiki/Overnight_indexed_swap][Wikipedia: Overnight indexed swap]]. This covers the OIS variant.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/swap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/swap.org
+++ b/doc/knowledge/domain/swap.org
@@ -155,6 +155,9 @@ Native ORE example portfolios with swaps sit under
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Overnight_indexed_swap][Wikipedia: Overnight indexed swap]]. This covers the OIS variant.

--- a/doc/knowledge/domain/swap.org
+++ b/doc/knowledge/domain/swap.org
@@ -36,7 +36,7 @@ in which one stream of future interest payments (leg) is exchanged for
 another based on a specified notional amount.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swap.tex][swap.tex]].
 
 Two properties are common to the whole family. The notional per leg may
 be fixed, amortising, or accreting. The fixed rate or floating spread
@@ -161,6 +161,6 @@ Native ORE example portfolios with swaps sit under
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
 - [[https://en.wikipedia.org/wiki/Overnight_indexed_swap][Wikipedia: Overnight indexed swap]]. This covers the OIS variant.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/swap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swap.tex][swap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/swaption.org
+++ b/doc/knowledge/domain/swaption.org
@@ -1,0 +1,195 @@
+:PROPERTIES:
+:ID: FCC37EB3-D654-4333-B110-3BF4AFA3A237
+:END:
+#+title: Swaption
+#+description: An option to enter an interest rate swap; ORE's Swaption product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:swaption:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A swaption gives the right, not the obligation, to enter an interest
+rate swap. The right can be European, Bermudan, or American. ORE
+models it with the trade type =Swaption=. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A swaption is an option to enter an underlying interest rate swap.
+The underlying swap may have varying notional, rates, and spreads. It
+can be single-currency or cross-currency. A payer swaption enters a
+swap that pays fixed and receives floating. A receiver swaption
+enters a swap that receives fixed and pays floating. A European
+swaption exercises only on its expiration date. A Bermudan swaption
+exercises on a predetermined set of dates. An American swaption
+exercises any time between two dates.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A swaption is an option which gives the buyer the right, but not the
+obligation, to enter into an underlying interest rate swap. The
+underlying swap may have varying notional, rates, and spreads during
+its lifetime, and can be single-currency or cross-currency.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+
+ORE splits swaptions into payer and receiver types. A payer swaption
+has an underlying swap that pays fixed and receives floating. A
+receiver swaption has an underlying swap that receives fixed and pays
+floating.
+
+ORE states the European form as follows:
+
+#+begin_quote
+With a European Swaption, the buyer is only allowed to exercise the
+option and enter into the swap on the expiration date of the
+swaption.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+
+ORE describes the settlement choices as follows:
+
+#+begin_quote
+European Swaption settlement can be either cash or physical delivery
+of the underlying swap. For cash settlement there are different
+methods to compute the settlement price (collateralized cash price,
+par yield curve).
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+
+ORE states the Bermudan form as follows:
+
+#+begin_quote
+In a Bermudan Swaption, the buyer is allowed to exercise the option
+and enter into the underlying swap on a predetermined set of dates
+rather than a single expiration date. The underlying swap may have
+varying notional, rates, and spreads during its lifetime.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+
+An American swaption allows exercise any time between two specified
+dates.
+
+** In plain terms
+
+A swaption is an option on a swap. The buyer pays a premium for the
+right to enter the swap later. At the exercise date the buyer decides
+whether the swap is worth entering. A payer swaption gains when
+rates rise. A receiver swaption gains when rates fall. Physical
+settlement creates the actual swap. Cash settlement pays the swap
+value in cash.
+
+** How it works in ORE
+
+The =SwaptionData= node is the trade data container for the
+=Swaption= trade type. The node has exactly one =OptionData= sub-node
+and at least one =LegData= sub-node. Supported exercise styles are
+=European=, =Bermudan=, and =American=. Swaptions of all styles can
+carry an arbitrary number of legs. Cross-currency swaptions are
+supported for all styles. Unless =MidCouponExercise= is true, at
+least one full coupon period must follow the exercise date for a
+European swaption. The same holds after the last exercise date for
+Bermudan and American swaptions. For swaptions, the payer and
+receiver legs of the underlying swap are always from the perspective
+of the party that is long.
+
+** Mathematical notes
+
+A European payer swaption at expiry is worth max(0, V). V is the
+value of the underlying payer swap at that date. The holder exercises
+when the swap has positive value. For a plain fixed-versus-floating
+swap this happens when the market swap rate stands above the fixed
+rate of the swap. A Bermudan swaption allows one decision per
+exercise date. The holder compares exercise value with the value of
+the rights that remain. An American swaption allows exercise any time
+in a window. Physical exercise creates the underlying swap. Cash
+settlement pays a settlement amount computed by the chosen method.
+
+** What moves its value (static sensitivities)
+
+- The level of the underlying swap rate against the fixed rate.
+- The volatility of that swap rate.
+- The discount curve.
+- The exercise schedule and the style.
+- The terms of the legs, including amortisation and day counts.
+
+A payer swaption gains as the swap rate rises above the fixed rate. A
+receiver swaption gains as the swap rate falls. Near the money, the
+value loads on volatility.
+
+** How the profile ages (dynamic sensitivities)
+
+A European swaption holds its optionality until expiry. At expiry one
+decision settles the trade. A Bermudan swaption faces one decision
+per exercise date. A date that passes without exercise consumes that
+right. After physical exercise the trade ages as the underlying swap.
+Its coupons and resets then run to maturity.
+
+** Why a customer would want it
+
+A customer locks today's rates for a future swap need. A treasurer
+hedges the refinancing of a loan. A desk expresses a view on swap
+rate volatility. The swaption is also the engine of callable
+structures. In ORE Studio a customer books swaptions to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long physically settled European receiver
+swaption on sterling:
+
+#+begin_example
+<SwaptionData>
+    <OptionData>
+        <LongShort>Long</LongShort>
+        <Style>European</Style>
+        <Settlement>Physical</Settlement>
+        <ExerciseDates>
+          <ExerciseDate>2027-03-02</ExerciseDate>
+        </ExerciseDates>
+        ...
+        <Premiums>
+          <Premium>
+            <Amount>807000</Amount>
+            <Currency>GBP</Currency>
+            <PayDate>2021-06-15</PayDate>
+          </Premium>
+        </Premiums>
+    </OptionData>
+    <LegData>
+        <LegType>Fixed</LegType>
+        <Payer>false</Payer>
+        <Currency>GBP</Currency>
+        ...
+    </LegData>
+    <LegData>
+        <LegType>Floating</LegType>
+        <Payer>true</Payer>
+        <Currency>GBP</Currency>
+        ...
+    </LegData>
+</SwaptionData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=,
+listing =Swaption data=.
+
+A callable swap embeds this optionality, see the
+[[id:0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE][Callable Swap]] note.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This note follows its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/swaption.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/swaption.org
+++ b/doc/knowledge/domain/swaption.org
@@ -189,6 +189,9 @@ A callable swap embeds this optionality, see the
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This note follows its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/swaption.tex=. The upstream

--- a/doc/knowledge/domain/swaption.org
+++ b/doc/knowledge/domain/swaption.org
@@ -38,7 +38,7 @@ underlying swap may have varying notional, rates, and spreads during
 its lifetime, and can be single-currency or cross-currency.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]].
 
 ORE splits swaptions into payer and receiver types. A payer swaption
 has an underlying swap that pays fixed and receives floating. A
@@ -53,7 +53,7 @@ option and enter into the swap on the expiration date of the
 swaption.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]].
 
 ORE describes the settlement choices as follows:
 
@@ -64,7 +64,7 @@ methods to compute the settlement price (collateralized cash price,
 par yield curve).
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]].
 
 ORE states the Bermudan form as follows:
 
@@ -75,7 +75,7 @@ rather than a single expiration date. The underlying swap may have
 varying notional, rates, and spreads during its lifetime.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]].
 
 An American swaption allows exercise any time between two specified
 dates.
@@ -181,7 +181,7 @@ swaption on sterling:
 </SwaptionData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/swaption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]],
 listing =Swaption data=.
 
 A callable swap embeds this optionality, see the
@@ -193,6 +193,6 @@ A callable swap embeds this optionality, see the
   with the alphabetical product run.
 
 - [[https://en.wikipedia.org/wiki/Swaption][Wikipedia: Swaption]]. This note follows its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/swaption.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/swaption.tex][swaption.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/syntheticcdo.org
+++ b/doc/knowledge/domain/syntheticcdo.org
@@ -38,7 +38,7 @@ specific tranche characterized by the attachment point A and
 detachment point D.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/syntheticcdo.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/syntheticcdo.tex][syntheticcdo.tex]].
 
 ** In plain terms
 
@@ -124,7 +124,7 @@ ORE's catalogue shows a mezzanine tranche of an index:
 </CdoData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/syntheticcdo.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/syntheticcdo.tex][syntheticcdo.tex]],
 listing =CDO Data= (leg and basket abbreviated).
 
 The tranche covers portfolio losses between 12 and 22 percent. The
@@ -139,6 +139,6 @@ the same protection.
 
 - [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows
   its general definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/syntheticcdo.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/syntheticcdo.tex][syntheticcdo.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/syntheticcdo.org
+++ b/doc/knowledge/domain/syntheticcdo.org
@@ -1,0 +1,141 @@
+:PROPERTIES:
+:ID: 8F0391AC-D748-459C-8DD8-5ABC8945E438
+:END:
+#+title: Synthetic CDO
+#+description: A tranched basket credit derivative; ORE's SyntheticCDO product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:syntheticcdo:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A synthetic CDO sells protection on the losses of a credit basket,
+limited to a tranche. ORE models it with the trade type =SyntheticCDO=
+and a =CdoData= block. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A synthetic collateralised debt obligation (CDO) is a basket credit
+derivative. The protection seller receives a premium and covers the
+portfolio losses of a tranche. The tranche runs from an attachment
+point to a detachment point. Losses below the attachment point fall on
+the protection buyer. Losses above the detachment point fall outside
+the contract. The basket can follow an index such as CDX or iTraxx, or
+name bespoke constituents.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A synthetic CDO is a basket credit derivative, where the protection
+seller receives a premium cash flow in exchange for providing
+(notional) protection against portfolio losses due to defaults in a
+specific tranche characterized by the attachment point A and
+detachment point D.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/syntheticcdo.tex=.
+
+** In plain terms
+
+A synthetic CDO is a slice of the credit risk of a group of
+borrowers. The seller of the slice covers the losses that fall inside
+it. Losses below the slice belong to the buyer. Losses above it belong
+to no one in this contract. The slice pays a premium for that
+exposure.
+
+** How it works in ORE
+
+The trade uses a =CdoData= block. The =AttachmentPoint= is the
+fraction of portfolio loss where protection starts. The
+=DetachmentPoint= is the fraction where it stops. The =Qualifier=
+names the credit index that defines the default and base correlation
+curves used for pricing. A bespoke basket sets the =Qualifier= to the
+index that matches it most closely and names its own constituents in a
+=BasketData= sub-node. A fixed =LegData= holds the premium leg. The
+protection mechanics follow the credit family conventions, with
+settlement, accrual, and upfront terms.
+
+** Mathematical notes
+
+The portfolio loss given default sums the loss of each defaulted
+asset. ORE states the loss of one asset as the notional reduced by the
+recovery: LGD equals (1 minus recovery) times notional. The tranche
+absorbs the portfolio loss between its two points. The premium pays on
+the tranche notional, which shrinks as losses consume the tranche.
+
+** What moves its value (static sensitivities)
+
+- The credit curves of the basket constituents. They drive the loss
+  distribution.
+- The base correlation surface. It prices the tranche between its
+  points.
+- The discount curve of the premium currency.
+- The attachment and detachment points. They set the risk window.
+- The composition and weights of the basket.
+
+A seller of a senior tranche gains when defaults stay below the
+attachment point. A seller of an equity tranche carries the first
+losses.
+
+** How the profile ages (dynamic sensitivities)
+
+Defaults reduce the basket and the outstanding tranche notional. Each
+loss inside the tranche is settled and deducted from the attachment
+base. The remaining premium pays on the reduced notional. Near
+maturity, the loss window narrows to the remaining life. At maturity
+the contract stops with the surviving basket and the residual
+tranche.
+
+** Why a customer would want it
+
+An investor buys a tranche to take a chosen slice of portfolio credit
+risk, from first-loss to senior. A bank sells tranches to transfer the
+risk of its loan book. The product tunes risk and return precisely.
+In ORE Studio a customer books synthetic CDO to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a mezzanine tranche of an index:
+
+#+begin_example
+<CdoData>
+  <Qualifier>RED:2I65BRHH6</Qualifier>
+  <AttachmentPoint>0.12</AttachmentPoint>
+  <DetachmentPoint>0.22</DetachmentPoint>
+  <ProtectionStart>20140425</ProtectionStart>
+  <UpfrontDate/>
+  <UpfrontFee/>
+  <SettlesAccrual>Y</SettlesAccrual>
+  <ProtectionPaymentTime>atDefault</ProtectionPaymentTime>
+  <LegData>
+    <LegType>Fixed</LegType>
+    <Payer>true</Payer>
+    ...
+  </LegData>
+  <BasketData>
+    ...
+  </BasketData>
+</CdoData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/syntheticcdo.tex=,
+listing =CDO Data= (leg and basket abbreviated).
+
+The tranche covers portfolio losses between 12 and 22 percent. The
+family basis is the [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]], applied to the
+basket. The [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] is the untranched form of
+the same protection.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows
+  its general definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/syntheticcdo.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/syntheticcdo.org
+++ b/doc/knowledge/domain/syntheticcdo.org
@@ -134,6 +134,9 @@ the same protection.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Collateralized_debt_obligation][Wikipedia: Collateralized debt obligation]]. This note follows
   its general definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/tarf.org
+++ b/doc/knowledge/domain/tarf.org
@@ -34,7 +34,7 @@ ORE introduces the product as follows:
 There are two types of knock out
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 A TaRF is a sequence of FX, equity or commodity forward contracts.
 Strikes and leverage factors apply to ranges of the underlying
@@ -49,7 +49,7 @@ fixing days where the buyer makes a profit reaches a pre-determined
 target.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 ORE distinguishes three payment types after the knock-out:
 
@@ -59,7 +59,7 @@ full: the unadjusted payment is made
 truncated: no payment is made
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 ** In plain terms
 
@@ -90,7 +90,7 @@ is adjusted so that the cumulated profit since the start of the TaRF
 matches the target amount.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 =TargetAmount= is a currency amount; for FX it is in the domestic
 currency. =TargetPoints= expresses the same target as a percentage
@@ -103,7 +103,7 @@ Pivots, where different strikes apply for different ranges of the
 fixing
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 =OptionData= holds =LongShort= and =PayoffType=. =PayoffType= takes
 the values =TargetFull=, =TargetExact= or =TargetTruncated=,
@@ -144,7 +144,7 @@ bounds and also not for a target amount / cumulated profit cap
 specification in points.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]].
 
 In the scripted node the ranges are given as parallel lists:
 =RangeUpperBounds=, =RangeLowerBounds=, =RangeLeverages= and
@@ -258,7 +258,7 @@ below 1.05, and a cumulated profit cap of 100000:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]],
 listing =FxTaRF data=. The catalogue also shows an equity TaRF with a
 =FixingCap= of three profitable fixings, a two-times leverage above
 3300 and a strike adjustment of 100.
@@ -268,6 +268,6 @@ listing =FxTaRF data=. The catalogue also shows an equity TaRF with a
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/tarf.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/tarf.tex][tarf.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/tarf.org
+++ b/doc/knowledge/domain/tarf.org
@@ -265,6 +265,9 @@ listing =FxTaRF data=. The catalogue also shows an equity TaRF with a
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/tarf.tex=. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/tarf.org
+++ b/doc/knowledge/domain/tarf.org
@@ -1,0 +1,270 @@
+:PROPERTIES:
+:ID: 808C159F-5852-45AD-AE49-B7A4488513CC
+:END:
+#+title: Target Redemption Forward
+#+description: A forward series that redeems early at a target profit; ORE's TaRF product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:tarf:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A target redemption forward is a sequence of forward contracts that
+redeems early when its accumulated profit reaches a target. ORE
+offers it for FX, equity and commodity underlyings. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+A TaRF is a strip of forwards on one underlying. Each fixing date
+settles a forward whose strike, and leverage, depend on the range the
+fixing falls into. Positive profits accumulate toward a cap. When
+the accumulated profit reaches the cap, the trade terminates early.
+In the digital form the trade terminates when the number of
+profitable fixing days reaches a target instead. The payment made
+after the knock-out can be exact, full, or truncated.
+
+* Detail
+
+** What it is
+
+ORE introduces the product as follows:
+
+#+begin_quote
+There are two types of knock out
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+A TaRF is a sequence of FX, equity or commodity forward contracts.
+Strikes and leverage factors apply to ranges of the underlying
+price. The trade terminates, or knocks out, when its accumulated
+profit reaches a pre-determined target. ORE distinguishes two
+knock-out types:
+
+#+begin_quote
+A Continuous TaRF terminates when the profit reaches or exceeds a
+pre-determined target. A Digital TaRF terminates when the number of
+fixing days where the buyer makes a profit reaches a pre-determined
+target.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+ORE distinguishes three payment types after the knock-out:
+
+#+begin_quote
+exact: the payment is adjusted to match the pre-determined target
+full: the unadjusted payment is made
+truncated: no payment is made
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+** In plain terms
+
+A target redemption forward is a strip of forwards that stops
+winning at a target. Each fixing date the buyer settles a forward on
+the underlying. The fixing is profitable when it sits on the
+favourable side of the strike. Profits accumulate, and when they
+reach the target the strip redeems early. The buyer gets the target
+amount, or the last payment, or nothing, per the payment type. In
+the digital form the count of profitable days is the target.
+
+** How it works in ORE
+
+The data node =FxTaRFData= is the trade data container for the
+=FxTaRF= trade type. =EquityTaRFData= and =CommodityTaRFData= play
+the same role for the equity and commodity trade types. =Currency=
+is the payout currency of the TaRF; the target amount and the payout
+formula results are expressed in it. =FixingAmount= is the unlevered
+amount used at each fixing date. For FX it is in the foreign
+currency, for equity in shares, for commodity in units. It must be
+positive for both long and short positions.
+
+ORE describes the target mechanics as follows:
+
+#+begin_quote
+If PayoffType = TargetExact, after a knock-out event the last payout
+is adjusted so that the cumulated profit since the start of the TaRF
+matches the target amount.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+=TargetAmount= is a currency amount; for FX it is in the domestic
+currency. =TargetPoints= expresses the same target as a percentage
+of the fixing amount. ORE lists the extra features as follows:
+
+#+begin_quote
+European Knock Ins (EKI), where no sells or buys happen if a fixing
+is between the strike and the EKI level
+Pivots, where different strikes apply for different ranges of the
+fixing
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+=OptionData= holds =LongShort= and =PayoffType=. =PayoffType= takes
+the values =TargetFull=, =TargetExact= or =TargetTruncated=,
+matching the three payment types above. =ScheduleData= holds the
+fixing dates. =SettlementLag=, =SettlementCalendar= and
+=SettlementConvention= derive the settlement dates from them.
+
+Strikes can be global or local. The =Strike= node gives a strike
+that is constant over time. The =Strikes= node gives time-varying
+strikes, either with a =startDate= attribute from which each strike
+is valid, or mapped to the fixing dates in order. A global strike is
+overwritten by a local strike in a range bound, or modified by a
+range strike adjustment. Without any strike for a range, an error is
+thrown. =RangeBounds= defines the ranges with =RangeFrom= and
+=RangeTo=, and each range carries a =Leverage= and a local =Strike=
+or =StrikeAdjustment=. A range without =RangeFrom= is unbounded
+towards minus infinity; a range without =RangeTo= is unbounded
+towards plus infinity. When the fixing falls outside every range, no
+payout occurs. =RangeBoundSet= is the time-varying form of the same
+information.
+
+=Barriers= carries the cap of the trade. =CumulatedProfitCap=
+terminates the trade when the profit from the long side's view
+reaches the cap, quoted in the domestic currency for FX.
+=CumulatedProfitCapPoints= measures the same profit as an amount
+divided by the fixing amount and by the absolute leverage.
+=FixingCap= terminates the trade when the number of profitable
+fixings reaches the cap; it makes the trade digital.
+=CumulatedProfitCapPoints= cannot combine with the other barrier
+types.
+
+ORE also provides a scripted representation with the =TaRFData= node
+under the trade type =ScriptedTrade=:
+
+#+begin_quote
+This representation does not allow for time varying strikes or range
+bounds and also not for a target amount / cumulated profit cap
+specification in points.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=.
+
+In the scripted node the ranges are given as parallel lists:
+=RangeUpperBounds=, =RangeLowerBounds=, =RangeLeverages= and
+=RangeStrikes=. A range without an upper bound takes the sentinel
+value 100000; a range without a lower bound takes 0. A positive
+leverage makes a bullish TaRF, a negative leverage a bearish one.
+=KnockOutProfitAmount= caps the accumulated profit,
+=KnockOutProfitEvents= caps the profitable fixing days, and
+=TargetType= selects the payment type: minus 1 for truncated, 0 for
+exact, 1 for full. A digital knock-out requires the full type.
+
+** Mathematical notes
+
+ORE states the payout formula for each fixing date of a TaRF, for a
+long position, as the range-bound leverage times the fixing amount
+times the fixing minus the global or local strike. The fixing only
+pays when it falls inside a defined range. Profits accumulate from
+zero: each positive payout adds to the accumulated profit and to the
+count of profitable days. The cap conditions fire when the
+accumulated profit reaches the cap amount, or the count reaches the
+cap number. Under the exact payment type the last payout is adjusted
+so the accumulated profit matches the target. The current notional
+of the scripted trade is the fixing amount times the first range
+strike.
+
+** What moves its value (static sensitivities)
+
+- The underlying price. Each fixing decides the payout size and
+  whether the fixing is profitable.
+- The volatility of the underlying. It drives how fast the profit
+  accumulates toward the cap.
+- The strikes, the range boundaries and the range leverages.
+- The cap level and the target amount.
+- The interest rates that discount the payments.
+
+The per-fixing payout is linear in the fixing. The cap adds a binary
+termination: the trade value concentrates on the path that reaches
+the target.
+
+** How the profile ages (dynamic sensitivities)
+
+Each fixing date settles its forward while the trade is alive.
+Profitable fixings accumulate toward the cap. In the continuous
+form the trade terminates on the fixing that first takes the
+accumulated profit to the cap; the exact payment type tops the last
+payout up to the target. In the digital form the count of profitable
+days decides the termination. Without a cap event the strip runs to
+its last fixing date and then settles.
+
+** Why a customer would want it
+
+A target redemption forward sells a strip of forwards at an
+attractive rate in exchange for capping the upside. Corporate
+treasuries use it to hedge or convert currency at better-than-market
+levels; the cap is the price of the improvement. In ORE Studio a
+customer books target redemption forwards to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long FX TaRF on EUR-USD with exact payment.
+It buys one million euros at 1.1 per fixing, with double leverage
+below 1.05, and a cumulated profit cap of 100000:
+
+#+begin_example
+<Trade id="FX_TARF">
+  <TradeType>FxTaRF</TradeType>
+  <Envelope/>
+  <FxTaRFData>
+    <Currency>USD</Currency>
+    <FixingAmount>1000000</FixingAmount>
+    <TargetAmount>100000</TargetAmount>
+    <Strike>1.1</Strike>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-EUR-USD</Name>
+    </Underlying>
+    <ScheduleData>
+      <Dates>
+        <Dates>
+          <Date>2017-03-01</Date>
+          <Date>2020-03-01</Date>
+          <Date>2025-03-01</Date>
+          <Date>2029-03-01</Date>
+        </Dates>
+      </Dates>
+    </ScheduleData>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <PayoffType>TargetExact</PayoffType>
+    </OptionData>
+    <RangeBounds>
+      <RangeBound>
+        <RangeTo>1.05</RangeTo>
+        <Leverage>2</Leverage>
+      </RangeBound>
+      <RangeBound>
+        <RangeFrom>1.1</RangeFrom>
+        <Leverage>1</Leverage>
+      </RangeBound>
+    </RangeBounds>
+    <Barriers>
+      <BarrierData>
+        <Type>CumulatedProfitCap</Type>
+        <Levels>
+          <Level>100000</Level>
+        </Levels>
+      </BarrierData>
+    </Barriers>
+  </FxTaRFData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/tarf.tex=,
+listing =FxTaRF data=. The catalogue also shows an equity TaRF with a
+=FixingCap= of three profitable fixings, a two-times leverage above
+3300 and a strike adjustment of 100.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/tarf.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/totalreturnswap.org
+++ b/doc/knowledge/domain/totalreturnswap.org
@@ -1,0 +1,280 @@
+:PROPERTIES:
+:ID: 5368EC07-71E8-4906-B897-AA41A57CE0FA
+:END:
+#+title: Total Return Swap
+#+description: A swap paying the total return of an asset against a funding leg; ORE's generic TRS product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:totalreturnswap:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A total return swap transfers the total return of an asset, its price
+move plus its income, to a counterparty in exchange for a funding
+payment. ORE prices the generic form with an accrual method. The same
+product is also known as a contract for difference. This note records
+the domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+The generic total return swap swaps the performance of an underlying
+asset against one or more funding legs. The underlying can be a
+single bond, equity, commodity or option, or a basket of positions,
+or an arbitrary derivative. The return leg pays the price movement of
+the underlying over each period, plus its cashflows. The funding legs
+pay interest on a notional that follows the underlying price. ORE
+also supports CFDs: total return swaps without funding, usually
+captured with two dates in the return schedule.
+
+* Detail
+
+** What it is
+
+ORE introduces the product as follows:
+
+#+begin_quote
+Generic TRS can be used to represent total return swaps on a wide
+range of underlying assets including e.g. single bonds or equities,
+CFDs on an underlying basket of EquityPositions, proprietary indices
+on equity options and equity or bond indices.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+
+The trade types =TotalReturnSwap= and =ContractForDifference= behave
+exactly the same. The difference is commercial. ORE describes the CFD
+form as follows:
+
+#+begin_quote
+Usually CFDs are traded without a funding component and captured with
+only two dates in the return schedule, namely the start date on which
+the initial price is fixed and a fictitious closing date usually set
+to "tomorrow" or another suitable future date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+
+** In plain terms
+
+A total return swap is a way to own an asset without buying it. The
+asset owner pays the price gains of the asset to the swap buyer, plus
+any income the asset produces. In return the swap buyer pays a
+funding rate on the asset value. The swap buyer gets the economic
+exposure. The asset owner keeps the legal ownership and its
+financing. A CFD is the same idea without the funding leg, used for
+short-term bets on the price.
+
+** How it works in ORE
+
+ORE prices the product with an accrual method, not with a full
+discounting method:
+
+#+begin_quote
+The accrual method is common practice when daily unwind rights are
+present in the trade terms or when the underlying valuation is too
+complex to allow for future projection.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+
+The =TotalReturnSwapData= node is made of four sub-blocks.
+
+=UnderlyingData= holds one or more =Trade= subnodes that describe the
+asset position. Each trade is a full trade of a supported type, such
+as =Bond=, =BondFuture=, =ForwardBond=, =CBO=, =CommodityPosition=,
+=ConvertibleBond=, =CallableBond=, =EquityPosition=,
+=EquityOptionPosition=, =BondPosition= or =CashPosition=. For a
+convertible bond or callable bond, a TRS on the plain bond type is
+enough: the pricer chooses the underlying from the reference data of
+the security id. A =Derivative= subnode holds an arbitrary derivative
+trade with an id, which supports portfolio swaps over several
+underlying derivatives. A =PortfolioIndexTradeData= subnode instead
+references a basket by =BasketName=, with =IndexQuantity= shares of
+the index. ORE notes the independence of the underlying schedule:
+
+#+begin_quote
+Notice that in every case, the UnderlyingData schedule (if applicable
+to the underlying trade type as e.g. for a bond) is completely
+independent from the funding / return schedules: The underlying
+schedule defines the underlying flows to compute its NPV, and is not
+directly related to the return swap itself.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+
+=ReturnData= describes the return leg. =Payer= says whether the leg
+is paid. =Currency= is the currency of the return. When it differs
+from the underlying currency the swap is composite; when it differs
+from the funding currency it is cross currency. Both features can
+occur alone or in combination. The =ScheduleData= node is the
+reference schedule. Valuation dates derive from it with
+=ObservationLag=, =ObservationConvention= and =ObservationCalendar=.
+Payment dates derive from it with =PaymentLag=, =PaymentConvention=
+and =PaymentCalendar=, or come as an explicit =PaymentDates= list of
+one date fewer than the schedule. =InitialPrice= is the underlying
+price on the valuation date of the start date, usually contractual.
+It can be a dirty price for bonds, a weighted price for baskets, an
+absolute amount when several underlyings or a derivative is present,
+or the NPV for a CBO. When omitted it defaults to the price on the
+valuation date of the start date, or to the forward price when that
+date is in the future. =InitialPriceCurrency= says whether the price
+is in the asset, return or funding currency. =FXTerms= is mandatory
+whenever the underlying, return, funding or cashflow currencies
+differ: each differing currency needs an =FXIndex= for the
+conversion. =FXConversion= picks the FX rate used at the start of the
+period, the default, or at its end.
+
+Underlying cashflows flow through the return leg. ORE describes the
+option as follows:
+
+#+begin_quote
+If true, underlying cashflows like coupon or amortisation payments
+from bonds or dividend payments from equities, are paid when they
+occur. If false, these cashflows are paid together with the next
+return payment. If omitted, the default value is false for trade type
+TotalReturnSwap and true for trade type ContractForDifference.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+
+=FundingData= is optional and holds one or more funding =LegData=
+nodes. The allowed leg types are =Fixed=, =Floating=, =CMS=, =CMB=
+and =ZeroCouponFixed=. All funding legs share one payment currency.
+The notional of each funding leg follows a =NotionalType=:
+=PeriodReset= sets it from the underlying price on the last valuation
+date on or before the accrual start date of the coupon, converted at
+the FX rate of the same date; =DailyReset= sets it from the
+underlying price of each day of the accrual period, and supports
+fixed rate legs only; =Fixed= takes the notional given in the leg
+data. Without a =NotionalType=, the leg defaults to =PeriodReset=
+when it carries no notional and to =Fixed= when it does.
+=FundingResetGracePeriod= allows valuation dates a few calendar days
+after the accrual start date to count for the reset.
+=AdditionalCashflowData= is optional: a =Cashflow= leg of unpaid
+amounts in the asset, funding or return currency, included in the
+NPV.
+
+** Mathematical notes
+
+ORE prices the return by accrual. The return over a period is the
+change in value of the underlying position:
+
+(Ntl x today's price x today's Fx rate) - (Ntl x initial price x
+initial Fx rate).
+
+With =FXConversion= =End= the second term converts the initial price
+at today's FX rate instead:
+
+(Ntl x final price x final Fx rate) - (Ntl x initial price x final Fx
+rate).
+
+The funding leg pays its rate on the notional determined by the
+=NotionalType=, as described above. The underlying trade is valued
+with its own engine and its own cashflows.
+
+** What moves its value (static sensitivities)
+
+- The price of the underlying asset. It drives the return leg and the
+  funding notionals.
+- The income of the underlying: coupons and dividends, and the timing
+  of their pass-through.
+- The funding rate of the floating funding leg and its spread.
+- The FX rates, when the return, funding or cashflow currencies
+  differ from the asset currency.
+- The interest rates that discount the flows.
+
+** How the profile ages (dynamic sensitivities)
+
+Each return period settles the price move of the underlying. The
+underlying cashflows pass through on occurrence, or with the next
+return payment, per the flag above. The funding notionals reset per
+period or per day, depending on their type. Because ORE prices by
+accrual, the swap tracks the underlying closely on every valuation
+date, which suits daily unwind rights. A CFD runs from its start date
+to its closing date and then settles.
+
+** Why a customer would want it
+
+A total return swap gives exposure to an asset without owning it.
+Hedge funds use TRSs to lever positions or to short assets they
+cannot borrow. Banks use them to fund long positions. Retail and
+institutional clients use CFDs for leveraged price bets. In ORE
+Studio a customer books TRSs and CFDs to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a generic total return swap on a convertible
+bond, with a daily-reset fixed funding leg, a period-reset floating
+funding leg, and an additional cashflow leg:
+
+#+begin_example
+<TotalReturnSwapData>
+  <UnderlyingData>
+    <Trade>
+      <TradeType>Bond</TradeType>
+      <BondData>
+        <SecurityId>ISIN:XY1000000000</SecurityId>
+        <BondNotional>1000000.00</BondNotional>
+      </BondData>
+    </Trade>
+  </UnderlyingData>
+  <ReturnData>
+    <Payer>false</Payer>
+    <Currency>EUR</Currency>
+    <ScheduleData>...</ScheduleData>
+    <ObservationLag>0D</ObservationLag>
+    <ObservationConvention>P</ObservationConvention>
+    <ObservationCalendar>USD</ObservationCalendar>
+    <PaymentLag>2D</PaymentLag>
+    <PaymentConvention>F</PaymentConvention>
+    <PaymentCalendar>TARGET</PaymentCalendar>
+    <!-- <PaymentDates> -->
+    <!--   <PaymentDate> ... </PaymentDate> -->
+    <!--   <PaymentDate> ... </PaymentDate> -->
+    <!-- </PaymentDates> -->
+    <InitialPrice>1.05</InitialPrice>
+    <InitialPriceCurrency>EUR</InitialPriceCurrency>
+    <FXTerms>
+      <FXIndex>FX-ECB-EUR-USD</FXIndex>
+      <FXIndex>FX-ECB-GBP-USD</FXIndex>
+    </FXTerms>
+    <PayUnderlyingCashFlowsImmediately>false</PayUnderlyingCashFlowsImmediately>
+  </ReturnData>
+  <FundingData>
+    <FundingResetGracePeriod>2</FundingResetGracePeriod>
+    <NotionalType>DailyReset</NotionalType>
+    <LegData>
+      <Payer>true</Payer>
+      <LegType>Fixed</LegType>
+      ...
+    </LegData>
+    <NotionalType>PeriodReset</NotionalType>
+    <LegData>
+      <Payer>true</Payer>
+      <LegType>Floating</LegType>
+      ...
+    </LegData>
+  </FundingData>
+  <AdditionalCashflowData>
+    <LegData>
+      <Payer>false</Payer>
+      <LegType>Cashflow</LegType>
+      ...
+    </LegData>
+  </AdditionalCashflowData>
+</TotalReturnSwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=,
+listing =Generic Total Return Swap with Convertible Bond underlying=.
+The catalogue shows further variants: equity basket, bond basket, bond
+future, commodity index and derivative underlyings, a
+=PortfolioIndexTradeData= underlying, and a CFD on STOXX50E with
+initial price 3399.20.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/totalReturnSwap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/totalreturnswap.org
+++ b/doc/knowledge/domain/totalreturnswap.org
@@ -39,7 +39,7 @@ CFDs on an underlying basket of EquityPositions, proprietary indices
 on equity options and equity or bond indices.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]].
 
 The trade types =TotalReturnSwap= and =ContractForDifference= behave
 exactly the same. The difference is commercial. ORE describes the CFD
@@ -52,7 +52,7 @@ the initial price is fixed and a fictitious closing date usually set
 to "tomorrow" or another suitable future date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]].
 
 ** In plain terms
 
@@ -75,7 +75,7 @@ present in the trade terms or when the underlying valuation is too
 complex to allow for future projection.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]].
 
 The =TotalReturnSwapData= node is made of four sub-blocks.
 
@@ -100,7 +100,7 @@ schedule defines the underlying flows to compute its NPV, and is not
 directly related to the return swap itself.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]].
 
 =ReturnData= describes the return leg. =Payer= says whether the leg
 is paid. =Currency= is the currency of the return. When it differs
@@ -135,7 +135,7 @@ return payment. If omitted, the default value is false for trade type
 TotalReturnSwap and true for trade type ContractForDifference.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]].
 
 =FundingData= is optional and holds one or more funding =LegData=
 nodes. The allowed leg types are =Fixed=, =Floating=, =CMS=, =CMB=
@@ -266,7 +266,7 @@ funding leg, and an additional cashflow leg:
 </TotalReturnSwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/totalReturnSwap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]],
 listing =Generic Total Return Swap with Convertible Bond underlying=.
 The catalogue shows further variants: equity basket, bond basket, bond
 future, commodity index and derivative underlyings, a
@@ -278,6 +278,6 @@ initial price 3399.20.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/totalReturnSwap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/totalReturnSwap.tex][totalReturnSwap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/totalreturnswap.org
+++ b/doc/knowledge/domain/totalreturnswap.org
@@ -275,6 +275,9 @@ initial price 3399.20.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/totalReturnSwap.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/var_and_vol_derivatives.org
+++ b/doc/knowledge/domain/var_and_vol_derivatives.org
@@ -41,7 +41,7 @@ knock-in/knock-out barrier/s, conditions for the accrual of variance,
 basket underlyings, optionality on the payoff, etc.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 ORE states the input representation:
 
@@ -51,13 +51,13 @@ scripted trades, refer to the scripted trade documentation in
 ore/Docs/ScriptedTrade for an introduction.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 #+begin_quote
 All swaps have an optional cap/floor feature.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 ** In plain terms
 
@@ -113,7 +113,7 @@ option is:
 An option on the realised variance/volatility of an underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 Its node adds =PutCall=, =PremiumAmount= and =PremiumDate=,
 =VarianceReference= and the =ValuationSchedule=. The option carries a
@@ -127,7 +127,7 @@ A capped and/or floored variance swap with a knock-in/knock-out
 feature.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 ORE notes a reuse of the trade type:
 
@@ -137,7 +137,7 @@ variance swaps without barrier, by setting the BarrierType to UpIn
 and BarrierLevel to zero.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The dual European binary pairs a volatility knock-out with a spot
 knock-out. Its node carries a fixed =SettlementAmount=, a
@@ -152,7 +152,7 @@ when the underlying trades within a pre-specified window defined by
 an upper and lower bound.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 Its node adds =UpperBarrierLevel= and =LowerBarrierLevel=, a
 =CountBothObservations= flag and an =AccrualAdjustment=. The
@@ -165,7 +165,7 @@ variance of one equity index (the Underlying) for the days another
 equity index (the CorridorIndex) is within a corridor.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The conditional variance swaps accrue variance in a single-barrier
 window. ORE describes the 01 variant:
@@ -177,7 +177,7 @@ a specified single barrier window - (differing from the
 CorridorVarianceSwap that has a double barrier window.)
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 In the 01 variant the variance amount that scales the notional comes
 directly from the =Strike= parameter. The node supports caps, floors,
@@ -193,7 +193,7 @@ notional amount, distinct from the Strike parameter used in the
 payoff calculation.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The pairwise variance swap is:
 
@@ -202,7 +202,7 @@ A capped and/or floored variance swap on a basket of two underlyings,
 with an optional lag in the variance accrual.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 Its node carries one underlying strike and notional per underlying
 plus a basket notional and basket strike, and a lagged valuation
@@ -215,7 +215,7 @@ A capped and/or floored variance swap that pays on the difference in
 the realised volatilities between two baskets of underlyings.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The corridor dispersion form restricts the accrual to a corridor, and
 the knock-out form adds a double-barrier knock-out:
@@ -225,7 +225,7 @@ This instrument is a variance dispersion swap with a double-barrier
 knock-out and a corridor feature.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The pairwise geometric form is documented by its node alone, with two
 baskets, per-pair and basket strikes, basket and variance weights, a
@@ -237,7 +237,7 @@ The gamma swap is:
 A vanilla variance swap with a weight function on the underlying.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 The basket variance swap is:
 
@@ -245,7 +245,7 @@ The basket variance swap is:
 A capped and/or floored variance swap on a basket of underlyings.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]].
 
 Its trade types are =FxBasketVarianceSwap=, =EquityBasketVarianceSwap=
 and =CommodityBasketVarianceSwap=, with a weight per underlying in the
@@ -365,7 +365,7 @@ The premium is zero and the premium date equals the first valuation
 date. ORE prices the trade with the =VarianceOption= script, shown in
 full in the catalogue.
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]],
 the example variance option trade in the section =Variance Option=.
 
 * See also
@@ -373,8 +373,8 @@ the example variance option trade in the section =Variance Option=.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
   which inputs
-  =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=. The
+  [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/var_and_vol_derivatives.tex][var_and_vol_derivatives.tex]]. The
   upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/var_and_vol_derivatives.org
+++ b/doc/knowledge/domain/var_and_vol_derivatives.org
@@ -370,6 +370,9 @@ the example variance option trade in the section =Variance Option=.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs
   =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=. The

--- a/doc/knowledge/domain/var_and_vol_derivatives.org
+++ b/doc/knowledge/domain/var_and_vol_derivatives.org
@@ -1,0 +1,377 @@
+:PROPERTIES:
+:ID: D3DF8CDD-2BD9-44BC-B805-D06C8A6C2074
+:END:
+#+title: Exotic Variance and Volatility Derivatives
+#+description: Variance and volatility swaps and options with barriers, corridors, baskets and optionality; ORE's exotic variance product family.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:var_and_vol_derivatives:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+Exotic variance and volatility derivatives are variance or volatility
+swaps and options with extra payoff features on top of the vanilla
+form. ORE documents the family in one catalogue section with fifteen
+variations, each with its own payoff script. This note records the
+domain grounding, as ORE documents it in its product catalogue.
+
+* Summary
+
+The family starts from the variance swap, which pays the realised
+variance of an underlying against a strike, and the variance option,
+which pays the positive difference. The variations add features: a
+knock-in or knock-out barrier, a corridor that restricts the variance
+accrual to a window of the underlying, a corridor defined by a second
+index, conditional accrual in a single-barrier window, a pair of
+underlyings, two baskets in the dispersion forms, a weight function,
+and caps and floors throughout. ORE represents every variation as a
+scripted trade, and documents the trade input and the payoff script
+for each one.
+
+* Detail
+
+** What it is
+
+ORE defines the family as follows:
+
+#+begin_quote
+These are vanilla variance/volatility swaps and options on an
+underlying with some additional payoff features, such as
+knock-in/knock-out barrier/s, conditions for the accrual of variance,
+basket underlyings, optionality on the payoff, etc.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+ORE states the input representation:
+
+#+begin_quote
+Exotic variance/volatility swaps and options are represented as
+scripted trades, refer to the scripted trade documentation in
+ore/Docs/ScriptedTrade for an introduction.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+#+begin_quote
+All swaps have an optional cap/floor feature.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+** In plain terms
+
+A variance swap is a bet on how much a market moves. The buyer pays a
+fixed strike and receives the realised variance of the market. The
+exotic family dresses that bet up. A barrier can switch the swap on
+or off. A corridor can make the bet count only on the days the market
+sits inside a window. The window can depend on another market. The
+variance can accrue only under one-sided conditions, or on a pair of
+markets, or on whole baskets. One form weighs the variance by the
+level of the market. Every variation can cap or floor the payout.
+
+** How it works in ORE
+
+The variations of the family, with the script each one prices, are:
+
+- Variance Option, script =VarianceOption=.
+- Variance Swap with KI/KO Barrier, script =KIKOVarianceSwap=.
+- Dual European Binary Option with Volatility and Spot KO Barrier,
+  script =DualEuroBinaryOptionDoubleKO=.
+- Corridor Variance Swap, script =CorridorVarianceSwap=.
+- Indexed Corridor Variance Swap, script =IndexedCorridorVarianceSwap=.
+- Corridor Variance Swap with KI/KO Barrier, script
+  =KIKOCorridorVarianceSwap=.
+- Conditional Variance Swap 01, script =ConditionalVarianceSwap01=.
+- Conditional Variance Swap 02, script =ConditionalVarianceSwap02=.
+- Pairwise Variance Swap, script =PairwiseVarianceSwap=.
+- Variance Dispersion Swap, script =VarianceDispersionSwap=.
+- Corridor Variance Dispersion Swap, script
+  =CorridorVarianceDispersionSwap=.
+- KO Corridor Variance Dispersion Swap, script
+  =KOCorridorVarianceDispersionSwap=.
+- Pairwise Geometric Variance Dispersion Swap, script
+  =PairwiseGeometricVarianceDispersionSwap=.
+- Gamma Swap, script =GammaSwap=.
+- Basket Variance Swap, script =BasketVarianceSwap=.
+
+The trade data nodes live under the =ScriptedTrade= trade type and
+carry typed fields. The common input pattern is the variance swap
+core: =LongShort=, =Strike=, =Notional=, =Underlying=, the daily
+=ValuationSchedule= that defines the variance observation period, a
+=SquaredPayoff= flag that selects variance or volatility, =Cap= and
+=Floor=, =SettlementDate= and =PayCcy=. The =PayCcy= payment
+currency: for FX, the underlying name has the form
+=FX-SOURCE-CCY1-CCY2= and =PayCcy= should be =CCY2=. Choosing =CCY1=,
+or the underlying currency for equity and commodity underlyings,
+produces a quanto payoff.
+
+ORE describes the individual variations as follows. The variance
+option is:
+
+#+begin_quote
+An option on the realised variance/volatility of an underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+Its node adds =PutCall=, =PremiumAmount= and =PremiumDate=,
+=VarianceReference= and the =ValuationSchedule=. The option carries a
+call or put on the realised variance or volatility against the
+strike, with the premium paid on the premium date.
+
+The variance swap with a barrier is:
+
+#+begin_quote
+A capped and/or floored variance swap with a knock-in/knock-out
+feature.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+ORE notes a reuse of the trade type:
+
+#+begin_quote
+Note that this trade type is also used for regular capped/floored
+variance swaps without barrier, by setting the BarrierType to UpIn
+and BarrierLevel to zero.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The dual European binary pairs a volatility knock-out with a spot
+knock-out. Its node carries a fixed =SettlementAmount=, a
+=SpotBarrierLevel=, a =VolBarrierLevel= with a =VolBarrierDate=, and
+a terminal-only flag.
+
+The corridor variance swap is:
+
+#+begin_quote
+A capped and/or floored variance swap where variance is accrued only
+when the underlying trades within a pre-specified window defined by
+an upper and lower bound.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+Its node adds =UpperBarrierLevel= and =LowerBarrierLevel=, a
+=CountBothObservations= flag and an =AccrualAdjustment=. The
+corridor with a barrier adds a knock-in or knock-out type and level
+of its own. The indexed corridor moves the window to a second index:
+
+#+begin_quote
+Also called Cross Corridor Variance Swap. The payoff depends on the
+variance of one equity index (the Underlying) for the days another
+equity index (the CorridorIndex) is within a corridor.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The conditional variance swaps accrue variance in a single-barrier
+window. ORE describes the 01 variant:
+
+#+begin_quote
+ConditionalVarianceSwap01 is a type of conditional variance swap that
+accrues variance contributions only when the underlying trades within
+a specified single barrier window - (differing from the
+CorridorVarianceSwap that has a double barrier window.)
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+In the 01 variant the variance amount that scales the notional comes
+directly from the =Strike= parameter. The node supports caps, floors,
+accrual adjustments and the count-both-observations choice. ORE
+describes the 02 variant:
+
+#+begin_quote
+ConditionalVarianceSwap02 accrues variance only when the underlying
+trades within the single barrier window, but differs from the 01
+variant by including an additional VarianceReference parameter. This
+parameter acts as a separate variance strike used to scale the
+notional amount, distinct from the Strike parameter used in the
+payoff calculation.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The pairwise variance swap is:
+
+#+begin_quote
+A capped and/or floored variance swap on a basket of two underlyings,
+with an optional lag in the variance accrual.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+Its node carries one underlying strike and notional per underlying
+plus a basket notional and basket strike, and a lagged valuation
+schedule with an accrual lag and a payoff limit.
+
+The variance dispersion swap is:
+
+#+begin_quote
+A capped and/or floored variance swap that pays on the difference in
+the realised volatilities between two baskets of underlyings.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The corridor dispersion form restricts the accrual to a corridor, and
+the knock-out form adds a double-barrier knock-out:
+
+#+begin_quote
+This instrument is a variance dispersion swap with a double-barrier
+knock-out and a corridor feature.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The pairwise geometric form is documented by its node alone, with two
+baskets, per-pair and basket strikes, basket and variance weights, a
+lag, a cap multiplier, a cap and a floor.
+
+The gamma swap is:
+
+#+begin_quote
+A vanilla variance swap with a weight function on the underlying.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+The basket variance swap is:
+
+#+begin_quote
+A capped and/or floored variance swap on a basket of underlyings.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=.
+
+Its trade types are =FxBasketVarianceSwap=, =EquityBasketVarianceSwap=
+and =CommodityBasketVarianceSwap=, with a weight per underlying in the
+basket.
+
+** Mathematical notes
+
+ORE computes the realised variance from the daily underlying prices
+on the valuation schedule. The daily log return is the natural log of
+the ratio of one price to the previous price. The realised variance
+is the sum of the squared daily log returns, scaled by the number of
+observation days and annualised to 252 days per year. The realised
+volatility is the square root of the realised variance.
+
+The variance option converts the vega notionals. The notional of the
+trade is the vega notional. ORE derives the variance notional from
+the vega notional and the variance reference: with the squared-payoff
+flag set, the payout is the converted notional times the positive
+difference between the realised variance and the squared strike, in
+the call or put direction. With the flag clear, the payout is the
+vega notional times the positive difference between the realised
+volatility and the strike. The strike is quoted as an absolute
+volatility level in decimal form, so a 20 percent volatility strike
+is 0.20. When the option was struck in variance terms, the square
+root of the variance is entered as the strike. The variance reference
+converts between the two notions, so the variance amount used to
+scale the notional can differ from the strike that determines the
+payoff.
+
+The corridor forms accrue only the observations inside the window,
+between the upper and the lower barrier level. The conditional forms
+accrue only inside a single-barrier window. The indexed corridor
+accrues the variance of one index only on the days a second index
+sits in its corridor. The count-both-observations choice and the
+accrual adjustment tune the accrual. The dispersion forms pay on the
+volatility difference between two baskets. Caps and floors bound the
+payouts, and the barrier forms condition them on their knock events.
+
+** What moves its value (static sensitivities)
+
+- The realised path of the underlying, or of each basket member. It
+  drives the realised variance.
+- The implied volatility of the underlying, which sets the expected
+  variance and the option value.
+- The strike, the variance reference and the notional.
+- The corridor levels and the accrual conditions.
+- The barrier types and levels of the barrier forms.
+- The correlation between the basket members and between the baskets,
+  in the dispersion and basket forms.
+- The caps and floors.
+- The interest rates that discount the payouts.
+
+** How the profile ages (dynamic sensitivities)
+
+Each date of the valuation schedule adds a daily return to the
+realised variance, subject to the accrual conditions of the
+variation. Barrier forms watch for their knock events over the
+observation period. The corridor forms accrue only inside their
+windows. The averaging of the variance ends with the schedule, and
+the strike comparison, the cap or floor, and the settlement follow on
+the settlement date.
+
+** Why a customer would want it
+
+A variance or volatility swap trades the size of market moves
+directly, without a view on direction. The exotic forms refine that
+exposure: corridors and conditions shape when the variance counts,
+barriers switch the trade on or off, and the dispersion forms trade
+the spread between baskets. In ORE Studio a customer books exotic
+variance and volatility derivatives to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long call on the realised variance of the
+S&P 500. The trade has a vega notional of 138000 USD, a strike of
+0.19 and a variance reference of 0.19, and observes the index daily
+from 2020-11-26 to 2021-09-18:
+
+#+begin_example
+<Trade id="EQ_VarianceOption">
+  <TradeType>ScriptedTrade</TradeType>
+  <Envelope>
+    .....
+  </Envelope>
+  <VarianceOptionData>
+    <LongShort type="longShort">Long</LongShort>
+    <PutCall type="optionType">Call</PutCall>
+    <PremiumAmount type="number">0</PremiumAmount>
+    <PremiumDate type="event">2020-11-26</PremiumDate>
+    <Notional type="number">138000</Notional>
+    <VarianceReference type="number">0.19</VarianceReference>
+    <Strike type="number">0.19</Strike>
+    <Underlying type="index">EQ-RIC:.SPX</Underlying>
+    <ValuationSchedule type="event">
+      <ScheduleData>
+        <Rules>
+          <StartDate>2020-11-26</StartDate>
+          <EndDate>2021-09-18</EndDate>
+          <Tenor>1D</Tenor>
+          <Convention>Following</Convention>
+          <TermConvention>Following</TermConvention>
+          <Calendar>USA</Calendar>
+          <Rule>Forward</Rule>
+        </Rules>
+      </ScheduleData>
+    </ValuationSchedule>
+    <SquaredPayoff type="bool">true</SquaredPayoff>
+    <SettlementDate type="event">2021-09-22</SettlementDate>
+    <PayCcy type="currency">USD</PayCcy>
+  </VarianceOptionData>
+</Trade>
+#+end_example
+
+The squared-payoff flag is true, so the trade is a variance option.
+The premium is zero and the premium date equals the first valuation
+date. ORE prices the trade with the =VarianceOption= script, shown in
+full in the catalogue.
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=,
+the example variance option trade in the section =Variance Option=.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs
+  =Docs/UserGuide/tradedata/var_and_vol_derivatives.tex=. The
+  upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/window_barrieroption.org
+++ b/doc/knowledge/domain/window_barrieroption.org
@@ -37,7 +37,7 @@ American Knock-In or Knock-Out barrier condition can be defined that
 are monitored continuously between a start and end date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
 
 ORE lists the barrier types:
 
@@ -46,7 +46,7 @@ The different barrier types are "UpAndIn", "UpAndOut", "DownAndIn",
 "DownAndOut".
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
 
 ** In plain terms
 
@@ -76,7 +76,7 @@ FixingAmount is expressed as number of units of the underlying
 commodity.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
 
 =Underlying= names the underlying of the instrument. For an FX
 underlying the name has the form =SOURCE-CCY1-CCY2=, with =CCY1= the
@@ -98,7 +98,7 @@ The barrier is continuously monitored between the StartDate and
 EndDate.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
 
 The barrier types are =UpAndOut=, =DownAndOut=, =UpAndIn= and
 =DownAndIn=, with exactly one level given as a positive real number.
@@ -110,7 +110,7 @@ Window Barrier Options can be alternatively represented as scripted
 trades, refer to ore/Docs/ScriptedTrade for an introduction.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
 
 In the scripted form the trade type is =ScriptedTrade= and the data
 node is =WindowBarrierOptionData=. The node carries the same terms as
@@ -210,7 +210,7 @@ and expiring in 2026:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]],
 the example FX window barrier option trade. The catalogue shows the
 same trade again as a scripted trade with the =WindowBarrierOptionData=
 node, and lists the payoff script that prices it.
@@ -220,7 +220,7 @@ node, and lists the payoff script that prices it.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/window_barrieroption.tex][window_barrieroption.tex]].
   The upstream project is
   [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/window_barrieroption.org
+++ b/doc/knowledge/domain/window_barrieroption.org
@@ -217,6 +217,9 @@ node, and lists the payoff script that prices it.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/window_barrieroption.tex=.
   The upstream project is

--- a/doc/knowledge/domain/window_barrieroption.org
+++ b/doc/knowledge/domain/window_barrieroption.org
@@ -1,0 +1,223 @@
+:PROPERTIES:
+:ID: 59A56773-6E82-421A-8E64-AA54D46489D4
+:END:
+#+title: Window Barrier Option
+#+description: An option with a barrier active only inside a time window; ORE's Window Barrier Option product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:window_barrieroption:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A window barrier option is a vanilla European call or put with an
+American barrier that is monitored only between a start date and an
+end date. ORE prices it on FX, equity and commodity underlyings. This
+note records the domain grounding, as ORE documents it in its product
+catalogue.
+
+* Summary
+
+The product pays the payoff of a European vanilla call or put. A
+knock-in or knock-out barrier condition is monitored continuously
+between a start date and an end date, the observation window. Four
+barrier types exist: up-and-in, up-and-out, down-and-in and
+down-and-out. The window can end long before the exercise date. A
+scripted representation expresses the same product with trigger
+probabilities over the window.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+Window Barrier Options pay a (European) vanilla call / put. An
+American Knock-In or Knock-Out barrier condition can be defined that
+are monitored continuously between a start and end date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+
+ORE lists the barrier types:
+
+#+begin_quote
+The different barrier types are "UpAndIn", "UpAndOut", "DownAndIn",
+"DownAndOut".
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+
+** In plain terms
+
+A window barrier option is a normal European option with a timed
+barrier. The barrier is not watched for the whole life of the trade.
+It is watched only inside a window, between a start date and an end
+date. If the underlying touches the barrier level inside that window,
+the option knocks in or out. After the window closes, the barrier
+can no longer fire. The vanilla payoff is decided at expiry, much
+later in the typical structure.
+
+** How it works in ORE
+
+The trade containers are =FxWindowBarrierOptionData=,
+=EquityWindowBarrierOptionData= and =CommodityWindowBarrierOptionData=,
+for the =FxWindowBarrierOption=, =EquityWindowBarrierOption= and
+=CommodityWindowBarrierOption= trade types. =Currency= is the payout
+currency. ORE describes the fixing amount per asset class as
+follows:
+
+#+begin_quote
+For FxWindowBarrierOptions: The FixingAmount is expressed in the
+foreign currency (CCY1). For EquityWindowBarrierOptions: The
+FixingAmount is expressed as number of shares/units of the underlying
+equity or equity index. For CommodityWindowBarrierOptions: The
+FixingAmount is expressed as number of units of the underlying
+commodity.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+
+=Underlying= names the underlying of the instrument. For an FX
+underlying the name has the form =SOURCE-CCY1-CCY2=, with =CCY1= the
+foreign currency and =CCY2= the domestic currency. =Strike= is the
+strike: for FX, the amount in domestic currency per unit of foreign
+currency. =StrikeData= is an optional node for the equity form only;
+it holds the strike in =Value= together with the =Currency= in which
+the underlying and the strike are quoted.
+
+=StartDate= and =EndDate= bound the continuous observation window.
+=OptionData= carries the option terms: =LongShort=, =OptionType=,
+the single =ExerciseDate=, an optional =Premiums= node, and an
+optional =PaymentData= node with the pay date of the exercise.
+=BarrierData= specifies the barrier type and level. ORE describes
+the monitoring:
+
+#+begin_quote
+The barrier is continuously monitored between the StartDate and
+EndDate.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+
+The barrier types are =UpAndOut=, =DownAndOut=, =UpAndIn= and
+=DownAndIn=, with exactly one level given as a positive real number.
+
+ORE also provides a scripted representation:
+
+#+begin_quote
+Window Barrier Options can be alternatively represented as scripted
+trades, refer to ore/Docs/ScriptedTrade for an introduction.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+
+In the scripted form the trade type is =ScriptedTrade= and the data
+node is =WindowBarrierOptionData=. The node carries the same terms as
+typed event, number, option-type, barrier-type, long-short, index and
+currency fields, with =Quantity= as the number of option contracts.
+
+** Mathematical notes
+
+The payoff script expresses the pricing. The raw payoff is the
+quantity times the call-put sign times the underlying at expiry minus
+the strike. A trigger probability is computed over the window: the
+probability that the underlying is below the barrier level for some
+barrier types, and above it for the others. For the knock-in types
+the payoff is scaled by the trigger probability; for the knock-out
+types it is scaled by one minus the trigger probability. The option
+is the long-short signed difference between the discounted scaled
+payoff and the discounted premium. The current notional of the trade
+is the quantity times the strike.
+
+** What moves its value (static sensitivities)
+
+- The underlying spot at expiry. It drives the vanilla payoff.
+- The volatility of the underlying, over both the window and the
+  remaining life.
+- The barrier level, and the length and placement of the window
+  relative to the expiry date.
+- The strike.
+- The interest rates that discount the payoff and the premium.
+
+** How the profile ages (dynamic sensitivities)
+
+The barrier lives only inside the window. Before the start date, and
+after the end date, the barrier is dormant. Inside the window the
+trade behaves like an American-barrier option. A knock-out inside the
+window kills the payoff; a knock-in inside the window grants it.
+After the window the trade becomes a plain European option until the
+exercise date, where the vanilla payoff is decided and settled.
+
+** Why a customer would want it
+
+A window barrier option prices a barrier view with a time limit. The
+buyer is protected from barrier events outside the window, which
+makes the structure cheaper than a whole-life barrier for the seller,
+or safer for the buyer. The structure suits views that say a market
+will, or will not, reach a level within a specific period. In ORE
+Studio a customer books window barrier options to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a long FX window barrier call on EUR-USD with a
+1.1 strike and an up-and-out barrier at 1.3, monitored during 2023
+and expiring in 2026:
+
+#+begin_example
+<Trade id="FX_Window_BarrierOption">
+  <TradeType>FxWindowBarrierOption</TradeType>
+  <Envelope>
+   ...
+  </Envelope>
+  <FxWindowBarrierOptionData>
+    <Currency>USD</Currency>
+    <FixingAmount>1000000</FixingAmount>
+    <Underlying>
+      <Type>FX</Type>
+      <Name>ECB-EUR-USD</Name>
+    </Underlying>
+    <Strike>1.1</Strike>
+    <StartDate>2023-03-01</StartDate>
+    <EndDate>2024-03-01</EndDate>
+    <OptionData>
+      <LongShort>Long</LongShort>
+      <OptionType>Call</OptionType>
+      <ExerciseDates>
+        <ExerciseDate>2026-03-01</ExerciseDate>
+      </ExerciseDates>
+      <Premiums>
+        <Premium>
+          <Amount>10900</Amount>
+          <Currency>EUR</Currency>
+          <PayDate>2018-03-01</PayDate>
+        </Premium>
+      </Premiums>
+      <PaymentData>
+        <Dates>
+          <Date>2026-03-01</Date>
+        </Dates>
+      </PaymentData>
+    </OptionData>
+    <BarrierData>
+      <Type>UpAndOut</Type>
+      <Levels>
+        <Level>1.3</Level>
+      </Levels>
+    </BarrierData>
+  </FxWindowBarrierOptionData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/window_barrieroption.tex=,
+the example FX window barrier option trade. The catalogue shows the
+same trade again as a scripted trade with the =WindowBarrierOptionData=
+node, and lists the payoff script that prices it.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/window_barrieroption.tex=.
+  The upstream project is
+  [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/worstofbasketswap.org
+++ b/doc/knowledge/domain/worstofbasketswap.org
@@ -266,6 +266,9 @@ explicitly: =EQ-RIC:.STOXX50E= and =EQ-RIC:.SPX= with initial prices
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
   which inputs =Docs/UserGuide/tradedata/worstofbasketswap.tex=. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/worstofbasketswap.org
+++ b/doc/knowledge/domain/worstofbasketswap.org
@@ -38,7 +38,7 @@ receives coupons based on an equity notional amount, subject to a
 coupon trigger event.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]].
 
 ORE describes the life of the contract as follows:
 
@@ -52,7 +52,7 @@ final determination date, then a final equity amount will be
 delivered to the buyer.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]].
 
 ** In plain terms
 
@@ -101,7 +101,7 @@ determine whether a coupon trigger event has occurred, upon which a
 fixed coupon is paid out at the corresponding payment date.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]].
 
 Coupons can accumulate. In the traditional data, a coupon not paid
 because its trigger did not fire is paid together with the next
@@ -155,7 +155,7 @@ price at the determination date is paid, although the settlement
 type does not affect pricing.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]].
 
 ** What moves its value (static sensitivities)
 
@@ -258,7 +258,7 @@ stands at 75% of the initial prices:
 </Trade>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]],
 listing =EquityWorstOfBasketSwap data=. The catalogue also shows the
 scripted representation, in which the basket names the two assets
 explicitly: =EQ-RIC:.STOXX50E= and =EQ-RIC:.SPX= with initial prices
@@ -269,6 +269,6 @@ explicitly: =EQ-RIC:.STOXX50E= and =EQ-RIC:.SPX= with initial prices
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/worstofbasketswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/worstofbasketswap.tex][worstofbasketswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/worstofbasketswap.org
+++ b/doc/knowledge/domain/worstofbasketswap.org
@@ -1,0 +1,271 @@
+:PROPERTIES:
+:ID: 428BA744-B3D3-486C-A3BF-39E59C6EC11F
+:END:
+#+title: Worst Of Basket Swap
+#+description: A swap whose coupon references the worst performing asset in a basket; ORE's WorstOfBasketSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:worstofbasketswap:
+#+created: 2026-09-07
+#+updated: 2026-09-07
+
+A worst of basket swap pays coupons while the assets in a basket stay
+above trigger levels, and settles an equity amount on the worst
+performing asset at the end. ORE offers it for FX, equity and
+commodity baskets. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+The buyer of a worst of basket swap receives an initial fixed amount
+and then pays a floating rate. In return the buyer receives fixed
+coupons, subject to a coupon trigger event, and a final equity
+amount linked to the worst performing asset in the basket. A
+knock-out event on any determination date ends the contract. A
+knock-in event on the final determination date delivers the final
+equity amount.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+The buyer receives an initial fixed amount from the seller and then
+pays a floating rate over the life of the contract and in turn
+receives coupons based on an equity notional amount, subject to a
+coupon trigger event.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+
+ORE describes the life of the contract as follows:
+
+#+begin_quote
+If a knock-out event occurs for any given determination date, then
+the contract is deemed to have terminated at the corresponding
+settlement date, and all payments will cease thereafter, and no final
+equity amount will be paid out (or shares delivered). If no
+knock-out events are triggered, and a knock-in event occurs at the
+final determination date, then a final equity amount will be
+delivered to the buyer.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+
+** In plain terms
+
+A worst of basket swap is a structured coupon product on a basket of
+assets. The buyer gets an upfront payment, pays a floating rate, and
+collects a high fixed coupon on each date when every asset in the
+basket is above its trigger level. If all assets rise above their
+knock-out levels, the product dies and the payments stop. At the end
+the buyer receives an amount based on the worst performing asset,
+unless that asset fell so far that a knock-in condition fires. The
+worst asset drives the final payout.
+
+** How it works in ORE
+
+The trade types =FxWorstOfBasketSwap=, =EquityWorstOfBasketSwap= and
+=CommodityWorstOfBasketSwap= have the data containers
+=FxWorstOfBasketSwapData=, =EquityWorstOfBasketSwapData= and
+=CommodityWorstOfBasketSwapData=. A scripted representation with the
+=WorstOfBasketSwapData= node is also available. =LongShort= is the
+own party position. =Quantity= is the equity notional amount, or the
+quantity multiplier. =Currency= is the payout currency for all
+cashflows; for FX it is the domestic =CCY2= currency.
+
+The product pays three kinds of flows. The first is the initial
+fixed amount: =InitialFixedRate= times the quantity, paid on
+=InitialFixedPayDate=, which defaults to the first floating pay date.
+
+At each determination date the floating leg pays the quantity times
+the floating rate times the accrual fraction, as long as no
+knock-out occurred before. =FloatingPeriodSchedule= gives the period
+dates and =FloatingPayDates= the payment dates. The floating rate
+fixes on =FloatingFixingSchedule= against =FloatingIndex=, plus the
+=Floatingspread=, and accrues with =FloatingDayCountFraction=. For
+overnight index legs, =FloatingLookback=, =FloatingRateCutoff=,
+=IsAveraged= and =IncludeSpread= tune the fixing mechanics.
+
+The coupon leg pays when a coupon trigger event fires. The trigger is
+checked on each determination date: when every underlying in the
+basket is at or above its =FixedTriggerLevel=, the buyer receives
+=FixedRate= times the quantity. ORE describes the level nodes as
+follows:
+
+#+begin_quote
+For each fixed trigger determination date, the barrier level used to
+determine whether a coupon trigger event has occurred, upon which a
+fixed coupon is paid out at the corresponding payment date.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+
+Coupons can accumulate. In the traditional data, a coupon not paid
+because its trigger did not fire is paid together with the next
+coupon whose trigger fires, unless =AccumulatingFixedCoupons= is
+false. In the scripted data the node is =AccumulatingCoupons=.
+Alternatively =AccruingFixedCoupons= scales the coupon by the
+fraction of days in the period on which the trigger held, using
+=FixedAccrualSchedule=.
+
+The knock-out is checked on =KnockOutDeterminationSchedule= with the
+=KnockOutLevels= barrier nodes. Each =KnockOutLevel= applies to its
+own determination date, except the first date of the schedule. When
+every asset is at or above its level, a knock-out trigger event
+occurs and the contract terminates at the corresponding settlement
+date.
+
+The final equity amount is decided on the last determination date.
+=BermudanKnockIn= selects whether the knock-in is observed on a
+regular basis on =KnockInDeterminationSchedule=, or only on the final
+date. =KnockInLevel= is the barrier, expressed as a percentage of the
+initial prices. The equity amount is paid on =KnockInPayDate=, which
+defaults to the last floating pay date.
+
+** Mathematical notes
+
+ORE states the cashflow amounts, at every settlement date from the
+second on, in terms of the equity notional Q. The floating amount is
+Q times phi times the accrual fraction times the floating rate
+fixing for the previous period. Phi is plus 1 for a long and minus 1
+for a short position. The coupon amount is Q times delta times the
+fixed coupon rate times N. Delta is 1 when a coupon trigger event
+occurs on the determination date, and zero otherwise. N is the number
+of periods until the next coupon trigger event, for accumulating
+coupons; without accumulation N is 1 for the life of the contract.
+
+After a knock-out, all floating and coupon amounts are zero. At the
+final determination date the performance of each asset is its final
+price over its initial price. The worst performance is the minimum
+of these. When the worst performance is below the smaller of the
+strike and the knock-in level, the equity amount pays the quantity
+times the difference between the strike and the worst performance.
+
+ORE notes the settlement mechanics as follows:
+
+#+begin_quote
+In the case of a physical settlement, the seller will deliver a
+number of shares of one of the underlying assets to the buyer at the
+final settlement date for the cost of an agreed strike price. For a
+cash settlement, the net difference between the strike price and the
+price at the determination date is paid, although the settlement
+type does not affect pricing.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=.
+
+** What moves its value (static sensitivities)
+
+- The prices of the basket assets. The worst performer drives the
+  final equity amount.
+- The correlation between the assets. The coupon and knock-out
+  triggers fire only when every asset is above its level, so lower
+  correlation makes both events less likely.
+- The volatility of each asset.
+- The trigger, knock-out and knock-in levels.
+- The floating rate of the floating leg and its spread.
+- The interest rates that discount the flows.
+
+** How the profile ages (dynamic sensitivities)
+
+The initial fixed amount settles at the start. On each determination
+date the floating leg pays while the contract is alive, and the
+coupon trigger is checked across all assets. Unpaid coupons
+accumulate until a trigger fires, or scale by the accrual fraction
+in the accruing variant. A knock-out on any determination date
+terminates the contract at the corresponding settlement date. On the
+final date the worst performing asset is measured against the
+knock-in level to settle the equity amount.
+
+** Why a customer would want it
+
+A worst of basket swap pays an enhanced coupon while the basket
+stays within its trigger structure. The product suits investors who
+expect the assets to hold their levels. The seller keeps the equity
+risk of the worst performer, which is the natural hedge for owning a
+diversified basket. In ORE Studio a customer books worst of basket
+swaps to value them and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows an equity worst of basket swap on the Euro
+Stoxx 50 and the S&P 500. The trade receives 4% coupons while the
+basket stays inside the trigger structure, and its knock-in level
+stands at 75% of the initial prices:
+
+#+begin_example
+<Trade id="EQ_WorstOfBasketSwap">
+  <TradeType>EquityWorstOfBasketSwap</TradeType>
+  <Envelope>
+    ......
+  </Envelope>
+  <EquityWorstOfBasketSwapData>
+    <LongShort>Long</LongShort>
+    <Currency>EUR</Currency>
+    <Quantity>1955000</Quantity>
+    <Underlyings>
+      <Underlying>
+        .......
+      </Underlying>
+    </Underlyings>
+    <InitialPrices>
+      <InitialPrice>...</InitialPrice>
+    </InitialPrices>
+    <FloatingPeriodSchedule>
+      <Dates>
+        ...
+      </Dates>
+    </FloatingPeriodSchedule>
+    <FixedDeterminationSchedule>
+            ............
+    </FixedDeterminationSchedule>
+    <KnockOutDeterminationSchedule>
+             .............
+    </KnockOutDeterminationSchedule>
+    <FloatingPayDates>
+      <Dates>
+        ....
+      </Dates>
+    </FloatingPayDates>
+    <KnockInDeterminationSchedule>
+            ............
+    </KnockInDeterminationSchedule>
+    <FixedPayDates>
+      ............
+    </FixedPayDates>
+    <KnockOutLevels>
+      <KnockOutLevel>...</KnockOutLevel>
+    </KnockOutLevels>
+    <FixedTriggerLevels>
+      <FixedTriggerLevel>...</FixedTriggerLevel>
+    </FixedTriggerLevels>
+    <KnockInLevel>0.75</KnockInLevel>
+    <FixedRate>0.04</FixedRate>
+    <FixedAccrualSchedule>
+      <Rules>
+        ...
+      </Rules>
+    </FixedAccrualSchedule>
+    <FloatingIndex>EUR-EURIBOR-3M</FloatingIndex>
+    <FloatingDayCountFraction>Actual/360</FloatingDayCountFraction>
+    <FloatingFixingSchedule>
+          ............
+    </FloatingFixingSchedule>
+  </EquityWorstOfBasketSwapData>
+</Trade>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/worstofbasketswap.tex=,
+listing =EquityWorstOfBasketSwap data=. The catalogue also shows the
+scripted representation, in which the basket names the two assets
+explicitly: =EQ-RIC:.STOXX50E= and =EQ-RIC:.SPX= with initial prices
+3481.44 and 3714.24.
+
+* See also
+
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/worstofbasketswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/yyswap.org
+++ b/doc/knowledge/domain/yyswap.org
@@ -121,6 +121,9 @@ listing =Year on Year Swap Data= (using Swap trade type).
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Inflation_swap][Wikipedia: Inflation swap]]. This note follows its general
   definition.
 - ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,

--- a/doc/knowledge/domain/yyswap.org
+++ b/doc/knowledge/domain/yyswap.org
@@ -37,7 +37,7 @@ coupon payments that are exchanged for fixed payments on the other
 leg.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/yyswap.tex][yyswap.tex]].
 YoYIIS is ORE's shorthand for the year-on-year inflation swap.
 
 ** In plain terms
@@ -56,7 +56,7 @@ A Year on Year inflation swap can be set up with trade type Swap, with
 one leg of type YY.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/yyswap.tex][yyswap.tex]].
 
 The YY leg carries a =YYLegData= block. It names the inflation index
 and the observation conventions. The structure mirrors the
@@ -116,7 +116,7 @@ fixed-rate leg is abbreviated.
 </SwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/yyswap.tex][yyswap.tex]],
 listing =Year on Year Swap Data= (using Swap trade type).
 
 * See also
@@ -126,6 +126,6 @@ listing =Year on Year Swap Data= (using Swap trade type).
 
 - [[https://en.wikipedia.org/wiki/Inflation_swap][Wikipedia: Inflation swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/yyswap.tex=. The upstream
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/yyswap.tex][yyswap.tex]]. The upstream
   project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/yyswap.org
+++ b/doc/knowledge/domain/yyswap.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: 2FC69DD5-D685-452B-8BCE-85CBCDD624E5
+:END:
+#+title: Year-on-Year Inflation Swap
+#+description: An inflation swap whose leg pays the annual change of an inflation index; ORE's YY leg.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:yyswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A year-on-year inflation swap pays the annual change of an inflation
+index on one leg. ORE models it as a =Swap= with a YY leg, or as a
+sibling of the [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] in its product catalogue. This note
+records the domain grounding, as ORE documents it.
+
+* Summary
+
+A year-on-year (YoY) inflation swap exchanges annual inflation-linked
+coupons for fixed payments. Each coupon depends on the index change
+over its own one-year period, not on the index level since issue. ORE
+models the product with the =Swap= trade type and one leg of type YY.
+The YY leg carries a =YYLegData= block for the index and observation
+conventions. The coupons can be capped or floored. The product gives
+annual inflation exposure without the long-dated index-ratio accrual of
+a CPI swap.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A YoYIIS is a swap contract where one leg has annual inflation linked
+coupon payments that are exchanged for fixed payments on the other
+leg.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=.
+YoYIIS is ORE's shorthand for the year-on-year inflation swap.
+
+** In plain terms
+
+Two parties swap the yearly change of an inflation index against a
+fixed rate. One side pays the index rise of each coming year. The other
+side pays a fixed rate for the whole life. The exposure resets every
+year, so each coupon covers only its own twelve months.
+
+** How it works in ORE
+
+ORE states the input form as follows:
+
+#+begin_quote
+A Year on Year inflation swap can be set up with trade type Swap, with
+one leg of type YY.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=.
+
+The YY leg carries a =YYLegData= block. It names the inflation index
+and the observation conventions. The structure mirrors the
+[[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]], which uses the =InflationSwap= trade type and a CPI leg.
+A year-on-year coupon at time Ti equals the notional times the index
+change I(Ti)/I(Ti-1) minus one, times the day count fraction. The
+fixings Ti-1 and Ti are one year apart. YoY coupons can be capped or
+floored.
+
+** What moves its value (static sensitivities)
+
+- The discount curve of the payment currency. It moves every payment.
+- The inflation index curve. It projects each annual index change.
+- The fixed rate. It sets the level of the non-inflation leg.
+- The cap or floor, when present. It adds an inflation-volatility
+  sensitivity.
+
+A long-inflation leg gains value when the projected index rises. The
+exposure resets each year, so the index curve matters mainly at its
+one-year points.
+
+** How the profile ages (dynamic sensitivities)
+
+Each printed fixing settles one annual coupon. The remaining coupons
+cover the years still ahead. Unlike a CPI swap, no index ratio
+accumulates over the whole life. The exposure rolls forward year by
+year, and the trade keeps a similar annual structure until maturity.
+
+** Why a customer would want it
+
+A customer who wants inflation protection for a defined horizon picks
+YoY exposure when annual index changes matter more than the cumulative
+level. The product suits caps and floors on single-year inflation. In
+ORE Studio a customer books YoY swaps to value them and run
+sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows the structure with the =Swap= trade type. The
+fixed-rate leg is abbreviated.
+
+#+begin_example
+<SwapData>
+  <LegData>
+    <LegType>Floating</LegType>
+    <Payer>true</Payer>
+    ...
+  </LegData>
+  <LegData>
+    <LegType>YY</LegType>
+    <Payer>false</Payer>
+    ...
+    <YYLegData>
+      ...
+    </YYLegData>
+  </LegData>
+</SwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/yyswap.tex=,
+listing =Year on Year Swap Data= (using Swap trade type).
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Inflation_swap][Wikipedia: Inflation swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/yyswap.tex=. The upstream
+  project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/zerocouponswap.org
+++ b/doc/knowledge/domain/zerocouponswap.org
@@ -1,0 +1,141 @@
+:PROPERTIES:
+:ID: D0F2BDFE-AA84-4472-86E5-AB273E1A8EEC
+:END:
+#+title: Zero Coupon Swap
+#+description: An interest rate swap whose zero-coupon leg pays one final amount at maturity; ORE's ZeroCouponSwap product.
+#+type: knowledge
+#+level: cross
+#+filetags: :domain:finance:zerocouponswap:
+#+created: 2026-09-06
+#+updated: 2026-09-06
+
+A zero coupon swap postpones the coupons of one leg into a single
+payment at maturity. That leg behaves like a zero-coupon bond. ORE
+models the product as a =Swap= with one leg of type
+=ZeroCouponFixed=. This note records the domain grounding, as ORE
+documents it in its product catalogue.
+
+* Summary
+
+A zero coupon swap has at least one zero-coupon leg. The leg makes no
+interest coupon payments during the life of the swap. It makes one
+final interest payment at maturity, akin to a zero-coupon bond. The
+zero-coupon leg compounds at the tenor of the swap. ORE sets the
+product up as a swap with a =ZeroCouponFixed= leg.
+
+* Detail
+
+** What it is
+
+ORE defines the product as follows:
+
+#+begin_quote
+A Zero-Coupon Swap has at least one zero-coupon leg. This leg has no
+interest rate coupon payments during the life of the swap, just one
+final interest payment at maturity, akin to a zero-coupon bond. The
+zero-coupon leg compounds at the tenor of the swap.
+#+end_quote
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/zerocouponswap.tex=.
+
+ORE sets the product up as a swap, trade type =Swap=, with one leg of
+type =ZeroCouponFixed=. The =ZeroCouponFixed= leg carries an
+additional =ZeroCouponFixedLegData= block. The block holds the rates
+and the compounding convention of the leg.
+
+** In plain terms
+
+Swap legs usually exchange coupon streams at regular dates. A
+zero-coupon leg changes that rhythm. It pays nothing during its life.
+One final payment then settles the interest that has accrued. The leg
+suits a party that wants a single bullet payment at a known date.
+
+** How it works in ORE
+
+The product data uses the =SwapData= container of the =Swap= trade
+type. One =LegData= node describes the floating leg. The other
+=LegData= node sets =LegType= to =ZeroCouponFixed= and embeds a
+=ZeroCouponFixedLegData= block. The block lists the =Rates= and the
+=Compounding= convention. ORE's example below pays floating and
+receives zero-coupon fixed at 2 percent with simple compounding.
+
+** Mathematical notes
+
+The zero-coupon leg compounds at the tenor of the swap. It behaves
+like a zero-coupon bond written on the leg notional. The final
+payment depends on the fixed rate, the notional, the tenor, and the
+compounding convention. =Simple= compounding accrues one payment over
+the full life of the leg. The floating leg accrues and pays coupons
+in the usual way.
+
+** What moves its value (static sensitivities)
+
+- The discount curve and the swap rates across maturities.
+- The fixed rate and the compounding convention of the zero-coupon
+  leg.
+- The floating index fixings on the other leg.
+- The notional and the day-count convention.
+- The distance to the single payment date.
+
+The trade concentrates most interest-rate risk in the one final
+payment. Its value therefore loads on the discount factor to that
+maturity.
+
+** How the profile ages (dynamic sensitivities)
+
+The zero-coupon leg accrues steadily toward its final payment. The
+present value of that payment grows as maturity approaches. The
+discount sensitivity of the payment shrinks as the payment date gets
+nearer. The floating leg keeps resetting with the market until
+maturity. At maturity the final payment settles and the trade stops.
+
+** Why a customer would want it
+
+A customer with a bullet liability can match it with a zero-coupon
+leg. A zero-coupon bond issuer can hedge the redemption payment. The
+structure removes the reinvestment decisions that coupon streams
+bring. In ORE Studio a customer books zero coupon swaps to value them
+and run sensitivities on the ORE engine.
+
+** Example
+
+ORE's catalogue shows a swap with a floating leg and a zero-coupon
+fixed leg:
+
+#+begin_example
+<SwapData>
+  <LegData>
+    <LegType>Floating</LegType>
+    <Payer>true</Payer>
+    ...
+  </LegData>
+  <LegData>
+    <LegType>ZeroCouponFixed</LegType>
+    <Payer>false</Payer>
+    ...
+    <ZeroCouponFixedLegData>
+        <Rates>
+            <Rate>0.02</Rate>
+        </Rates>
+        <Compounding>Simple</Compounding>
+    </ZeroCouponFixedLegData>
+  </LegData>
+</SwapData>
+#+end_example
+
+Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/zerocouponswap.tex=,
+listing =Zero Coupon Swap Data=.
+
+The plain vanilla swap family sits in the [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]]
+note. The zero coupon swap is that product with a deferred payment
+leg.
+
+* See also
+
+- [[https://en.wikipedia.org/wiki/Zero-coupon_bond][Wikipedia: Zero-coupon bond]]. The zero-coupon leg behaves like this
+  instrument.
+- [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
+  definition.
+- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
+  which inputs =Docs/UserGuide/tradedata/zerocouponswap.tex=. The
+  upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/domain/zerocouponswap.org
+++ b/doc/knowledge/domain/zerocouponswap.org
@@ -132,6 +132,9 @@ leg.
 
 * See also
 
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
+  with the alphabetical product run.
+
 - [[https://en.wikipedia.org/wiki/Zero-coupon_bond][Wikipedia: Zero-coupon bond]]. The zero-coupon leg behaves like this
   instrument.
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general

--- a/doc/knowledge/domain/zerocouponswap.org
+++ b/doc/knowledge/domain/zerocouponswap.org
@@ -36,7 +36,7 @@ final interest payment at maturity, akin to a zero-coupon bond. The
 zero-coupon leg compounds at the tenor of the swap.
 #+end_quote
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/zerocouponswap.tex=.
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/zerocouponswap.tex][zerocouponswap.tex]].
 
 ORE sets the product up as a swap, trade type =Swap=, with one leg of
 type =ZeroCouponFixed=. The =ZeroCouponFixed= leg carries an
@@ -123,7 +123,7 @@ fixed leg:
 </SwapData>
 #+end_example
 
-Source: ORE User Guide, Products catalogue, =Docs/UserGuide/tradedata/zerocouponswap.tex=,
+Source: ORE User Guide, Products catalogue, [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/zerocouponswap.tex][zerocouponswap.tex]],
 listing =Zero Coupon Swap Data=.
 
 The plain vanilla swap family sits in the [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]]
@@ -139,6 +139,6 @@ leg.
   instrument.
 - [[https://en.wikipedia.org/wiki/Interest_rate_swap][Wikipedia: Interest rate swap]]. This note follows its general
   definition.
-- ORE User Guide, Product catalogue: =Docs/UserGuide/products.tex=,
-  which inputs =Docs/UserGuide/tradedata/zerocouponswap.tex=. The
+- ORE User Guide, Product catalogue: [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/products.tex][products.tex]],
+  which inputs [[https://github.com/OpenSourceRisk/Engine/blob/master/Docs/UserGuide/tradedata/zerocouponswap.tex][zerocouponswap.tex]]. The
   upstream project is [[https://github.com/OpenSourceRisk/Engine][OpenSourceRisk/Engine]].

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -35,14 +35,45 @@ description with domain grounding and ORE examples.
   and CMS; definition, variants, sensitivities, and ORE examples.
 - [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
   credit-risk flag, and sensitivities.
+- [[id:DBC183E7-9AB4-481A-8A27-A70966EE4D48][Ascot]] — the American option on a convertible bond: the right to
+  sell it back at a strike set from a reference swap, the call and put
+  forms, and sensitivities.
 - [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — prepayment-linked amortisation:
   the notional follows a reference security's prepayments, the Flexi
   Swap pricing proxy, and sensitivities.
+- [[id:C00D82F7-942F-4270-AB9F-D0C31F0881A9][Bond Forward (Reference Data)]] — a forward contract on a bond with
+  the underlying from reference data: physical or cash settlement,
+  the T-Lock form, and sensitivities.
+- [[id:B50027E5-44CD-49FA-B4DF-1177E321F156][Bond Future]] — a contract to buy or sell a bond at a future point
+  in time: the named contract, the eligible delivery basket, the
+  cheapest-to-deliver choice, and sensitivities.
+- [[id:52C1431E-517D-40EC-AE9F-838F040A4103][Bond Option]] — the right to buy or sell a given bond at a fixed
+  price: European exercise on the vanilla bond, and sensitivities.
+- [[id:0E145E20-C296-4D0F-B26C-2CC5EAA22F3B][Bond Option (Reference Data)]] — a bond option on a bond from
+  reference data: European exercise on the par redemption vanilla
+  bond, and sensitivities.
+- [[id:531499CE-C843-4178-8F89-CA901B1BA9AE][Bond Position]] — a weighted basket of underlying bonds: the
+  stand-alone position or the total return swap component, and
+  sensitivities.
+- [[id:C96BBC70-71C1-442A-97FF-CCD596C193DB][Bond Repo]] — a secured cash borrowing: the bond posted as
+  collateral against the cash leg, and sensitivities.
+- [[id:0727A454-AB7F-4202-A3A8-A4A183683566][Bond Total Return Swap]] — the return of a bond against a funding
+  leg: coupons, redemptions and clean value changes along the TRS
+  schedule, and sensitivities.
+- [[id:4E78B88B-432F-445D-9FEA-9DBE80718DBF][Callable Bond]] — issuer call and investor put rights on a bond:
+  the American or Bermudan styles, the exercise prices, and
+  sensitivities.
 - [[id:0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE][Callable Swap]] — cancellable optionality: the swap with an
   embedded physically settled swaption, the call dates, and
   sensitivities.
 - [[id:3DCC5F43-9728-4E67-8720-AE307E780CBF][Cap/Floor]] — a strip of rate options: the caplets or floorlets
   on a floating leg, the collar form, and sensitivities.
+- [[id:940CB31A-BD50-45D6-98AC-4B0D53973825][Cash Position]] — an amount of cash in a currency: the stand-alone
+  trade or the component inside a total return swap, and
+  sensitivities.
+- [[id:F8341BB7-33FE-4441-8C2D-56B8DDDCA91C][Collateral Bond Obligation]] — a tranched securitisation of a bond
+  or loan portfolio: the short and long forms, the waterfalls, and
+  sensitivities.
 - [[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]] — Asian optionality: the
   single-period swap observing daily fixings, period-end exercise,
   and sensitivities.
@@ -62,6 +93,9 @@ description with domain grounding and ORE examples.
   commodity swap: payer and receiver rights, and sensitivities.
 - [[id:1989F85A-42F8-4894-8982-AC34D19B0351][Commodity Variance Swap]] — commodity volatility traded directly:
   the realised variance payoff and sensitivities.
+- [[id:F5D8E0C4-EC67-4210-AF1C-B664246810C9][Convertible Bond]] — a bond convertible into a prespecified number
+  of shares: parity against the bond floor, calls and puts, forced
+  conversion, and sensitivities.
 - [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — inflation swaps: the real-rate leg scaled by the index
   ratio, the InflationSwap trade type, and sensitivities.
 - [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] — single-name protection: premium leg,
@@ -113,6 +147,8 @@ description with domain grounding and ORE examples.
 - [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — flexible amortisation: the option to cut the
   notional toward lower bounds, the replication price, and
   sensitivities.
+- [[id:8CCD37D5-1D16-4972-8582-13595E62381C][Forward Bond]] — a forward contract on a bond: physical or cash
+  settlement, the T-Lock and J-Lock forms, and sensitivities.
 - [[id:11714B3F-A790-4797-BE01-41426289E7C7][Forward Rate Agreement]] — a single-period rate lock: the forward
   rate against a reference IBOR, the long or short position, and
   sensitivities.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -167,6 +167,9 @@ description with domain grounding and ORE examples.
 - [[id:F0727CDB-4696-4C25-BFF5-AF0D302B5A71][European Option Contingent on a Barrier]] — a vanilla European
   option gated by a barrier on another underlying: American or
   European monitoring, and sensitivities.
+- [[id:D3DF8CDD-2BD9-44BC-B805-D06C8A6C2074][Exotic Variance and Volatility Derivatives]] — the variance and
+  volatility family beyond the vanilla swap: barriers, corridors,
+  conditional accrual, baskets and optionality, and sensitivities.
 - [[id:90DDE9BB-770F-4337-AF0E-69698AF2A2A1][Extended Accumulator]] — the accumulator that can extend past a
   barrier decision date: the extension trigger and the conditional
   observation dates, and sensitivities.
@@ -209,6 +212,9 @@ description with domain grounding and ORE examples.
 - [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] — a vanilla, asset-or-nothing or
   cash-or-nothing payoff with American barriers and a transatlantic
   barrier at expiry, and sensitivities.
+- [[id:2F5B28D9-9AB7-401E-8EF3-612712F626C1][Generic Scripted Products]] — the scripted trade module: flexible
+  payoff scripts across five asset classes, embedded or library
+  scripts, and sensitivities.
 - [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — protection on an index: unfactored
   and factored notional, the bespoke basket, and sensitivities.
 - [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] — options on index protection:
@@ -218,6 +224,9 @@ description with domain grounding and ORE examples.
 - [[id:AEB7149D-EE91-4912-A663-D7A0261B87A0][Performance Option Type 01]] — the capped participation in the
   performance of a basket against an option strike, and
   sensitivities.
+- [[id:E5C8CE52-C382-4523-8BB9-1A3698ABB0BF][Rainbow Options]] — the best or worst of a range of assets: the
+  asset-or-cash, max and min forms, the spread and worst performance
+  variations, and sensitivities.
 - [[id:94B1DBE3-33AB-44F5-B9F1-B71E34A58123][Rate Digital Option]] — a binary bet on a rate fixing: the fixed
   payout above or below strike, and sensitivities.
 - [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] — protection on swap counterparties:

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -60,8 +60,34 @@ description with domain grounding and ORE examples.
   protection mechanics, the quanto form, and sensitivities.
 - [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — swap payments with credit triggers: the four
   payment classes and sensitivities.
+- [[id:9C395333-73C7-401D-9E71-5333E1645E1A][FX Asian Option]] — the averaging option of the FX family: the
+  arithmetic or geometric average, the observation schedule, and
+  sensitivities.
+- [[id:6CAED5F9-21CB-4300-B1B0-89599CFBFC7C][FX Barrier Option]] — the path-dependent core of the FX exotic
+  family: the single monitored barrier, knock-in and knock-out
+  types.
+- [[id:8668F997-2609-47C6-BF5C-EE35F21405EE][FX Digital Barrier Option]] — a digital payout behind a barrier:
+  the four main types, the strike test at expiry.
+- [[id:C880CEB4-4FB7-41AA-8A4A-A650B6FC388C][FX Digital Option]] — the binary bet of the FX family: a fixed
+  payout or nothing, decided by the terminal rate.
+- [[id:0AA6F04D-C049-43D5-8307-82A9562E2883][FX Double Barrier Option]] — a vanilla option inside a corridor:
+  two monitored barriers, the single knock-in or knock-out type.
+- [[id:7BA83993-32A7-4090-A6A9-A07AA3AF2B1D][FX Double Touch Option]] — a fixed payout on a corridor: the
+  double one-touch and double no-touch forms.
+- [[id:4BAF88FA-7FDF-4B01-9A52-7AAE733A02B5][FX European Barrier Option]] — the barrier checked once at expiry:
+  the single European-monitored barrier, the rebate.
 - [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — deliverable and cash-settled forwards: definition,
   FxForwardData fields, the NDF form, and sensitivities.
+- [[id:B6A26725-EC1A-482D-A920-3CAB8834ED6D][FX KIKO Barrier Option]] — the knock-in knock-out hybrid: two
+  barriers of mixed type, the exercise condition.
+- [[id:199AB340-A254-40A9-8CBE-FBABB17FF51F][FX Option]] — the vanilla of the FX family: European and American
+  styles, cash or physical settlement, and sensitivities.
+- [[id:E9A214DE-AD39-4128-9EDB-106C4A606B90][FX Swap]] — the spot-forward pair: near and far exchanges, the
+  forward points, and sensitivities.
+- [[id:EA6E4A7A-6229-4F8C-93C5-426D1E4CB496][FX Touch Option]] — a pure bet on a touch: the one-touch and
+  no-touch forms, the fixed payout.
+- [[id:7A2186FB-33C3-4916-B62C-A14468EE713F][FX Variance Swap]] — FX volatility traded directly: the realised
+  variance payoff, vega notional, and sensitivities.
 - [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — protection on an index: unfactored
   and factored notional, the bespoke basket, and sensitivities.
 - [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] — options on index protection:

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -37,8 +37,20 @@ description with domain grounding and ORE examples.
   credit-risk flag, and sensitivities.
 - [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — inflation swaps: the real-rate leg scaled by the index
   ratio, the InflationSwap trade type, and sensitivities.
+- [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] — single-name protection: premium leg,
+  protection mechanics, the quanto form, and sensitivities.
+- [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — swap payments with credit triggers: the four
+  payment classes and sensitivities.
 - [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — deliverable and cash-settled forwards: definition,
   FxForwardData fields, the NDF form, and sensitivities.
+- [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — protection on an index: unfactored
+  and factored notional, the bespoke basket, and sensitivities.
+- [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] — options on index protection:
+  strike types, index terms, front-end protection.
+- [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] — protection on swap counterparties:
+  the participation rate and the underlying swap.
+- [[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]] — tranched basket protection: attachment and
+  detachment points, the CdoData block.
 - [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] — annual inflation exposure: the YY
   leg, its Swap trade type, and sensitivities.
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -24,6 +24,20 @@ documentation see [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]
 
 Finance concepts the codebase relies on, grouped by topic.
 
+** Products
+
+Knowledge notes for the ORE product set, the trade types the ORE
+engine prices. ORE documents each product in its User Guide products
+catalogue, =Docs/UserGuide/tradedata/=. The notes pair that official
+description with domain grounding and ORE examples.
+
+- [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]] — the interest-rate swap family: vanilla IRS, basis, OIS, BMA,
+  and CMS; definition, variants, sensitivities, and ORE examples.
+- [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
+  credit-risk flag, and sensitivities.
+- [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — deliverable and cash-settled forwards: definition,
+  FxForwardData fields, the NDF form, and sensitivities.
+
 ** Currency
 
 - [[id:3407B8DF-D446-4658-8B5D-3368FFA44AD8][Currency]] — hub note: the money/currency/cash foundation, ISO 4217

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -35,8 +35,12 @@ description with domain grounding and ORE examples.
   and CMS; definition, variants, sensitivities, and ORE examples.
 - [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
   credit-risk flag, and sensitivities.
+- [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — inflation swaps: the real-rate leg scaled by the index
+  ratio, the InflationSwap trade type, and sensitivities.
 - [[id:47598B8D-0121-4989-9661-79A8E6D1A070][FX Forward]] — deliverable and cash-settled forwards: definition,
   FxForwardData fields, the NDF form, and sensitivities.
+- [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] — annual inflation exposure: the YY
+  leg, its Swap trade type, and sensitivities.
 
 ** Currency
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -35,6 +35,14 @@ description with domain grounding and ORE examples.
   and CMS; definition, variants, sensitivities, and ORE examples.
 - [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
   credit-risk flag, and sensitivities.
+- [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — prepayment-linked amortisation:
+  the notional follows a reference security's prepayments, the Flexi
+  Swap pricing proxy, and sensitivities.
+- [[id:0EE613F9-9A1F-4B03-A1B2-FB4791D6C2EE][Callable Swap]] — cancellable optionality: the swap with an
+  embedded physically settled swaption, the call dates, and
+  sensitivities.
+- [[id:3DCC5F43-9728-4E67-8720-AE307E780CBF][Cap/Floor]] — a strip of rate options: the caplets or floorlets
+  on a floating leg, the collar form, and sensitivities.
 - [[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]] — Asian optionality: the
   single-period swap observing daily fixings, period-end exercise,
   and sensitivities.
@@ -60,6 +68,12 @@ description with domain grounding and ORE examples.
   protection mechanics, the quanto form, and sensitivities.
 - [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — swap payments with credit triggers: the four
   payment classes and sensitivities.
+- [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — flexible amortisation: the option to cut the
+  notional toward lower bounds, the replication price, and
+  sensitivities.
+- [[id:11714B3F-A790-4797-BE01-41426289E7C7][Forward Rate Agreement]] — a single-period rate lock: the forward
+  rate against a reference IBOR, the long or short position, and
+  sensitivities.
 - [[id:9C395333-73C7-401D-9E71-5333E1645E1A][FX Asian Option]] — the averaging option of the FX family: the
   arithmetic or geometric average, the observation schedule, and
   sensitivities.
@@ -92,12 +106,20 @@ description with domain grounding and ORE examples.
   and factored notional, the bespoke basket, and sensitivities.
 - [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] — options on index protection:
   strike types, index terms, front-end protection.
+- [[id:37689AC9-DBA5-41AA-866E-19522F733D2E][Knock Out Swap]] — a barrier on a swap: the fixed-versus-floating
+  swap that dies on a fixing, and sensitivities.
+- [[id:94B1DBE3-33AB-44F5-B9F1-B71E34A58123][Rate Digital Option]] — a binary bet on a rate fixing: the fixed
+  payout above or below strike, and sensitivities.
 - [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] — protection on swap counterparties:
   the participation rate and the underlying swap.
+- [[id:FCC37EB3-D654-4333-B110-3BF4AFA3A237][Swaption]] — an option on a swap: payer and receiver rights,
+  European, Bermudan and American styles, and sensitivities.
 - [[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]] — tranched basket protection: attachment and
   detachment points, the CdoData block.
 - [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] — annual inflation exposure: the YY
   leg, its Swap trade type, and sensitivities.
+- [[id:D0F2BDFE-AA84-4472-86E5-AB273E1A8EEC][Zero Coupon Swap]] — the deferred-payment swap: the zero-coupon
+  leg's single final payment, and sensitivities.
 
 ** Currency
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -68,6 +68,48 @@ description with domain grounding and ORE examples.
   protection mechanics, the quanto form, and sensitivities.
 - [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — swap payments with credit triggers: the four
   payment classes and sensitivities.
+- [[id:90BB6829-31EC-4C86-BE17-FDABF670DDB6][Equity Asian Option]] — the averaging option of the equity family: the
+  arithmetic or geometric average of the spot, the observation
+  schedule, and sensitivities.
+- [[id:E9DCA7FE-1680-435D-BAD3-956E809BD71C][Equity Auto Delta Hedged Option]] — the discretely hedged structure:
+  batches of European options with an embedded delta-hedging
+  strategy, and sensitivities.
+- [[id:80C9B215-EBBA-4367-902B-C0687C0E43E8][Equity Barrier Option]] — the path-dependent barrier core: the single
+  continuously monitored barrier, knock-in and knock-out forms, and
+  sensitivities.
+- [[id:F3398C7E-E978-45C4-94AA-6EBB6DA98EC9][Equity Cliquet Option]] — the ratchet structure: periodic returns
+  locked in with local and global caps and floors, and sensitivities.
+- [[id:FCD38489-372D-4CD4-9A8A-DB0A332DE26E][Equity Digital Option]] — the binary bet of the equity family: a fixed
+  payout or nothing, decided by the spot at expiry, and sensitivities.
+- [[id:06615BB7-3A1C-407D-8745-010DB52BD053][Equity Double Barrier Option]] — a vanilla option inside a corridor:
+  two continuously monitored barriers, knock-in and knock-out forms,
+  and sensitivities.
+- [[id:44BB5D47-C9CF-4E77-A4A9-50F14044A535][Equity Double Touch Option]] — a fixed payout on a corridor: the
+  double one-touch and double no-touch forms, payout at expiry, and
+  sensitivities.
+- [[id:0415E392-7423-411F-A83B-C791E6BE3078][Equity European Barrier Option]] — the once-checked barrier: a single
+  barrier monitored only at expiry, knock-in and knock-out forms, and
+  sensitivities.
+- [[id:D60CBEE4-AE5C-421B-AAEF-5E56DC75A662][Equity Forward]] — the equity linear building block: the forward
+  purchase or sale of shares or an index, cash settlement, and
+  sensitivities.
+- [[id:67ECE260-9D52-4183-882D-06F795AF9BA1][Equity Futures Option]] — optionality on a futures price: European and
+  American exercise, the futures price flag, and sensitivities.
+- [[id:803F50A7-7DB5-4F6B-81F4-BE48C6EEFAB1][Equity Option]] — vanilla equity optionality: European and American
+  styles, quanto and composite forms, and sensitivities.
+- [[id:643843A9-B265-49B3-85BA-0E2F261DE7A9][Equity Option Position]] — direct option exposure: the single equity
+  option or the weighted basket, the total return swap component
+  role, and sensitivities.
+- [[id:0AE749B3-E51A-4036-8561-622F5EE69C02][Equity Position]] — direct equity exposure: the single underlying or
+  the weighted basket, the total return swap component role, and
+  sensitivities.
+- [[id:D45F8289-3F31-462F-9C98-460CE820F75F][Equity Swap]] — equity performance against funding: the price return
+  or total return coupon, the fixed or floating funding leg, and
+  sensitivities.
+- [[id:45585B0A-31A1-49D9-9CF3-A5C240F9607D][Equity Touch Option]] — the binary barrier bet: a fixed payout on a
+  touch, the one-touch and no-touch forms, and sensitivities.
+- [[id:D69C0964-9F15-43BC-8A13-66ECED718BED][Equity Variance Swap]] — equity volatility traded directly: the
+  realised variance payoff and sensitivities.
 - [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — flexible amortisation: the option to cut the
   notional toward lower bounds, the replication price, and
   sensitivities.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -35,6 +35,25 @@ description with domain grounding and ORE examples.
   and CMS; definition, variants, sensitivities, and ORE examples.
 - [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
   credit-risk flag, and sensitivities.
+- [[id:D16393FC-784B-4BCB-90B9-7010894CD2D2][Commodity Average Price Option]] — Asian optionality: the
+  single-period swap observing daily fixings, period-end exercise,
+  and sensitivities.
+- [[id:992F5349-6D73-4780-855C-532B63073191][Commodity Forward]] — the commodity linear building block:
+  definition, CommodityForwardData fields, and sensitivities.
+- [[id:EC6DB3A0-4B34-4CD2-A3B7-ED004F3FA1B8][Commodity Option]] — vanilla commodity optionality: European and
+  American styles, cash or physical settlement, and sensitivities.
+- [[id:48305B53-26C5-474D-8AA2-0DC425F96E3B][Commodity Option Strip]] — a strip of APOs or European options:
+  the per-period options, the Calls and Puts nodes, and
+  sensitivities.
+- [[id:8B992141-85D3-4480-ABAF-9E2BD1BEB01B][Commodity Position]] — direct commodity exposure: the single
+  underlying or weighted basket, and sensitivities.
+- [[id:0C0FDF39-B4D4-4794-83AD-076B4681830B][Commodity Swap]] — floating commodity prices against a fixed
+  price: the averaging payoff, the basis swap form, and
+  sensitivities.
+- [[id:8FAE9780-9737-49DB-87E7-D678F3AEBD69][Commodity Swaption]] — European option on a forward-starting
+  commodity swap: payer and receiver rights, and sensitivities.
+- [[id:1989F85A-42F8-4894-8982-AC34D19B0351][Commodity Variance Swap]] — commodity volatility traded directly:
+  the realised variance payoff and sensitivities.
 - [[id:13D3230A-D5C2-46DA-92E6-1DB128B8392A][CPI Swap]] — inflation swaps: the real-rate leg scaled by the index
   ratio, the InflationSwap trade type, and sensitivities.
 - [[id:1A201C57-AC68-4D0F-94A8-E33490D65EA3][Credit Default Swap]] — single-name protection: premium leg,

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -28,7 +28,7 @@ Finance concepts the codebase relies on, grouped by topic.
 
 Knowledge notes for the ORE product set, the trade types the ORE
 engine prices. ORE documents each product in its User Guide products
-catalogue, =Docs/UserGuide/tradedata/=. The notes pair that official
+catalogue, [[https://github.com/OpenSourceRisk/Engine/tree/master/Docs/UserGuide/tradedata][Docs/UserGuide/tradedata/]]. The notes pair that official
 description with domain grounding and ORE examples. The set is
 organised by asset class on the [[id:C5C95B29-2EF9-4DFC-9E04-428C41C1925D][ORE Products by Asset Class]] page.
 

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -29,7 +29,8 @@ Finance concepts the codebase relies on, grouped by topic.
 Knowledge notes for the ORE product set, the trade types the ORE
 engine prices. ORE documents each product in its User Guide products
 catalogue, =Docs/UserGuide/tradedata/=. The notes pair that official
-description with domain grounding and ORE examples.
+description with domain grounding and ORE examples. The set is
+organised by asset class on the [[id:C5C95B29-2EF9-4DFC-9E04-428C41C1925D][ORE Products by Asset Class]] page.
 
 - [[id:28DFC605-9F3D-470D-A45B-347EBA4B45B7][Swap]] — the interest-rate swap family: vanilla IRS, basis, OIS, BMA,
   and CMS; definition, variants, sensitivities, and ORE examples.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -41,12 +41,18 @@ description with domain grounding and ORE examples.
 - [[id:DBC183E7-9AB4-481A-8A27-A70966EE4D48][Ascot]] — the American option on a convertible bond: the right to
   sell it back at a strike set from a reference swap, the call and put
   forms, and sensitivities.
+- [[id:6B1D0C78-0CAF-4A1C-BA34-56FB07C4F107][Autocallable Type 01]] — the structured option that pays
+  accumulated amounts on fixing dates and redeems early at a trigger
+  level, and sensitivities.
 - [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — prepayment-linked amortisation:
   the notional follows a reference security's prepayments, the Flexi
   Swap pricing proxy, and sensitivities.
 - [[id:00DE9B53-9E4F-4FD4-A5E9-BE00B0956710][Basket Option]] — the option on a weighted basket of assets: the
   vanilla, Asian, average strike and lookback forms, and
   sensitivities.
+- [[id:18891481-BBFE-4731-A677-DB66400A724C][Best Entry Option]] — an option whose payoff uses the best
+  observed entry level of the underlying: the trigger path, the capped
+  participation and the downside branch, and sensitivities.
 - [[id:C00D82F7-942F-4270-AB9F-D0C31F0881A9][Bond Forward (Reference Data)]] — a forward contract on a bond with
   the underlying from reference data: physical or cash settlement,
   the T-Lock form, and sensitivities.
@@ -111,6 +117,8 @@ description with domain grounding and ORE examples.
   protection mechanics, the quanto form, and sensitivities.
 - [[id:B74A3D5C-1001-490D-9840-976C4E85E12F][Credit Linked Swap]] — swap payments with credit triggers: the four
   payment classes and sensitivities.
+- [[id:E63E99AD-6C5E-446B-BE14-57A8D9042AFD][Double Digital Option]] — a fixed payout when two underlyings
+  are simultaneously in the money, and sensitivities.
 - [[id:90BB6829-31EC-4C86-BE17-FDABF670DDB6][Equity Asian Option]] — the averaging option of the equity family: the
   arithmetic or geometric average of the spot, the observation
   schedule, and sensitivities.
@@ -143,6 +151,9 @@ description with domain grounding and ORE examples.
 - [[id:643843A9-B265-49B3-85BA-0E2F261DE7A9][Equity Option Position]] — direct option exposure: the single equity
   option or the weighted basket, the total return swap component
   role, and sensitivities.
+- [[id:9033DF60-3AD6-45FB-9DF7-1094D9B489FF][Equity Outperformance Option]] — the outperformance of one
+  index over another floored at zero, the knock-in and knock-out
+  levels, and sensitivities.
 - [[id:0AE749B3-E51A-4036-8561-622F5EE69C02][Equity Position]] — direct equity exposure: the single underlying or
   the weighted basket, the total return swap component role, and
   sensitivities.
@@ -153,6 +164,9 @@ description with domain grounding and ORE examples.
   touch, the one-touch and no-touch forms, and sensitivities.
 - [[id:D69C0964-9F15-43BC-8A13-66ECED718BED][Equity Variance Swap]] — equity volatility traded directly: the
   realised variance payoff and sensitivities.
+- [[id:F0727CDB-4696-4C25-BFF5-AF0D302B5A71][European Option Contingent on a Barrier]] — a vanilla European
+  option gated by a barrier on another underlying: American or
+  European monitoring, and sensitivities.
 - [[id:90DDE9BB-770F-4337-AF0E-69698AF2A2A1][Extended Accumulator]] — the accumulator that can extend past a
   barrier decision date: the extension trigger and the conditional
   observation dates, and sensitivities.
@@ -192,12 +206,18 @@ description with domain grounding and ORE examples.
   no-touch forms, the fixed payout.
 - [[id:7A2186FB-33C3-4916-B62C-A14468EE713F][FX Variance Swap]] — FX volatility traded directly: the realised
   variance payoff, vega notional, and sensitivities.
+- [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] — a vanilla, asset-or-nothing or
+  cash-or-nothing payoff with American barriers and a transatlantic
+  barrier at expiry, and sensitivities.
 - [[id:FB662CB6-F6E7-4BD5-8616-CC767D60E8C6][Index Credit Default Swap]] — protection on an index: unfactored
   and factored notional, the bespoke basket, and sensitivities.
 - [[id:6DDAEC85-6DE9-436F-83D1-BB3D8F4A6F58][Index Credit Default Swap Option]] — options on index protection:
   strike types, index terms, front-end protection.
 - [[id:37689AC9-DBA5-41AA-866E-19522F733D2E][Knock Out Swap]] — a barrier on a swap: the fixed-versus-floating
   swap that dies on a fixing, and sensitivities.
+- [[id:AEB7149D-EE91-4912-A663-D7A0261B87A0][Performance Option Type 01]] — the capped participation in the
+  performance of a basket against an option strike, and
+  sensitivities.
 - [[id:94B1DBE3-33AB-44F5-B9F1-B71E34A58123][Rate Digital Option]] — a binary bet on a rate fixing: the fixed
   payout above or below strike, and sensitivities.
 - [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] — protection on swap counterparties:
@@ -215,6 +235,9 @@ description with domain grounding and ORE examples.
 - [[id:5368EC07-71E8-4906-B897-AA41A57CE0FA][Total Return Swap]] — the return of an asset against a funding leg:
   the generic TRS and CFD forms, the accrual pricing method, and
   sensitivities.
+- [[id:59A56773-6E82-421A-8E64-AA54D46489D4][Window Barrier Option]] — an option with a barrier active only
+  inside a time window: the continuously monitored knock-in or
+  knock-out, and sensitivities.
 - [[id:428BA744-B3D3-486C-A3BF-39E59C6EC11F][Worst Of Basket Swap]] — a swap referencing the worst performing
   basket asset: the fixed coupons, the trigger, knock-out and
   knock-in barriers, and sensitivities.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -35,12 +35,18 @@ description with domain grounding and ORE examples.
   and CMS; definition, variants, sensitivities, and ORE examples.
 - [[id:691B6CE9-930A-4015-942C-A0DD4B04E690][Bond]] — debt securities: definition, reference-data short form,
   credit-risk flag, and sensitivities.
+- [[id:6B186A8F-B261-40A4-B950-932AB735AE95][Accumulator]] — the forward purchase of an asset in daily
+  instalments: the accumulator and decumulator forms, the knock-out
+  and leverage features, and sensitivities.
 - [[id:DBC183E7-9AB4-481A-8A27-A70966EE4D48][Ascot]] — the American option on a convertible bond: the right to
   sell it back at a strike set from a reference swap, the call and put
   forms, and sensitivities.
 - [[id:EE7D0A97-FD6D-46AA-9419-C6F01275F7E2][Balance Guaranteed Swap]] — prepayment-linked amortisation:
   the notional follows a reference security's prepayments, the Flexi
   Swap pricing proxy, and sensitivities.
+- [[id:00DE9B53-9E4F-4FD4-A5E9-BE00B0956710][Basket Option]] — the option on a weighted basket of assets: the
+  vanilla, Asian, average strike and lookback forms, and
+  sensitivities.
 - [[id:C00D82F7-942F-4270-AB9F-D0C31F0881A9][Bond Forward (Reference Data)]] — a forward contract on a bond with
   the underlying from reference data: physical or cash settlement,
   the T-Lock form, and sensitivities.
@@ -93,6 +99,9 @@ description with domain grounding and ORE examples.
   commodity swap: payer and receiver rights, and sensitivities.
 - [[id:1989F85A-42F8-4894-8982-AC34D19B0351][Commodity Variance Swap]] — commodity volatility traded directly:
   the realised variance payoff and sensitivities.
+- [[id:2D1B9342-FC33-49DF-8F23-5B2248968156][Composite Trade]] — a position bundling several component trades:
+  the components list, the currency and notional method, the
+  portfolio basket form, and sensitivities.
 - [[id:F5D8E0C4-EC67-4210-AF1C-B664246810C9][Convertible Bond]] — a bond convertible into a prespecified number
   of shares: parity against the bond floor, calls and puts, forced
   conversion, and sensitivities.
@@ -144,6 +153,9 @@ description with domain grounding and ORE examples.
   touch, the one-touch and no-touch forms, and sensitivities.
 - [[id:D69C0964-9F15-43BC-8A13-66ECED718BED][Equity Variance Swap]] — equity volatility traded directly: the
   realised variance payoff and sensitivities.
+- [[id:90DDE9BB-770F-4337-AF0E-69698AF2A2A1][Extended Accumulator]] — the accumulator that can extend past a
+  barrier decision date: the extension trigger and the conditional
+  observation dates, and sensitivities.
 - [[id:A4785FCB-5001-46DF-8F65-F63BB12526F3][Flexi Swap]] — flexible amortisation: the option to cut the
   notional toward lower bounds, the replication price, and
   sensitivities.
@@ -190,10 +202,22 @@ description with domain grounding and ORE examples.
   payout above or below strike, and sensitivities.
 - [[id:95005252-270D-44DE-8A26-C61CE5D860E0][Risk Participation Agreement]] — protection on swap counterparties:
   the participation rate and the underlying swap.
+- [[id:18E6A88B-6F6E-488F-91B2-B6106C43AF73][Strike Resettable Option]] — an option whose strike resets on a
+  trigger: the observation dates, the trigger price and the reset
+  strike, and sensitivities.
 - [[id:FCC37EB3-D654-4333-B110-3BF4AFA3A237][Swaption]] — an option on a swap: payer and receiver rights,
   European, Bermudan and American styles, and sensitivities.
 - [[id:8F0391AC-D748-459C-8DD8-5ABC8945E438][Synthetic CDO]] — tranched basket protection: attachment and
   detachment points, the CdoData block.
+- [[id:808C159F-5852-45AD-AE49-B7A4488513CC][Target Redemption Forward]] — the forward series that redeems at a
+  target profit: the continuous and digital forms, the exact, full
+  and truncated payment types, and sensitivities.
+- [[id:5368EC07-71E8-4906-B897-AA41A57CE0FA][Total Return Swap]] — the return of an asset against a funding leg:
+  the generic TRS and CFD forms, the accrual pricing method, and
+  sensitivities.
+- [[id:428BA744-B3D3-486C-A3BF-39E59C6EC11F][Worst Of Basket Swap]] — a swap referencing the worst performing
+  basket asset: the fixed coupons, the trigger, knock-out and
+  knock-in barriers, and sensitivities.
 - [[id:2FC69DD5-D685-452B-8BCE-85CBCDD624E5][Year-on-Year Inflation Swap]] — annual inflation exposure: the YY
   leg, its Swap trade type, and sensitivities.
 - [[id:D0F2BDFE-AA84-4472-86E5-AB273E1A8EEC][Zero Coupon Swap]] — the deferred-payment swap: the zero-coupon

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -256,6 +256,7 @@ Tags that describe the business or technical domain of the content.
 | =fxswap= | FX swaps and the FX derivatives market. |
 | =fxvarianceswap= | FX variance swaps and FX volatility markets. |
 | =generic_barrieroption= | Generic barrier options and multi-barrier structured payoffs. |
+| =genericscriptedproducts= | Generic scripted products and flexible payoff script structures. |
 | =indexcds= | Index credit default swaps and credit indices. |
 | =indexcdsoption= | Options on index credit default swaps. |
 | =knowledge_graph= | org-roam knowledge graph management. |
@@ -269,6 +270,7 @@ Tags that describe the business or technical domain of the content.
 | =performance= | Performance measurement and optimisation. |
 | =performanceoption_01= | Performance options and basket performance participation structures. |
 | =provisioning= | System provisioning workflows and wizards. |
+| =rainbow_option= | Rainbow options and best-or-worst multi-asset structures. |
 | =ratedigitaloption= | Rate digital options and binary interest rate derivatives. |
 | =rbac= | Role-Based Access Control. |
 | =refdata= | Reference data (currencies, countries, calendars, etc.). |
@@ -286,6 +288,7 @@ Tags that describe the business or technical domain of the content.
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
+| =var_and_vol_derivatives= | Exotic variance and volatility swaps and options with barriers and corridors. |
 | =window_barrieroption= | Window barrier options and time-windowed barrier structures. |
 | =worstofbasketswap= | Worst of basket swaps and basket trigger structures. |
 | =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -269,6 +269,7 @@ Tags that describe the business or technical domain of the content.
 | =modelling= | Domain or system modelling. |
 | =performance= | Performance measurement and optimisation. |
 | =performanceoption_01= | Performance options and basket performance participation structures. |
+| =products_by_asset_class= | Entry page grouping the ORE product knowledge notes by asset class. |
 | =provisioning= | System provisioning workflows and wizards. |
 | =rainbow_option= | Rainbow options and best-or-worst multi-asset structures. |
 | =ratedigitaloption= | Rate digital options and binary interest rate derivatives. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -200,6 +200,18 @@ Tags that describe the business or technical domain of the content.
 | =entity= | Domain entity (also used as type tag). |
 | =finance= | Finance domain, products, and markets. |
 | =fx_forward= | FX forward contracts and the FX derivatives market. |
+| =fx_asianoption= | FX Asian options and averaged-rate FX derivatives. |
+| =fx_barrieroption= | FX barrier options and path-dependent FX derivatives. |
+| =fx_digitalbarrieroption= | FX digital barrier options and binary FX derivatives. |
+| =fx_digitaloption= | FX digital options and binary FX derivatives. |
+| =fx_doublebarrieroption= | FX double barrier options and path-dependent FX derivatives. |
+| =fx_doubletouchoption= | FX double touch options and binary FX derivatives. |
+| =fx_europeanbarrieroption= | FX European barrier options and path-dependent FX derivatives. |
+| =fx_kikobarrieroption= | FX KIKO barrier options and path-dependent FX derivatives. |
+| =fx_touchoption= | FX touch options and binary FX derivatives. |
+| =fxoption= | FX options and the FX derivatives market. |
+| =fxswap= | FX swaps and the FX derivatives market. |
+| =fxvarianceswap= | FX variance swaps and FX volatility markets. |
 | =indexcds= | Index credit default swaps and credit indices. |
 | =indexcdsoption= | Options on index credit default swaps. |
 | =knowledge_graph= | org-roam knowledge graph management. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -201,6 +201,22 @@ Tags that describe the business or technical domain of the content.
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
 | =entity= | Domain entity (also used as type tag). |
+| =eq_asianoption= | Equity Asian options and averaged-price equity derivatives. |
+| =eq_barrieroption= | Equity barrier options and path-dependent equity derivatives. |
+| =eq_digitaloption= | Equity digital options and binary equity derivatives. |
+| =eq_doublebarrieroption= | Equity double barrier options and path-dependent equity derivatives. |
+| =eq_doubletouchoption= | Equity double touch options and binary equity derivatives. |
+| =eq_europeanbarrieroption= | Equity European barrier options and path-dependent equity derivatives. |
+| =eq_touchoption= | Equity touch options and binary equity derivatives. |
+| =equityautodeltahedgedoption= | Equity auto delta hedged options and discretely hedged structures. |
+| =equitycliquetoption= | Equity cliquet options and ratchet structures. |
+| =equityforward= | Equity forward contracts and equity derivatives markets. |
+| =equityfuturesoption= | Options on equity futures and equity derivatives markets. |
+| =equityoption= | Equity options and equity derivatives markets. |
+| =equityoptionposition= | Equity option positions and weighted option baskets. |
+| =equityposition= | Equity positions and weighted equity baskets. |
+| =equityswap= | Equity swaps and equity derivatives markets. |
+| =equityvarianceswap= | Equity variance swaps and equity volatility markets. |
 | =finance= | Finance domain, products, and markets. |
 | =flexiswap= | Flexi swaps and flexible amortisation structures. |
 | =forwardrateagreement= | Forward rate agreements and the money market forward curve. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -184,12 +184,16 @@ Tags that describe the business or technical domain of the content.
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
 | =cpiswap= | CPI inflation swaps and inflation-linked markets. |
+| =creditdefaultswap= | Single-name credit default swaps and credit markets. |
+| =creditlinkedswap= | Credit linked swaps and structured credit. |
 | =deployment= | Deployment and environment provisioning. |
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
 | =entity= | Domain entity (also used as type tag). |
 | =finance= | Finance domain, products, and markets. |
 | =fx_forward= | FX forward contracts and the FX derivatives market. |
+| =indexcds= | Index credit default swaps and credit indices. |
+| =indexcdsoption= | Options on index credit default swaps. |
 | =knowledge_graph= | org-roam knowledge graph management. |
 | =lifecycle= | Entity or component lifecycle management. |
 | =llm_code_review= | LLM-assisted code review tooling. |
@@ -202,9 +206,11 @@ Tags that describe the business or technical domain of the content.
 | =rbac= | Role-Based Access Control. |
 | =refdata= | Reference data (currencies, countries, calendars, etc.). |
 | =release= | Release management and release notes. |
+| =rpa= | Risk participation agreements and counterparty credit risk. |
 | =security= | Security features and hardening (also component tag). |
 | =sprint= | Sprint-level document (also type tag). |
 | =swap= | Swap products and interest-rate derivatives. |
+| =syntheticcdo= | Synthetic collateralised debt obligations and tranches. |
 | =testing= | Test infrastructure, test coverage. |
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -179,8 +179,10 @@ Tags that describe the business or technical domain of the content.
 | =ascot= | Ascot options and convertible bond buyback structures. |
 | =authentication= | Authentication flows and session management. |
 | =authorization= | Authorisation, roles, permissions. |
+| =autocallable_01= | Autocallables and autocallable structured products. |
 | =balanceguaranteedswap= | Balance guaranteed swaps and prepayment-linked amortising structures. |
 | =basketoption= | Basket options and multi-asset option structures. |
+| =bestentryoption= | Best entry options and best-entry participation structures. |
 | =build= | Build system, CI, packaging. |
 | =bond= | Bond instruments and fixed-income cash products. |
 | =bondforward_refdata= | Bond forwards settled against reference-data bonds. |
@@ -215,6 +217,7 @@ Tags that describe the business or technical domain of the content.
 | =deployment= | Deployment and environment provisioning. |
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
+| =doubledigitaloption= | Double digital options and simultaneous two-underlying binary payouts. |
 | =entity= | Domain entity (also used as type tag). |
 | =eq_asianoption= | Equity Asian options and averaged-price equity derivatives. |
 | =eq_barrieroption= | Equity barrier options and path-dependent equity derivatives. |
@@ -222,6 +225,7 @@ Tags that describe the business or technical domain of the content.
 | =eq_doublebarrieroption= | Equity double barrier options and path-dependent equity derivatives. |
 | =eq_doubletouchoption= | Equity double touch options and binary equity derivatives. |
 | =eq_europeanbarrieroption= | Equity European barrier options and path-dependent equity derivatives. |
+| =eq_outperformance= | Equity outperformance options and relative-performance equity derivatives. |
 | =eq_touchoption= | Equity touch options and binary equity derivatives. |
 | =equityautodeltahedgedoption= | Equity auto delta hedged options and discretely hedged structures. |
 | =equitycliquetoption= | Equity cliquet options and ratchet structures. |
@@ -232,6 +236,7 @@ Tags that describe the business or technical domain of the content.
 | =equityposition= | Equity positions and weighted equity baskets. |
 | =equityswap= | Equity swaps and equity derivatives markets. |
 | =equityvarianceswap= | Equity variance swaps and equity volatility markets. |
+| =europeanoptioncontingentonabarrier= | European options contingent on a barrier on another underlying. |
 | =extendedaccumulator= | Extended accumulators and barrier-extended forward accumulations. |
 | =finance= | Finance domain, products, and markets. |
 | =flexiswap= | Flexi swaps and flexible amortisation structures. |
@@ -250,6 +255,7 @@ Tags that describe the business or technical domain of the content.
 | =fxoption= | FX options and the FX derivatives market. |
 | =fxswap= | FX swaps and the FX derivatives market. |
 | =fxvarianceswap= | FX variance swaps and FX volatility markets. |
+| =generic_barrieroption= | Generic barrier options and multi-barrier structured payoffs. |
 | =indexcds= | Index credit default swaps and credit indices. |
 | =indexcdsoption= | Options on index credit default swaps. |
 | =knowledge_graph= | org-roam knowledge graph management. |
@@ -261,6 +267,7 @@ Tags that describe the business or technical domain of the content.
 | =model= | Codegen data model. |
 | =modelling= | Domain or system modelling. |
 | =performance= | Performance measurement and optimisation. |
+| =performanceoption_01= | Performance options and basket performance participation structures. |
 | =provisioning= | System provisioning workflows and wizards. |
 | =ratedigitaloption= | Rate digital options and binary interest rate derivatives. |
 | =rbac= | Role-Based Access Control. |
@@ -279,6 +286,7 @@ Tags that describe the business or technical domain of the content.
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
+| =window_barrieroption= | Window barrier options and time-windowed barrier structures. |
 | =worstofbasketswap= | Worst of basket swaps and basket trigger structures. |
 | =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |
 | =zerocouponswap= | Zero coupon swaps and zero-coupon interest rate structures. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -183,6 +183,7 @@ Tags that describe the business or technical domain of the content.
 | =ci= | Continuous integration. |
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
+| =cpiswap= | CPI inflation swaps and inflation-linked markets. |
 | =deployment= | Deployment and environment provisioning. |
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
@@ -208,6 +209,7 @@ Tags that describe the business or technical domain of the content.
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
+| =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |
 
 * Story and ancestry slug tags
 

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -175,14 +175,25 @@ Tags that describe the business or technical domain of the content.
 | =accounts= | User accounts and authentication. |
 | =agile= | Agile process, sprint planning, retrospectives. |
 | =architecture= | Software architecture documentation. |
+| =ascot= | Ascot options and convertible bond buyback structures. |
 | =authentication= | Authentication flows and session management. |
 | =authorization= | Authorisation, roles, permissions. |
 | =balanceguaranteedswap= | Balance guaranteed swaps and prepayment-linked amortising structures. |
 | =build= | Build system, CI, packaging. |
 | =bond= | Bond instruments and fixed-income cash products. |
+| =bondforward_refdata= | Bond forwards settled against reference-data bonds. |
+| =bondfuture= | Bond futures and the delivery-basket contract market. |
+| =bondoption= | Bond options and government bond options markets. |
+| =bondoption_refdata= | Bond options settled against reference-data bonds. |
+| =bondposition= | Bond positions and weighted bond baskets. |
+| =bondrepo= | Bond repos and secured money market funding. |
+| =bondtotalreturnswap= | Bond total return swaps and secured financing markets. |
+| =callablebond= | Callable bonds and embedded-option bond structures. |
 | =calendars= | Business calendars and day-count conventions. |
 | =callableswap= | Callable swaps and cancellable interest rate swaps. |
 | =capfloor= | Interest rate caps, floors, collars, and caplet markets. |
+| =cashposition= | Cash positions and cash funding components. |
+| =cbodata= | Collateral bond obligations and cashflow securitisation. |
 | =ci= | Continuous integration. |
 | =commodityapo= | Commodity average price options and Asian commodity options. |
 | =commodityforward= | Commodity forward contracts and commodity derivatives markets. |
@@ -192,6 +203,7 @@ Tags that describe the business or technical domain of the content.
 | =commodityswap= | Commodity swaps and commodity derivatives markets. |
 | =commodityswaption= | Commodity swaptions and commodity derivatives markets. |
 | =commodityvarianceswap= | Commodity variance swaps and commodity volatility markets. |
+| =convertiblebond= | Convertible bonds and hybrid equity-debt instruments. |
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
 | =cpiswap= | CPI inflation swaps and inflation-linked markets. |
@@ -219,6 +231,7 @@ Tags that describe the business or technical domain of the content.
 | =equityvarianceswap= | Equity variance swaps and equity volatility markets. |
 | =finance= | Finance domain, products, and markets. |
 | =flexiswap= | Flexi swaps and flexible amortisation structures. |
+| =forwardbond= | Forward bonds, T-Locks and J-Locks. |
 | =forwardrateagreement= | Forward rate agreements and the money market forward curve. |
 | =fx_forward= | FX forward contracts and the FX derivatives market. |
 | =fx_asianoption= | FX Asian options and averaged-rate FX derivatives. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -178,6 +178,7 @@ Tags that describe the business or technical domain of the content.
 | =authentication= | Authentication flows and session management. |
 | =authorization= | Authorisation, roles, permissions. |
 | =build= | Build system, CI, packaging. |
+| =bond= | Bond instruments and fixed-income cash products. |
 | =calendars= | Business calendars and day-count conventions. |
 | =ci= | Continuous integration. |
 | =currencies= | Currency reference data. |
@@ -186,6 +187,8 @@ Tags that describe the business or technical domain of the content.
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
 | =entity= | Domain entity (also used as type tag). |
+| =finance= | Finance domain, products, and markets. |
+| =fx_forward= | FX forward contracts and the FX derivatives market. |
 | =knowledge_graph= | org-roam knowledge graph management. |
 | =lifecycle= | Entity or component lifecycle management. |
 | =llm_code_review= | LLM-assisted code review tooling. |
@@ -200,6 +203,7 @@ Tags that describe the business or technical domain of the content.
 | =release= | Release management and release notes. |
 | =security= | Security features and hardening (also component tag). |
 | =sprint= | Sprint-level document (also type tag). |
+| =swap= | Swap products and interest-rate derivatives. |
 | =testing= | Test infrastructure, test coverage. |
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -177,9 +177,12 @@ Tags that describe the business or technical domain of the content.
 | =architecture= | Software architecture documentation. |
 | =authentication= | Authentication flows and session management. |
 | =authorization= | Authorisation, roles, permissions. |
+| =balanceguaranteedswap= | Balance guaranteed swaps and prepayment-linked amortising structures. |
 | =build= | Build system, CI, packaging. |
 | =bond= | Bond instruments and fixed-income cash products. |
 | =calendars= | Business calendars and day-count conventions. |
+| =callableswap= | Callable swaps and cancellable interest rate swaps. |
+| =capfloor= | Interest rate caps, floors, collars, and caplet markets. |
 | =ci= | Continuous integration. |
 | =commodityapo= | Commodity average price options and Asian commodity options. |
 | =commodityforward= | Commodity forward contracts and commodity derivatives markets. |
@@ -199,6 +202,8 @@ Tags that describe the business or technical domain of the content.
 | =domain= | Business domain modelling. |
 | =entity= | Domain entity (also used as type tag). |
 | =finance= | Finance domain, products, and markets. |
+| =flexiswap= | Flexi swaps and flexible amortisation structures. |
+| =forwardrateagreement= | Forward rate agreements and the money market forward curve. |
 | =fx_forward= | FX forward contracts and the FX derivatives market. |
 | =fx_asianoption= | FX Asian options and averaged-rate FX derivatives. |
 | =fx_barrieroption= | FX barrier options and path-dependent FX derivatives. |
@@ -215,6 +220,7 @@ Tags that describe the business or technical domain of the content.
 | =indexcds= | Index credit default swaps and credit indices. |
 | =indexcdsoption= | Options on index credit default swaps. |
 | =knowledge_graph= | org-roam knowledge graph management. |
+| =knockoutswap= | Knock-out swaps and barrier-terminated interest rate swaps. |
 | =lifecycle= | Entity or component lifecycle management. |
 | =llm_code_review= | LLM-assisted code review tooling. |
 | =logging= | Logging and observability. |
@@ -223,6 +229,7 @@ Tags that describe the business or technical domain of the content.
 | =modelling= | Domain or system modelling. |
 | =performance= | Performance measurement and optimisation. |
 | =provisioning= | System provisioning workflows and wizards. |
+| =ratedigitaloption= | Rate digital options and binary interest rate derivatives. |
 | =rbac= | Role-Based Access Control. |
 | =refdata= | Reference data (currencies, countries, calendars, etc.). |
 | =release= | Release management and release notes. |
@@ -230,12 +237,14 @@ Tags that describe the business or technical domain of the content.
 | =security= | Security features and hardening (also component tag). |
 | =sprint= | Sprint-level document (also type tag). |
 | =swap= | Swap products and interest-rate derivatives. |
+| =swaption= | Swaptions and the interest rate option market. |
 | =syntheticcdo= | Synthetic collateralised debt obligations and tranches. |
 | =testing= | Test infrastructure, test coverage. |
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
 | =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |
+| =zerocouponswap= | Zero coupon swaps and zero-coupon interest rate structures. |
 
 * Story and ancestry slug tags
 

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -173,12 +173,14 @@ Tags that describe the business or technical domain of the content.
 | Tag | Description |
 |-----+-------------|
 | =accounts= | User accounts and authentication. |
+| =accumulator= | Accumulators, decumulators and forward-accumulation structures. |
 | =agile= | Agile process, sprint planning, retrospectives. |
 | =architecture= | Software architecture documentation. |
 | =ascot= | Ascot options and convertible bond buyback structures. |
 | =authentication= | Authentication flows and session management. |
 | =authorization= | Authorisation, roles, permissions. |
 | =balanceguaranteedswap= | Balance guaranteed swaps and prepayment-linked amortising structures. |
+| =basketoption= | Basket options and multi-asset option structures. |
 | =build= | Build system, CI, packaging. |
 | =bond= | Bond instruments and fixed-income cash products. |
 | =bondforward_refdata= | Bond forwards settled against reference-data bonds. |
@@ -203,6 +205,7 @@ Tags that describe the business or technical domain of the content.
 | =commodityswap= | Commodity swaps and commodity derivatives markets. |
 | =commodityswaption= | Commodity swaptions and commodity derivatives markets. |
 | =commodityvarianceswap= | Commodity variance swaps and commodity volatility markets. |
+| =compositetrade= | Composite trades and multi-component trade structures. |
 | =convertiblebond= | Convertible bonds and hybrid equity-debt instruments. |
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
@@ -229,6 +232,7 @@ Tags that describe the business or technical domain of the content.
 | =equityposition= | Equity positions and weighted equity baskets. |
 | =equityswap= | Equity swaps and equity derivatives markets. |
 | =equityvarianceswap= | Equity variance swaps and equity volatility markets. |
+| =extendedaccumulator= | Extended accumulators and barrier-extended forward accumulations. |
 | =finance= | Finance domain, products, and markets. |
 | =flexiswap= | Flexi swaps and flexible amortisation structures. |
 | =forwardbond= | Forward bonds, T-Locks and J-Locks. |
@@ -265,13 +269,17 @@ Tags that describe the business or technical domain of the content.
 | =rpa= | Risk participation agreements and counterparty credit risk. |
 | =security= | Security features and hardening (also component tag). |
 | =sprint= | Sprint-level document (also type tag). |
+| =strikeresettableoption= | Strike resettable options and trigger-reset option structures. |
 | =swap= | Swap products and interest-rate derivatives. |
 | =swaption= | Swaptions and the interest rate option market. |
 | =syntheticcdo= | Synthetic collateralised debt obligations and tranches. |
+| =tarf= | Target redemption forwards and forward-accumulation structures. |
 | =testing= | Test infrastructure, test coverage. |
+| =totalreturnswap= | Total return swaps and funded asset exposure structures. |
 | =trading= | Trading domain (also component tag). |
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
+| =worstofbasketswap= | Worst of basket swaps and basket trigger structures. |
 | =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |
 | =zerocouponswap= | Zero coupon swaps and zero-coupon interest rate structures. |
 

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -181,6 +181,14 @@ Tags that describe the business or technical domain of the content.
 | =bond= | Bond instruments and fixed-income cash products. |
 | =calendars= | Business calendars and day-count conventions. |
 | =ci= | Continuous integration. |
+| =commodityapo= | Commodity average price options and Asian commodity options. |
+| =commodityforward= | Commodity forward contracts and commodity derivatives markets. |
+| =commodityoption= | Commodity options and commodity derivatives markets. |
+| =commodityoptionstrip= | Commodity option strips and commodity derivatives markets. |
+| =commodityposition= | Commodity positions and weighted commodity baskets. |
+| =commodityswap= | Commodity swaps and commodity derivatives markets. |
+| =commodityswaption= | Commodity swaptions and commodity derivatives markets. |
+| =commodityvarianceswap= | Commodity variance swaps and commodity volatility markets. |
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
 | =cpiswap= | CPI inflation swaps and inflation-linked markets. |


### PR DESCRIPTION
## Summary

Adds an ORE product knowledge catalogue to the documentation site. 88 product knowledge notes now live in `doc/knowledge/domain/`, one org-roam page per ORE product. A new entry page, "ORE Products by Asset Class" (`doc/knowledge/domain/products_by_asset_class.org`), groups every product into a table per asset class. Each row links to the product's served page with an absolute URL.

## Changes

- Add 88 product knowledge notes in `doc/knowledge/domain/`. Each note describes the product, its trade data, and its market conventions, with a `See also` org-roam link back to the knowledge hub and a `Source` line pointing at the product chapter in the upstream ORE User Guide.
- Add the entry page `products_by_asset_class.org`. It has one section per asset class (Rates, FX, Commodity, Credit, Equity, Bond and Cash, Composite and Scripted waves) and a two-column org table per section, with absolute links to the served `.html` pages.
- Link every product page back to the knowledge hub (`doc/knowledge/knowledge.org`, ID `7474935C-95D1-3034-B833-83DCD9FB3A09`) via org-roam links.
- Convert the `=Docs/UserGuide/...tex=` code references in every product note into org-mode http links to the actual files in the OpenSourceRisk/Engine repository. Every referenced `.tex` file was verified to exist on upstream `master` before linking.
- Update the hub page `doc/knowledge/knowledge.org` to point at the catalogue and at the upstream `Docs/UserGuide/tradedata/` directory, and update `doc/meta/tag_inventory.org` for the new filetags.

## Verification

- `compass lint --path doc`: all filetags valid. Ran after the rebase onto the latest `origin/main`.
- Full site build: succeeded (exit 0), which republished all catalogue pages and regenerated the roam graph (5178 nodes). Ran before the rebase on identical file content.
- Incremental site build after the rebase: succeeded, publishing only changed pages.
- Served pages checked over HTTP: the entry page returns 200 at `http://192.168.1.172:21404/OreStudio/doc/knowledge/domain/products_by_asset_class.html`; the built HTML carries one table per asset class with 88 absolute links; product pages carry the hub backlink; the GitHub `.tex` hrefs resolve to the upstream files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
