### PR TITLE
Add code-review-data-model skill

### DIFF
--- a/doc/knowledge/architecture/data_oriented_design.org
+++ b/doc/knowledge/architecture/data_oriented_design.org
@@ -1,0 +1,219 @@
+:PROPERTIES:
+:ID: BBD43BF2-9FEE-42B0-A667-9468AF759DC2
+:END:
+#+title: Data-Oriented Design in ORE Studio
+#+description: What data-oriented design means for ORE Studio and the criteria for reviewing a component's data model against it.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:architecture:modelling:performance:data_oriented_design:
+#+created: 2026-09-08
+#+updated: 2026-09-08
+
+* Summary
+
+Data-oriented design (DOD) organises data by how code accesses it,
+not by the conceptual hierarchy of the domain. In ORE Studio it
+governs two regimes: /numerical kernels/ (pricing, simulation,
+analytics) where layout decides cache and vectorisation performance,
+and /persisted domain data/ (entities, reference data, trades) where
+the value-semantics and shape of the C++ types decide cost. A third
+regime, the wire format, applies the same axioms to NATS messages and
+JSON. The [[id:AE72D444-02B1-4428-B56C-062B849ED568][code-review-data-model]] skill reviews a
+component's data model against the criteria below; this page is the
+canonical statement of those criteria.
+
+* Detail
+
+** The principle and the axioms
+
+The first statement is the founding principle of DOD. The five that
+follow are the operational axioms derived from it. Only the axioms
+produce review checks. The principle explains why the axioms hold;
+it is not itself a check, so never score it.
+
+1. /Data is memory/ — the principle. Code exists only to transform
+   data from one representation to another. The representation
+   decides the cost.
+2. /Access patterns drive layout./ Organise data by how and when code
+   reads and writes it together, not by real-world taxonomy.
+3. /Structure of Arrays (SoA) over Array of Structures (AoS)./ Prefer
+   parallel contiguous arrays per attribute over arrays of fat
+   heap-allocated objects.
+4. /Separate hot and cold data./ Isolate state read or written on
+   high-frequency paths from metadata read rarely or once.
+5. /Handles over pointers./ Use keys, indices, and offsets instead of
+   per-object heap pointers and object trees.
+6. /Batch over per-object./ Write functions that process contiguous
+   collections in bulk, not one call per object.
+
+** Where each axiom applies
+
+ORE Studio is a database-backed application with Qt clients and a
+quantitative engine on QuantLib. DOD is not one rule for the whole
+codebase. A review that demands SoA for a CRUD entity, or accepts a
+pointer graph inside a simulation kernel, has misread the regime.
+
+*** Regime 1 — numerical kernels
+
+The hot paths: valuation, simulation, curve bootstrapping, analytics,
+compute workunits. Axioms 2-6 apply in full. Typical evidence: a loop
+over trades, paths, or steps that reads a few fields of each object.
+
+*** Regime 2 — persisted domain data
+
+Entities and their C++ value types: reference data, trading
+instruments, market data, synthetic entities. The database owns the
+storage layout; the C++ types are the in-memory and wire shape. DOD
+here means value semantics, identity by key, and a clean split of
+core state from cold annexes — not cache-line gymnastics.
+
+*** Regime 3 — wire and messaging
+
+NATS messages, JSON, CSV, and table I/O. The axioms apply as: flat
+value-shaped messages, versioned schemas, closed explicit
+polymorphism (see [[id:C951B5F1-B51C-4274-BA4D-6297AD46A4FB][Polymorphic types over NATS]]), and batched
+messages for high-volume feeds.
+
+The wire shape is a codegen projection of the Regime 2 entity, not a
+second artefact: one entity yields one JSON codec and one table
+codec. Review each entity once — its org model, its generated C++
+type, and its projections together — and do not walk the message
+shape again separately. Hand-written message types are the
+exception; they get their own Regime 3 walk.
+
+*** The boundary of the regimes
+
+The three regimes cover table-shaped data and its projections. They
+are a labelled cover of this codebase, not a partition of every
+possible data shape. One category sits outside them: document-shaped
+payloads — an FpML trade document, an ORE XML input, an org-mode
+file parsed into a heading tree. Such documents enter at the
+boundary of the stack, where a mapping layer converts them to and
+from the core data-model representation (for example, an FpML trade
+maps to =trade= and its instrument entities). The document tree is
+transient; the entity representation, designed for performance, is
+the review target.
+
+For a document-shaped type, mark the table-shaped-children and
+flat-value-message checks as not applicable and say why. In-tree
+today the category exists only as hand-written core types in
+=ores.orgmode= (the heading/document structure) and in the FpML
+parsing path of =ores.fpml=; no entity model instantiates it yet.
+Revisit this paragraph if an entity model ever persists document
+trees.
+
+** The data model of a component
+
+The artefacts a review reads, per component under =projects/ores.<name>=:
+
+- =modeling/*.org= — the codegen entity, junction, and field-group
+  models (where the component is codegen-driven). The
+  =lookup_entity= metatype is reserved in codegen but has no
+  authored instances; do not hunt for lookup models.
+- The domain C++ types they generate, or hand-written domain headers
+  in the =core= facet. This generated representation is the core
+  data model, designed for performance; the review target.
+- The SQL schema the entity maps to: the =CREATE TABLE= statements
+  generated under =projects/ores.sql/create/<component>/=.
+- Repository and service signatures: how code fetches collections and
+  looks up records.
+- Kernel entry points and their inner loops, for Regime 1 components.
+
+** Review criteria
+
+*** Regime 1 checklist
+
+| Check | Description |
+|-------+-------------|
+| SoA on the hot path | Fields a kernel iterates sit in parallel contiguous arrays, not in an array of fat objects. |
+| No hot-loop allocation | Buffers are reused; no allocate/free or lock inside the loop. |
+| No per-object dispatch | The hot path calls batch free functions over spans; no virtual or per-object indirection. |
+| Hot/cold kernel inputs | Metadata read once per run is not interleaved with per-step state. |
+| Predictable access | Inner loops are stride-1 over contiguous memory so the compiler can vectorise. |
+| Plain inputs | Kernels take plain structs and free functions (e.g. a log-normal short-rate SDE), not stateful class hierarchies. |
+
+*** Regime 2 checklist
+
+Regime 2 review walks two surfaces, and each check below states
+which one it applies to:
+
+- /The decision surface/: the =modeling/*.org= model choices — key
+  style, field-group split, junction versus blob, batched access.
+  These choices can fail; codegen does not rescue them. Review them
+  per entity model.
+- /The invariant surface/: on codegen entities, value semantics,
+  pointer-freedom, and generated codecs are generator invariants.
+  Codegen cannot emit a =shared_ptr= or a hand-rolled codec. Walking
+  a guarantee per entity rubber-stamps it. Spot-check each invariant
+  once per component on the generated output, or rely on the codegen
+  drift check (the [[id:7908E2AF-E196-443F-8FB7-0047553D8EFE][codegen-fix-drift]] skill owns drift). Hand-written
+  domain types in the =core= facet have no generator; walk both
+  tables in full on them.
+
+Decision checks — walk per entity model:
+
+| Check | Description |
+|-------+-------------|
+| Identity by key | Relationships are keys and foreign keys, not pointers or owning-parent links. |
+| Table-shaped children | Child records are rows in their own table (junction/FK), not nested object trees. |
+| Core/cold split | =field_group= and table design separate core fields from cold annexes (change-reason cache, history, versioning, audit). |
+| Batched collection access | Repositories and services return collections, not row-at-a-time callbacks. |
+| Explicit variation | A family of related entities (for example, instruments) states its variation explicitly — per-type tables or a closed variant — not open inheritance webs. |
+
+Invariant checks — spot-check once per component:
+
+| Check | Description |
+|-------+-------------|
+| Value semantics | Generated domain types are plain values with a key; no owning-pointer members. |
+| No shared-ownership webs | No =shared_ptr= inside domain types; ownership sits at component boundaries. |
+| Codec drift | JSON/CSV/table codecs come from codegen unmodified; regenerate rather than hand-patch. |
+
+*** Regime 3 checklist
+
+| Check | Description |
+|-------+-------------|
+| Flat value messages | Messages are value-shaped, not object graphs over the wire. |
+| Versioned and closed | Schema evolution is explicit; polymorphism is closed and versioned. |
+| Feed batching | High-volume feeds batch items per message instead of one message per item. |
+
+** Report conventions
+
+A component review produces, per component:
+
+- A regime classification with the reasons (what is hot, what is
+  cold, where the boundaries are).
+- A findings table: severity (Critical / Important / Minor), effort
+  (Small / Medium / Large), and the criterion each finding maps to.
+- A per-regime score of 1-5 where the regime applies.
+- An overall data-model verdict and a debt level of Low / Medium /
+  High.
+
+Scores are anchored, not arithmetic. Pick the row the review most
+resembles:
+
+| Score | What that looks like | Debt |
+|-------+----------------------+------|
+| 5 | All applicable checks pass; only evidence-free opportunities remain. | Low |
+| 4 | Decisions pass with Minor findings; invariants hold. | Low |
+| 3 | One Important finding, localised to one model or one kernel. | Medium |
+| 2 | Several Important findings, or one Critical finding in a main flow. | Medium |
+| 1 | Critical findings on identity, core/cold split, or a hot loop; systemic. | High |
+
+The debt bands follow the score: 4-5 is Low, 3 is Medium, 1-2 is
+High. A regime that does not apply to the component is unscored,
+not scored 0. Two reviews of the same component should land within
+one point of each other; if they do not, the classification or the
+evidence was unclear, not the scale.
+
+Hot-path claims need evidence: the loop structure, a profile, or a
+benchmark. Without evidence, record a layout risk as an opportunity,
+not a defect. A finding that demands a transformation outside the
+component's regime is a review error, not a finding.
+
+* See also
+
+- [[id:0FB2EA84-EBB8-45C8-A8C8-F5815431C2D2][Code Review Checklist]] — the sibling criteria set for general
+  component and PR review.
+- [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]] — the broad whole-component audit this lens
+  complements.
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the index this page belongs to.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -413,6 +413,10 @@ organised by asset class on the [[id:C5C95B29-2EF9-4DFC-9E04-428C41C1925D][ORE P
 
 How the codebase is put together.
 
+- [[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-Oriented Design in ORE Studio]] — what data-oriented design
+  means for this codebase: the three regimes (numerical kernels,
+  persisted domain data, wire), and the criteria for reviewing a
+  component's data model against them.
 - [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]] — api/core/service split, facet
   placement, CMake dependency chain, and scaffold profiles.
 - [[id:1805BAFC-7E43-4D9C-822F-17C3455C6E00][Compute job lifecycle]] — how a compute job travels through the

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -104,6 +104,7 @@ Build, tests, review, investigation — code written by hand.
 | [[id:CB56337E-4839-4048-B5A7-C481812CE3D0][code-add-tests]] | Code Add Tests | Generate Catch2 unit tests for ORE Studio components — domain, repository, messaging, generators, service,... |
 | [[id:8C1E8069-F6D1-44C2-8EE1-CE01FD59D527][code-investigate-test-failure]] | Code Investigate Test Failure | Investigate unit test failures by enabling logging, running the failing suite, parsing the result XML, and... |
 | [[id:5A95BE6A-2B11-402F-A427-71F93FA06A25][code-review-comments]] | Review and clean code comments | Review and clean code comments — remove clutter, keep necessary explanations, place comments above the code... |
+| [[id:AE72D444-02B1-4428-B56C-062B849ED568][code-review-data-model]] | Code Review Data Model Skill | Review a component's data model against the data-oriented design criteria: regime classification, layout, value semantics, ho... |
 | [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]] | Code Review Component Skill | Deep audit of one or more ORE Studio components for technical debt, modernisation opportunities, and conven... |
 | [[id:04CA6BD9-7739-4213-A9DC-17AAACE43252][code-review-pr]] | Code Review PR Skill | Review changes in a pull request against the ORE Studio code-review checklist; produce findings bucketed by... |
 | [[id:654D4A70-E63D-4C18-B5A5-886066E36314][code-run-build]] | Code Run Build | Run CMake operations on ORE Studio — configure, build, test, deploy site, deploy skills, generate PlantUML... |

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -68,7 +68,7 @@ PR lifecycle.
 |------+-------+-------------|
 | [[id:38ACE767-95D6-4A6E-88A8-EC93BB350292][pr-address-review]] | PR Address Review | Handle one complete PR review round: sync, read comments, decide, fix, push, reply, resolve, record. |
 | [[id:D36BCA19-8926-4E06-8C0B-7F607BD3D4EC][pr-merge]] | PR Merge | Merge a PR with guard rails: threads resolved, CI green, task bookkeeping already closed. |
-| [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][pr-raise]] | PR Raise | Open a pull request with compass pr create, then post an @claude comment to trigger the interactive code re... |
+| [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][pr-raise]] | PR Raise | Run the local code review, then open a pull request with compass pr create and post an @claude comment to t... |
 | [[id:25EDDA60-36D2-4F7C-9D99-D75B43705D08][pr-show-checks]] | PR Show Checks | Show CI check status for a PR, optionally watching until completion. |
 | [[id:D3CF614D-4889-409F-B938-22C877189B07][pr-sync-branch]] | PR Sync Branch | Rebase the current feature branch on origin/main and report divergence; never work on a stale branch. |
 
@@ -87,6 +87,7 @@ Recipes, knowledge, manual, memory, diagrams, search.
 | [[id:7357C672-A49F-4974-9399-A166F761D222][doc-add-memory]] | Doc Add Memory | When the user gives feedback worth remembering, or asks "remember this", write or update a memory under doc... |
 | [[id:28AAF9A6-B1E4-402A-83BB-289090990FB8][doc-add-recipe]] | Doc Add Recipe | Add new how-do-I recipes to ORE Studio under doc/recipes/<topic>/. Pick the right topic, scaffold via the c... |
 | [[id:D4B099D0-FF9B-4029-96ED-6EE77439DF41][doc-find]] | Doc Find | Search every document in the repository: full-text search and structured filters over the org-roam graph. |
+| [[id:180D0EB5-C08A-4C96-B266-3DF593E8F5E3][doc-review-academic]] | Review and write academic prose | Layered review of argumentative documentation: claim, spine, paragraph, sentence, term, evidence, honesty. |
 | [[id:ADDFBA8F-EAE3-47DD-9FFA-A171DA47ABA3][doc-review-ste100]] | Review and rewrite agent output using ASD-STE100 Simplified Technical English | Rewrites ambiguous English into ASD-STE100 style — one meaning per word, active voice, simple tense, short... |
 | [[id:9CCEF67E-1BCF-440B-8112-093B40085A7C][doc-run-manual-screenshots]] | Doc Run Manual Screenshots | Turn a manual chapter's [SCREENSHOT NEEDED] placeholders into real, cropped screenshots -- confirm a build... |
 | [[id:0F8DE59C-9CD1-463A-9148-0B452A985C23][doc-show]] | Doc Show | Show one document by UUID or prefix: metadata, blurb, incoming and outgoing links. |
@@ -104,8 +105,8 @@ Build, tests, review, investigation — code written by hand.
 | [[id:CB56337E-4839-4048-B5A7-C481812CE3D0][code-add-tests]] | Code Add Tests | Generate Catch2 unit tests for ORE Studio components — domain, repository, messaging, generators, service,... |
 | [[id:8C1E8069-F6D1-44C2-8EE1-CE01FD59D527][code-investigate-test-failure]] | Code Investigate Test Failure | Investigate unit test failures by enabling logging, running the failing suite, parsing the result XML, and... |
 | [[id:5A95BE6A-2B11-402F-A427-71F93FA06A25][code-review-comments]] | Review and clean code comments | Review and clean code comments — remove clutter, keep necessary explanations, place comments above the code... |
-| [[id:AE72D444-02B1-4428-B56C-062B849ED568][code-review-data-model]] | Code Review Data Model Skill | Review a component's data model against the data-oriented design criteria: regime classification, layout, value semantics, ho... |
 | [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]] | Code Review Component Skill | Deep audit of one or more ORE Studio components for technical debt, modernisation opportunities, and conven... |
+| [[id:AE72D444-02B1-4428-B56C-062B849ED568][code-review-data-model]] | Code Review Data Model Skill | Review a component's data model against the data-oriented design criteria: regime classification, layout, v... |
 | [[id:04CA6BD9-7739-4213-A9DC-17AAACE43252][code-review-pr]] | Code Review PR Skill | Review changes in a pull request against the ORE Studio code-review checklist; produce findings bucketed by... |
 | [[id:654D4A70-E63D-4C18-B5A5-886066E36314][code-run-build]] | Code Run Build | Run CMake operations on ORE Studio — configure, build, test, deploy site, deploy skills, generate PlantUML... |
 | [[id:4FEB154D-50EF-4346-BB75-B0881188E4F5][code-run-feature-test]] | Code Run Feature Test | Test a feature after finishing implementation — ask about a build, confirm/recreate a fresh database, provi... |

--- a/doc/llm/skills/code-review-data-model/SKILL.org
+++ b/doc/llm/skills/code-review-data-model/SKILL.org
@@ -1,0 +1,121 @@
+:PROPERTIES:
+:ID: AE72D444-02B1-4428-B56C-062B849ED568
+:END:
+#+title: Code Review Data Model Skill
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :llm:skill:skills:claude_code:review:modelling:data_oriented_design:
+#+created: 2026-09-08
+#+updated: 2026-09-08
+
+#+begin_export markdown
+---
+name: code-review-data-model
+description: Review a component's data model against the data-oriented design criteria: regime classification, layout, value semantics, hot/cold split, batch access. Use when asked to review or audit the data model or domain types of one or more ORE Studio components.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When you must assess a component's /data model/ — its domain types,
+entity models, schemas, and kernel data structures — against the
+[[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][data-oriented design]] criteria: layout, value semantics, hot/cold
+split, batch access. Use before major data-model refactors, when
+onboarding to a component, or periodically to track data-model debt.
+It is the single-lens complement to the broad
+[[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]] audit. For PR-delta reviews, use
+[[id:04CA6BD9-7739-4213-A9DC-17AAACE43252][code-review-pr]].
+
+* How to use this skill
+
+1. /Identify the component(s)/. Components live under
+   =projects/ores.<component>=. To see all known components:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh list --type component
+   #+end_src
+
+2. /Classify the regimes/. For each component, map its parts onto the
+   three regimes in [[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-Oriented Design in ORE Studio]]: numerical
+   kernels (Regime 1), persisted domain data (Regime 2), wire and
+   messaging (Regime 3). A component spans regimes; state which part
+   is which and why. Document-shaped payloads sit outside the three
+   regimes — the knowledge doc states the boundary.
+
+3. /Gather the data-model artefacts/. Regime 2 review walks two
+   surfaces, and the checklist states which surface each check
+   applies to:
+   - /The decision surface/: the =modeling/*.org= entity, junction,
+     and field-group models. The =lookup_entity= metatype is reserved
+     but has no authored instances; do not hunt for lookup models.
+   - /The invariant surface/: the domain C++ types codegen generates
+     from those models, and hand-written domain headers in the
+     =core= facet.
+   Also gather, per regime: the SQL schema the entities map to (the
+   =CREATE TABLE= statements under
+   =projects/ores.sql/create/<component>/=); repository and service
+   signatures; and kernel entry points with their inner loops.
+
+4. /Apply the matching checklists/. The checklists live under
+   =* Review criteria= in the knowledge doc. Walk the Regime 1, 2, or
+   3 checklist for each classified part; on Regime 2, walk the
+   decision checks per entity model and spot-check the invariant
+   checks once per component. Mark checks outside a part's regime as
+   not-applicable — never demand SoA of a CRUD entity, never accept a
+   pointer graph inside a simulation kernel, and never force
+   table-shaped or flat-message checks onto document-shaped payloads.
+
+5. /Apply the evidence rule/. Hot-path claims need the loop
+   structure, a profile, or a benchmark as evidence. Without
+   evidence, record a layout risk as an opportunity, not a defect.
+
+6. /Score and report/. Per component: a 1-5 score per applicable
+   regime using the scoring anchors in the knowledge doc, a findings
+   table (severity, effort, mapped criterion), an overall data-model
+   verdict, and a debt level of Low / Medium / High. Follow the
+   report conventions in the knowledge doc.
+
+7. /Summarise/. Conclude with the per-component score table, the top
+   3-5 recommendations, and the overall debt level. This skill only
+   reviews — filing remediation stories is a separate decision made
+   through the backlog.
+
+* Recipes
+
+- [[id:E8231C22-CB31-4D85-A9C0-7602953764FF][How do I show a doc by UUID?]] — to inspect the component's
+  =component_overview.org= and its modeling docs.
+- [[id:D1AE0786-5F2F-4437-8449-0E480C278A1B][How do I find docs matching a pattern?]] — to enumerate a
+  component's modeling files, tasks, and stories.
+
+* Reference
+
+- [[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-Oriented Design in ORE Studio]] — the criteria, regimes, and
+  report conventions this skill applies.
+- [[id:0FB2EA84-EBB8-45C8-A8C8-F5815431C2D2][Code Review Checklist]] — the sibling criteria set for general
+  component and PR review.
+- [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]] — the broad whole-component audit this lens
+  complements.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/systems/s1_agent.org
+++ b/doc/systems/s1_agent.org
@@ -71,6 +71,9 @@ The Claude Code [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skills]] you invoke p
   failures until green.
 - [[id:DADF4117-757A-4EEF-A137-CC2EE8023C73][code-review-component]], [[id:04CA6BD9-7739-4213-A9DC-17AAACE43252][code-review-pr]] — self-review before
   asking for human review.
+- [[id:AE72D444-02B1-4428-B56C-062B849ED568][code-review-data-model]] — when the review target is a
+  component's data model: assess domain types, entity models, and
+  kernel data structures against the data-oriented design criteria.
 - [[id:5A95BE6A-2B11-402F-A427-71F93FA06A25][code-review-comments]] — when creating,
   editing, or cleaning code comments: keep them sparse, above the
   code, with no edit-history narration.


### PR DESCRIPTION
## Summary

Adds a new Claude Code skill, `code-review-data-model`, whose purpose is to review a component's data model against data-oriented design (DOD) principles — the review lens requested for the data-oriented domain-modelling workstream. It is review-only: it produces a findings report; it does not refactor.

## What changed

- **`doc/knowledge/architecture/data_oriented_design.org`** (new) — the canonical criteria doc: the principle and five axioms, three regimes (numerical kernels / persisted domain data / wire), the data model of a component, per-regime checklists, report conventions with anchored 1-5 scoring and debt bands. Regime 2 checklists split into per-entity-model *decisions* (key style, field-group split, batching) and spot-checked *codegen invariants* (value semantics, pointer-freedom, codec drift). Names the boundary of the regimes: document-shaped payloads (FpML/ORE XML/org files) convert through the mapping layer into the core representation and are exempt from table-shaped checks.
- **`doc/llm/skills/code-review-data-model/SKILL.org`** (new) — thin-index skill: regime classification, two-surface artefact gathering, checklist application, evidence rule, scoring, reporting.
- **Wiring** — catalogue row in `claude_code_skills.org`, link in the knowledge index, entry in the S1 system doc.

## Verification

- Reviewed by a three-member council (Aristotle / Ada Lovelace / Feynman): unanimous **revise**, all six agreed repairs applied.
- Factual claims grounded in-tree: DDL lives under `projects/ores.sql/create/<component>/` (586 files); the `lookup_entity` metatype has zero authored instances.
- Live-run gate: the fixed skill was run against `ores.trading` — Regime 2 score 4/5, Low debt, two Minor decision-level findings, all three pre-fix noise predictions falsified. Report is in the session transcript; no remediation stories filed (review-only).

## Follow-up (out of scope)

- Re-run the skill after the next `ores.trading` model change to confirm two-run score agreement.
- Decide the instrument-family cross-type query story and the `party_id` derivation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)