### PR TITLE
[doc] Separate skill judgement from recipe commands

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -66,3 +66,8 @@ jobs:
         # the attenuation. A skill missing from the table is an error
         # rather than a default, so a new skill needs a considered level.
         run: python3 build/scripts/apply_skill_levels.py --check
+
+      - name: Check every skill links the recipes that own its commands
+        # The recipe holds the command and the skill holds the judgement,
+        # so drift has one place to be detected rather than two.
+        run: python3 build/scripts/link_skill_recipes.py --check

--- a/build/scripts/link_skill_recipes.py
+++ b/build/scripts/link_skill_recipes.py
@@ -55,8 +55,10 @@ OWNERS = {
          "the environment lifecycle verbs"),
     ],
     "compass-devops-run-client": [
-        ("compass/how-do-i-use-named-env-files",
-         "launching the client per environment, with colour"),
+        ("ops/how_do_i_ready_up_an_environment",
+         "the readiness the client assumes, and the launch with a scenario"),
+        ("ops/how_do_i_test_a_feature_after_implementation",
+         "handing a readied client to a tester"),
     ],
     "compass-devops-deploy-manual": [
         ("cmake/how_do_i_build_the_system", "the deploy_manual target"),

--- a/build/scripts/link_skill_recipes.py
+++ b/build/scripts/link_skill_recipes.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Point every action skill at the recipes that own its commands.
+
+Under the architecture the recipe holds the command, tested and runnable by
+a human, and the skill holds the judgement: when to reach for it, what must
+hold first, what to do when the guard rails refuse. A skill that restates a
+recipe's command creates a second place for it to drift.
+
+The mapping below is a judgement about which recipe owns which skill's
+commands, so it is a reviewed table. Applying it is mechanical: each skill's
+Recipes section gains the links it lacks, in the order given, without
+disturbing links it already carries.
+
+Usage: python3 build/scripts/link_skill_recipes.py [--check]
+  --check  exit non-zero if a skill is missing one of its recipe links.
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILLS = ROOT / "doc" / "llm" / "skills"
+RECIPES = ROOT / "doc" / "recipes"
+
+# Skill -> the recipes that own its commands, as (recipe path, why it is
+# reached for). The path is resolved to its :ID: so a moved recipe fails
+# loudly here rather than leaving a dead link in a skill.
+OWNERS = {
+    "compass-devops-provision-environment": [
+        ("compass/how_do_i_provision_an_environment_with_compass",
+         "creates the worktree, assigns ports, writes the .env"),
+    ],
+    "compass-devops-deprovision-environment": [
+        ("compass/how_do_i_deprovision_an_environment_with_compass",
+         "stops the services and removes the worktree"),
+    ],
+    "compass-devops-run-shell": [
+        ("compass/how_do_i_run_the_ores_shell",
+         "interactive and scripted invocations"),
+    ],
+    "compass-devops-run-sql": [
+        ("sql/how_do_i_run_sql_with_compass",
+         "credentials and connection come from the .env"),
+    ],
+    "compass-devops-recreate-db": [
+        ("cmake/how_do_i_start_services",
+         "the database rebuild and the service restart around it"),
+    ],
+    "compass-devops-start-services": [
+        ("cmake/how_do_i_start_services", "starting the fleet and verifying it"),
+    ],
+    "compass-devops-stop-services": [
+        ("compass/how_do_i_manage_the_environment_with_compass",
+         "the environment lifecycle verbs"),
+    ],
+    "compass-devops-run-client": [
+        ("compass/how-do-i-use-named-env-files",
+         "launching the client per environment, with colour"),
+    ],
+    "compass-devops-deploy-manual": [
+        ("cmake/how_do_i_build_the_system", "the deploy_manual target"),
+    ],
+    "compass-devops-deploy-site": [
+        ("cmake/how_do_i_deploy_the_site", "building and publishing the site"),
+    ],
+    "compass-devops-deploy-settings": [
+        ("cmake/how_do_i_deploy_the_settings",
+         "tangling settings.json from its org source"),
+    ],
+    "compass-agile-close-task": [
+        ("agile/how_do_i_work_a_task",
+         "the state transitions and the story and sprint sync"),
+    ],
+    "compass-code-start-branch": [
+        ("git/how_do_i_start_a_new_feature_branch_phase",
+         "branching off a fresh main"),
+    ],
+    "compass-agile-review-sprint": [
+        ("agile/how_do_i_get_a_sprint_or_story_status",
+         "the status and audit commands the review reads"),
+    ],
+    "compass-doc-add-component-model": [
+        ("codegen/how_do_i_create_a_component_overview",
+         "scaffolding and filling the overview"),
+    ],
+    "compass-codegen-add-component": [
+        ("codegen/how_do_i_create_a_component_overview",
+         "the overview every new component needs"),
+    ],
+    "compass-pr-sync-branch": [
+        ("git/how_do_i_rebase_my_branch_on_main",
+         "the rebase and what to do when it conflicts"),
+    ],
+}
+
+
+def recipe_id(rel):
+    path = RECIPES / f"{rel}.org"
+    if not path.is_file():
+        raise SystemExit(f"❌ no recipe at {path.relative_to(ROOT)}")
+    m = re.search(r"^:ID:\s*(\S+)\s*$", path.read_text(encoding="utf-8"), re.M)
+    if not m:
+        raise SystemExit(f"❌ no :ID: in {path.relative_to(ROOT)}")
+    return m.group(1)
+
+
+def recipe_title(rel):
+    path = RECIPES / f"{rel}.org"
+    m = re.search(r"^#\+title:\s*(.+?)\s*$", path.read_text(encoding="utf-8"), re.M)
+    return m.group(1) if m else rel
+
+
+def link_line(rel, why):
+    return f"- [[id:{recipe_id(rel)}][{recipe_title(rel)}]] — {why}."
+
+
+def apply(name, wanted, check):
+    path = SKILLS / name / "SKILL.org"
+    if not path.is_file():
+        raise SystemExit(f"❌ no skill at {path.relative_to(ROOT)}")
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^\* Recipes\s*$(.*?)(?=^\* )", text, re.M | re.S)
+    if not m:
+        # A skill with no Recipes section has nowhere to delegate its
+        # commands to, which is the state this sweep exists to end. Create
+        # it above the artefacts block the scaffold always carries.
+        if check:
+            print(f"❌ {name} has no Recipes section", file=sys.stderr)
+            return True
+        anchor = "* Artefacts"
+        block = "* Recipes\n\n* Reference\n\n"
+        if anchor in text:
+            text = text.replace(anchor, block + anchor, 1)
+        else:
+            text = text.rstrip("\n") + "\n\n" + block
+        path.write_text(text, encoding="utf-8")
+        m = re.search(r"^\* Recipes\s*$(.*?)(?=^\* )", text, re.M | re.S)
+
+    body = m.group(1)
+    missing = [(rel, why) for rel, why in wanted
+               if f"id:{recipe_id(rel)}" not in body]
+    if not missing:
+        return False
+    if check:
+        for rel, _why in missing:
+            print(f"❌ {name} does not link {rel}", file=sys.stderr)
+        return True
+
+    added = "\n".join(link_line(rel, why) for rel, why in missing)
+    existing = body.strip("\n")
+    new_body = f"\n\n{existing}\n{added}\n\n" if existing else f"\n\n{added}\n\n"
+    path.write_text(text[:m.start(1)] + new_body + text[m.end(1):],
+                    encoding="utf-8")
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if a link is missing")
+    args = ap.parse_args()
+
+    changed = [name for name, wanted in OWNERS.items()
+               if apply(name, wanted, args.check)]
+
+    if args.check:
+        if changed:
+            print("   run: python3 build/scripts/link_skill_recipes.py",
+                  file=sys.stderr)
+            return 1
+        print(f"✅ all {len(OWNERS)} skills link the recipes that own their "
+              "commands.")
+        return 0
+
+    print(f"✅ linked {len(changed)} skill(s) to their recipes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -80,7 +80,7 @@ Tasks are listed in intended execution order.
 | [[id:629B48C7-BC7E-44A8-8979-3E05D6DA5BFE][Collapse the uniform verbs into polymorphic actions]] | DONE | 2026-09-10 | 2026-09-10 | Shrink the execution function before the imports land: one skill per verb that behaves uniformly across artefact types, driven by a type table. |
 | [[id:7DFA4343-E553-4D3A-B71F-057329821EE5][Rename every skill into the compass- namespace]] | DONE | 2026-09-10 | 2026-09-10 | Mechanical rename of every skill, with every incoming link, catalogue row, runbook, memory and settings entry updated. |
 | [[id:3969C185-48DE-47F0-A00D-FD28CD58C1B0][Tag every skill with its cybernetic level]] | DONE | 2026-09-10 | 2026-09-10 | Add the mandatory level keyword to every skill and make the declared System attenuate which skills a session sees. |
-| [[id:F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59][Separate skill judgement from recipe commands]] | BACKLOG | | | Make every action delegate its commands to a recipe and keep only the judgement, so each has one source of truth. |
+| [[id:F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59][Separate skill judgement from recipe commands]] | DONE | 2026-09-10 | 2026-09-10 | Make every action delegate its commands to a recipe and keep only the judgement, so each has one source of truth. |
 | [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | BACKLOG | | | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
 | [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | BACKLOG | | | Cite the eleven adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
@@ -98,6 +98,7 @@ Tasks are listed in intended execution order.
 | [[id:96FCA6C1-7E9C-4D25-BFE1-ADB308E58172][Establish the writing standards and the genres they govern]] | BACKLOG | | | Three writing authorities now apply: ASD-STE100 for instructions, thesis prose for knowledge documents, and writing-for-agents for skills. Settle which governs what and port the two imports. |
 | [[id:9F694794-A0A0-4625-A6C9-38B8743EC2FF][Add the missing document type templates to codegen]] | BACKLOG | | | The design type has a contract and no mustache template, so compass add design does not exist; audit every type contract against the template library. |
 | [[id:39264768-EE92-4DB1-B048-3C960415B358][Specify the skills framework as a regulator]] | DONE | 2026-09-07 | 2026-09-07 | Respecify the framework as a regulator over an agent, deriving its scope and its seven classes of document from cybernetics rather than stipulating them, and classify the upstream pstack collection against that derivation. |
+| [[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][Delegate the remaining skill commands to recipes]] | DISCOVERED | | | Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place. |
 
 * Decisions
 
@@ -141,6 +142,13 @@ Tasks are listed in intended execution order.
 - The audit channel's slice is derived from the verb register rather than
   tagged. =show-= and =find-= promised to change nothing, and that promise is
   now load-bearing rather than decorative.
+- A skill that is a command and nothing else is a recipe wearing a costume.
+  The fix is to write the judgement it should have carried, not to keep the
+  duplicate: when to reach for it, what must hold first, what to do when it
+  refuses.
+- Most missing recipes were missing links. Survey before writing: of the 17
+  skills carrying an unbacked command, 16 already had a recipe nobody had
+  pointed at.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_delegate_remaining_skill_commands.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_delegate_remaining_skill_commands.org
@@ -1,0 +1,93 @@
+:PROPERTIES:
+:ID: 86F4C1E0-6F35-4AA7-9C95-3991D4F5F831
+:END:
+#+title: Task: Delegate the remaining skill commands to recipes
+#+description: Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place.
+#+type: task
+#+level: s1
+#+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The boundary sweep delegated the commands in the skills that were nothing
+but a command, and pointed every skill at the recipe that owns its
+commands. It did not finish the harder half: 105 shell blocks remain across
+the catalogue, in skills where the command sits inside a judged sequence.
+
+=compass-devops-setup-environment= is the shape of what is left. Its ten
+commands each have a recipe elsewhere — indexing, deploying the skills,
+deploying the settings, recreating the database, provisioning the tenant —
+and what the skill actually contributes is the /order/. Delegating each
+step leaves the ordering, which is the judgement, and removes the second
+copy of every command.
+
+Sweep the remainder on that test: if a recipe carries the command, the
+skill links it and states why the step is where it is in the sequence.
+
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DISCOVERED                              |
+| Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
+| Now          | Discovered while separating the boundaries. |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-10                               |
+
+* Acceptance
+
+- Every skill command that a recipe already carries is replaced by a link to that recipe.
+- A skill that is a sequence keeps the ordering and the reason for it, and delegates each step.
+- =compass-doc-sync-recipes= detects command drift in exactly one place afterwards.
+- A skill left with no judgement after delegation is reported, not silently kept.
+
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_delegate_remaining_skill_commands.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_delegate_remaining_skill_commands.org
@@ -35,6 +35,13 @@ copy of every command.
 Sweep the remainder on that test: if a recipe carries the command, the
 skill links it and states why the step is where it is in the sequence.
 
+Not every one of the 105 is a judged sequence, and the sweep should not
+assume it. =compass-agile-refine-backlog= already links the recipe that owns
+its commands and still restates them, =git mv= and =git commit= invocations
+included, adding no ordering judgement of its own. Cases of that shape are
+mechanical: delete the duplicate and keep the link. Sort the 105 into the
+two kinds before writing any prose, because the mechanical half needs none.
+
 
 (Describe what user-visible-or-internal change this task produces.)
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
@@ -99,7 +99,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | The rewrite of =compass-devops-run-client= dropped two hard-won rules: =--open-scenario= must be an absolute path, and the system must be readied and a login step written into the scenario before handing it to a tester | doc/llm/skills/compass-devops-run-client/SKILL.org | Accept | A real regression I introduced. Both restored, and the recipe link re-pointed: the named-env-files recipe covers neither flag, so it now links the ready-up and feature-test recipes that do |
+| 2 | The rewrite of =compass-devops-deploy-skills= dropped the reminder to reload skills, which no linked recipe carries | doc/llm/skills/compass-devops-deploy-skills/SKILL.org | Accept | Restored, with the reason stated: a running session holds the bundle it started with, so the edit is live on disk and invisible to the session that made it |
+| 3 | The follow-up task's framing that all 105 remaining blocks are judged sequences is optimistic; =compass-agile-refine-backlog= restates its already-linked recipe verbatim and adds no ordering | task_delegate_remaining_skill_commands.org | Accept | Framing amended. The sweep now starts by sorting the 105 into mechanical duplicates and genuine sequences, because the mechanical half needs no prose |
+| 4 | Six of the eight rewritten skills carry genuine judgement | — | Accept | No change needed; recorded because it is the finding the round was requested for |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:skills:recipes:refactor:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/separate-skill-recipe-boundaries
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ Skills and recipes restate each other today. compass-pr-merge the skill and the 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -43,11 +43,40 @@ Skills and recipes restate each other today. compass-pr-merge the skill and the 
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The survey came first, because the sweep's size depended on how much was
+already written. 17 of the 69 skills carried a command with no recipe behind
+it, and almost every one of those commands turned out to have a recipe
+already — unlinked rather than unwritten. Only one operation had no recipe
+at all: rebasing a branch on main.
+
+So the work split three ways. Write the one missing recipe. Link the 17
+skills to the recipes that own their commands, through
+=build/scripts/link_skill_recipes.py=, whose mapping is the judgement and
+whose application is mechanical. Then fill in what the skills should have
+been carrying instead: every Reference section now names the knowledge the
+skill assumes, and eight skills that were nothing but a command gained the
+judgement they lacked.
+
+The sequencing rule went into
+[[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]], where a
+method author meets it: a missing effector becomes a recipe, never an inline
+command.
 
 * Notes
+
+Eight skills were a command and nothing else. Under the architecture that
+is a recipe wearing a skill costume, and the honest options were to retire
+them or to write the judgement they should always have carried. Writing it
+was right: knowing to check what is running before stopping a fleet, or that
+a service outliving NATS logs a misleading error, is judgement a recipe
+should not carry.
+
+105 shell blocks remain in skills where the command sits inside a judged
+sequence. =compass-devops-setup-environment= is the shape of it: ten
+commands, each with a recipe elsewhere, where what the skill contributes is
+the order. That is a real remaining violation rather than a permitted
+exception, so it is filed as its own task in this story rather than being
+quietly counted as done here.
 
 * Test Scenarios
 
@@ -73,3 +102,25 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Four of the five acceptance criteria are met, and the fifth is partly met
+with the remainder tracked.
+
+Every action's Recipes section names the recipes it delegates to, and every
+Reference section names the knowledge it assumes. Both were empty in
+several skills and are now filled across all 69.
+
+The one command with no backing recipe has one:
+[[id:4B8BB864-AEA3-4720-9BB3-DCF4397000D2][How do I rebase my branch on main?]],
+covering the rebase, the force-with-lease push, and the conflict paths.
+
+Drift now has one place to be detected for every delegated command, and
+=link_skill_recipes.py --check= holds that in CI.
+
+The sequencing rule is documented where a method author meets it.
+
+Not fully met: /no action skill carries a command that a recipe should own/.
+The eight skills that were pure command wrappers are converted, and the 17
+that lacked a recipe now delegate. 105 shell blocks remain inside judged
+sequences, and clearing them is
+[[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][its own task]] in this story.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:recipes:refactor:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/separate-skill-recipe-boundaries
-#+pr:
+#+pr: 2053
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -93,7 +93,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2053][#2053]] | [doc] Separate skill judgement from recipe commands |
 
 * Review
 

--- a/doc/llm/skills/compass-agile-close-task/SKILL.org
+++ b/doc/llm/skills/compass-agile-close-task/SKILL.org
@@ -58,6 +58,8 @@ routine review feedback as reopening the task by default.
 
 * Recipes
 
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the state transitions and the story and sprint sync.
+
 * Reference
 
 - [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]] — steps 8–9.

--- a/doc/llm/skills/compass-agile-review-sprint/SKILL.org
+++ b/doc/llm/skills/compass-agile-review-sprint/SKILL.org
@@ -314,8 +314,18 @@ New sprints scaffolded with =compass add sprint= include an empty
 | # | Date | Day | Overall | Task |
 |---+------+-----+---------+------|
 
-(Run =sprint-reviewer= to populate this table.)
+(Run =compass-agile-review-sprint= to populate this table.)
 #+end_example
 
 This placeholder is present from day one. Each run of this skill
 adds one row; the full analysis lives in the task linked from that row.
+
+* Recipes
+
+- [[id:A7D3C1E5-9F2B-4A8D-B6E4-3C7F1D9A2E5B][How do I get a sprint or story status?]] — the status and audit commands the review reads.
+
+* Reference
+
+- [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]] — the sprint lifecycle this review reports against.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
+

--- a/doc/llm/skills/compass-code-start-branch/SKILL.org
+++ b/doc/llm/skills/compass-code-start-branch/SKILL.org
@@ -36,6 +36,8 @@ Out-of-band work with no task attached: experiments, throwaway spikes, one-off f
 
 * Recipes
 
+- [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]] — branching off a fresh main.
+
 * Reference
 
 - [[id:C1813B64-1647-4B49-B856-A8345850001C][Clean up the compass work lifecycle]] — the traceability invariant this escape hatch bends.

--- a/doc/llm/skills/compass-codegen-add-component/SKILL.org
+++ b/doc/llm/skills/compass-codegen-add-component/SKILL.org
@@ -118,6 +118,12 @@ group + 3 subs).
 - [[id:B0B99088-D88E-4980-A4EE-7D6A9A8E96A5][component-model-creator]] — write the architecture docs once scaffold is working.
 - [[id:654D4A70-E63D-4C18-B5A5-886066E36314][cmake-runner]] — build and test commands.
 
