### PR TITLE
[compass] Instrument skill selection

### DIFF
--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -73,7 +73,7 @@ Tasks are listed in intended execution order.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:FE910755-16F8-4854-BA3D-D780BE5AFB64][Fix the invisible knowledge cluster and audit graph integrity]] | DONE | 2026-09-09 | 2026-09-09 | The whole doc/knowledge/external cluster does not resolve in the graph; diagnose, fix, and add a continuous S3-star check so it cannot recur. Unblocks domain grounding. |
-| [[id:37BC3547-4FE9-4D13-B3E7-5C071C5155B9][Instrument skill selection so the baseline accrues forward]] | BACKLOG | | | Record selection events as they happen rather than scoring past tasks, so skill-choice quality becomes measurable and reportable from now on. |
+| [[id:37BC3547-4FE9-4D13-B3E7-5C071C5155B9][Instrument skill selection so the baseline accrues forward]] | DONE | 2026-09-10 | 2026-09-10 | Record selection events as they happen rather than scoring past tasks, so skill-choice quality becomes measurable and reportable from now on. |
 | [[id:9388A184-1EFA-4855-8C0B-7FDFE93C3647][Decide the disposition of every external skill]] | DONE | 2026-08-26 | 2026-08-26 | Read every pstack and Matt Pocock skill in full and record a per-skill disposition against the skill architecture: adopt, adapt, harvest or reject, with the reason. |
 | [[id:F7B5BED7-AB0A-4ECD-A8E4-B31E7A77F2EF][Land the skill architecture into policy]] | BACKLOG | | | Turn the skill architecture document into enforceable policy: amended naming conventions, the terminology table in the glossary, and the mandatory level keyword. |
 | [[id:1EF24A09-F4D7-4DA7-BB54-1BC91F5CB8BE][Define the upstream attribution contract for imported skills]] | ABANDONED | | 2026-09-04 | Superseded by the reference approach. Upstream skills are referenced rather than copied, so no fork exists to attribute or drift-check; the classification table in The pstack Collection replaces it. 
@@ -108,6 +108,12 @@ Tasks are listed in intended execution order.
 - =compass lint= is the enforced channel for corpus invariants, and it shares
   the graph's own walker. The S3\* auditor states that every id link must
   resolve; the lint now proves it on every push and pull request.
+- Measurement is split by what is knowable when. A hook records the selection
+  as it happens, because an instrument the agent must remember measures its
+  memory. A correction is a judgement, so it is a separate explicit event
+  against a fixed one-word vocabulary, and the log is append-only.
+- Instrument state lives in the git common directory, so the baseline accrues
+  across the whole fleet rather than restarting on each =env provision=.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_selection_instrumentation.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_selection_instrumentation.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:skills:measurement:instrumentation:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/add-selection-instrumentation
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ We know skill mis-selection is a real problem because it has been corrected by h
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -44,11 +44,43 @@ We know skill mis-selection is a real problem because it has been corrected by h
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The instrument splits along what is knowable at the moment of choosing.
+
+A =PreToolUse= hook on the =Skill= tool records the selection: the skill
+chosen, the session, the environment, how many skills were visible, and
+the attenuation level from =ORES_SKILL_LEVEL=. The hook is the only
+place the selection is observable as it happens, which is what satisfies
+"runs without the agent having to remember": an instrument you have to
+remember measures your memory, not your skill choice.
+
+Whether a selection was *wrong* is not knowable then, so a correction is
+a second, explicit event: =compass skills correct --cause <cause>=,
+against the fixed vocabulary the acceptance names. The log is
+append-only, so a correction never rewrites the selection it judges.
+
+The log is JSONL in the git common directory. Every worktree in the
+fleet shares that directory, so the baseline accrues project-wide
+instead of restarting on each =env provision=.
+
+=compass skills report= reads a window and prints the correction rate,
+the causes ranked, the level split, and the most corrected and most
+chosen skills. The level split is what lets the attenuation axis be
+judged on evidence rather than argued.
 
 * Notes
+
+The hook returns 0 on every path, including a malformed payload and an
+unwritable log. Claude Code treats a failing hook command as a hard
+block of its tool, and blocking every skill invocation to protect a
+metric would be a poor trade.
+
+The catalogue count spans the project, user and plugin skill roots, so
+it reflects what the agent could actually choose from. It read 188 in
+this worktree.
+
+The first report is the zero baseline: the log starts empty and accrues
+from the moment the settings are tangled into a session. The gate that
+wants a populated report is the sequencing function's, not this task's.
 
 * Test Scenarios
 
