### PR TITLE
[doc] Expand the random walk knowledge page

### DIFF
--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
@@ -47,6 +47,7 @@ come up rather than scoping the whole story up front.
 | [[id:00289422-24F1-4124-B3D1-1261B52ABCE7][Add a quickstart CLI snippet to the homepage]] | BACKLOG | | | A short terminal install/quickstart command block on the homepage for fast developer onboarding, per external review. Scope: what the snippet actually shows (git clone + build? a hosted install script?) needs deciding before implementation. |
 | [[id:CBE53221-9F38-4C94-8AE5-AA86867965C8][Add compass-code-review-comments skill]] | DONE | 2026-08-11 | 2026-08-11 | New Claude Code skill that reviews and cleans code comments, wired into CLAUDE.md so it applies to all code we create or edit. |
 | [[id:374CFD96-B8B0-4812-9870-FF91168EE828][Document Skew Stickiness Ratio knowledge page]] | DONE | | 2026-08-25 | Add a knowledge page on how implied volatility surfaces move when spot moves: sticky strike vs sticky delta, the Skew Stickiness Ratio (SSR) that measures ATM-vol response against the ATM skew, and its effect on delta and gamma. |
+| [[id:A572C320-A132-477B-9170-6CB5A0466D2D][Expand the Random Walk knowledge page]] | DONE | | 2026-09-10 | Fold the stationarity, unit-root and first-passage material into the Random Walk knowledge page, with the source attributed. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
@@ -88,6 +88,7 @@ via its "Verifies task" field.
 | 1 | Citation used square brackets, which org renders as literal text and which read as a malformed link. | doc/knowledge/domain/random_walk.org | Accepted | Quoted the post's opening line as the title, matching the Pearson and Donsker entries. |
 | 2 | Attribution sits in Further reading, not in a top-level =* Source= block as in =lightyear_pnl_approach.org=. | doc/knowledge/domain/random_walk.org | Declined | That convention is for pages that are /about/ external material; here the post is one of five references. |
 | 3 | =#+description= was not extended to mention first passage. | doc/knowledge/domain/random_walk.org | Declined | Still accurate at the granularity that descriptions work at. |
+| 4 | Bot review: line 152 runs to ~93 columns where the file wraps at ~72-76; move the Generic Barrier Option link to its own line. | doc/knowledge/domain/random_walk.org | Accepted | Rewrapped, so the link now sits on its own line as the Geometric Brownian Motion link does. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
@@ -1,0 +1,98 @@
+:PROPERTIES:
+:ID: A572C320-A132-477B-9170-6CB5A0466D2D
+:END:
+#+title: Task: Expand the Random Walk knowledge page
+#+description: Fold the stationarity, unit-root and first-passage material into the Random Walk knowledge page, with the source attributed.
+#+type: task
+#+level: s1
+#+filetags: :documentation-improvements:sprint_25:v0:
+#+owner: marco
+#+branch: feature/update-random-walk-knowledge
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+#+environment: clever_dijkstra
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The [[id:F07B50E2-0B51-4230-8D0D-F0587663BC9F][Random Walk]] page covers the
+definition, the Markov property and the Wiener-process limit. An
+external write-up on random walks passes through five themes, three of
+which the page does not carry: stationary increments against a
+non-stationary level, unit-root persistence, and first-passage
+questions. Add those three sections, tie each to the ORE Studio
+process it bears on, and attribute the source.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
+
+* Acceptance
+
+- The page states that the increments are stationary while the level is
+  not, with the variance growing with the horizon.
+- The page states the unit-root property and contrasts it with a
+  mean-reverting process.
+- The page covers first-passage times and names an ORE Studio product
+  family that asks the question.
+- Each new section links to the related knowledge pages by id.
+- The source is attributed in Further reading, with author,
+  publication and retrieval date.
+- The site build publishes the page without error.
+
+* Plan
+
+Fold the three missing themes into the existing page rather than
+creating a second page, because the page already exists and the new
+material is the same subject. Sit the new sections between the
+definition and the Markov section, so the page runs definition,
+stationarity, unit root, Markov property, continuous-time limit, first
+passage. Grade the page against the code review checklist; the
+class check for a doc-only change is the site build.
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+| 1 | Citation used square brackets, which org renders as literal text and which read as a malformed link. | doc/knowledge/domain/random_walk.org | Accepted | Quoted the post's opening line as the title, matching the Pearson and Donsker entries. |
+| 2 | Attribution sits in Further reading, not in a top-level =* Source= block as in =lightyear_pnl_approach.org=. | doc/knowledge/domain/random_walk.org | Declined | That convention is for pages that are /about/ external material; here the post is one of five references. |
+| 3 | =#+description= was not extended to mention first passage. | doc/knowledge/domain/random_walk.org | Declined | Still accurate at the granularity that descriptions work at. |
+
+* Result
+
+Added three sections to the Random Walk page — stationarity of the
+increments against the non-stationarity of the level, the unit root
+and its contrast with mean reversion, and first-passage times — plus
+the source in Further reading. Every new section links to the related
+knowledge pages by id. The site build publishes the page clean.

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.org
@@ -8,7 +8,7 @@
 #+filetags: :documentation-improvements:sprint_25:v0:
 #+owner: marco
 #+branch: feature/update-random-walk-knowledge
