### PR TITLE
[ores.trading] Bond relational model: population loader wave 1.4

### DIFF
--- a/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
+++ b/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
@@ -473,5 +473,7 @@ via its "Verifies task" field.
 |---+-----------------+------+----------+-------|
 | 1 | The synthetic generators always emit 0 for =sequence_number= | =bond_issue_call_date.org= (and =bond_issue_conversion_target.org=) | Recorded, not changed | No collision reachable today: each generated child draws its own random =issue_id=. A real ordinal needs parent-keyed generation. See the Notes entry. |
 | 2 | =int sequence_number= has no in-class default, unlike =version= | =cpp_domain_type_generator.cpp.mustache= | Recorded, not changed | Defaulting the int alone leaves =issue_id= uninitialized, like every uuid primary-key member. A template-level default for all primary-key members is a codegen decision. See the Notes entry. |
+| 3 | =--rows= not a multiple of 10 silently truncates the family counts, leaving the last instrument block without its issue row | =load_trade_population.py= =main()= | Accepted | A guard after argparse exits with a clear message unless =--rows= is a multiple of 10, before any DB work. |
+| 4 | =counts[next(iter(family))]= pulls an arbitrary set member to print the family count | =load_trade_population.py= =main()= | Accepted | A =family_size= computed once now feeds both the per-table counts and the header printout. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
+++ b/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
@@ -28,9 +28,9 @@ Bond is the pilot for the relational target model of the trading analysis (dfe15
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:688959F0-A1AB-4021-A57E-1103AD92773A][Redesign ores.trading on data-oriented principles]] |
-| Now          | Wave 1.3 done and gated: all eight additive entities have orgs and their full generated stacks sit in the tree, F1 is closed through the org-source is_int branches, the SQL create/drop/RLS files are wired, and every entity re-diffs clean against the final tangled template. Check gate: full build green (linux-clang-debug-make) and ctest 71/71 passed after a targeted refresh of the seven synthetic RLS policies in the worktree database, whose live shape predated the read-side rework of fce56925b4. The wave record is in the Notes. |
+| Now          | Wave 1.4 done and gated: the loader loads the family to its model premise, with the ten codes cycling over the instrument rows and the issue, child and fact tables at rows / 10. The account-validated triggers are satisfied through a resolved service account, the gate run at 1000 rows reports zero findings (49 tables, 41,800 rows), and coherence of the kept population is proven by SQL joins and a seed-layout recomputation. The wave record, the RLS measurement lesson and the ownership split are in the Notes. |
 | Waiting on   | Nothing.                               |
-| Next         | Wave 1.4: extend the population loader (scripts/load_trade_population.py) so the family loads with a coherent population: the REFERENCES chains, the per-family fact/instrument pairing by product code and the issue amortisation per ISIN. |
+| Next         | Wave 1.5, the reshape: author ores.trading.bond_instrument.org per the deliverable (instrument_id key, the ten-code trade_type_code check, issue_id FK, soft FKs, profile spine), delete the hand-written bond stack the generated files supersede, migrate every consumer in one wave (ores.ore mapper switch-over, ores.shell verb, ores.cli call sites, the qt minimum), write and validate the migration script against an old-shape database, and recreate the test database. |
 | Last touched | 2026-09-09                               |
 
 * Acceptance
@@ -384,6 +384,70 @@ leaves a default-constructed row unreadable: =issue_id= stays
 uninitialized like every uuid primary-key member in the tree. A
 deterministic default for all primary-key members is a
 domain-template decision; it rides with the F1 follow-up work.