@@ -71,6 +103,24 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | The correction rate divided all corrections by selections, so two corrections on one selection could report over 100% | src/compass_skills.py | Accept | Rate now counts distinct corrected selections; the raw correction count is still shown, and a test pins it |
+| 2 | The durable settings document linked to this task, which =compass lint --strict-links= flags | doc/llm/claude_code_settings.org | Accept | Replaced the link with prose; the lint advisory count is back at its pre-existing 160 |
 
 * Result
+
+Five of the six acceptance criteria are met, and the sixth is a gate on
+a later task.
+
+Every =Skill= invocation records the skills visible, the one chosen, the
+session and the environment, through the =PreToolUse= hook in
+=doc/llm/claude_code_settings.org=. A correction records one word from
+=description=, =catalogue-size=, =level= or =none=. =compass skills
+report= reports the correction rate and the causes ranked over a window.
+The hook needs no cooperation from the agent. The report splits
+selections by attenuation level, so the level axis can be judged on
+evidence.
+
+The first report ran clean against the empty log, which is the zero
+baseline. The reviewed report the acceptance asks for is the gate before
+the sequencing function lands; the instrument that produces it exists
+now.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_selection_instrumentation.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_selection_instrumentation.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:measurement:instrumentation:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/add-selection-instrumentation
-#+pr:
+#+pr: 2048
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -97,7 +97,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2048][#2048]] | [compass] Instrument skill selection |
 
 * Review
 

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -774,6 +774,137 @@ def test_malformed_json_does_not_crash(monkeypatch):
     assert hook.main() == 0
 #+end_src
 
+** Record every skill selection
+
+The selection instrument needs an
+event for every skill the agent picks, and it must not depend on the
+agent remembering to write one: an instrument you have to remember is an
+instrument that measures how good your memory is. A =PreToolUse= hook on
+the =Skill= tool is the only place the selection is observable at the
+moment it happens, so that is where the event is recorded.
+
+The hook records the skill chosen, the session, the environment, how
+many skills were visible to choose from, and the attenuation level. It
+records no judgement: whether a selection was wrong is not knowable at
+the moment of choosing, so a correction is a separate event, written by
+hand with =compass skills correct --cause <cause>=. A cause is one word
+from a fixed set: =description=, =catalogue-size=, =level= or =none=.
+
+The log is append-only JSONL in the git common directory, which every
+worktree in the fleet shares. A per-worktree log would restart the
+baseline on every =env provision=, which defeats the point of a
+measurement that accrues.
+
+*The hook never blocks the tool.* It exists to observe, so every failure
+path returns 0: malformed payload, unreadable log, missing module. It is
+wrapped in the same =if=/=then=/=else= file guard as the piping hook
+above, and for the same reason — a hook command that cannot execute
+blocks its tool outright, and blocking every skill invocation to protect
+a metric would be a poor trade.
+
+#+begin_src python :tangle ../../projects/ores.compass/src/record_skill_selection_hook.py :mkdirp yes :shebang "#!/usr/bin/env python3"
+"""PreToolUse hook: record which skill the agent chose.
+
+Feeds 'compass skills report'. See doc/llm/claude_code_settings.org's
+Hooks section. Observing only: this hook never blocks the Skill tool,
+so every failure path returns 0.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Skill":
+        return 0
+    skill = data.get("tool_input", {}).get("skill")
+    if not skill:
+        return 0
+    try:
+        import compass_skills
+        compass_skills.record_selection(
+            data.get("cwd") or os.getcwd(), skill, data.get("session_id"))
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+#+end_src
+
+#+begin_src python :tangle ../../projects/ores.compass/tests/test_record_skill_selection_hook.py :mkdirp yes
+"""
+Tests for the skill-selection PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_record_skill_selection_hook.py -v
+No live database required.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import compass_skills
+import record_skill_selection_hook as hook
+
+
+def run(payload, monkeypatch, tmp_path):
+    monkeypatch.setattr(compass_skills, "log_path",
+                        lambda _root: tmp_path / "skill_selections.jsonl")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return hook.main()
+
+
+def events(tmp_path):
+    path = tmp_path / "skill_selections.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_skill_call_is_recorded(monkeypatch, tmp_path):
+    assert run({"tool_name": "Skill", "session_id": "s1", "cwd": str(tmp_path),
+                "tool_input": {"skill": "pr-merge"}}, monkeypatch, tmp_path) == 0
+    recorded = events(tmp_path)
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "selection"
+    assert recorded[0]["skill"] == "pr-merge"
+    assert recorded[0]["session"] == "s1"
+
+
+def test_other_tools_are_ignored(monkeypatch, tmp_path):
+    assert run({"tool_name": "Bash", "tool_input": {"command": "ls"}},
+               monkeypatch, tmp_path) == 0
+    assert events(tmp_path) == []
+
+
+def test_malformed_payload_does_not_crash(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
+
+
+def test_recording_failure_never_blocks_the_tool(monkeypatch, tmp_path):
+    def explode(*_args, **_kwargs):
+        raise OSError("log is unwritable")
+    monkeypatch.setattr(compass_skills, "record_selection", explode)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(
+        {"tool_name": "Skill", "cwd": str(tmp_path),
+         "tool_input": {"skill": "pr-merge"}})))
+    assert hook.main() == 0
+#+end_src
+
 #+begin_src json :tangle no :noweb-ref hooks-pretooluse
     "PreToolUse": [
       {
@@ -782,6 +913,15 @@ def test_malformed_json_does_not_crash(monkeypatch):
           {
             "type": "command",
             "command": "sh -c 'f=projects/ores.compass/src/deny_piped_compass_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=projects/ores.compass/src/record_skill_selection_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
           }
         ]
       }

