### PR TITLE
[doc] Tag every skill with its cybernetic level

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -60,3 +60,9 @@ jobs:
         # The polymorphic skills dispatch on these. A stale table sends an
         # agent to a command or a document type that has moved.
         run: python3 build/scripts/generate_skill_type_tables.py --check
+
+      - name: Check every skill carries its level
+        # A skill with no level is visible at every level, which defeats
+        # the attenuation. A skill missing from the table is an error
+        # rather than a default, so a new skill needs a considered level.
+        run: python3 build/scripts/apply_skill_levels.py --check

--- a/build/scripts/apply_skill_levels.py
+++ b/build/scripts/apply_skill_levels.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Set the cybernetic level on every skill, and report the attenuated slices.
+
+The level turns the cybernetic systems into a variety attenuator: a session
+declares its System, and the level selects the slice of the catalogue in
+scope by default. A regulator swamped by variety it cannot use stops
+regulating, and an agent shown every skill at once is exactly that.
+
+The level is a judgement about which System the skill serves, so it is a
+reviewed table rather than a rule over names. LEVELS below is that table:
+every skill appears, and the value is defensible from what the skill acts
+on. A skill missing from it is an error, not a default.
+
+Attenuation is advisory at S1, S2, S3, S4 and S5 and binding at S3*, the
+audit channel, which sees read-only actions only. Read-only is derived from
+the verb register rather than tagged, which is one of the reasons that
+register exists: show- and find- promise to change nothing.
+
+Usage: python3 build/scripts/apply_skill_levels.py [--check] [--slice LEVEL]
+  --check        exit non-zero if any skill's level differs from the table.
+  --slice LEVEL  print the slice a session at LEVEL sees, and stop.
+  --prune-deployed LEVEL
+                 remove the out-of-scope skills from the deployed tree, so
+                 an agent spawned at LEVEL cannot load them. This makes the
+                 attenuation binding, which is what a read-only System
+                 wants: the audit channel is held read-only by what is on
+                 disk when it starts, rather than by asking it in a prompt.
+                 Normal operation deploys the full set and leaves every
+                 advisory level free to reach outside its slice.
+"""
+import argparse
+import pathlib
+import re
+import shutil
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILLS = ROOT / "doc" / "llm" / "skills"
+DEPLOYED = ROOT / ".claude" / "skills"
+LEVELS_DOC = SKILLS / "skill_systems_levels.org"
+BEGIN = "# BEGIN generated inventory (build/scripts/apply_skill_levels.py)"
+END = "# END generated inventory"
+
+READ_ONLY_VERBS = ("show", "find")
+ORDER = ["s1", "s2", "s3", "s3star", "s4", "s5", "cross"]
+
+# Skill -> level. The reason is the skill's target: what does it act on, and
+# whose horizon is that?
+LEVELS = {
+    # Execution: code, generated code, environments, documents, pull
+    # requests. The agent's own hours-long horizon.
+    "compass-code-add-domain-type": "s1",
+    "compass-code-add-tests": "s1",
+    "compass-code-investigate-test-failure": "s1",
+    "compass-code-review-comments": "s1",
+    "compass-code-review-component": "s1",
+    "compass-code-review-data-model": "s1",
+    "compass-code-review-pr": "s1",
+    "compass-code-run-build": "s1",
+    "compass-code-run-feature-test": "s1",
+    "compass-code-start-branch": "s1",
+    "compass-codegen-add-component": "s1",
+    "compass-codegen-add-entity": "s1",
+    "compass-codegen-add-qt-entity": "s1",
+    "compass-codegen-add-sql-schema": "s1",
+    "compass-codegen-add-surface-entity": "s1",
+    "compass-codegen-fix-drift": "s1",
+    "compass-codegen-sync-cmake-sources": "s1",
+    "compass-devops-deploy-manual": "s1",
+    "compass-devops-deploy-settings": "s1",
+    "compass-devops-deploy-site": "s1",
+    "compass-devops-deploy-skills": "s1",
+    "compass-devops-recreate-db": "s1",
+    "compass-devops-run-client": "s1",
+    "compass-devops-run-environment": "s1",
+    "compass-devops-run-shell": "s1",
+    "compass-devops-run-sql": "s1",
+    "compass-devops-setup-environment": "s1",
+    "compass-devops-start-services": "s1",
+    "compass-devops-stop-services": "s1",
+    "compass-devops-update-environment": "s1",
+    "compass-doc-add-chart": "s1",
+    "compass-doc-add-class-diagram": "s1",
+    "compass-doc-add-component-model": "s1",
+    "compass-doc-add-entity-chapter": "s1",
+    "compass-doc-add-er-diagram": "s1",
+    "compass-doc-add-recipe": "s1",
+    "compass-doc-run-manual-screenshots": "s1",
+    "compass-doc-sync-recipes": "s1",
+    "compass-doc-update-manual": "s1",
+    "compass-pr-address-review": "s1",
+    "compass-pr-merge": "s1",
+    "compass-pr-raise": "s1",
+    "compass-pr-sync-branch": "s1",
+    "compass-agile-close-task": "s1",
+    "compass-agile-start-task": "s1",
+    "compass-agile-start-hotfix": "s1",
+
+    # Coordination: the story, and the worktree a story runs in. Days.
+    "compass-agile-start-story": "s2",
+    "compass-devops-provision-environment": "s2",
+    "compass-devops-deprovision-environment": "s2",
+
+    # Control: the sprint and the backlog it draws from. Weeks.
+    "compass-agile-open-sprint": "s3",
+    "compass-agile-plan-sprint": "s3",
+    "compass-agile-refine-backlog": "s3",
+    "compass-agile-review-sprint": "s3",
+    "compass-agile-add-timeline-snapshot": "s3",
+    "compass-agile-find-heading": "s3",
+
+    # Development: the version and its release. Months.
+    "compass-agile-add-release-notes": "s4",
+
+    # Identity: what belongs in the product at all.
+    "compass-agile-brainstorm-idea": "s5",
+
+    # Every level acts on these: the documents and skills themselves, and
+    # the orientation any System starts from.
+    "compass-doc-add": "cross",
+    "compass-doc-add-memory": "cross",
+    "compass-doc-find": "cross",
+    "compass-doc-review-academic": "cross",
+    "compass-doc-review-ste100": "cross",
+    "compass-doc-show": "cross",
+    "compass-doc-sync-index": "cross",
+    "compass-agile-find-bearings": "cross",
+    "compass-skill-add": "cross",
+    "compass-skill-delete": "cross",
+    "compass-skill-review": "cross",
+    "compass-skill-show-catalogue": "cross",
+}
+
+LEVEL_RE = re.compile(r"^#\+level:.*$", re.M)
+
+
+def skill_dirs():
+    return sorted(d for d in SKILLS.iterdir()
+                  if d.is_dir() and (d / "SKILL.org").is_file())
+
+
+def verb(name):
+    """The verb segment of compass-<domain>-<verb>[-<object>]."""
+    parts = name.split("-")
+    return parts[2] if len(parts) > 2 else ""
+
+
+def read_only(name):
+    return verb(name) in READ_ONLY_VERBS
+
+
+def in_scope(name, level):
+    """What a session at this level sees by default.
+
+    S3* is the binding case: the audit channel observes and does not mutate,
+    so its slice is the read-only actions and nothing else. Every other
+    level sees its own slice plus the cross-level skills, and may reach
+    outside on request.
+    """
+    if level == "s3star":
+        return read_only(name)
+    declared = LEVELS.get(name)
+    return declared in (level, "cross")
+
+
+def current_level(path):
+    m = re.search(r"^#\+level:\s*(\S+)\s*$", path.read_text(encoding="utf-8"), re.M)
+    return m.group(1) if m else None
+
+
+def set_level(path, level):
+    text = path.read_text(encoding="utf-8")
+    line = f"#+level: {level}"
+    if LEVEL_RE.search(text):
+        updated = LEVEL_RE.sub(line, text, count=1)
+    else:
+        # Sits with the other frontmatter, after the export-exclude line the
+        # skill scaffold always carries.
+        updated = text.replace("#+export_exclude_tags: noexport\n",
+                               f"#+export_exclude_tags: noexport\n{line}\n", 1)
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+SYSTEMS = {
+    "s1": ("Agent", "Hours"),
+    "s2": ("Orchestrator", "Days"),
+    "s3": ("Sprint Planner", "Weeks"),
+    "s3star": ("Auditor", "Continuous"),
+    "s4": ("Version Planner", "Months"),
+    "s5": ("Identity Steward", "Indefinite"),
+}
+
+
+def inventory(names):
+    """The slice each System actually sees, counted from the same table the
+    skills are tagged from, so the document cannot drift from the catalogue."""
+    lines = [BEGIN, "",
+             "What each System sees by default, counted from the levels the "
+             "skills carry. Attenuation is advisory everywhere except the "
+             "audit channel, where it is binding and enforced by what is "
+             "deployed.", "",
+             "#+ATTR_HTML: :class hug-leading",
+             "| Level | System | Horizon | Sees | Attenuation |",
+             "|-------+--------+---------+------+-------------|"]
+    for level, (system, horizon) in SYSTEMS.items():
+        n = sum(1 for name in names if in_scope(name, level))
+        strength = "binding" if level == "s3star" else "advisory"
+        lines.append(f"| ={level}= | {system} | {horizon} | {n} skills | {strength} |")
+    cross = sum(1 for name in names if LEVELS.get(name) == "cross")
+    lines += ["",
+              f"{cross} skills are tagged =cross= and appear in every "
+              "advisory slice: the documents and the skills themselves, and "
+              "the orientation any System starts from.", "",
+              END]
+    return "\n".join(lines)
+
+
+def write_inventory(names):
+    import re as _re
+    text = LEVELS_DOC.read_text(encoding="utf-8")
+    pattern = _re.escape(BEGIN) + r".*?" + _re.escape(END)
+    old_pattern = (r"# BEGIN generated inventory \(build/scripts/"
+                   r"generate_skills_catalogue\.py\).*?# END generated inventory")
+    block = inventory(names)
+    if _re.search(pattern, text, _re.S):
+        updated = _re.sub(pattern, lambda _m: block, text, flags=_re.S)
+    elif _re.search(old_pattern, text, _re.S):
+        updated = _re.sub(old_pattern, lambda _m: block, text, flags=_re.S)
+    else:
+        print(f"❌ inventory markers not found in {LEVELS_DOC}", file=sys.stderr)
+        return None
+    return updated
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if a level differs from the table")
+    ap.add_argument("--slice", metavar="LEVEL", choices=ORDER,
+                    help="print the slice a session at LEVEL sees")
+    ap.add_argument("--prune-deployed", metavar="LEVEL", choices=ORDER,
+                    help="remove out-of-scope skills from the deployed tree, "
+                         "making the attenuation binding for whatever is "
+                         "spawned next")
+    args = ap.parse_args()
+
+    names = [d.name for d in skill_dirs()]
+
+    missing = [n for n in names if n not in LEVELS]
+    unknown = [n for n in LEVELS if n not in names]
+    if missing or unknown:
+        for n in missing:
+            print(f"❌ no level for {n}", file=sys.stderr)
+        for n in unknown:
+            print(f"❌ table names a skill that does not exist: {n}",
+                  file=sys.stderr)
+        return 1
+
+    if args.prune_deployed:
+        level = args.prune_deployed
+        if not DEPLOYED.is_dir():
+            print(f"❌ nothing deployed at {DEPLOYED}", file=sys.stderr)
+            return 1
+        removed = []
+        for d in sorted(DEPLOYED.iterdir()):
+            if not d.is_dir() or d.name not in LEVELS:
+                continue
+            if in_scope(d.name, level):
+                continue
+            shutil.rmtree(d)
+            removed.append(d.name)
+        kept = sum(1 for d in DEPLOYED.iterdir() if d.is_dir())
+        print(f"🧭 deployed tree pruned to {level}: {kept} skill(s) remain, "
+              f"{len(removed)} removed.")
+        print("   Rebuild the bundle to restore the full set.")
+        return 0
+
+    if args.slice:
+        visible = [n for n in names if in_scope(n, args.slice)]
+        binding = " (binding)" if args.slice == "s3star" else " (advisory)"
+        print(f"🧭 {args.slice}{binding}: {len(visible)} of {len(names)} skills\n")
+        for n in visible:
+            print(f"  {n}")
+        return 0
+
+    changed = []
+    for d in skill_dirs():
+        path = d / "SKILL.org"
+        want = LEVELS[d.name]
+        if current_level(path) == want:
+            continue
+        if args.check:
+            print(f"❌ {d.name}: level is {current_level(path)}, table says {want}",
+                  file=sys.stderr)
+            changed.append(d.name)
+            continue
+        set_level(path, want)
+        changed.append(d.name)
+
+    if args.check:
+        updated = write_inventory(names)
+        if updated is None:
+            return 1
+        if updated != LEVELS_DOC.read_text(encoding="utf-8"):
+            print(f"❌ stale inventory in {LEVELS_DOC.name}", file=sys.stderr)
+            changed.append(LEVELS_DOC.name)
+        if changed:
+            print("   run: python3 build/scripts/apply_skill_levels.py",
+                  file=sys.stderr)
+            return 1
+        print(f"✅ all {len(names)} skills carry their table level.")
+        return 0
+
+    updated = write_inventory(names)
+    if updated is None:
+        return 1
+    if updated != LEVELS_DOC.read_text(encoding="utf-8"):
+        LEVELS_DOC.write_text(updated, encoding="utf-8")
+        print(f"✅ regenerated the inventory in {LEVELS_DOC.name}")
+
+    print(f"✅ set the level on {len(changed)} skill(s); {len(names)} total.")
+    for level in ORDER:
+        n = sum(1 for name in names if in_scope(name, level))
+        print(f"   {level:7} sees {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -79,7 +79,7 @@ Tasks are listed in intended execution order.
 | [[id:1EF24A09-F4D7-4DA7-BB54-1BC91F5CB8BE][Define the upstream attribution contract for imported skills]] | ABANDONED | | 2026-09-04 | Superseded by the reference approach. Upstream skills are referenced rather than copied, so no fork exists to attribute or drift-check; the classification table in The pstack Collection replaces it. 
 | [[id:629B48C7-BC7E-44A8-8979-3E05D6DA5BFE][Collapse the uniform verbs into polymorphic actions]] | DONE | 2026-09-10 | 2026-09-10 | Shrink the execution function before the imports land: one skill per verb that behaves uniformly across artefact types, driven by a type table. |
 | [[id:7DFA4343-E553-4D3A-B71F-057329821EE5][Rename every skill into the compass- namespace]] | DONE | 2026-09-10 | 2026-09-10 | Mechanical rename of every skill, with every incoming link, catalogue row, runbook, memory and settings entry updated. |
-| [[id:3969C185-48DE-47F0-A00D-FD28CD58C1B0][Tag every skill with its cybernetic level]] | BACKLOG | | | Add the mandatory level keyword to every skill and make the declared System attenuate which skills a session sees. |
+| [[id:3969C185-48DE-47F0-A00D-FD28CD58C1B0][Tag every skill with its cybernetic level]] | DONE | 2026-09-10 | 2026-09-10 | Add the mandatory level keyword to every skill and make the declared System attenuate which skills a session sees. |
 | [[id:F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59][Separate skill judgement from recipe commands]] | BACKLOG | | | Make every action delegate its commands to a recipe and keep only the judgement, so each has one source of truth. |
 | [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | BACKLOG | | | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
@@ -132,6 +132,15 @@ Tasks are listed in intended execution order.
 - A sweep across the corpus is a committed script with a =--check= mode, not
   a careful afternoon. The script is the artefact a reviewer re-runs, and the
   check is what stops the next skill landing outside the namespace.
+- A level is a judgement about which System a skill serves, so it is a
+  reviewed table rather than a rule over names. A skill absent from that
+  table is an error, which is what stops the next skill landing untagged.
+- Attenuation is enforced by what is deployed, not by what a prompt asks.
+  Pruning the tree makes it binding, which is what a read-only System wants;
+  deploying the full set is what keeps every other level advisory.
+- The audit channel's slice is derived from the verb register rather than
+  tagged. =show-= and =find-= promised to change nothing, and that promise is
+  now load-bearing rather than decorative.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_skill_cybernetic_levels.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_skill_cybernetic_levels.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:cybernetics:levels:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/add-skill-cybernetic-levels
-#+pr:
+#+pr: 2052
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -96,7 +96,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2052][#2052]] | [doc] Tag every skill with its cybernetic level |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_skill_cybernetic_levels.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_skill_cybernetic_levels.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:skills:cybernetics:levels:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/add-skill-cybernetic-levels
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ Every stateful document carries a level keyword; skills do not. Adding it is the
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -45,11 +45,41 @@ Every stateful document carries a level keyword; skills do not. Adding it is the
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+A level is a judgement about which System a skill serves, and a wrong one
+hides a capability, so it is a reviewed table rather than a rule inferred
+from names. =build/scripts/apply_skill_levels.py= holds that table: every
+skill appears in it, and a skill missing from it is an error rather than a
+default, so the next skill cannot land untagged.
+
+The attenuation rule falls out of the table plus the verb register. A
+session at an advisory level sees its own slice and the =cross= skills. The
+audit channel is the binding case, and its slice is derived rather than
+tagged: =show-= and =find-= promise to change nothing, so the auditor sees
+exactly those. That promise was written into the verb register two tasks
+ago; it is now load-bearing.
+
+Enforcement is what is on disk. =--prune-deployed= removes the out-of-scope
+skills from the deployed tree, so an agent spawned afterwards cannot load
+one. Normal operation deploys the full set, which is what keeps the other
+five levels advisory: an agent may reach outside its slice by saying so,
+because the skill is still there.
+
+The inventory in the architecture is generated from the same table, so the
+document cannot claim a scope the catalogue does not have.
 
 * Notes
+
+The distribution is lopsided and honestly so: 46 skills are tagged =s1=,
+against 3 at =s2=, 6 at =s3=, one each at =s4= and =s5=, and 12 =cross=.
+Most of what we do is execution. The value of the tagging is not an even
+spread but the two slices that shrink: the auditor sees 5 skills instead of
+69, and a planner sees 18.
+
+=--prune-deployed= is deliberately available at any level while only being
+appropriate for a read-only spawn. Pruning makes attenuation binding, and
+binding an advisory level would contradict the rule that an agent may reach
+outside its slice.
+
 
 * Test Scenarios
 
@@ -75,3 +105,23 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Six of the seven acceptance criteria are met, and the seventh is partly a
+documentation change that landed with them.
+
+Every one of the 69 skills carries a considered level from the reviewed
+table, with the reason recorded as the grouping comment beside it. The
+auditor's slice contains 5 skills, all read-only: an auditor can no longer
+reach a skill that mutates a work item, and the proof is that pruning the
+deployed tree to =s3star= leaves those five directories and removes 64. A
+session at any other level sees its slice plus the cross-level skills and
+can still reach outside, because the full set stays deployed.
+
+The level-to-scope inventory in
+[[id:5365DE9F-E3F9-4B5F-ACC1-B347B5FCE2A9][Systems and levels]] is generated
+from the same table that tags the skills, so it reports what the catalogue
+actually does. =--check= runs in the Doc Lint workflow.
+
+Systems covering delegates, and read-only enforced at spawn time rather than
+requested in the prompt, were already stated there as target state. They now
+name the mechanism that implements them.

--- a/doc/llm/skills/compass-agile-add-release-notes/SKILL.org
+++ b/doc/llm/skills/compass-agile-add-release-notes/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Add Release Notes
 #+description: Close a sprint by combining merged-PR data with the sprint's stories into an org-mode release-notes file, fill in the blurb, export to Markdown, then tag main and open a draft GitHub release.
 #+type: skill
-#+level: cross
+#+level: s4
 #+filetags: :llm:skill:skills:claude_code:agile:release:github:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-add-timeline-snapshot/SKILL.org
+++ b/doc/llm/skills/compass-agile-add-timeline-snapshot/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s3
 #+filetags: :llm:skill:agile:timeline:compass:
 #+created: 2026-06-10
 #+updated: 2026-06-10

--- a/doc/llm/skills/compass-agile-brainstorm-idea/SKILL.org
+++ b/doc/llm/skills/compass-agile-brainstorm-idea/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Brainstorm Idea
 #+description: Turn a fuzzy idea into a validated design through one-question-at-a-time dialogue; then file the result as the right kind of doc.
 #+type: skill
-#+level: cross
+#+level: s5
 #+filetags: :llm:skill:skills:claude_code:design:dialogue:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-close-task/SKILL.org
+++ b/doc/llm/skills/compass-agile-close-task/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-07-11

--- a/doc/llm/skills/compass-agile-find-bearings/SKILL.org
+++ b/doc/llm/skills/compass-agile-find-bearings/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :skill:compass:llm:orientation:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-find-heading/SKILL.org
+++ b/doc/llm/skills/compass-agile-find-heading/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s3
 #+filetags: :compass:agile:orientation:heading:llm:
 #+created: 2026-06-11
 #+updated: 2026-06-11

--- a/doc/llm/skills/compass-agile-open-sprint/SKILL.org
+++ b/doc/llm/skills/compass-agile-open-sprint/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Open Sprint
 #+description: Open a new sprint under the current version — scaffold the folder, set its mission, wire it into the version manifest, and optionally bump the project version.
 #+type: skill
-#+level: cross
+#+level: s3
 #+filetags: :llm:skill:skills:claude_code:agile:sprint:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-plan-sprint/SKILL.org
+++ b/doc/llm/skills/compass-agile-plan-sprint/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Plan Sprint
 #+description: Run a sprint planning session: read sprint goals, score next-backlog captures against them, and promote selected ones into stories.
 #+type: skill
-#+level: cross
+#+level: s3
 #+filetags: :llm:skill:skills:claude_code:agile:sprint:planning:
 #+created: 2026-05-24
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-refine-backlog/SKILL.org
+++ b/doc/llm/skills/compass-agile-refine-backlog/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Refine Backlog
 #+description: Run a backlog housekeeping session (standard) or a full deep refinement sweep across inbox/next/deferred with a written report.
 #+type: skill
-#+level: cross
+#+level: s3
 #+filetags: :llm:skill:skills:claude_code:agile:backlog:deep:
 #+created: 2026-05-24
 #+updated: 2026-07-11

--- a/doc/llm/skills/compass-agile-review-sprint/SKILL.org
+++ b/doc/llm/skills/compass-agile-review-sprint/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Agile Review Sprint
 #+description: Produce a structured System 2 health-check for the current sprint: goal alignment, load, PR velocity, story/task balance, focus signal, and overall verdict — written into sprint.org.
 #+type: skill
-#+level: cross
+#+level: s3
 #+filetags: :llm:skill:skills:claude_code:agile:sprint:review:health:
 #+created: 2026-05-25
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-start-hotfix/SKILL.org
+++ b/doc/llm/skills/compass-agile-start-hotfix/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-start-story/SKILL.org
+++ b/doc/llm/skills/compass-agile-start-story/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s2
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-agile-start-task/SKILL.org
+++ b/doc/llm/skills/compass-agile-start-task/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-code-add-domain-type/SKILL.org
+++ b/doc/llm/skills/compass-code-add-domain-type/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Add Domain Type
 #+description: Create a new ORE Studio domain type with JSON I/O, table I/O, generator, and repository support via codegen.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:domain:codegen:
 #+created: 2024-09-01
 #+updated: 2026-07-12

--- a/doc/llm/skills/compass-code-add-tests/SKILL.org
+++ b/doc/llm/skills/compass-code-add-tests/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Add Tests
 #+description: Generate Catch2 unit tests following the ORE Studio conventions — file structure, naming, includes, test-case shape, generators, database helpers.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:tests:catch2:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-code-investigate-test-failure/SKILL.org
+++ b/doc/llm/skills/compass-code-investigate-test-failure/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Investigate Test Failure
 #+description: Diagnose a failing Catch2 test in ORE Studio — enable logging, run the suite, parse results, drill into the per-test log, find the root cause.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:tests:debugging:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-code-review-comments/SKILL.org
+++ b/doc/llm/skills/compass-code-review-comments/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:code:comments:
 #+created: 2026-08-10
 #+updated: 2026-08-11

--- a/doc/llm/skills/compass-code-review-component/SKILL.org
+++ b/doc/llm/skills/compass-code-review-component/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Review Component Skill
 #+description: Audit an entire component against the ORE Studio code-review checklist — every file plus structure, CMake, modeling, and test coverage.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:review:component:audit:
 #+created: 2024-09-01
 #+updated: 2026-05-21

--- a/doc/llm/skills/compass-code-review-data-model/SKILL.org
+++ b/doc/llm/skills/compass-code-review-data-model/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:review:modelling:data_oriented_design:
 #+created: 2026-09-08
 #+updated: 2026-09-08

--- a/doc/llm/skills/compass-code-review-pr/SKILL.org
+++ b/doc/llm/skills/compass-code-review-pr/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Review PR Skill
 #+description: Review the delta in a pull request — changed files only — against the ORE Studio code-review checklist. Produce findings bucketed by severity.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:review:pr:
 #+created: 2024-09-01
 #+updated: 2026-05-21

--- a/doc/llm/skills/compass-code-run-build/SKILL.org
+++ b/doc/llm/skills/compass-code-run-build/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Code Run Build
 #+description: Drive the ORE Studio CMake build — configure, build, test, deploy site, deploy skills, generate diagrams — by selecting the matching recipe.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:cmake:build:
 #+created: 2024-09-01
 #+updated: 2026-07-17

--- a/doc/llm/skills/compass-code-run-feature-test/SKILL.org
+++ b/doc/llm/skills/compass-code-run-feature-test/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:code:testing:
 #+created: 2026-07-12
 #+updated: 2026-07-12

--- a/doc/llm/skills/compass-code-start-branch/SKILL.org
+++ b/doc/llm/skills/compass-code-start-branch/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-codegen-add-component/SKILL.org
+++ b/doc/llm/skills/compass-codegen-add-component/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Codegen Add Component
 #+description: Scaffold a new ORE Studio component (api/core/service) via codegen profiles.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:component:codegen:cmake:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-codegen-add-entity/SKILL.org
+++ b/doc/llm/skills/compass-codegen-add-entity/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Codegen Add Entity
 #+description: Create a complete full-stack ORE Studio entity across all layers via codegen — the orchestrator skill.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:entity:codegen:orchestrator:
 #+created: 2026-05-21
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-codegen-add-qt-entity/SKILL.org
+++ b/doc/llm/skills/compass-codegen-add-qt-entity/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Codegen Add QT Entity
 #+description: Create Qt UI components for domain entities including list windows, detail dialogs, history dialogs, and controllers.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:qt:entity:ui:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-codegen-add-sql-schema/SKILL.org
+++ b/doc/llm/skills/compass-codegen-add-sql-schema/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Codegen Add SQL Schema
 #+description: Create SQL table definitions, triggers, indexes, and population scripts for ORE Studio entities via codegen.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:sql:schema:codegen:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-codegen-fix-drift/SKILL.org
+++ b/doc/llm/skills/compass-codegen-fix-drift/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:codegen:drift:
 #+created: 2026-09-04
 #+updated: 2026-09-07

--- a/doc/llm/skills/compass-codegen-sync-cmake-sources/SKILL.org
+++ b/doc/llm/skills/compass-codegen-sync-cmake-sources/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: 
 #+created: 2026-07-29
 #+updated: 2026-07-29

--- a/doc/llm/skills/compass-devops-deploy-manual/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-manual/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-deploy-settings/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-settings/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-deploy-site/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-site/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-deprovision-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-deprovision-environment/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s2
 #+filetags: :compass:env:deprovision:worktree:
 #+created: 2026-06-16
 #+updated: 2026-06-16

--- a/doc/llm/skills/compass-devops-provision-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-provision-environment/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s2
 #+filetags: :compass:env:provision:worktree:
 #+created: 2026-06-16
 #+updated: 2026-06-16

--- a/doc/llm/skills/compass-devops-recreate-db/SKILL.org
+++ b/doc/llm/skills/compass-devops-recreate-db/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-run-client/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-client/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-run-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-environment/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:environment:devops:
 #+created: 2026-07-07
 #+updated: 2026-07-07

--- a/doc/llm/skills/compass-devops-run-shell/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-shell/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-run-sql/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-sql/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-setup-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-setup-environment/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:environment:
 #+created: 2026-06-06
 #+updated: 2026-08-11

--- a/doc/llm/skills/compass-devops-start-services/SKILL.org
+++ b/doc/llm/skills/compass-devops-start-services/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-stop-services/SKILL.org
+++ b/doc/llm/skills/compass-devops-stop-services/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-devops-update-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-update-environment/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :devops:environment:vcpkg:skills:settings:
 #+created: 2026-07-12
 #+updated: 2026-07-12

--- a/doc/llm/skills/compass-doc-add-chart/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-chart/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Add Chart
 #+description: Design and critique data visualisations using Edward Tufte's principles — data-ink ratio, chartjunk elimination, graphical integrity, small multiples, and analytical design.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:design:visualisation:tufte:
 #+created: 2026-05-25
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-add-class-diagram/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-class-diagram/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Add Class Diagram
 #+description: Produce a clean PlantUML class diagram for a component (or the system as a whole) following the ORE Studio conventions.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:plantuml:diagrams:modeling:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-add-component-model/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-component-model/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Add Component Model
 #+description: Create or update component_overview.org and the PlantUML class diagram for an ORE Studio component.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:component:documentation:plantuml:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-add-entity-chapter/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-entity-chapter/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:documentation:manual:
 #+created: 2026-07-10
 #+updated: 2026-07-17

--- a/doc/llm/skills/compass-doc-add-er-diagram/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-er-diagram/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Add ER Diagram
 #+description: Produce a clean PlantUML entity-relationship diagram for the ORE Studio SQL schema following the project conventions.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:plantuml:sql:diagrams:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-add-recipe/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-recipe/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Add Recipe
 #+description: Add new recipes to ORE Studio — pick the topic, scaffold via codegen, follow the recipe contract (filename = title = question, executable babel blocks).
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:recipes:documentation:
 #+created: 2024-09-01
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-find/SKILL.org
+++ b/doc/llm/skills/compass-doc-find/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-review-ste100/SKILL.org
+++ b/doc/llm/skills/compass-doc-review-ste100/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :llm:skill:skills:claude_code:ste100:writing:
 #+created: 2026-08-08
 #+updated: 2026-08-10

--- a/doc/llm/skills/compass-doc-run-manual-screenshots/SKILL.org
+++ b/doc/llm/skills/compass-doc-run-manual-screenshots/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:documentation:testing:
 #+created: 2026-07-17
 #+updated: 2026-07-17

--- a/doc/llm/skills/compass-doc-sync-index/SKILL.org
+++ b/doc/llm/skills/compass-doc-sync-index/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-sync-recipes/SKILL.org
+++ b/doc/llm/skills/compass-doc-sync-recipes/SKILL.org
@@ -4,7 +4,7 @@
 #+title: Doc Sync Recipes
 #+description: Keep recipe documentation in sync with the source it describes — CLI parsers, HTTP routes, shell commands, or any other recipe topic.
 #+type: skill
-#+level: cross
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:recipes:documentation:
 #+created: 2026-05-21
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-doc-update-manual/SKILL.org
+++ b/doc/llm/skills/compass-doc-update-manual/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:manual:doc:pdf:
 #+created: 2026-05-24
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-pr-address-review/SKILL.org
+++ b/doc/llm/skills/compass-pr-address-review/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-08-11

--- a/doc/llm/skills/compass-pr-merge/SKILL.org
+++ b/doc/llm/skills/compass-pr-merge/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-07-11

--- a/doc/llm/skills/compass-pr-raise/SKILL.org
+++ b/doc/llm/skills/compass-pr-raise/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:pr:github:claude:review:
 #+created: 2026-06-07
 #+updated: 2026-08-11

--- a/doc/llm/skills/compass-pr-sync-branch/SKILL.org
+++ b/doc/llm/skills/compass-pr-sync-branch/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: s1
 #+filetags: :llm:skill:skills:claude_code:compass:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-skill-delete/SKILL.org
+++ b/doc/llm/skills/compass-skill-delete/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :llm:skill:skills:claude_code:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/compass-skill-show-catalogue/SKILL.org
+++ b/doc/llm/skills/compass-skill-show-catalogue/SKILL.org
@@ -6,6 +6,7 @@
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
+#+level: cross
 #+filetags: :llm:skill:skills:claude_code:
 #+created: 2026-06-06
 #+updated: 2026-06-06

--- a/doc/llm/skills/skill_systems_levels.org
+++ b/doc/llm/skills/skill_systems_levels.org
@@ -120,6 +120,20 @@ it at spawn time is worth more than any instruction inside the prompt,
 because a delegate under pressure to finish will reinterpret an
 instruction and cannot reinterpret a capability it does not have.
 
+The enforcement is what is on disk when the delegate starts. Pruning the
+deployed catalogue to a level removes every out-of-scope skill from it, so
+an agent spawned afterwards cannot load one:
+
+#+begin_src sh :results verbatim
+python3 build/scripts/apply_skill_levels.py --prune-deployed s3star
+#+end_src
+
+An auditor spawned into that tree sees five skills, all of them read-only.
+Rebuilding the bundle restores the full set. Read-only is derived from the
+verb register rather than declared per skill, which is one of the reasons
+the register exists: =show-= and =find-= promise to change nothing, and the
+promise is now load-bearing.
+
 *** Structural Findings
 
 A read-only System that cannot change the code is not thereby limited
@@ -141,9 +155,22 @@ that ends in a structural flag outlives a finding that ends in a deletion.
 
 ** Inventory
 
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Every System, its level, the regulatory functions it sees, and whether it may
-mutate. Populated when levels are assigned.
+# BEGIN generated inventory (build/scripts/apply_skill_levels.py)
+
+What each System sees by default, counted from the levels the skills carry. Attenuation is advisory everywhere except the audit channel, where it is binding and enforced by what is deployed.
+
+#+ATTR_HTML: :class hug-leading
+| Level | System | Horizon | Sees | Attenuation |
+|-------+--------+---------+------+-------------|
+| =s1= | Agent | Hours | 58 skills | advisory |
+| =s2= | Orchestrator | Days | 15 skills | advisory |
+| =s3= | Sprint Planner | Weeks | 18 skills | advisory |
+| =s3star= | Auditor | Continuous | 5 skills | binding |
+| =s4= | Version Planner | Months | 13 skills | advisory |
+| =s5= | Identity Steward | Indefinite | 13 skills | advisory |
+
+12 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
+
 # END generated inventory
 
 * See also


### PR DESCRIPTION
## Summary

The level turns the cybernetic systems into a variety attenuator. A regulator swamped by variety it cannot use stops regulating, and an agent shown the whole catalogue at once is exactly that. Every skill now declares which System it serves, and a declared System selects the slice in scope by default.

## Changes

- apply_skill_levels.py holds the level table. A level is a judgement about which System a skill serves and a wrong one hides a capability, so it is a reviewed table rather than a rule inferred from names. A skill missing from it is an error rather than a default, so the next skill cannot land untagged.
- The audit channel's slice is derived rather than tagged: show- and find- promise to change nothing, so the auditor sees exactly those five skills. The promise written into the verb register earlier in this story is now load-bearing.
- --prune-deployed removes the out-of-scope skills from the deployed tree, so an agent spawned afterwards cannot load one. That is the spawn-time enforcement a read-only System needs, rather than an instruction in a prompt a delegate under pressure can reinterpret.
- Normal operation deploys the full set, which is what keeps the other five levels advisory: an agent may reach outside its slice because the skill is still there.
- The level-to-scope inventory in Systems and levels is generated from the same table that tags the skills, so the document cannot claim a scope the catalogue does not have. --check runs in the Doc Lint workflow.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Tag every skill with its cybernetic level](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_skill_cybernetic_levels.html) | 3969C185-48DE-47F0-A00D-FD28CD58C1B0 |
| Environment | bright_faraday | |

## Testing

Plan. Apply the table, read every slice back, prove the audit channel is actually enforced rather than merely described, and run the docs and python-tooling checks.

Evidence. docs and python tooling. All 69 skills carry a table level and --check passes. Slices: s1 sees 58, s2 15, s3 18, s3star 5, s4 13, s5 13, with 12 cross skills in every advisory slice. Enforcement proved on a copy of the deployed tree: pruning to s3star removed 64 directories and left exactly the five read-only ones, then the full tree was restored and rebuilt to 69. compass lint: clean, durable-link advisory unchanged at its pre-existing 158. Site build: Build succeeded. Compass suite: 145 passed, 1 skipped. misspell-fixer on the new files: nothing to replace.

Limitations. No C++ was touched, so no build or ctest run. The distribution is lopsided at 46 s1 skills, which reflects that most of what we do is execution rather than a tagging error. --prune-deployed is available at any level while only being appropriate for a read-only spawn: pruning makes attenuation binding, and binding an advisory level would contradict the rule that an agent may reach outside its slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)