+
+Wave 1.4, the loader extension (2026-09-09).
+
+=scripts/load_trade_population.py= now loads the family to its model
+premise. The ten trade-type codes cycle over the bond instrument rows,
+so block =j= of ten consecutive rows trades one ISIN. The issue row of
+that ISIN, the issue-keyed child rows and the per-product fact rows
+load one per block. The family tables therefore load at =rows / 10=;
+every other table loads at =rows=. The family set derives from the
+loader's own table constants, and the header prints the family count
+when every family table is present.
+
+The chains the wave names are wired at the seed level, per the
+loader's uuid5 grammar. The instrument rows of code =k= sit at the
+row indices congruent to =k= modulo ten, so the =j=-th fact row of a
+product pairs instrument row =10j + code_index= by seed; a
+recomputation of the expected seed set per code over the live rows
+proves the layout (all ten codes, zero mismatches). The child rows
+couple to the issue rows row-wise through the new =REFERENCES=
+entries, one child row per issue. The =instrument.issue_id= hook
+fires only when the reshaped instrument table replaces the legacy one
+in wave 1.5; the legacy table has no such column, and the comment on
+the hook records that.
+
+*Account validation.* The insert triggers validate =modified_by= and
+=performed_by= through =ores_iam_validate_account_username_fn=, which
+is strict whenever accounts exist. This schema-era validation postdates
+the deliverable's baseline loader runs, which is why the first probe
+of this wave loaded zero tables with username findings. The loader now
+resolves a service account up front (=ores_brave_hopper_analytics_service=
+on this database) and reuses it for both columns. The enumeration
+learning count is unchanged at 23.
+
+*Loader evidence.* The gate run at =--rows 1000 --keep= loaded 49
+tables and 41,800 rows in 10.88s, with the family at 100 and zero
+findings. Coherence was verified by SQL over the kept population as
+the loader's own user: per-table counts exact (instruments 1000,
+issues, children and facts 100 each), the ten codes at 100 rows each,
+100 distinct XS-shaped =security_id=s, zero orphaned children, zero
+orphan, wrong-code or uncovered fact rows per product, and no NULL in
+any family column. The database holds the kept population for wave
+1.5's use. The deterministic seeds mean a =--keep= rerun over a
+standing population collides on primary keys; a default (non-=--keep=)
+run first removes the bench rows, which is the loader's own cleanup
+path.
+
+*RLS measurement lesson.* The loader reaches postgres as the .env
+=PGUSER= (the postgres superuser here), so COPY bypasses row-level
+security on every table, the RLS-enabled legacy tables included. A
+verification session as the DDL user is RLS-filtered instead: the
+legacy tables' party-scoped policies hide their rows when
+=app.current_party_id= is not set, while the family's tenant-only
+policies let rows through under the default system tenant. A first
+verification pass misread those filtered counts as vanished rows;
+counts for loader verification must run as the loader's own user. The
+ownership split is recorded too: the family tables are owned by the
+test DDL user (hand-applied in wave 1.3) and the legacy tables by the
+main DDL user. The loader is unaffected, and the wave 1.5 recreate
+resolves the split.
+
+The wave leaves observation F2 open: the loader copies rows and never
+consumes the generated registrars or repositories, so the
+compound-key registrar representation and the F1 repository-bind
+question both land with the first real consumer in the reshape.
 
 * Test Scenarios
 

--- a/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
+++ b/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.org
@@ -8,7 +8,7 @@
 #+filetags: :data-oriented-trading-model:sprint_25:v0:
 #+owner: marco
 #+branch: feature/implement-bond-relational-codegen