+* Recipes
+
+- [[id:0806C8FB-43D2-497E-900D-5F2E0B3472FD][How do I create a component overview?]] — the overview every new component needs.
+
+* Reference
+
 * Artefacts                                                        :noexport:
 
 ** Licence

--- a/doc/llm/skills/compass-devops-deploy-manual/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-manual/SKILL.org
@@ -25,16 +25,21 @@ Building the user manual PDF after manual content changes.
 
 * How to use this skill
 
-1. /Build/:
+1. /Confirm the chapters build before publishing/. The manual is assembled
+   from many org files, and one malformed chapter fails the whole PDF.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh build --direct manual
-   #+end_src
+2. /Run the target/ from the recipe below.
 
+3. /Check the screenshots came through/. A chapter carrying a
+   =[SCREENSHOT NEEDED]= placeholder builds cleanly and ships a gap.
 
 * Recipes
 
+- [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]] — the deploy_manual target.
+
 * Reference
+
+- [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — the preset names and the output layout the targets write to.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-deploy-settings/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-settings/SKILL.org
@@ -25,16 +25,23 @@ Claude Code settings.json is older than its org source (compass bearings warns):
 
 * How to use this skill
 
-1. /Build/:
+1. /Edit the org source, never the JSON/. =.claude/settings.json= is
+   generated; an edit there is lost on the next tangle without warning.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh build --direct settings
-   #+end_src
+2. /Tangle it/ through the recipe below. It must run outside the sandbox,
+   because the tangle needs a full environment.
 
+3. /Reload before trusting it/. A running session holds the settings it
+   started with, so a new hook or permission reaches only sessions started
+   afterwards.
 
 * Recipes
 
+- [[id:3DDB2AFA-9CAA-44A0-A91A-645A95320A5F][How do I deploy the settings?]] — tangling settings.json from its org source.
+
 * Reference
+
+- [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — the preset names and the output layout the targets write to.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-deploy-site/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-site/SKILL.org
@@ -25,17 +25,24 @@ Building and publishing the documentation website from the org-roam graph — al
 
 * How to use this skill
 
-1. /Build/:
+1. /Build before you publish/. The site build is where a broken id-link
+   surfaces, and publishing a build you have not read means the broken
+   link ships.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh build --direct site
-   #+end_src
+2. /Run the target/ from the recipe below. It prints its own log path;
+   follow that file rather than piping the command.
 
-   A broken id-link aborts the export naming the unresolvable UUID — fix every one; deletions must heal the graph (see =compass-skill-delete=).
+3. /Read the tail, not the exit code alone/. The build reports success
+   while still naming files it skipped, and a skipped file is a page that
+   silently did not update.
 
 * Recipes
 
+- [[id:6930472B-222C-4621-AB37-CFEE3070A8BD][How do I deploy the site?]] — building and publishing the site.
+
 * Reference
+
+- [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — the preset names and the output layout the targets write to.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
@@ -25,14 +25,17 @@ Skill sources changed and the deployed bundle is stale (compass bearings warns):
 
 * How to use this skill
 
+
 1. /Deploy after every skill edit/. The harness reads the deployed bundle,
    not the org sources, so an unbuilt edit changes nothing for any session.
 
-2. /Run the target/ from the recipe below.
-
-3. /Purge what the deploy leaves behind/. Deployment writes but never
+2. /Purge what the deploy leaves behind/. Deployment writes but never
    deletes, so a renamed or retired skill keeps loading under its old name
    until its deployed directory is removed.
+
+3. /Tell the user to run =/reload-skills=/. A running session holds the
+   bundle it started with, so until it reloads, the edit is live on disk
+   and invisible to the very session that made it.
 
 * Recipes
 

--- a/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
+++ b/doc/llm/skills/compass-devops-deploy-skills/SKILL.org
@@ -25,22 +25,22 @@ Skill sources changed and the deployed bundle is stale (compass bearings warns):
 
 * How to use this skill
 
-1. /Rebuild the bundle/:
+1. /Deploy after every skill edit/. The harness reads the deployed bundle,
+   not the org sources, so an unbuilt edit changes nothing for any session.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh build --direct skills
-   #+end_src
+2. /Run the target/ from the recipe below.
 
-
-2. /Purge stale deployed directories/ — deployment does not remove them: delete any =.claude/skills/<dir>= with no matching =doc/llm/skills/<dir>=.
-
-3. /Remind the user/ to =/reload-skills= in their Claude Code session.
+3. /Purge what the deploy leaves behind/. Deployment writes but never
+   deletes, so a renamed or retired skill keeps loading under its old name
+   until its deployed directory is removed.
 
 * Recipes
 
 - [[id:B5F231A9-5403-482C-8F2A-12D6917C58CD][How do I deploy the skills?]]
 
 * Reference
+
+- [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — the preset names and the output layout the targets write to.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-deprovision-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-deprovision-environment/SKILL.org
@@ -60,10 +60,12 @@ unless decommissioning the machine — all other worktrees depend on it.
 * Recipes
 
 - [[file:../../../recipes/compass/how_do_i_deprovision_an_environment_with_compass.org][How do I deprovision an environment with compass?]]
+- [[id:429671CA-2960-4560-84FD-6C1DE80A1BA6][How do I deprovision an environment with compass?]] — stops the services and removes the worktree.
 
 * Reference
 
 - [[file:../../../recipes/compass/how_do_i_provision_an_environment_with_compass.org][How do I provision a new environment with compass?]] — the symmetric operation
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-provision-environment/SKILL.org
+++ b/doc/llm/skills/compass-devops-provision-environment/SKILL.org
@@ -65,10 +65,12 @@ worktree", "set up a new dev env".
 * Recipes
 
 - [[file:../../../recipes/compass/how_do_i_provision_an_environment_with_compass.org][How do I provision a new environment with compass?]]
+- [[id:E9297D15-F053-4B76-92DF-ED87E7205020][How do I provision a new environment with compass?]] — creates the worktree, assigns ports, writes the .env.
 
 * Reference
 
 - [[file:../../../recipes/compass/how_do_i_manage_the_environment_with_compass.org][How do I manage the checkout environment with compass?]] — =env configure=
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-recreate-db/SKILL.org
+++ b/doc/llm/skills/compass-devops-recreate-db/SKILL.org
@@ -42,6 +42,8 @@ The schema drifted (bearings warns), migrations need a clean slate, or the datab
 
 * Recipes
 
+- [[id:D8663EF2-5626-462E-AADC-AB2717F49C0D][How do I start the ORE Studio services?]] — the database rebuild and the service restart around it.
+
 * Reference
 
 - [[id:FE388774-0714-4D93-AEB0-D6221314D4F9][How do I orient a new session?]] — surfaces schema drift.

--- a/doc/llm/skills/compass-devops-run-client/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-client/SKILL.org
@@ -25,48 +25,24 @@ Launching the Qt client, detached so the terminal stays free; colour keeps paral
 
 * How to use this skill
 
-1. /Launch/:
+1. /Give the client a colour when more than one runs/. Parallel worktrees
+   each start their own client, and the colour is what tells them apart on
+   screen and in the window title.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh client start --colour <colour>
-   #+end_src
+2. /Launch it detached/ through the recipe below, so the session stays free
+   to keep working while the client is up.
 
-2. /Launch with a test scenario pre-loaded/ — whenever there's UI testing to do, always supply this instead of a bare launch. =--open-scenario= must be an *absolute* path — the client's working directory is not the repo root, so a relative path (even one that's correct from your own shell) fails with a filesystem error:
-
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh client start --colour <colour> --open-scenario /absolute/path/to/scenario_*.org
-   #+end_src
-
-   Opens the Scenario Runner (System > Testing) with that =test_scenario=
-   doc already loaded, so the tester can start working through steps
-   immediately instead of using Scenario Runner's own Open button.
-
-3. /Ensure the system is actually ready before opening the client/ —
-   confirm/recreate the database and provision it yourself (see
-   [[id:0A22B752-D5CF-4B36-8429-2950130AAABD][How do I ready up an environment?]]), recorded in the scenario's own
-   =* Before you start= section, not left for the tester to sort out.
-   Never hand the tester a scenario against a system you haven't
-   already verified is in the right state.
-
-4. /Always include a connect/login step in the scenario itself/ — every
-   =test_scenario= doc opened this way must have, as its *first =* Steps=
-   entry* (not just prose in =* Context=, which the Scenario Runner
-   panel doesn't track pass/fail for), a step naming the specific
-   persona to log in as: the exact account and its password (e.g.
-   =tenant_admin@acme_corporation= / =Secure-Password-123=). This step
-   is pure tester mechanics — it assumes the readiness work from step 3
-   above, not a conditional the tester has to evaluate. Never leave the
-   tester to guess credentials.
-
-4. /Stop/ (pass the same =--colour= the instance was started with):
-
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh client stop --colour <colour>
-   #+end_src
+3. /Stop the one you started/, not all of them. The stop verb takes the
+   same colour, and stopping the wrong client interrupts another
+   environment's test run.
 
 * Recipes
 
+- [[id:0168F066-BFA4-4CFE-8A61-A2C727D91D10][How do I use named env files?]] — launching the client per environment, with colour.
+
 * Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-run-client/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-client/SKILL.org
@@ -27,18 +27,30 @@ Launching the Qt client, detached so the terminal stays free; colour keeps paral
 
 1. /Give the client a colour when more than one runs/. Parallel worktrees
    each start their own client, and the colour is what tells them apart on
-   screen and in the window title.
+   screen and in the window title. The stop verb takes the same colour, so
+   stopping without it interrupts another environment's run.
 
-2. /Launch it detached/ through the recipe below, so the session stays free
-   to keep working while the client is up.
+2. /Ready the system before opening the client, and verify it yourself/.
+   Confirm or recreate the database and provision it, and record what you
+   did in the scenario's =* Before you start= section. Never hand a tester
+   a scenario against a system you have not already checked.
 
-3. /Stop the one you started/, not all of them. The stop verb takes the
-   same colour, and stopping the wrong client interrupts another
-   environment's test run.
+3. /Pass an absolute path to =--open-scenario=/. The client's working
+   directory is not the repository root, so a relative path that is correct
+   in your own shell fails with a filesystem error. Opening the scenario
+   this way lands the tester in the Scenario Runner with the document
+   loaded, rather than hunting for it.
+
+4. /Put the login in the scenario's first step/, naming the persona and its
+   password. It has to be a =* Steps= entry rather than prose in
+   =* Context=, because the Scenario Runner tracks pass and fail per step
+   and ignores the prose. A tester left to guess credentials stops there.
 
 * Recipes
 
-- [[id:0168F066-BFA4-4CFE-8A61-A2C727D91D10][How do I use named env files?]] — launching the client per environment, with colour.
+
+- [[id:0A22B752-D5CF-4B36-8429-2950130AAABD][How do I ready up an environment?]] — the readiness the client assumes, and the launch with a scenario.
+- [[id:BE325E3E-1BAB-4D9D-964E-78333CDB97D7][How do I test a feature after implementation?]] — handing a readied client to a tester.
 
 * Reference
 

--- a/doc/llm/skills/compass-devops-run-shell/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-shell/SKILL.org
@@ -41,7 +41,11 @@ Launching ores.shell with NATS and login defaults from .env — interactive, or 
 
 * Recipes
 
+- [[id:C210CB09-291B-4B2A-8C90-22EB4364DCA3][How do I run the ores shell?]] — interactive and scripted invocations.
+
 * Reference
+
+- [[id:D0876A24-69BA-F484-ED9B-71CD3AA8710C][ores.shell]] — the REPL this launches, and what it can do once up.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-run-sql/SKILL.org
+++ b/doc/llm/skills/compass-devops-run-sql/SKILL.org
@@ -25,17 +25,24 @@ Running SQL in the environment — queries or scripts, with credentials and conn
 
 * How to use this skill
 
-1. /One-liner/:
+1. /Know which database you are about to touch/. The connection comes from
+   this worktree's =.env=, so the same command hits a different database in
+   another worktree. Check =compass where= if unsure.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh sql -- -c "<sql>"
-   #+end_src
+2. /Run the query/ through the recipe below, which supplies the credentials
+   and connection rather than having you retype them.
 
-   Everything after =--= goes to psql; =-f file.sql= runs a script.
+3. /Prefer a read before a write/. A =SELECT= that returns the rows a
+   =DELETE= would remove costs one command and prevents the mistake that
+   needs a database rebuild.
 
 * Recipes
 
+- [[id:ABFC1EB5-5314-43C6-80B8-E2967254F867][How do I run SQL in the environment?]] — credentials and connection come from the .env.
+
 * Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-start-services/SKILL.org
+++ b/doc/llm/skills/compass-devops-start-services/SKILL.org
@@ -25,16 +25,24 @@ Bringing the service fleet up — NATS and the ores services.
 
 * How to use this skill
 
-1. /Start and verify/:
+1. /Check the database is up and current/ before starting anything. The
+   services fail their first query against a missing or stale schema, and
+   the failure surfaces as a service crash rather than a database error.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh services start && ./projects/ores.compass/compass.sh services status
-   #+end_src
+2. /Start the fleet/ with the recipe below, then verify. Starting is
+   asynchronous: the command returns before the services are ready.
 
+3. /Read the status, do not assume it/. =running= is the only state that
+   means ready; =starting= means the health check has not passed yet, and
+   =missing= means the unit is not installed in this worktree at all.
 
 * Recipes
 
+- [[id:D8663EF2-5626-462E-AADC-AB2717F49C0D][How do I start the ORE Studio services?]] — starting the fleet and verifying it.
+
 * Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-devops-stop-services/SKILL.org
+++ b/doc/llm/skills/compass-devops-stop-services/SKILL.org
@@ -25,16 +25,25 @@ Stopping the service fleet cleanly — before db recreate, env changes, or shutd
 
 * How to use this skill
 
-1. /Stop/:
+1. /Check what is running first/. =compass services status= names what is
+   up. Stopping a fleet nobody started wastes a minute; stopping one mid
+   test run loses the run.
 
-   #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh services stop
-   #+end_src
+2. /Stop the fleet/ with the recipe below. It stops the services and NATS
+   together, which matters because a service outliving NATS logs
+   connection failures that look like a different fault.
 
+3. /Confirm it went down/. A service left running holds the database port
+   and the next =db recreate= fails with a confusing error rather than a
+   clear one.
 
 * Recipes
 
+- [[id:13209197-CDBD-4807-A8F9-9653AFA96CBF][How do I manage the checkout environment with compass?]] — the environment lifecycle verbs.
+
 * Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-doc-add-chart/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-chart/SKILL.org
@@ -70,3 +70,14 @@ code and when reviewing existing displays for clarity or integrity.
 - [ ] Reveals multiple levels of detail (micro + macro).
 - [ ] Layering: primary data dominates, secondary recedes.
 - [ ] Appropriate data density.
+
+* Recipes
+
+This skill runs no commands: it is judgement applied to a chart someone
+else renders.
+
+* Reference
+
+- [[id:F322DD08-D114-4B9E-8B89-E392ED5C591E][Tufte principles]] — data-ink, chartjunk, graphical integrity, the lie factor.
+- [[id:613C09B0-D516-417F-9627-2349D46A3645][Analytical design]] — comparison, causality, multivariate display, evidence.
+

--- a/doc/llm/skills/compass-doc-add-component-model/SKILL.org
+++ b/doc/llm/skills/compass-doc-add-component-model/SKILL.org
@@ -76,6 +76,12 @@ overview), and again whenever the architecture changes.
 - [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]] — api/core/service split, facets, CMake deps.
 - [[id:59D662B0-D4E4-6A34-9EAB-EAC6E98F6BC9][component-creator]] — scaffold the component before documenting it.
 
+* Recipes
+
+- [[id:0806C8FB-43D2-497E-900D-5F2E0B3472FD][How do I create a component overview?]] — scaffolding and filling the overview.
+
+* Reference
+
 * Artefacts                                                        :noexport:
 
 ** Licence

--- a/doc/llm/skills/compass-doc-find/SKILL.org
+++ b/doc/llm/skills/compass-doc-find/SKILL.org
@@ -50,6 +50,8 @@ Finding documents: full-text search or structured filters across the whole org-r
 
 * Reference
 
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the graph the index is built from.
+
 * Artefacts                                                        :noexport:
 
 ** Licence

--- a/doc/llm/skills/compass-doc-review-ste100/SKILL.org
+++ b/doc/llm/skills/compass-doc-review-ste100/SKILL.org
@@ -97,6 +97,7 @@ sequences, and defined domain terms.
   (Issue 9, Jan 2025) for word-by-word dictionary checks.
 - [[https://github.com/danyuchn/asd-ste100-skill][Upstream repo]] — original skill by Dustin Yuchen Teng
   (MIT license), adapted for ORE Studio.
+- [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — one word per concept, which the rewrite must preserve.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/compass-doc-sync-index/SKILL.org
+++ b/doc/llm/skills/compass-doc-sync-index/SKILL.org
@@ -39,6 +39,8 @@ The search index or org-roam database is stale (compass prints staleness chips) 
 
 * Reference
 
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the graph the index is built from.
+
 * Artefacts                                                        :noexport:
 
 ** Licence

--- a/doc/llm/skills/compass-pr-sync-branch/SKILL.org
+++ b/doc/llm/skills/compass-pr-sync-branch/SKILL.org
@@ -37,7 +37,11 @@ The branch is stale relative to origin/main — rebase before doing anything els
 
 * Recipes
 
+- [[id:4B8BB864-AEA3-4720-9BB3-DCF4397000D2][How do I rebase my branch on main?]] — the rebase and what to do when it conflicts.
+
 * Reference
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the tool every one of these commands runs through.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -117,6 +117,15 @@ rather than its output ([[id:D8CB6EED-1F6A-4EE5-840B-2FE28DE17911][Generated
 artefacts]]). At a fork the evidence cannot settle, the method convenes
 *deliberation* and records the verdict on the task.
 
+*A missing effector becomes a recipe, never an inline command.* When a
+phase needs a command no recipe carries, the command is written as a
+recipe and the phase reaches for it. Improvising it inline buys one
+session and costs every later one: the command is untested, it is invisible
+to [[id:B5766B0E-24F0-45C3-B35D-E762BBAB5206][compass-doc-sync-recipes]], and
+the next method that needs the same effector improvises its own. The recipe
+holds the command and the skill holds the judgement, so drift has exactly
+one place to be detected.
+
 Verification climbs the ladder as far as the work requires, routing
 first to the checkers that do not share the session model's priors
 ([[id:DEE49C55-1626-470D-BB0F-D58A11D35769][Verification]]). The session closes

--- a/doc/recipes/git/how_do_i_rebase_my_branch_on_main.org
+++ b/doc/recipes/git/how_do_i_rebase_my_branch_on_main.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 4B8BB864-AEA3-4720-9BB3-DCF4397000D2
+:END:
+#+title: How do I rebase my branch on main?
+#+description: Bring a feature branch up to date with origin/main, and what to do when the rebase conflicts.
+#+type: recipe
+#+level: cross
+#+filetags: :git:compass:branch:rebase:recipe:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+Working on a stale branch wastes a review round: the diff carries changes
+main already has, and CI runs against a base nobody else is on.
+
+* Question
+
+How do I bring my feature branch up to date with =origin/main=, and what do
+I do when the rebase stops on a conflict?
+
+* Answer
+
+** Rebase
+
+#+begin_src sh :results verbatim
+./compass.sh pr sync
+#+end_src
+
+Compass fetches =origin/main= and rebases the current branch on it, then
+reports how far ahead the branch now is. An up-to-date branch is reported as
+such and nothing is rewritten.
+
+** Push the rebased branch
+
+A rebase rewrites the branch's commits, so an ordinary push is refused.
+
+#+begin_src sh :results verbatim
+./compass.sh pr sync --push
+#+end_src
+
+This pushes with =--force-with-lease=, which refuses if someone else has
+pushed to the branch in the meantime. Prefer it to =--force=, which does
+not check.
+
+** When the rebase conflicts
+
+Compass stops where git stops, lists the conflicted files, and names the
+ways out. Resolve them in place, then continue:
+
+#+begin_src sh :results verbatim
+git add <resolved-files>
+git rebase --continue
+#+end_src
+
+To back out and leave the branch as it was:
+
+#+begin_src sh :results verbatim
+git rebase --abort
+#+end_src
+
+For an unattended run, =./compass.sh pr sync --abort-on-conflict= aborts
+rather than leaving the worktree mid-rebase for a human to find.
+
+* Script
+
+[[proj:projects/ores.compass/src/compass_pr.py][=projects/ores.compass/src/compass_pr.py=]] implements =pr sync=.
+
+* Tested by
+
+Manual. Exercised on every feature branch before its PR is raised.
+
+* See also
+
+- [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]] — starting from a fresh main instead.
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — where syncing sits in the lifecycle.


### PR DESCRIPTION
## Summary

The recipe holds the command, tested and runnable by a human; the skill holds the judgement — when to reach for it, what must hold first, what to do when the guard rails refuse. A skill that restates a recipe's command creates a second place for it to drift. The survey changed the shape of the work: of the 17 skills carrying a command with no recipe behind it, 16 already had a recipe nobody had linked, and only one operation had none.

## Changes

- New recipe: How do I rebase my branch on main, covering the rebase, the force-with-lease push, and both conflict paths.
- link_skill_recipes.py points each of the 17 skills at the recipe that owns its commands. The mapping is the judgement, applying it is mechanical, and --check holds it in CI so the delegation cannot rot.
- Every Reference section now names the knowledge the skill assumes. Seventeen were empty.
- Eight skills were a command and nothing else, which under the architecture is a recipe wearing a skill costume. Rather than keep the duplicate they gained the judgement they should have carried: what to check first, what the command does that is not obvious, and how its failure misleads.
- The sequencing rule is documented in Methods and the mode, where a method author meets it: a missing effector becomes a recipe, never an inline command.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Separate skill judgement from recipe commands](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_separate_skill_recipe_boundaries.html) | F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59 |
| Environment | bright_faraday | |

## Testing

Plan. Survey which skills carry commands and which recipes already own them, apply the links, fill what the skills were missing, and run the docs checks.

Evidence. docs. link_skill_recipes.py --check passes across all 17 skills; every one of the 69 skills now names both its recipes and the knowledge it assumes, verified by counting id-links in both sections. compass lint: clean, durable-link advisory unchanged at its pre-existing 158. Site build: Build succeeded. Skills bundle rebuilt, and this session's harness reloaded the rewritten skills. misspell-fixer on the new files: nothing to replace.

Limitations. The first acceptance criterion is only partly met and is filed rather than counted as done: 105 shell blocks remain in skills where the command sits inside a judged sequence, compass-devops-setup-environment being the shape of it. That is a real remaining violation, so it is a DISCOVERED task in this story with its own acceptance. No code was touched, so no build, ctest or drift run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)