--- a/doc/recipes/llm/how_do_i_report_on_skill_selection.org
+++ b/doc/recipes/llm/how_do_i_report_on_skill_selection.org
@@ -1,0 +1,78 @@
+:PROPERTIES:
+:ID: 7742AC84-C722-4CFA-8D70-8AB1C6DFD45A
+:END:
+#+title: How do I report on skill selection?
+#+description: Read the skill-selection instrument: what compass skills report shows, and how to record a correction.
+#+type: recipe
+#+level: cross
+#+filetags: :llm:skills:measurement:compass:recipe:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+The instrument records every skill the agent chooses, through a
+=PreToolUse= hook on the =Skill= tool. The hook and its rationale live in
+[[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]]; this recipe is how you read what it collected.
+
+* Question
+
+How good is our skill selection, and how do I record that a skill was
+chosen wrongly?
+
+* Answer
+
+** Read the report
+
+#+begin_src sh :results verbatim
+./compass.sh skills report
+#+end_src
+
+The window defaults to 14 days. Pass =--since 6h=, =--since 30d= or
+=--since all=.
+
+The report shows the number of selections, the correction rate, the
+range of catalogue sizes the agent chose from, the causes ranked, the
+split between attenuated and unattenuated sessions, and the most
+corrected and most chosen skills.
+
+** Record a correction
+
+Selection is recorded automatically; whether it was *wrong* is a
+judgement, so it is recorded by hand, right after the correction
+happens:
+
+#+begin_src sh :results verbatim
+./compass.sh skills correct --cause description --chose pr-merge
+#+end_src
+
+This marks the most recent selection. Pass =--selection <id>= to correct
+an earlier one. The cause is one word from a fixed set:
+
+| Cause            | Meaning                                                       |
+|------------------+---------------------------------------------------------------|
+| =description=    | The chosen skill's description misled; another skill fit better |
+| =catalogue-size= | Too many skills were visible to pick well                     |
+| =level=          | The skill was wrong for the acting System                     |
+| =none=           | Corrected, with no cause worth naming                         |
+
+** Where the log lives
+
+Append-only JSONL in the git common directory, so every worktree in the
+fleet appends to one file and the baseline accrues across checkouts
+rather than restarting on each =env provision=. =compass skills report=
+prints the path when the log is empty.
+
+* Script
+
+[[proj:projects/ores.compass/src/compass_skills.py][=projects/ores.compass/src/compass_skills.py=]] holds the command and the
+event shapes. [[proj:projects/ores.compass/src/record_skill_selection_hook.py][=record_skill_selection_hook.py=]] is the hook, tangled from
+[[proj:doc/llm/claude_code_settings.org][=doc/llm/claude_code_settings.org=]].
+
+* Tested by
+
+=projects/ores.compass/tests/test_compass_skills.py= and
+=projects/ores.compass/tests/test_record_skill_selection_hook.py=.
+
+* See also
+
+- [[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]] — the hook, and why it records no judgement.
+- [[id:3DDB2AFA-9CAA-44A0-A91A-645A95320A5F][How do I deploy the settings?]] — the hook reaches a session only once the settings are tangled.

