### PR TITLE
[compass] Index doc/knowledge/external and lint dangling id links

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+---
+name: Doc Lint
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+    paths: ['**.org', '.github/workflows/doc-lint.yml']
+  pull_request:
+    paths: ['**.org', '.github/workflows/doc-lint.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: compass lint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate the org corpus
+        # Filetags, generator markers and dangling id links. A dangling
+        # link makes its target invisible to search and to graph
+        # traversal, and nothing else reports it.
+        run: ./projects/ores.compass/compass.sh --no-deps lint

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:claude_code:refactor:naming:sprint_25:v0:
 #+created: 2026-08-25
 #+updated: 2026-08-25
-#+environment:
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -21,7 +21,7 @@ Our 79 skills describe our process well but never tell an agent how to think or 
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -72,7 +72,7 @@ Tasks are listed in intended execution order.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:FE910755-16F8-4854-BA3D-D780BE5AFB64][Fix the invisible knowledge cluster and audit graph integrity]] | BACKLOG | | | The whole doc/knowledge/external cluster does not resolve in the graph; diagnose, fix, and add a continuous S3-star check so it cannot recur. Unblocks domain grounding. |
+| [[id:FE910755-16F8-4854-BA3D-D780BE5AFB64][Fix the invisible knowledge cluster and audit graph integrity]] | DONE | 2026-09-09 | 2026-09-09 | The whole doc/knowledge/external cluster does not resolve in the graph; diagnose, fix, and add a continuous S3-star check so it cannot recur. Unblocks domain grounding. |
 | [[id:37BC3547-4FE9-4D13-B3E7-5C071C5155B9][Instrument skill selection so the baseline accrues forward]] | BACKLOG | | | Record selection events as they happen rather than scoring past tasks, so skill-choice quality becomes measurable and reportable from now on. |
 | [[id:9388A184-1EFA-4855-8C0B-7FDFE93C3647][Decide the disposition of every external skill]] | DONE | 2026-08-26 | 2026-08-26 | Read every pstack and Matt Pocock skill in full and record a per-skill disposition against the skill architecture: adopt, adapt, harvest or reject, with the reason. |
 | [[id:F7B5BED7-AB0A-4ECD-A8E4-B31E7A77F2EF][Land the skill architecture into policy]] | BACKLOG | | | Turn the skill architecture document into enforceable policy: amended naming conventions, the terminology table in the glossary, and the mandatory level keyword. |
@@ -100,6 +100,14 @@ Tasks are listed in intended execution order.
 | [[id:39264768-EE92-4DB1-B048-3C960415B358][Specify the skills framework as a regulator]] | DONE | 2026-09-07 | 2026-09-07 | Respecify the framework as a regulator over an agent, deriving its scope and its seven classes of document from cybernetics rather than stipulating them, and classify the upstream pstack collection against that derivation. |
 
 * Decisions