-#+pr: 2041
+#+pr: 2042
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-09
@@ -464,6 +464,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/2042][#2042]] | [ores.trading] Bond relational model: population loader wave 1.4 |
 | [[https://github.com/OreStudio/OreStudio/pull/2041][#2041]] | [ores.trading] Bond relational model: additive codegen waves 1.1 to 1.3 |
 
 * Review

--- a/scripts/load_trade_population.py
+++ b/scripts/load_trade_population.py
@@ -525,11 +525,11 @@ def main():
           f"account {account}")
 
     family = {BOND_ISSUES, *CHILD_TABLES, *FACT_TABLES.values()}
-    counts = {t: args.rows // len(TRADE_TYPE_CODES) if t in family else args.rows
-              for t in cols}
+    family_size = args.rows // len(TRADE_TYPE_CODES)
+    counts = {t: family_size if t in family else args.rows for t in cols}
     print(f"{len(cols)} tables, {sum(len(v) for v in cols.values())} columns, "
           f"{args.rows} rows per table"
-          f"{', family at ' + str(counts[next(iter(family))]) if family <= set(cols) else ''}\n")
+          f"{', family at ' + str(family_size) if family <= set(cols) else ''}\n")
 
     results, findings, discovered = [], [], []
     if args.attribute:

--- a/scripts/load_trade_population.py
+++ b/scripts/load_trade_population.py
@@ -11,6 +11,12 @@ a finding instead of failing silently. Two outputs: a per-table cost table that
 shows where the time goes, and a findings list that shows where the model
 resists being populated.
 
+The bond family (pilot task D7943D7E) loads to its model premise rather than to
+uniform counts. Its ten trade-type codes cycle over the bond instrument rows, so
+each block of ten consecutive rows trades one ISIN; the issue row of that ISIN,
+the issue-keyed child rows and the per-product fact rows load one per block.
+The family tables therefore load at rows / 10; every other table loads at rows.
+
 Reaches postgres through psql. Deletes the rows it inserted unless --keep.
 
   ./scripts/load_trade_population.py --rows 1000
@@ -71,8 +77,43 @@ BOOK_SQL = ("select id, parent_portfolio_id from ores_refdata_books_tbl "
             "and valid_to = ores_utility_infinity_timestamp_fn() "
             "and parent_portfolio_id is not null order by id limit 1;")
 
+# The insert triggers stamp modified_by and performed_by with a validated value,
+# so a text value of the loader's own making is rejected. Any account username
+# passes; service accounts keep the bench rows from impersonating a user.
+ACCOUNT_SQL = ("select username from ores_iam_accounts_tbl "
+               "where valid_to = ores_utility_infinity_timestamp_fn() "
+               "order by (account_type = 'service') desc, username limit 1;")
+
+# The legacy bond instrument table keeps its name through the reshape, so the
+# family entries below stay valid when the reshaped table replaces it.
+BOND_INSTRUMENTS = "ores_trading_bond_instruments_tbl"
+BOND_ISSUES = "ores_trading_bond_issues_tbl"
+
+# The ten bond trade-type codes, in declaration order. One trade of each code
+# loads per ISIN, so the j-th instrument row of a code sits at
+# j * len(codes) + code_index, and that row belongs to issue block j. The
+# facts and children load one row per block, aligned to the same index.
+TRADE_TYPE_CODES = ("Bond", "ForwardBond", "BondFuture", "BondOption",
+                    "BondRepo", "BondTRS", "BondPosition", "CallableBond",
+                    "ConvertibleBond", "Ascot")
+
+# The five codes whose product carries structure beyond the instrument row.
+# Each fact table extends the instrument rows of its own code.
+FACT_TABLES = {
+    "BondOption": "ores_trading_bond_options_tbl",
+    "BondFuture": "ores_trading_bond_futures_tbl",
+    "BondRepo": "ores_trading_bond_repos_tbl",
+    "BondTRS": "ores_trading_bond_trs_tbl",
+    "Ascot": "ores_trading_ascots_tbl",
+}
+
+FACT_CODE = {t: c for c, t in FACT_TABLES.items()}
+CHILD_TABLES = ("ores_trading_bond_issue_call_dates_tbl",
+                "ores_trading_bond_issue_conversion_targets_tbl")
+
 # Soft foreign keys, enforced in PL/pgSQL. A referencing column must carry an id
-# the referenced table already holds, so the referenced table loads first.
+# the referenced table already holds, so the referenced table loads first. Row
+# i of the referencing table couples to row i of the referenced one.
 REFERENCES = {
     ("ores_trading_composite_legs_tbl", "instrument_id"):
         ("ores_trading_composite_instruments_tbl", "id"),
@@ -80,6 +121,10 @@ REFERENCES = {
         ("ores_trading_trades_tbl", "id"),
     ("ores_trading_trade_identifiers_tbl", "trade_id"):
         ("ores_trading_trades_tbl", "id"),
+    ("ores_trading_bond_issue_call_dates_tbl", "issue_id"):
+        ("ores_trading_bond_issues_tbl", "issue_id"),
+    ("ores_trading_bond_issue_conversion_targets_tbl", "issue_id"):
+        ("ores_trading_bond_issues_tbl", "issue_id"),
 }
 
 INTROSPECT_COLUMNS = """
@@ -160,7 +205,7 @@ class Generator:
     """Produces a value for one column, given its type and any check constraint."""
 
     def __init__(self, allowed, bounds, enums, tenant, workspace, party, reason,
-                 book, portfolio, counterparty=None, status=None,
+                 book, portfolio, account=None, counterparty=None, status=None,
                  required_null=None):
         self.required_null = required_null or {}
         self.counterparty = counterparty
@@ -174,6 +219,7 @@ class Generator:
         self.workspace = workspace
         self.party = party
         self.reason = reason
+        self.account = account
 
     def value(self, table, col, dtype, udt, i):
         if col == "tenant_id":
@@ -182,6 +228,8 @@ class Generator:
             return self.workspace
         if col == "change_reason_code":
             return self.reason
+        if col in ("modified_by", "performed_by") and self.account:
+            return self.account
         if col in NULLABLE_SELF_REFS:
             return "\\N"
         if col in self.required_null.get(table, ()):
@@ -196,6 +244,22 @@ class Generator:
             return self.book
         if col == "portfolio_id" and self.portfolio:
             return self.portfolio
+        if table == BOND_INSTRUMENTS:
+            if col == "trade_type_code":
+                return TRADE_TYPE_CODES[i % len(TRADE_TYPE_CODES)]
+            if col == "issue_id":
+                # Row i trades the i // len(codes) issue's ISIN. Inert while the
+                # legacy table lacks the column; the reshaped instrument rows
+                # carry it, and the seed couples them to the loaded issue.
+                return str(uuid.uuid5(NS, f"{BOND_ISSUES}.issue_id."
+                                        f"{i // len(TRADE_TYPE_CODES)}"))
+        if col == "security_id" and table == BOND_ISSUES:
+            return f"XS{i:010d}"
+        if col == "instrument_id" and table in FACT_CODE:
+            # The fact row of the j-th instrument row of its own product code.
+            return str(uuid.uuid5(
+                NS, f"{BOND_INSTRUMENTS}.id."
+                    f"{i * len(TRADE_TYPE_CODES) + TRADE_TYPE_CODES.index(FACT_CODE[table])}"))
         ref = REFERENCES.get((table, col))
         if ref:
             return str(uuid.uuid5(NS, f"{ref[0]}.{ref[1]}.{i}"))
@@ -438,6 +502,9 @@ def main():
         if r.returncode == 0 and r.stdout.strip() else []
     book = book_row[0] if book_row else None
     portfolio = book_row[1] if len(book_row) > 1 else None
+    r = sql(ACCOUNT_SQL, check=False)
+    account = r.stdout.strip().splitlines()[-1] if r.returncode == 0 and \
+        r.stdout.strip() else None
     r = sql(COUNTERPARTY_SQL.format(tenant=tenant), check=False)
     counterparty = r.stdout.strip().splitlines()[-1] if r.returncode == 0 and \
         r.stdout.strip() else None
@@ -445,13 +512,19 @@ def main():
     status = r.stdout.strip().splitlines()[-1] if r.returncode == 0 and \
         r.stdout.strip() else None
     gen = Generator(allowed, bounds, enums, tenant, workspace, party, reason,
-                    book, portfolio, counterparty, status, required_null)
+                    book, portfolio, account, counterparty, status,
+                    required_null)
     preamble = SESSION_PREAMBLE.format(party=party)
     print(f"tenant {tenant}\nworkspace {workspace}\nparty {party}\n"
-          f"change reason {reason}\nbook {book}  portfolio {portfolio}")
+          f"change reason {reason}\nbook {book}  portfolio {portfolio}\n"
+          f"account {account}")
 
+    family = {BOND_ISSUES, *CHILD_TABLES, *FACT_TABLES.values()}
+    counts = {t: args.rows // len(TRADE_TYPE_CODES) if t in family else args.rows
+              for t in cols}
     print(f"{len(cols)} tables, {sum(len(v) for v in cols.values())} columns, "
-          f"{args.rows} rows each\n")
+          f"{args.rows} rows per table"
+          f"{', family at ' + str(counts[next(iter(family))]) if family <= set(cols) else ''}\n")
 
     results, findings, discovered = [], [], []
     if args.attribute:
@@ -466,9 +539,10 @@ def main():
     for table in order:
         spec = cols[table]
         names = [c for c, _, _, _ in spec]
+        count = counts[table]
         try:
             body = []
-            for i in range(args.rows):
+            for i in range(count):
                 body.append("\t".join(
                     gen.value(table, c, d, u, i).replace("\t", " ")
                     for c, d, _, u in spec))
@@ -483,7 +557,7 @@ def main():
             r = sql(stdin=preamble + stmt + payload + "\\.\n", check=False)
             elapsed = time.perf_counter() - start
             if r.returncode == 0:
-                results.append((table, len(spec), elapsed))
+                results.append((table, count, len(spec), elapsed))
                 break
             learned = _learn(r.stderr, table, gen)
             if not learned:
@@ -494,21 +568,22 @@ def main():
                 payload = "\n".join(
                     "\t".join(gen.value(table, c, d, u, i).replace("\t", " ")
                                for c, d, _, u in spec)
-                    for i in range(args.rows)) + "\n"
+                    for i in range(count)) + "\n"
             except KeyError as e:
                 findings.append((table, f"cannot generate: {e}"))
                 break
         else:
             findings.append((table, "still rejected after learning 6 sets"))
 
-    results.sort(key=lambda r: -r[2])
-    total = sum(e for _, _, e in results)
-    print(f"{'table':<52} {'cols':>5} {'seconds':>9} {'rows/sec':>10} {'%':>6}")
-    for t, n, e in results:
-        print(f"{t:<52} {n:>5} {e:>9.3f} {args.rows / e:>10.0f} "
+    results.sort(key=lambda r: -r[3])
+    total = sum(e for _, _, _, e in results)
+    print(f"{'table':<52} {'rows':>6} {'cols':>5} {'seconds':>9} "
+          f"{'rows/sec':>10} {'%':>6}")
+    for t, c, n, e in results:
+        print(f"{t:<52} {c:>6} {n:>5} {e:>9.3f} {c / e:>10.0f} "
               f"{100 * e / total:>5.1f}%")
     print(f"\n{len(results)} tables loaded in {total:.2f}s "
-          f"({args.rows * len(results):,} rows)")
+          f"({sum(c for _, c, _, _ in results):,} rows)")
 
     if discovered:
         print(f"\n{len(discovered)} enumeration(s) learned from trigger errors, "

--- a/scripts/load_trade_population.py
+++ b/scripts/load_trade_population.py
@@ -477,6 +477,11 @@ def main():
                     help="time one table with each trigger disabled in turn, "
                          "to attribute the cost")
     args = ap.parse_args()
+    if args.rows % len(TRADE_TYPE_CODES):
+        sys.exit(f"--rows must be a multiple of {len(TRADE_TYPE_CODES)}: the "
+                 f"family loads one issue, child and fact row per block of "
+                 f"{len(TRADE_TYPE_CODES)} instrument rows, so a partial "
+                 f"block would reference an issue row that never loads.")
 
     sql = make_sql(read_env())
 


### PR DESCRIPTION
## Summary

Wave 1.4 of the bond relational pilot on story 688959F0 extends the population loader so the family loads to its model premise: the ten trade-type codes cycle over the bond instrument rows, each block of ten consecutive rows trades one ISIN, and the issue row of that ISIN, the issue-keyed child rows and the per-product fact rows load one per block. The loader satisfies the account-validated insert triggers through a resolved service account, and every family column fills with zero findings.

## Changes

- ores.trading loader: family constants, per-family row counts at rows / 10, seed hooks for the ten codes, the ISIN issue blocks, the fact/instrument pairing by product code and the inert instrument.issue_id hook for the reshape
- ores.trading loader: resolution of a service account for the account-validated modified_by and performed_by triggers
- docs: wave 1.4 record in the task Notes, including the RLS measurement lesson and the table-ownership split
- Verification: sql class per the wave plan (recreate plus loader run). The loader gate run at --rows 1000 --keep loaded 49 tables and 41,800 rows in 10.88s with the family at 100 and zero findings; coherence proven by SQL joins over the kept population (counts exact, codes at 100 each, unique XS security_ids, zero orphaned children, zero orphan, wrong-code or uncovered fact rows per product, no NULL family column) and by a seed-layout recomputation (all ten codes, zero mismatches); docs class site build clean.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Redesign ores.trading on data-oriented principles](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/story.html) | 688959F0-A1AB-4021-A57E-1103AD92773A |
| Task | [Implement the bond relational model: codegen, SQL and the loader exercise](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/data-oriented-trading-model/task_implement-bond-relational-codegen.html) | D7943D7E-2889-4C6B-857A-C382DBF755BA |
| Environment | brave_hopper | |

## Testing

Plan. Load the family to its model premise at the gate size: the loader run at --rows 1000 --keep, then SQL coherence joins over the kept population as the loader's own user (per-table counts, code distribution, issue shape, child chains, fact pairing per product, column fill) and a recomputation of the expected uuid5 seed set per trade-type code against the live rows.

Evidence. Gate run: 49 tables, 41,800 rows in 10.88s, family at 100, zero findings, 23 enumerations learned. Coherence: instruments 1000 with the ten codes at 100 rows each; issues 100 with 100 distinct XS-shaped security_ids; children 100 each with zero orphaned issue_ids; per-product facts 100 each with zero orphan, wrong-code or uncovered instrument rows; no NULL in any family column; seed layout matches for all ten codes, zero mismatches. Site build clean.

Limitations. The from-scratch database recreate is wave 1.5's gate per the standing DB discipline, so the loader ran against the worktree database whose family schema comes from the committed create SQL, hand-applied in wave 1.3. The full measured exercise at 1k, 10k and 20k rows belongs to wave 1.6 on the recreated database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)