--- a/doc/recipes/llm/llm.org
+++ b/doc/recipes/llm/llm.org
@@ -24,3 +24,8 @@ operating inside this repo.
 * Planning
 
 - [[id:6FE5A0E1-4C96-4B13-A2B9-64590AD6DB46][How do I ask an LLM to spec a new feature?]]
+
+* Agent configuration
+
+- [[id:5295951B-CD43-4FDC-B1E9-0FFF9BEEFE02][How do I update Claude Code permissions?]]
+- [[id:7742AC84-C722-4CFA-8D70-8AB1C6DFD45A][How do I report on skill selection?]]

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -7322,6 +7322,9 @@ def main():
         sys.exit(cmd_shell(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "review":
         sys.exit(cmd_review(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "skills":
+        import compass_skills
+        sys.exit(compass_skills.run(sys.argv[2:], PROJECT_ROOT))
     if len(sys.argv) >= 2 and sys.argv[1] == "timeline":
         import compass_timeline
         sys.exit(compass_timeline.run(sys.argv[2:], PROJECT_ROOT))
@@ -7360,6 +7363,7 @@ def main():
             "env", "image", "nats", "db", "sql", "services", "client", "claude", "test", "build",
             "site", "shell", "review", "pr", "release-notes", "bearings",
             "orient", "timeline", "capture", "lint", "codegen", "branches",
+            "skills",
             "inbox", "next", "deferred", "discarded", "backlog",
         ]
         cmd_given = sys.argv[1]
@@ -7391,6 +7395,7 @@ def main():
         "  Release:   release-notes create | charts | export | commit | draft\n"
         "  Bearings:  bearings (alias: orient)\n"
         "  Lint:      lint\n"
+        "  Skills:    skills report | skills correct\n"
         "\n"
         "Entity commands (sub-subcommands span pillars):\n"
         "  sprint:   status | audit (orient)\n"
@@ -7529,6 +7534,11 @@ def main():
                           help="PR: pull-request lifecycle verbs via gh — "
                                "'pr checks [--watch]', 'pr create', 'pr merge [--force]', "
                                "'pr record'; 'pr --help'")
+    subparsers.add_parser("skills",
+                          help="Skills: the selection instrument — "
+                               "'skills report [--since 14d]', "
+                               "'skills correct --cause <cause>'; "
+                               "'skills --help'")
     subparsers.add_parser("timeline",
                           help="Timeline: everyone × past — 'timeline generate [--since 20m]', "
                                "'timeline now', 'timeline snapshot [--since 20m]', "

--- a/projects/ores.compass/src/compass_skills.py
+++ b/projects/ores.compass/src/compass_skills.py
@@ -1,0 +1,289 @@
+"""compass skills — the skill-selection instrument.
+
+Selections are recorded by a PreToolUse hook on the Skill tool (see
+doc/llm/claude_code_settings.org), so the measurement accrues without
+anyone remembering to record it. Corrections are a judgement, so they are
+recorded explicitly with 'compass skills correct'.
+
+The log is append-only JSONL in the git common directory, which every
+worktree in the fleet shares, so the baseline is project-wide rather than
+per-checkout.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import uuid
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+LOG_NAME = "skill_selections.jsonl"
+CAUSES = ("description", "catalogue-size", "level", "none")
+DEFAULT_WINDOW = "14d"
+
+SKILL_ROOTS = (
+    Path(".claude") / "skills",
+    Path.home() / ".claude" / "skills",
+    Path.home() / ".claude" / "plugins" / "cache",
+)
+
+
+def log_path(project_root):
+    """The shared log, in the git common dir so every worktree appends to one
+    file. Falls back to the worktree when git cannot answer."""
+    try:
+        p = subprocess.run(["git", "rev-parse", "--git-common-dir"],
+                           cwd=project_root, capture_output=True, text=True)
+        if p.returncode == 0 and p.stdout.strip():
+            common = Path(p.stdout.strip())
+            if not common.is_absolute():
+                common = Path(project_root) / common
+            return common / LOG_NAME
+    except OSError:
+        pass
+    return Path(project_root) / LOG_NAME
+
+
+def count_visible_skills(project_root):
+    """How many skills the agent could choose from: project, user and plugin
+    catalogues, counted by their SKILL.md files."""
+    total = 0
+    for root in SKILL_ROOTS:
+        base = root if root.is_absolute() else Path(project_root) / root
+        if not base.is_dir():
+            continue
+        total += sum(1 for _ in base.glob("**/SKILL.md"))
+    return total
+
+
+def environment_label(project_root):
+    env_file = Path(project_root) / ".env"
+    try:
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("ORES_CHECKOUT_LABEL="):
+                return line.split("=", 1)[1].strip()
+    except OSError:
+        pass
+    return None
+
+
+def now_iso():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def append(project_root, event):
+    path = log_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event, sort_keys=True) + "\n")
+    return event
+
+
+def record_selection(project_root, skill, session):
+    """Called by the PreToolUse hook. ORES_SKILL_LEVEL is the attenuation
+    axis: unset until the declared System filters the catalogue."""
+    return append(project_root, {
+        "kind": "selection",
+        "id": uuid.uuid4().hex[:12],
+        "ts": now_iso(),
+        "session": session,
+        "env": environment_label(project_root),
+        "skill": skill,
+        "offered": count_visible_skills(project_root),
+        "level": os.environ.get("ORES_SKILL_LEVEL") or None,
+    })
+
+
+def read_events(project_root):
+    path = log_path(project_root)
+    events = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return events
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except ValueError:
+            continue
+    return events
+
+
+def parse_duration(spec):
+    """'20m' / '2h' / '14d' -> timedelta, else None."""
+    m = re.fullmatch(r"(\d+)([mhd])", spec.strip())
+    if not m:
+        return None
+    n, unit = int(m.group(1)), m.group(2)
+    return {"m": timedelta(minutes=n),
+            "h": timedelta(hours=n),
+            "d": timedelta(days=n)}[unit]
+
+
+def within_window(events, since):
+    if since is None:
+        return events
+    cutoff = (datetime.now(timezone.utc) - since).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return [e for e in events if e.get("ts", "") >= cutoff]
+
+
+def summarise(events):
+    """Selections, the corrections pointing at them, and the level split.
+
+    A correction naming no selection still counts, so a correction recorded
+    against a lost or trimmed selection is never silently dropped.
+    """
+    selections = {e["id"]: e for e in events
+                  if e.get("kind") == "selection" and e.get("id")}
+    corrections = [e for e in events if e.get("kind") == "correction"]
+
+    corrected_ids = {c.get("selection") for c in corrections}
+    by_level = Counter()
+    corrected_by_level = Counter()
+    for sid, sel in selections.items():
+        level = sel.get("level") or "unattenuated"
+        by_level[level] += 1
+        if sid in corrected_ids:
+            corrected_by_level[level] += 1
+
+    return {
+        "selections": selections,
+        "corrections": corrections,
+        "corrected": len(corrected_ids & set(selections)),
+        "causes": Counter(c.get("cause") or "none" for c in corrections),
+        "skills": Counter(s.get("skill") for s in selections.values()),
+        "corrected_skills": Counter(
+            selections[i]["skill"] for i in corrected_ids if i in selections),
+        "by_level": by_level,
+        "corrected_by_level": corrected_by_level,
+        "offered": [s.get("offered") for s in selections.values()
+                    if isinstance(s.get("offered"), int)],
+    }
+
+
+def cmd_report(argv, project_root):
+    ap = argparse.ArgumentParser(
+        prog="compass skills report",
+        description="Report skill-selection quality over a window.")
+    ap.add_argument("--since", default=DEFAULT_WINDOW,
+                    help=f"Window, e.g. 20m/6h/14d (default: {DEFAULT_WINDOW}); "
+                         "'all' for the whole log.")
+    args = ap.parse_args(argv)
+
+    since = None
+    if args.since != "all":
+        since = parse_duration(args.since)
+        if since is None:
+            print(f"❌  unrecognised window '{args.since}'; use 20m, 6h or 14d.",
+                  file=sys.stderr)
+            return 1
+
+    events = within_window(read_events(project_root), since)
+    s = summarise(events)
+    n = len(s["selections"])
+    c = len(s["corrections"])
+
+    print(f"🧭 ores.compass — skill selection ({args.since})\n")
+    if not n and not c:
+        print("  No selections recorded yet.")
+        print(f"  Log: {log_path(project_root)}")
+        return 0
+
+    rate = (s["corrected"] / n * 100) if n else 0.0
+    print(f"  Selections:  {n}")
+    print(f"  Corrections: {c}  ({rate:.0f}% of selections corrected)")
+    if s["offered"]:
+        lo, hi = min(s["offered"]), max(s["offered"])
+        span = f"{lo}" if lo == hi else f"{lo}–{hi}"
+        print(f"  Catalogue:   {span} skills visible")
+
+    if s["causes"]:
+        print("\n  Causes")
+        for cause, count in s["causes"].most_common():
+            print(f"    {count:4}  {cause}")
+
+    print("\n  Level")
+    for level, count in s["by_level"].most_common():
+        bad = s["corrected_by_level"][level]
+        pct = (bad / count * 100) if count else 0.0
+        print(f"    {count:4}  {level}  ({bad} corrected, {pct:.0f}%)")
+
+    if s["corrected_skills"]:
+        print("\n  Most corrected")
+        for skill, count in s["corrected_skills"].most_common(5):
+            print(f"    {count:4}  {skill}")
+
+    print("\n  Most chosen")
+    for skill, count in s["skills"].most_common(5):
+        print(f"    {count:4}  {skill}")
+    return 0
+
+
+def cmd_correct(argv, project_root):
+    ap = argparse.ArgumentParser(
+        prog="compass skills correct",
+        description="Mark the last recorded selection as corrected.")
+    ap.add_argument("--cause", required=True, choices=CAUSES,
+                    help="Why the wrong skill was chosen.")
+    ap.add_argument("--chose", default=None,
+                    help="The skill that should have been chosen.")
+    ap.add_argument("--selection", default=None,
+                    help="Selection id to correct (default: the most recent).")
+    args = ap.parse_args(argv)
+
+    events = read_events(project_root)
+    selections = [e for e in events if e.get("kind") == "selection"]
+    if args.selection:
+        target = next((e for e in selections
+                       if e.get("id") == args.selection), None)
+        if target is None:
+            print(f"❌  no selection with id '{args.selection}'.",
+                  file=sys.stderr)
+            return 1
+    elif selections:
+        target = selections[-1]
+    else:
+        print("❌  nothing to correct: no selection recorded yet.",
+              file=sys.stderr)
+        return 1
+
+    append(project_root, {
+        "kind": "correction",
+        "ts": now_iso(),
+        "session": target.get("session"),
+        "selection": target.get("id"),
+        "cause": args.cause,
+        "chose": args.chose,
+    })
+    instead = f" → {args.chose}" if args.chose else ""
+    print(f"📝 corrected {target.get('skill')}{instead} "
+          f"({args.cause}, selection {target.get('id')})")
+    return 0
+
+
+def run(argv, project_root):
+    ap = argparse.ArgumentParser(
+        prog="compass skills",
+        description="The skill-selection instrument: report quality, record "
+                    "a correction.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+    sub.add_parser("report", add_help=False,
+                   help="Selection quality over a window.")
+    sub.add_parser("correct", add_help=False,
+                   help="Mark the last selection as corrected.")
+    if not argv:
+        ap.print_help()
+        return 1
+    if argv[0] == "report":
+        return cmd_report(argv[1:], project_root)
+    if argv[0] == "correct":
+        return cmd_correct(argv[1:], project_root)
+    ap.parse_args(argv)
+    return 1

--- a/projects/ores.compass/src/record_skill_selection_hook.py
+++ b/projects/ores.compass/src/record_skill_selection_hook.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: record which skill the agent chose.
+
+Feeds 'compass skills report'. See doc/llm/claude_code_settings.org's
+Hooks section. Observing only: this hook never blocks the Skill tool,
+so every failure path returns 0.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Skill":
+        return 0
+    skill = data.get("tool_input", {}).get("skill")
+    if not skill:
+        return 0
+    try:
+        import compass_skills
+        compass_skills.record_selection(
+            data.get("cwd") or os.getcwd(), skill, data.get("session_id"))
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/ores.compass/tests/test_compass_skills.py
+++ b/projects/ores.compass/tests/test_compass_skills.py
@@ -1,0 +1,129 @@
+"""
+Tests for the skill-selection instrument.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_compass_skills.py -v
+No live database required.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import compass_skills as skills
+
+
+def use_log(monkeypatch, tmp_path):
+    log = tmp_path / "skill_selections.jsonl"
+    monkeypatch.setattr(skills, "log_path", lambda _root: log)
+    return log
+
+
+def test_selection_records_the_attenuation_level(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    monkeypatch.setenv("ORES_SKILL_LEVEL", "s1")
+
+    event = skills.record_selection(tmp_path, "pr-merge", "s-1")
+
+    assert event["level"] == "s1"
+    assert event["skill"] == "pr-merge"
+    assert isinstance(event["offered"], int)
+
+
+def test_selection_without_a_level_is_unattenuated(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    monkeypatch.delenv("ORES_SKILL_LEVEL", raising=False)
+
+    assert skills.record_selection(tmp_path, "pr-merge", "s-1")["level"] is None
+
+
+def test_correct_marks_the_most_recent_selection(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    monkeypatch.delenv("ORES_SKILL_LEVEL", raising=False)
+    skills.record_selection(tmp_path, "pr-raise", "s-1")
+    second = skills.record_selection(tmp_path, "pr-merge", "s-1")
+
+    assert skills.cmd_correct(["--cause", "description"], tmp_path) == 0
+
+    corrections = [e for e in skills.read_events(tmp_path)
+                   if e["kind"] == "correction"]
+    assert len(corrections) == 1
+    assert corrections[0]["selection"] == second["id"]
+    assert corrections[0]["cause"] == "description"
+
+
+def test_correct_refuses_an_empty_log(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    assert skills.cmd_correct(["--cause", "level"], tmp_path) == 1
+
+
+def test_summary_splits_the_correction_rate_by_level(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    monkeypatch.delenv("ORES_SKILL_LEVEL", raising=False)
+    plain = skills.record_selection(tmp_path, "pr-raise", "s-1")
+    monkeypatch.setenv("ORES_SKILL_LEVEL", "s1")
+    skills.record_selection(tmp_path, "pr-merge", "s-2")
+    skills.cmd_correct(["--cause", "catalogue-size",
+                        "--selection", plain["id"]], tmp_path)
+
+    s = skills.summarise(skills.read_events(tmp_path))
+
+    assert s["by_level"] == {"unattenuated": 1, "s1": 1}
+    assert s["corrected_by_level"]["unattenuated"] == 1
+    assert s["corrected_by_level"]["s1"] == 0
+    assert s["causes"]["catalogue-size"] == 1
+
+
+def test_two_corrections_on_one_selection_count_once(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    monkeypatch.delenv("ORES_SKILL_LEVEL", raising=False)
+    skills.record_selection(tmp_path, "pr-raise", "s-1")
+    skills.cmd_correct(["--cause", "description"], tmp_path)
+    skills.cmd_correct(["--cause", "level"], tmp_path)
+
+    s = skills.summarise(skills.read_events(tmp_path))
+
+    assert len(s["corrections"]) == 2
+    assert s["corrected"] == 1
+
+
+def test_window_excludes_older_events(monkeypatch, tmp_path):
+    events = [{"kind": "selection", "id": "old", "ts": "2020-01-01T00:00:00Z"},
+              {"kind": "selection", "id": "new", "ts": skills.now_iso()}]
+
+    kept = skills.within_window(events, skills.parse_duration("1d"))
+
+    assert [e["id"] for e in kept] == ["new"]
+
+
+def test_unreadable_log_reads_as_empty(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    assert skills.read_events(tmp_path) == []
+
+
+def test_malformed_lines_are_skipped(monkeypatch, tmp_path):
+    log = use_log(monkeypatch, tmp_path)
+    log.write_text('{"kind": "selection", "id": "a", "ts": "x"}\nnot json\n')
+
+    assert [e["id"] for e in skills.read_events(tmp_path)] == ["a"]
+
+
+def test_report_runs_on_an_empty_log(monkeypatch, tmp_path, capsys):
+    use_log(monkeypatch, tmp_path)
+
+    assert skills.cmd_report([], tmp_path) == 0
+    assert "No selections recorded yet" in capsys.readouterr().out
+
+
+def test_report_rejects_an_unparsable_window(monkeypatch, tmp_path):
+    use_log(monkeypatch, tmp_path)
+    assert skills.cmd_report(["--since", "yesterday"], tmp_path) == 1
+
+
+def test_log_is_shared_across_worktrees(tmp_path):
+    """The log lives in the git common dir, so every worktree appends to one
+    file rather than restarting the baseline per checkout."""
+    path = skills.log_path(Path(__file__).resolve().parent)
+    assert path.name == skills.LOG_NAME
+    assert path.parent.name.endswith(".git")

--- a/projects/ores.compass/tests/test_record_skill_selection_hook.py
+++ b/projects/ores.compass/tests/test_record_skill_selection_hook.py
@@ -1,0 +1,62 @@
+"""
+Tests for the skill-selection PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_record_skill_selection_hook.py -v
+No live database required.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import compass_skills
+import record_skill_selection_hook as hook
+
+
+def run(payload, monkeypatch, tmp_path):
+    monkeypatch.setattr(compass_skills, "log_path",
+                        lambda _root: tmp_path / "skill_selections.jsonl")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return hook.main()
+
+
+def events(tmp_path):
+    path = tmp_path / "skill_selections.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_skill_call_is_recorded(monkeypatch, tmp_path):
+    assert run({"tool_name": "Skill", "session_id": "s1", "cwd": str(tmp_path),
+                "tool_input": {"skill": "pr-merge"}}, monkeypatch, tmp_path) == 0
+    recorded = events(tmp_path)
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "selection"
+    assert recorded[0]["skill"] == "pr-merge"
+    assert recorded[0]["session"] == "s1"
+
+
+def test_other_tools_are_ignored(monkeypatch, tmp_path):
+    assert run({"tool_name": "Bash", "tool_input": {"command": "ls"}},
+               monkeypatch, tmp_path) == 0
+    assert events(tmp_path) == []
+
+
+def test_malformed_payload_does_not_crash(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
+
+
+def test_recording_failure_never_blocks_the_tool(monkeypatch, tmp_path):
+    def explode(*_args, **_kwargs):
+        raise OSError("log is unwritable")
+    monkeypatch.setattr(compass_skills, "record_selection", explode)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(
+        {"tool_name": "Skill", "cwd": str(tmp_path),
+         "tool_input": {"skill": "pr-merge"}})))
+    assert hook.main() == 0


### PR DESCRIPTION
## Summary

We know skill mis-selection is real because it has been corrected by hand for months, but we have no instrument, so we cannot quantify or report it. This builds one that records selections forward rather than scoring past tasks, so the measurement accrues while the migration proceeds and keeps working after it lands.

## Changes

- PreToolUse hook on the Skill tool records every selection: the skill chosen, the session, the environment, how many skills were visible, and the attenuation level from ORES_SKILL_LEVEL. Literate source in doc/llm/claude_code_settings.org, tangled with its tests.
- The hook returns 0 on every failure path, including a malformed payload and an unwritable log, because a hook command that cannot execute blocks its tool outright.
- compass skills correct records the judgement half as a separate append-only event, against the fixed cause vocabulary: description, catalogue-size, level and none.
- compass skills report prints the correction rate, the causes ranked, the split between attenuated and unattenuated sessions, and the most corrected and most chosen skills over a window.
- The log is JSONL in the git common directory, so every worktree in the fleet appends to one file and the baseline never restarts on env provision.
- New recipe: How do I report on skill selection?

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Instrument skill selection so the baseline accrues forward](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_selection_instrumentation.html) | 37BC3547-4FE9-4D13-B3E7-5C071C5155B9 |
| Environment | bright_faraday | |

## Testing

Plan. Drive the real hook end to end with a synthetic PreToolUse payload, record a correction, read the report, and run the checks for the python tooling and docs classes the diff spans.

Evidence. python tooling and docs. Compass suite: 144 passed, 1 skipped, including 16 new tests. Site build: Build succeeded. cmake-sources drift: All component_files.cmake up to date. compass lint: clean, with the durable-link advisory back at its pre-existing 160. End to end: piping a Skill payload into record_skill_selection_hook.py exited 0 and appended a selection reading offered 188, level null; compass skills correct --cause description then made the report show Corrections 1, the cause ranked, and the level split as unattenuated. The probe rows were removed afterwards so the shared baseline starts clean.

Limitations. No C++ was touched, so no build or ctest run. Codegen drift was not run: the diff touches no model, template or generated source. The hook reaches a session only after the settings are tangled, so it records nothing for sessions already running. The first populated report is the gate before the sequencing function lands, not this task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)