+
+- Directory exclusions in the doc walker are anchored at the repository root.
+  A bare name matched at any depth, and =external= then hid
+  =doc/knowledge/external= as well as the vendored tree it was written for.
+  Names that are noise at any depth (=.git=, =node_modules=) stay unanchored.
+- =compass lint= is the enforced channel for corpus invariants, and it shares
+  the graph's own walker. The S3\* auditor states that every id link must
+  resolve; the lint now proves it on every push and pull request.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
@@ -92,7 +92,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =compass lint --help= claimed only the first two checks are enforced | src/compass.py | Accept | Three checks are enforced now; reworded to name the durable-link check as the advisory one |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:knowledge:zettelkasten:audit:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/fix-knowledge-graph-visibility
-#+pr:
+#+pr: 2043
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -86,7 +86,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2043][#2043]] | [compass] Index doc/knowledge/external and lint dangling id links |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:knowledge:zettelkasten:audit:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/fix-knowledge-graph-visibility
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ The knowledge index carries eight id references that do not resolve, and all eig
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-09                               |
 
 * Acceptance
 
@@ -42,11 +42,34 @@ The knowledge index carries eight id references that do not resolve, and all eig
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The cause was diagnosed, not guessed. =doc_index.EXCLUDED_DIRS= held the
+bare name =external=, and the walker pruned any directory with that name at
+any depth. The entry exists to skip the vendored =./external= tree at the
+repository root. It also pruned =doc/knowledge/external=, so all twelve
+documents in that folder were absent from the corpus that =compass show=,
+=compass list= and =compass search= read.
+
+The fix splits the two intents. =EXCLUDED_DIRS= keeps the names that are
+noise at any depth (=.git=, =.claude=, =node_modules=, =__pycache__=).
+=EXCLUDED_ROOT_DIRS= holds the large repository-root trees (=build=,
+=.packages=, =vcpkg=, =external=), and the walker prunes those only at the
+root.
+
+The invariant then goes into =compass lint=, which is the enforced corpus
+channel: =_lint_dangling_links= reports every =[[id:...]]= whose target
+=:ID:= is in no document, and it fails the command. =cmd_lint= now walks
+through =doc_index.find_org_files=, so the lint and the graph share one
+definition of the corpus. The new =Doc Lint= workflow runs the command on
+every push and pull request that touches an =.org= file.
 
 * Notes
+
+=cmd_lint= used =rglob= and filtered afterwards, so every run descended into
+=build/=. The command took over two minutes. On the shared pruned walker it
+takes one second.
+
+The per-worktree =.journal.org= links to documents that live on other
+branches, so the lint skips dotfiles.
 
 * Test Scenarios
 
@@ -72,3 +95,26 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All four acceptance criteria are met.
+
+The cause is diagnosed and recorded in =* Plan=: =doc_index= pruned every
+directory named =external= at any depth, so it pruned the documentation
+folder along with the vendored tree at the repository root.
+
+All twelve documents under =doc/knowledge/external= resolve again. =compass
+show 0412444A-0A4C-4611-887C-09353A3CB253= returns QuantLib with ten inbound
+links, and =compass search quantlib= ranks it at 84%.
+
+=compass lint= reports every =[[id:...]]= that resolves to no =:ID:= in the
+corpus, and it exits non-zero. A probe document with a bogus link produced
+=dangling id links: 1 link(s)=.
+
+The =Doc Lint= workflow runs the command on every push and pull request that
+touches an =.org= file, so the check is continuous rather than on request.
+Its first full run over the corpus is clean: the only dangling links anywhere
+were eight in the untracked per-worktree =.journal.org=, which points at
+documents on other branches, so the lint skips dotfiles.
+
+=test_doc_graph_integrity.py= holds the regression test. It fails against the
+old exclusion list with =assert set() == {'quantlib.org'}=.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2460,6 +2460,24 @@ def _lint_durable_links(files, id_types):
     return out
 
 
+def _lint_dangling_links(files, id_types):
+    """Report [[id:...]] links whose target :ID: exists nowhere in the corpus.
+
+    A dangling link makes its target invisible to graph traversal and to
+    compass search, and nothing else notices: the link renders, it just goes
+    nowhere.
+    """
+    out = []
+    for rel, text in files:
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for m in _ID_LINK_RE.finditer(line):
+                if m.group(1).upper() in id_types:
+                    continue
+                label = (m.group(2) or "(no label)")[:50]
+                out.append((str(rel), lineno, m.group(1), label))
+    return out
+
+
 def _collect_org_types(files):
     """Map every :ID: in the corpus to the #+type: of its document."""
     types = {}
@@ -2478,7 +2496,8 @@ def cmd_lint(argv):
         description=(
             "Validate the org corpus. Checks filetags (every tag lowercase, "
             "matching [a-z][a-z0-9_-]*), generator markers (every BEGIN has a "
-            "matching END on its own line), and links from durable documents "
+            "matching END on its own line), dangling id links (every "
+            "[[id:...]] resolves), and links from durable documents "
             "into agile content. The first two are enforced; the link check is "
             "advisory unless --strict-links is given."
         ),
@@ -2505,10 +2524,10 @@ def cmd_lint(argv):
     all_exclude = always_exclude | extra_exclude
 
     files = []
-    for org_file in sorted(root.rglob("*.org")):
+    for org_file in sorted(doc_index.find_org_files(root)):
         rel = org_file.relative_to(Path(PROJECT_ROOT))
         first_part = rel.parts[0] if rel.parts else ""
-        if first_part in all_exclude:
+        if first_part in all_exclude or org_file.name.startswith("."):
             continue
         try:
             files.append((rel, org_file.read_text(encoding="utf-8",
@@ -2528,7 +2547,9 @@ def cmd_lint(argv):
             break
 
     markers = _lint_generator_markers(files)
-    links = _lint_durable_links(files, _collect_org_types(files))
+    id_types = _collect_org_types(files)
+    links = _lint_durable_links(files, id_types)
+    dangling = _lint_dangling_links(files, id_types)
 
     failed = False
 
@@ -2545,6 +2566,14 @@ def cmd_lint(argv):
               file=sys.stderr)
         for path, lineno, msg in markers:
             print(f"  {path}:{lineno}: {msg}", file=sys.stderr)
+
+    if dangling:
+        failed = True
+        print(f"\u274c  dangling id links: {len(dangling)} link(s) resolve to "
+              f"no :ID: in the corpus:\n", file=sys.stderr)
+        for path, lineno, target, label in dangling:
+            print(f"  {path}:{lineno}: [[id:{target}]] -> {label}",
+                  file=sys.stderr)
 
     if links:
         by_file = {}

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2498,8 +2498,8 @@ def cmd_lint(argv):
             "matching [a-z][a-z0-9_-]*), generator markers (every BEGIN has a "
             "matching END on its own line), dangling id links (every "
             "[[id:...]] resolves), and links from durable documents "
-            "into agile content. The first two are enforced; the link check is "
-            "advisory unless --strict-links is given."
+            "into agile content. All but the last are enforced; the durable "
+            "link check is advisory unless --strict-links is given."
         ),
     )
     ap.add_argument(

--- a/projects/ores.compass/src/doc_index.py
+++ b/projects/ores.compass/src/doc_index.py
@@ -22,7 +22,8 @@ from typing import Iterable, Iterator
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-EXCLUDED_DIRS = {"build", ".packages", "vcpkg", "external", ".git", "node_modules", ".claude"}
+EXCLUDED_DIRS = {".git", ".claude", "node_modules", "__pycache__"}
+EXCLUDED_ROOT_DIRS = {"build", ".packages", "vcpkg", "external"}
 
 ID_RE       = re.compile(r"^:ID:\s+([0-9A-Fa-f-]+)\s*$",   re.MULTILINE)
 TITLE_RE    = re.compile(r"^#\+title:\s*(.*?)\s*$",        re.MULTILINE | re.IGNORECASE)
@@ -191,11 +192,20 @@ def parse_doc(path: Path) -> Doc | None:
 
 
 def find_org_files(root: Path = REPO_ROOT) -> Iterator[Path]:
-    """Walk root for *.org files, pruning EXCLUDED_DIRS so the walk never
-    descends into them (build/ and friends can be huge and slow/IO-bound;
-    filtering after Path.rglob had already visited every file inside)."""
+    """Walk root for *.org files, pruning excluded directories so the walk
+    never descends into them (build/ and friends can be huge and
+    slow/IO-bound; filtering after Path.rglob had already visited every file
+    inside).
+
+    EXCLUDED_ROOT_DIRS is anchored at the repository root: doc/knowledge/external
+    is documentation and must be indexed, while the vendored ./external is not."""
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = sorted(d for d in dirnames if d not in EXCLUDED_DIRS)
+        at_root = Path(dirpath) == Path(root)
+        dirnames[:] = sorted(
+            d for d in dirnames
+            if d not in EXCLUDED_DIRS
+            and not (at_root and d in EXCLUDED_ROOT_DIRS)
+        )
         for name in sorted(filenames):
             if name.endswith(".org"):
                 yield Path(dirpath) / name

--- a/projects/ores.compass/tests/test_doc_graph_integrity.py
+++ b/projects/ores.compass/tests/test_doc_graph_integrity.py
@@ -1,0 +1,50 @@
+"""
+Tests for the doc-graph integrity invariants: which .org files the walker
+sees, and the dangling id-link check that guards the corpus.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_doc_graph_integrity.py -v
+No live database required.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import doc_index
+import compass
+
+
+def write_doc(path: Path, uuid: str, body: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f":PROPERTIES:\n:ID: {uuid}\n:END:\n"
+        f"#+title: {path.stem}\n#+type: knowledge\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_vendored_external_pruned_but_documentation_external_indexed(tmp_path):
+    write_doc(tmp_path / "external" / "vendored.org",
+              "11111111-1111-1111-1111-111111111111")
+    write_doc(tmp_path / "doc" / "knowledge" / "external" / "quantlib.org",
+              "22222222-2222-2222-2222-222222222222")
+
+    found = {p.name for p in doc_index.find_org_files(tmp_path)}
+    assert found == {"quantlib.org"}
+
+
+def test_dangling_links_reported_and_resolved_ones_are_not():
+    files = [
+        (Path("a.org"), ":ID: AAAAAAAA-0000-0000-0000-000000000000\n"
+                        "[[id:BBBBBBBB-0000-0000-0000-000000000000][b]]\n"
+                        "[[id:CCCCCCCC-0000-0000-0000-000000000000][gone]]\n"),
+        (Path("b.org"), ":ID: BBBBBBBB-0000-0000-0000-000000000000\n"),
+    ]
+    id_types = compass._collect_org_types(files)
+
+    dangling = compass._lint_dangling_links(files, id_types)
+
+    assert [(path, target) for path, _line, target, _label in dangling] == [
+        ("a.org", "CCCCCCCC-0000-0000-0000-000000000000"),
+    ]


### PR DESCRIPTION
## Summary

The doc walker pruned every directory named external at any depth. The entry exists for the vendored ./external tree at the repository root, but it also hid all twelve documents under doc/knowledge/external, so that cluster resolved nowhere in the graph and never appeared in compass search. This anchors the large exclusions at the repository root, then turns the invariant into an enforced check so the failure cannot recur unnoticed.

## Changes

- doc_index: split the exclusions. EXCLUDED_DIRS keeps the names that are noise at any depth; EXCLUDED_ROOT_DIRS holds the large repository-root trees and is pruned only at the root.
- compass lint: report every [[id:...]] whose target :ID: is in no document, and fail on it.
- compass lint walks through doc_index.find_org_files, so the lint and the graph share one definition of the corpus; a run drops from over two minutes to one second. Dotfiles are skipped, since the per-worktree .journal.org links to documents on other branches.
- New Doc Lint workflow runs the command on every push and pull request that touches an .org file.
- Regression test for the walker and for the dangling-link check.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Fix the invisible knowledge cluster and audit graph integrity](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_knowledge_graph_visibility.html) | FE910755-16F8-4854-BA3D-D780BE5AFB64 |
| Environment | bright_faraday | |

## Testing

Plan. Reproduce the missing cluster, fix the walker, prove the new check fires on a dangling link and passes on the clean corpus, and run the checks for the python tooling, ci and docs classes the diff spans.

Evidence. python tooling, ci and docs. Compass suite: 129 passed, 1 skipped. Site build: Build succeeded. Roundtrip check: exit 0. misspell-fixer: exit 0. compass lint over the whole corpus: clean, and it now runs in 1s. Repro before the fix: compass show 0412444A-0A4C-4611-887C-09353A3CB253 answered 'No doc or anchor matches'; after it returns QuantLib with ten inbound links, compass search quantlib ranks it at 84%, and all twelve external documents load. A probe document carrying a bogus link made lint exit 1 with 'dangling id links: 1 link(s) resolve to no :ID: in the corpus'. The walker regression test fails against the old exclusion list with assert set() == {'quantlib.org'}.

Limitations. No C++ was touched, so no build or ctest run. Codegen drift was not run: the diff touches no model, template or generated source. The Doc Lint workflow itself is first exercised by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)