-#+pr:
+#+pr: 2054
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-10
@@ -79,7 +79,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2054][#2054]] | [doc] Expand the random walk knowledge page |
 
 * Review
 

--- a/doc/knowledge/domain/random_walk.org
+++ b/doc/knowledge/domain/random_walk.org
@@ -149,11 +149,12 @@ infinite. And the crossing event, not the terminal level, is often
 what a decision or a payoff depends on — a barrier option pays out or
 expires at the moment of passage, not at maturity.
 
-In ORE Studio the [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] and the
-wider barrier product family are the products that ask exactly this
-question; their valuation needs the distribution of the passage time of
-the underlying through the barrier, not only the distribution of the
-underlying at expiry.
+In ORE Studio the
+[[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] and
+the wider barrier product family are the products that ask exactly
+this question; their valuation needs the distribution of the passage
+time of the underlying through the barrier, not only the distribution
+of the underlying at expiry.
 
 * See also
 

--- a/doc/knowledge/domain/random_walk.org
+++ b/doc/knowledge/domain/random_walk.org
@@ -176,10 +176,9 @@ underlying at expiry.
   treatment of random walks, including the simple $\pm 1$ walk and its
   key combinatorial results.
 - Wikipedia: [[https://en.wikipedia.org/wiki/Random_walk][Random walk]].
-- Tuncer, T. D. (2026). [LinkedIn post on random walks as a
-  discrete-time stochastic process driven by successive random
-  increments.] LinkedIn. Retrieved 10 September 2026. The post
-  prompted the "Stationary steps, non-stationary level", "A unit root,
-  not a force", and "First-passage problems" sections above; this
-  document restates that material in its own terms and ties it to ORE
-  Studio's processes.
+- Tuncer, T. D. (2026). "A random walk is a discrete-time stochastic
+  process driven by successive random increments." LinkedIn post,
+  September 2026. Retrieved 10 September 2026. The post prompted the
+  "Stationary steps, non-stationary level", "A unit root, not a force",
+  and "First-passage problems" sections above; this document restates
+  that material in its own terms and ties it to ORE Studio's processes.

--- a/doc/knowledge/domain/random_walk.org
+++ b/doc/knowledge/domain/random_walk.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :knowledge:domain:quantitative_finance:stochastic_processes:ore:
 #+created: 2026-07-16
-#+updated: 2026-07-16
+#+updated: 2026-09-10
 
 * Summary
 
@@ -20,7 +20,11 @@ becomes in the limit of infinitely many, infinitesimally small steps —
 and it already has the [[id:09BA4EBB-BEC0-4AAB-95B1-419B134C9795][Markov
 property]] every process in the
 [[id:A8C46639-0639-4587-B07D-B8B006C46618][Stochastic Processes]] cluster
-relies on, in its plainest possible form.
+relies on, in its plainest possible form. Its increments are stationary
+while its level is not — variance grows with the horizon and no force
+pulls it back — so it stands as the canonical unit-root process; and
+the question it is most often asked is not where it ends up, but when
+it first reaches a given level.
 
 * Layperson's mental model
 
@@ -58,6 +62,50 @@ probability — the textbook coin-flip walk — but the step distribution
 need not be so restricted: any independent, identically-distributed
 sequence of steps produces a random walk in this general sense.
 
+** Stationary steps, non-stationary level
+
+The steps $X_1, X_2, \ldots$ are drawn independently and from one common
+distribution, so the *increments* of a random walk are stationary: the
+law of the change $X_{i+1}$ does not depend on the index $i$. The
+*level* $S_n$ is a different matter — it is not stationary, and its
+variance grows without bound:
+
+\begin{equation}
+\operatorname{Var}(S_n) = n\,\sigma^2
+\end{equation}
+
+where $\sigma^2$ is the variance of a single step. The horizon widens
+the distribution rather than pinning it down: uncertainty accumulates
+with time instead of settling to a fixed spread. That pairing —
+stationary increments, a non-stationary level — is the signature that
+makes the random walk the natural model for prices, cumulative P&L,
+and inventory drift rather than for a quantity that fluctuates around a
+fixed level. The
+[[id:3AD7973A-57ED-43EB-9504-825719F601A8][Geometric Brownian Motion]]
+behind the synthetic market data generators is the same accumulation
+carried out on a logarithmic scale, so its log-level is the
+non-stationary object.
+
+** A unit root, not a force
+
+A random walk is the canonical *unit-root* process. In the recursion
+$S_n = S_{n-1} + X_n$ the coefficient on the previous level is exactly
+one, and that single fact separates it from every mean-reverting
+process: a shock never decays. A step taken a thousand periods ago is
+still present in full in today's level, and no force pulls the process
+back toward a long-run average — the best forecast of the next level
+is simply the last observation.
+
+Contrast the
+[[id:4F7C0348-3C53-44E2-8C95-B3B26852FB94][Ornstein-Uhlenbeck process]]
+— the mean-reverting building block behind the
+[[id:6FD62097-BF1C-4A29-AD6A-88281F457812][Vasicek]] and Hull-White short
+rates — where a restoring force proportional to the distance from the
+mean makes each shock's influence fade geometrically. In time-series
+language a random walk is $I(1)$: the level must be differenced once to
+become stationary, and it is the differenced series — the increments,
+not the level — that estimation and modelling work with.
+
 ** Already Markov, already no-memory
 
 Because each step $X_i$ is drawn independently of every earlier step,
@@ -81,6 +129,32 @@ Wiener process on a computer, which necessarily advances in discrete
 ticks, is already an approximating random walk that targets the
 continuous idealisation, not the continuous process itself.
 
+** First-passage problems
+
+The question most often put to a random walk is not "where is the
+level at time $n$?" but "when does it first reach a given level?" The
+*first-passage* time is
+
+\begin{equation}
+\tau = \inf\{\, n \ge 0 : S_n \in A \,\}
+\end{equation}
+
+for a target set $A$ — a barrier, a ruin level, a reliability
+threshold. First-passage questions differ from terminal-value
+questions in two ways. The distribution of $\tau$ is long-tailed and
+skewed: crossings cluster neither around a typical time nor
+symmetrically about it, and in the symmetric $\pm 1$ walk every level
+is reached with probability one while the expected time to reach it is
+infinite. And the crossing event, not the terminal level, is often
+what a decision or a payoff depends on — a barrier option pays out or
+expires at the moment of passage, not at maturity.
+
+In ORE Studio the [[id:2C172183-1513-45EC-9A42-F0F3AB0E1F56][Generic Barrier Option]] and the
+wider barrier product family are the products that ask exactly this
+question; their valuation needs the distribution of the passage time of
+the underlying through the barrier, not only the distribution of the
+underlying at expiry.
+
 * See also
 
 - [[id:A8C46639-0639-4587-B07D-B8B006C46618][Stochastic Processes]] — the hub.
@@ -102,3 +176,10 @@ continuous idealisation, not the continuous process itself.
   treatment of random walks, including the simple $\pm 1$ walk and its
   key combinatorial results.
 - Wikipedia: [[https://en.wikipedia.org/wiki/Random_walk][Random walk]].
+- Tuncer, T. D. (2026). [LinkedIn post on random walks as a
+  discrete-time stochastic process driven by successive random
+  increments.] LinkedIn. Retrieved 10 September 2026. The post
+  prompted the "Stationary steps, non-stationary level", "A unit root,
+  not a force", and "First-passage problems" sections above; this
+  document restates that material in its own terms and ties it to ORE
+  Studio's processes.


### PR DESCRIPTION
## Summary

The Random Walk page already covered the definition, the Markov property and the Wiener-process limit. It did not cover the three properties that matter most in practice: stationary increments against a non-stationary level, unit-root persistence, and first-passage questions. This adds those three sections, ties each to the ORE Studio process it bears on, and cites the post that prompted them.

## Changes

- Add a 'Stationary steps, non-stationary level' section: the increments are stationary while the level is not, variance grows as n times sigma squared, and that pairing is the signature which makes the walk the model for prices, cumulative P&L and inventory drift. Links to Geometric Brownian Motion.
- Add a 'A unit root, not a force' section: the coefficient on the previous level is exactly one, shocks never decay, and the best forecast of the next level is the last observation. Contrasts the Ornstein-Uhlenbeck process behind Vasicek and Hull-White, and states the I(1) differencing consequence.
- Add a 'First-passage problems' section: the passage time tau, its long-tailed and skewed distribution, recurrence with infinite expected hitting time in the symmetric walk, and the tie-in to the Generic Barrier Option family.
- Extend the Summary with the stationarity and first-passage framing, and add the source to Further reading.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Documentation improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/documentation-improvements/story.html) | B660460A-682B-4728-9A8F-21B9A9AF52E4 |
| Task | [Expand the Random Walk knowledge page](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/documentation-improvements/task_expand-random-walk-page.html) | A572C320-A132-477B-9170-6CB5A0466D2D |
| Environment | clever_dijkstra | |

## Testing

Plan. Documentation-only change, so the matching class check is the local site build, which publishes every org document and fails on a malformed file or a broken link target. Alongside it: the misspell check over the changed file, and a check that every org id the new prose links to resolves.

Evidence. docs class; local site build clean (compass.sh build --direct site, Build succeeded, and random_walk.org was published in the pass taken after the final edit); misspell-fixer clean on doc/knowledge/domain/random_walk.org (exit 0); all four newly referenced org ids resolve to existing pages (Geometric Brownian Motion, Ornstein-Uhlenbeck Process, Vasicek Process, Generic Barrier Option); the geometric-Brownian-motion claim is corroborated by doc/knowledge/domain/synthetic_market_data_generators.org.

Limitations. No automated test covers prose accuracy; the stationarity, unit-root and first-passage statements are standard results verified by reading only. The citation carries no permalink, because the post was supplied as text and no URL was available. The repo-wide misspell-fixer run exits 1 on pre-existing drift elsewhere in the tree; the check was scoped to the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)