### PR TITLE
[doc] Add structure notes to the knowledge Zettelkasten

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -71,3 +71,8 @@ jobs:
         # The recipe holds the command and the skill holds the judgement,
         # so drift has one place to be detected rather than two.
         run: python3 build/scripts/link_skill_recipes.py --check
+
+      - name: Check structure notes are reachable from what they order
+        # A hub only helps readers who already found it, unless every page
+        # it orders points back at it.
+        run: python3 build/scripts/link_structure_notes.py --check

--- a/build/scripts/link_structure_notes.py
+++ b/build/scripts/link_structure_notes.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Make every structure note reachable from the pages it orders.
+
+A structure note is a hub: it names a cluster and puts its pages in an
+argued order. Reachability has to work both ways. A reader who finds the
+hub gets the order; a reader who lands on one page by search needs to be
+told the order exists, or the note only helps people who already knew
+about it.
+
+The hubs are the source of truth: whatever a hub links to, it orders. This
+script reads each hub's outbound links and adds a back-link to the hub in
+each ordered page's See also section, skipping pages that already carry
+one.
+
+Usage: python3 build/scripts/link_structure_notes.py [--check]
+  --check  exit non-zero if an ordered page lacks its back-link.
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SEARCH = [ROOT / "doc", ROOT / "projects" / "modeling"]
+TAG = "structure_note"
+
+LINK = re.compile(r"\[\[id:([0-9A-Fa-f-]{36})\]\[([^\]]*)\]\]")
+
+
+def org_files():
+    for base in SEARCH:
+        for p in base.rglob("*.org"):
+            yield p
+
+
+def frontmatter(text, field):
+    m = re.search(rf"^#\+{field}:\s*(.+?)\s*$", text, re.M)
+    return m.group(1) if m else ""
+
+
+def doc_id(text):
+    m = re.search(r"^:ID:\s*(\S+)\s*$", text, re.M)
+    return m.group(1).upper() if m else None
+
+
+def load():
+    docs = {}
+    for p in org_files():
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        did = doc_id(text)
+        if did:
+            docs[did] = (p, text)
+    return docs
+
+
+def hubs(docs):
+    return {did: (p, t) for did, (p, t) in docs.items()
+            if TAG in frontmatter(t, r"filetags")}
+
+
+# A hub's later sections point outwards: at the neighbouring cluster it
+# excludes, and at the index and method pages every hub cites. Only the
+# ordering sections name cluster members, so the scan stops at the first
+# of these headings.
+STOP_HEADINGS = ("* What this cluster does not cover", "* See also")
+
+
+def ordering_section(hub_text):
+    """The part of a hub that names its cluster: everything before the
+    sections that deliberately point outside it."""
+    end = len(hub_text)
+    for heading in STOP_HEADINGS:
+        i = hub_text.find("\n" + heading)
+        if i != -1:
+            end = min(end, i)
+    return hub_text[:end]
+
+
+def ordered_by(hub_text, docs, hub_id):
+    """The cluster pages a hub orders, read from its ordering sections."""
+    out = []
+    for m in LINK.finditer(ordering_section(hub_text)):
+        target = m.group(1).upper()
+        if target == hub_id or target not in docs:
+            continue
+        if target not in out:
+            out.append(target)
+    return out
+
+
+def add_backlink(path, text, hub_id, hub_title):
+    if f"id:{hub_id}" in text or f"id:{hub_id.lower()}" in text:
+        return None
+    line = (f"- [[id:{hub_id}][{hub_title}]] — the structure note that "
+            "orders this cluster, and where to read this page in it.")
+    m = re.search(r"^\* See also\s*$", text, re.M)
+    if m:
+        insert = m.end()
+        return text[:insert] + "\n\n" + line + text[insert:].rstrip("\n") + "\n" \
+            if text[insert:].strip() == "" else \
+            text[:insert] + "\n\n" + line + text[insert:]
+    return text.rstrip("\n") + "\n\n* See also\n\n" + line + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if a back-link is missing")
+    args = ap.parse_args()
+
+    docs = load()
+    found = hubs(docs)
+    if not found:
+        print(f"❌ no document carries the {TAG} tag", file=sys.stderr)
+        return 1
+
+    missing = []
+    for hub_id, (hub_path, hub_text) in sorted(found.items()):
+        title = frontmatter(hub_text, "title")
+        for target in ordered_by(hub_text, docs, hub_id):
+            path, text = docs[target]
+            if target in found:
+                continue
+            updated = add_backlink(path, text, hub_id, title)
+            if updated is None:
+                continue
+            missing.append(path.relative_to(ROOT))
+            if not args.check:
+                path.write_text(updated, encoding="utf-8")
+                docs[target] = (path, updated)
+
+    if args.check:
+        if missing:
+            for m in missing:
+                print(f"❌ {m} does not link its structure note", file=sys.stderr)
+            print("   run: python3 build/scripts/link_structure_notes.py",
+                  file=sys.stderr)
+            return 1
+        print(f"✅ every page ordered by a structure note links back to it "
+              f"({len(found)} notes).")
+        return 0
+
+    print(f"✅ added {len(missing)} back-link(s) across {len(found)} "
+          "structure note(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/scripts/link_structure_notes.py
+++ b/build/scripts/link_structure_notes.py
@@ -67,6 +67,15 @@ def hubs(docs):
 # of these headings.
 STOP_HEADINGS = ("* What this cluster does not cover", "* See also")
 
+# A hub may also carry a section for pages that belong to the cluster but
+# sit outside its sequence — reached when the question is provenance, or
+# method, rather than when working through the subject. The section marks
+# itself, because a heading's wording is not something a script should be
+# parsing for meaning.
+ASIDE_MARKER = "# aside"
+
+HEADING = re.compile(r"^\*+ .*$", re.M)
+
 
 def ordering_section(hub_text):
     """The part of a hub that names its cluster: everything before the
@@ -79,23 +88,41 @@ def ordering_section(hub_text):
     return hub_text[:end]
 
 
-def ordered_by(hub_text, docs, hub_id):
-    """The cluster pages a hub orders, read from its ordering sections."""
-    out = []
-    for m in LINK.finditer(ordering_section(hub_text)):
-        target = m.group(1).upper()
-        if target == hub_id or target not in docs:
-            continue
-        if target not in out:
-            out.append(target)
+def sections(text):
+    """(body,) per heading, plus whatever precedes the first heading."""
+    bounds = [m.start() for m in HEADING.finditer(text)]
+    if not bounds:
+        return [text]
+    out = [text[:bounds[0]]]
+    for i, start in enumerate(bounds):
+        end = bounds[i + 1] if i + 1 < len(bounds) else len(text)
+        out.append(text[start:end])
     return out
 
 
-def add_backlink(path, text, hub_id, hub_title):
+def cluster_pages(hub_text, docs, hub_id):
+    """The cluster's pages, split into the ones the hub orders and the ones
+    it deliberately leaves outside its sequence."""
+    ordered, aside = [], []
+    for body in sections(ordering_section(hub_text)):
+        bucket = aside if ASIDE_MARKER in body else ordered
+        for m in LINK.finditer(body):
+            target = m.group(1).upper()
+            if target == hub_id or target not in docs:
+                continue
+            if target not in ordered and target not in aside:
+                bucket.append(target)
+    return ordered, aside
+
+
+def add_backlink(path, text, hub_id, hub_title, ordered=True):
     if f"id:{hub_id}" in text or f"id:{hub_id.lower()}" in text:
         return None
-    line = (f"- [[id:{hub_id}][{hub_title}]] — the structure note that "
-            "orders this cluster, and where to read this page in it.")
+    why = ("the structure note that orders this cluster, and where to read "
+           "this page in it." if ordered else
+           "the structure note for this cluster; this page sits alongside "
+           "its sequence rather than in it.")
+    line = f"- [[id:{hub_id}][{hub_title}]] — {why}"
     m = re.search(r"^\* See also\s*$", text, re.M)
     if m:
         insert = m.end()
@@ -120,11 +147,13 @@ def main():
     missing = []
     for hub_id, (hub_path, hub_text) in sorted(found.items()):
         title = frontmatter(hub_text, "title")
-        for target in ordered_by(hub_text, docs, hub_id):
+        ordered, aside = cluster_pages(hub_text, docs, hub_id)
+        for target in ordered + aside:
             path, text = docs[target]
             if target in found:
                 continue
-            updated = add_backlink(path, text, hub_id, title)
+            updated = add_backlink(path, text, hub_id, title,
+                                   ordered=target in ordered)
             if updated is None:
                 continue
             missing.append(path.relative_to(ROOT))

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -81,7 +81,7 @@ Tasks are listed in intended execution order.
 | [[id:7DFA4343-E553-4D3A-B71F-057329821EE5][Rename every skill into the compass- namespace]] | DONE | 2026-09-10 | 2026-09-10 | Mechanical rename of every skill, with every incoming link, catalogue row, runbook, memory and settings entry updated. |
 | [[id:3969C185-48DE-47F0-A00D-FD28CD58C1B0][Tag every skill with its cybernetic level]] | DONE | 2026-09-10 | 2026-09-10 | Add the mandatory level keyword to every skill and make the declared System attenuate which skills a session sees. |
 | [[id:F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59][Separate skill judgement from recipe commands]] | DONE | 2026-09-10 | 2026-09-10 | Make every action delegate its commands to a recipe and keep only the judgement, so each has one source of truth. |
-| [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | BACKLOG | | | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
+| [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | DONE | 2026-09-10 | 2026-09-10 | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
 | [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | BACKLOG | | | Cite the eleven adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
 | [[id:08F7F925-49B2-40E0-A298-E300353CAE2E][Port the sequencing function and bind it to recipes and actions]] | BACKLOG | | | Import the adopted methods and interview skills as compass-method skills, with every step bound to one of our actions or recipes. |
@@ -149,6 +149,12 @@ Tasks are listed in intended execution order.
 - Most missing recipes were missing links. Survey before writing: of the 17
   skills carrying an unbacked command, 16 already had a recipe nobody had
   pointed at.
+- A structure note argues its order or it is a table of contents. What makes
+  it worth reading is the claim that each page makes the next one possible,
+  which search cannot supply and an index does not attempt.
+- A hub declares its own cluster membership, and the sections that point
+  outside it are headings so a script can tell the difference. The first
+  back-link sweep wrongly claimed four pages a hub merely cross-referenced.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
@@ -104,7 +104,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | The back-link script swept the aside sections into the ordered set, so three pages carried a back-link claiming an order the hub's own prose denies | build/scripts/link_structure_notes.py | Accept | A real bug. Aside sections now mark themselves with =# aside= and aside pages get their own wording. Marking beats matching on heading text, which would ask a script to interpret prose |
+| 2 | The GARCH placement overreached: realised volatility clustering is a real-world-measure time-series property and the surface's shape is a risk-neutral cross-sectional one | doc/knowledge/domain/volatility_hub.org | Accept | Narrowed to the leverage asymmetry, which is the connection that holds, with the limit stated so the next reader does not re-widen it. GARCH stays second |
+| 3 | The =entity_lifecycle= skill-name updates read as an unrelated rename swept into this PR | projects/modeling/entity_lifecycle.org | Accept | Fair. They are stale labels from a naming era before the compass rename, caught while tagging the page as a structure note; the PR description now says so |
+| 4 | Interest rate curves, identity and access, MASD, and the SSR ordering all check out against the source pages, and none of the four reads as a table of contents | — | Accept | No change. Recorded because a challenge that finds nothing is the evidence the rest of the review is worth trusting |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:knowledge:zettelkasten:documentation:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/add-knowledge-structure-notes
-#+pr:
+#+pr: 2055
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -98,7 +98,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2055][#2055]] | [doc] Add structure notes to the knowledge Zettelkasten |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:knowledge:zettelkasten:documentation:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/add-knowledge-structure-notes
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ Luhmann's slip-box had structure notes, the entry points that list a cluster's n
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -43,11 +43,45 @@ Luhmann's slip-box had structure notes, the entry points that list a cluster's n
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Two of the six clusters already had their entry point, which changed the
+work from writing six notes to writing four and adopting a convention.
+=Market Data Requirements and Resolution= was already a full structure note
+under the name /hub note/, with a pipeline and an argued order.
+=Entity Lifecycle= already carried the layer ordering with its skills,
+pattern documents and recipes per row, and needed only the reason for the
+order stated and the tag applied.
+
+The four written from scratch are interest rate curves, volatility,
+identity and access, and MASD. Each argues its order from what the pages
+make possible for each other rather than from any taxonomy: pillars before
+interpolation because interpolation is only a question once the curve is
+known to be defined at finitely many points; realised volatility before
+implied because the surface is priced rather than measured; logical space
+before physical because a file layout reads as arbitrary without the model
+it projects.
+
+Reachability is mechanical, through
+=build/scripts/link_structure_notes.py=. The hubs are the source of truth
+for cluster membership, and every page a hub orders gains a back-link. The
+=structure_note= tag makes the set listable, which is what lets the
+grounding phase name a cluster and get a path.
 
 * Notes
+
+The first run of the back-link script treated every outbound link in a
+hub as a cluster member, so it wrote back-links into pages the hubs merely
+cross-reference — the neighbouring cluster named under /what this cluster
+does not cover/, and the index every hub cites. Four pages were wrongly
+claimed before the diff showed it. The scan now stops at those sections,
+which is why hubs carry them as headings rather than as prose.
+
+Each of the four new notes says what it excludes and where that material
+lives instead. The reader who arrived at the wrong hub needs pointing at
+the right one more than the reader at the right hub needs reassurance.
+
+=Interpolation= is ordered by two hubs, curves and market data, and carries
+a back-link to each. A page belonging to two clusters is expected in a
+Zettelkasten rather than a fault to resolve.
 
 * Test Scenarios
 
@@ -73,3 +107,25 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All five acceptance criteria are met.
+
+Six clusters have a structure note: market data resolution and the entity
+lifecycle, which existed and are now named and tagged as such, plus
+interest rate curves, volatility, identity and access, and MASD, written
+here. Each gives an argued reading order, and each argues it: no note is a
+bare list, and every section says what the previous one makes possible.
+
+All six are reachable from
+[[id:7474935C-95D1-3034-B833-83DCD9FB3A09][the knowledge index]], which now
+opens with them, and from the pages they order: 33 back-links were added,
+and =link_structure_notes.py --check= holds that in CI.
+
+[[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] documented the
+theory and said we had none. It now describes the convention we hold them
+under, with the three rules that keep them honest.
+
+The grounding phase reads a cluster's structure note first where one
+exists, which is stated in
+[[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]]. Listing
+the =structure_note= tag returns the six.

--- a/doc/knowledge/architecture/internal_actor_impersonation.org
+++ b/doc/knowledge/architecture/internal_actor_impersonation.org
@@ -161,6 +161,7 @@ construction left in that handler.
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:3E20C1A0-7BA1-4F31-8C34-1E5F13558890][Service-to-Service Auth: Client Credentials vs. On-Behalf-Of Delegation]]
   — the other two service-to-service auth flows this pattern sits
   alongside.

--- a/doc/knowledge/architecture/service_to_service_auth_patterns.org
+++ b/doc/knowledge/architecture/service_to_service_auth_patterns.org
@@ -152,6 +152,7 @@ around the service boundary.
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:8ECCBD02-21F5-455C-B520-193E4631092F][Anatomy of a Service]] — "Calling another service: mint or delegate", the
   mechanics this doc names and expands on.
 - [[id:4B02695C-7C59-487A-8450-4240EC836685][Service-to-Service JWT Delegation]] — the original delegation design plan.

--- a/doc/knowledge/documentation/zettelkasten.org
+++ b/doc/knowledge/documentation/zettelkasten.org
@@ -121,6 +121,14 @@ A cluster earns a structure note when reading its pages in the wrong
 order costs something real. Where the order does not matter, the index
 entry is enough.
 
+Some pages belong to a cluster without belonging to its sequence: a
+provenance note, a research paper, anything reached when the question
+changes rather than when the subject advances. A note holds these in a
+section marked =# aside=, and the marker is what the tooling reads. The
+alternative was to recognise such sections by their wording, which asks a
+script to interpret prose and gets it wrong the first time a note is
+phrased differently.
+
 * See also
 
 - [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the Emacs package that implements Zettelkasten over =.org= files in ORE Studio.

--- a/doc/knowledge/documentation/zettelkasten.org
+++ b/doc/knowledge/documentation/zettelkasten.org
@@ -101,11 +101,25 @@ before doing work has the reader's problem in an acute form: it knows
 the subject and not the identifiers, and the cost of reading the wrong
 five pages is paid in context it cannot recover.
 
-ORE Studio does not yet have them. [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][The knowledge index]] is a flat list
-of topics, which tells a reader that a page exists without telling them
-where to start or in what order to continue. Writing one structure note
-per domain cluster is tracked work, and the links it would order already
-exist — what is missing is the argued sequence.
+ORE Studio holds them under the =structure_note= tag, and
+[[id:7474935C-95D1-3034-B833-83DCD9FB3A09][the knowledge index]] opens with
+the set. One exists per domain cluster: market data resolution, interest
+rate curves, volatility, identity and access, MASD, and the entity
+lifecycle.
+
+Three conventions keep them honest. A structure note *argues* its order
+rather than listing one, saying what each page makes possible for the
+next; an order with no reason is a table of contents, which the index
+already provides. It *gists and links*, holding no content its cluster
+does not, so there is nothing in it to drift. And it *says what it
+excludes*, naming the neighbouring cluster and why the boundary falls
+where it does, because the reader who arrived at the wrong hub needs
+pointing at the right one more than the reader at the right hub needs
+reassurance.
+
+A cluster earns a structure note when reading its pages in the wrong
+order costs something real. Where the order does not matter, the index
+entry is enough.
 
 * See also
 

--- a/doc/knowledge/domain/book_access_and_permissions.org
+++ b/doc/knowledge/domain/book_access_and_permissions.org
@@ -53,6 +53,7 @@ see risk concentration as a pie-chart-like breakdown.
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:130A3261-E788-4222-9BD7-371AD92982FB][Book]] — hub note.
 - [[id:07CEDE6A-21B7-4F87-9745-708FDCA8C362][Book lifecycle]] — the opening workflow's access-review step.
 - [[id:D18DF500-2C6C-42FF-BBAE-D5A46D410910][Book groups and rates centres]] — centre ownership as trade-level

--- a/doc/knowledge/domain/curve_point_provenance.org
+++ b/doc/knowledge/domain/curve_point_provenance.org
@@ -97,6 +97,7 @@ cluster.
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data Quality]] — the general provenance/lineage definitions and the standard reference-data provenance fields this document extends.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification the proposed derivation-kind field records.

--- a/doc/knowledge/domain/curve_point_provenance.org
+++ b/doc/knowledge/domain/curve_point_provenance.org
@@ -97,7 +97,8 @@ cluster.
 
 * See also
 
-- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
+
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note for this cluster; this page sits alongside its sequence rather than in it.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:A19D2750-D97D-09A4-BD2B-5218D9654E56][Data Quality]] — the general provenance/lineage definitions and the standard reference-data provenance fields this document extends.
 - [[id:4DF1F49A-9AB4-4B56-B170-808490071799][Broken Dates and Turn Points]] — the three-way classification the proposed derivation-kind field records.

--- a/doc/knowledge/domain/curve_sets_storage.org
+++ b/doc/knowledge/domain/curve_sets_storage.org
@@ -54,6 +54,7 @@ were constructed.
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — the hub.
 - [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][Funding and Projection Curves]] — the family typically stored as one curve set.
 - [[id:A26CFA71-21C0-4E98-ABC4-25F0EAD517E3][Multicurve Management]] — how a curve set would be presented once retrieved.

--- a/doc/knowledge/domain/external_market_data_identifiers.org
+++ b/doc/knowledge/domain/external_market_data_identifiers.org
@@ -876,6 +876,7 @@ that every row in this document's comparison tables above draws from.
 
 * See also
 
+- [[id:FD427B5B-BDC5-4803-AFCD-97A59E31FE25][Market Data Requirements and Resolution]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][Open Source Risk Engine (ORE)]] — source of the canonical key format.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — the authoritative, per-type quote-key dimension inventory (49 types) that every ORE quote key in this document's comparison tables is drawn from.
 - [[id:0FF6A2DC-EE01-4C3C-AF86-A0D08FD93925][Market Data Definition Language (MDDL)]] — the fourth scheme compared above: version history, content model, and where its retrieved specification files live.

--- a/doc/knowledge/domain/funding_and_projection_curves.org
+++ b/doc/knowledge/domain/funding_and_projection_curves.org
@@ -110,6 +110,7 @@ small, deliberately-curated set rather than a continuum.
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — the hub.
 - [[id:A1BA9EE6-313E-4802-8F63-FEE6BFB63A69][Driver and derived rates]] — the CRM's similar-sounding but mechanically different split.
 - [[id:5170B17B-188B-45CA-A1B6-1F27A97E1CF8][Interest Rate Benchmark Types: IBOR vs. RFR]] — the benchmark-type attribute of curve identity.

--- a/doc/knowledge/domain/fx_vol_surface_driving.org
+++ b/doc/knowledge/domain/fx_vol_surface_driving.org
@@ -80,6 +80,7 @@ parameterisation and conventions.
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:48F6FD8D-56C7-4FF7-A369-CD13D08A6057][Cross-rates matrix (CRM)]] — the hub; same driver/derived pattern for spot.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the authoritative note on pillar quoting (ATM/RR/STR),
   delta conventions and smile models; this note covers only the *driving* of one

--- a/doc/knowledge/domain/fx_volatility_surface.org
+++ b/doc/knowledge/domain/fx_volatility_surface.org
@@ -283,3 +283,7 @@ ORE configuration files:
 
 ORE Studio will need to model vol surface configurations as domain entities (see
 [[id:A3B7C9E1-4F2D-8A6B-5E1C-9D3F7A0B2E4C][ORE Model Configuration]] for the wider configuration landscape).
+
+* See also
+
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.

--- a/doc/knowledge/domain/garch_volatility_models.org
+++ b/doc/knowledge/domain/garch_volatility_models.org
@@ -484,6 +484,7 @@ violations.
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:3F849D36-022B-49CC-AD71-791481F36581][Paper summary: GJR-GARCH neural-network option pricing]] — full treatment
   of the MDN surrogate: architecture, error bounds, QuantLib parallels,
   and integration questions.

--- a/doc/knowledge/domain/interest_rate_curve_bundles.org
+++ b/doc/knowledge/domain/interest_rate_curve_bundles.org
@@ -120,6 +120,7 @@ the order a reader should approach them:
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — the companion hub for single-curve bootstrapping mechanics.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — a genuine bivariate surface, and the source of the forward-forward approximation technique reused here.
 - [[id:CD3E82C6-AE56-4D06-B949-0B3A5CE7A5FC][Deliverability and non-deliverable instruments]] — the pseudo currency code mechanism behind onshore/offshore namespacing.

--- a/doc/knowledge/domain/interest_rate_curves.org
+++ b/doc/knowledge/domain/interest_rate_curves.org
@@ -226,3 +226,7 @@ takes place. The interpolation method for each curve is set in =curveconfig.xml=
 ORE Studio exposes these configurations through the reference data domain
 (=ores.refdata=) and will eventually surface them as editable entities in the
 UI.
+
+* See also
+
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.

--- a/doc/knowledge/domain/interest_rate_curves_hub.org
+++ b/doc/knowledge/domain/interest_rate_curves_hub.org
@@ -80,6 +80,7 @@ booking jurisdiction. Read last: it is a refinement of identity, and only
 makes sense once curve identity is understood as a discrete label.
 
 ** Alongside, when the question is provenance
+# aside
 
 [[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — where
 a curve point came from and why market data needs lineage at all. Not part

--- a/doc/knowledge/domain/interest_rate_curves_hub.org
+++ b/doc/knowledge/domain/interest_rate_curves_hub.org
@@ -1,0 +1,101 @@
+:PROPERTIES:
+:ID: FA45D3D1-C3D9-4FDB-B03B-8AB724D71092
+:END:
+#+title: Interest Rate Curves
+#+description: Structure note for the interest rate curve cluster: what a curve is, how one is built from pillars, why one curve became many, and how the family is stored and namespaced.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:structure_note:rates:curves:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+* Summary
+
+A discount curve answers one question — what is a future cashflow worth
+today — and everything else in this cluster exists because that question
+turned out to be harder than it looks. The curve is not observed. It is
+*bootstrapped* from a handful of quoted instruments, which fixes its value
+at a few tenors and leaves every point between them to *interpolation*. The
+2008 crisis then broke the assumption that one curve could both discount a
+cashflow and project the rate that cashflow depends on, so a single curve
+became a *family*, and the family needs an order to build it in, a way to
+be stored, and a way to be namespaced when the same currency has more than
+one.
+
+Read the cluster in that sequence: what a curve is, what it is made of, why
+there are several, and how the several are held. Each step creates the
+problem the next one answers, which is why this order and not the
+alphabet.
+
+* Reading order
+
+** 1. What a curve is, and how one is built
+
+[[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — start
+here. Day-count conventions, discount factors, and bootstrapping from
+deposits, FRAs, swaps and OIS. Everything downstream assumes this
+vocabulary, and the bootstrap is where the cluster's central fact appears:
+the curve is constructed from a small set of quotes rather than observed.
+
+** 2. What it is made of, and what fills the gaps
+
+[[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — the tenor points that
+are genuinely quoted inputs, as against the continuum the curve pretends to
+be. Read it immediately after the bootstrap, because it names what the
+bootstrap actually produces.
+
+[[id:85B48CF7-3858-44C8-97AA-91D21C634A9D][Interpolation]] — what happens
+between pillars, and the local versus non-local method families. This
+follows pillars necessarily: interpolation is only a question once you know
+the curve is defined at finitely many points.
+
+** 3. Why there is more than one curve
+
+[[id:7CB0024B-84FB-4AE0-ADF2-763079E888D5][Multi-Curve Construction]] — the
+history and the build order: one curve served both discounting and
+projection until basis spreads made that untenable; now the Funding Curve
+is built first and each Projection Curve is discounted off it. Read the
+history before the taxonomy, because the taxonomy is a response to it.
+
+[[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][Funding and Projection Curves]] —
+the resulting family: one funding curve for discounting, one projection
+curve per floating index tenor, and why curve identity is a discrete label
+rather than a continuous axis. That last point is the one most often got
+wrong when modelling curves as data.
+
+** 4. How the family is held
+
+[[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Bundles]] —
+how a currency's curves compose above the level of a single curve.
+
+[[id:71E4EB7A-20EA-46E1-8832-05D103C330EF][Curve Sets Storage]] — the
+storage-only grouping of several small related curve time series into one
+composite. Storage-only is the load-bearing word: it is a persistence
+concern and carries no pricing meaning, and conflating it with a bundle is
+a recurring mistake.
+
+[[id:D1A196C0-DD73-4B0E-B7C3-9768FCA2CCE7][Onshore/Offshore Curve
+Namespacing]] — when one currency has parallel discount curves selected by
+booking jurisdiction. Read last: it is a refinement of identity, and only
+makes sense once curve identity is understood as a discrete label.
+
+** Alongside, when the question is provenance
+
+[[id:573F9165-C20B-463C-B0B3-F324AFE4E81F][Curve Point Provenance]] — where
+a curve point came from and why market data needs lineage at all. Not part
+of the construction story, so it does not sit in the sequence; reach for it
+when the question is trust rather than shape.
+
+* What this cluster does not cover
+
+Volatility surfaces are a separate cluster with their own structure note,
+even though both are term structures built from quoted pillars. The
+resolution of a logical market data need into the physical identifiers a
+curve is built from belongs to
+[[id:FD427B5B-BDC5-4803-AFCD-97A59E31FE25][Market Data Requirements and
+Resolution]].
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the index this structure note hangs from.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — what a structure note is and why the order is authored rather than computed.

--- a/doc/knowledge/domain/interpolation.org
+++ b/doc/knowledge/domain/interpolation.org
@@ -110,6 +110,8 @@ results rather than an error.
 
 * See also
 
+- [[id:FD427B5B-BDC5-4803-AFCD-97A59E31FE25][Market Data Requirements and Resolution]] — the structure note that orders this cluster, and where to read this page in it.
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:F85AB5BD-CCBF-4031-AD73-ADD9797DE5C2][Extrapolation]] — the sister concept for values outside the pillar range entirely.
 - [[id:D5FAFA10-333D-44BC-B993-4B5C4C4D803F][Pillar]] — what a pillar is, and how it differs from a tenor in general.

--- a/doc/knowledge/domain/market_data_requirements_resolution_hub.org
+++ b/doc/knowledge/domain/market_data_requirements_resolution_hub.org
@@ -5,7 +5,7 @@
 #+description: Hub note for how a logical need for market data (a requirement) resolves into concrete items drawn from the market data universe: requirements, identifiers, the universe, configuration/resolution, dependency closure, snapshotting, and filtering.
 #+type: knowledge
 #+level: cross
-#+filetags: :knowledge:domain:marketdata:requirements:resolution:
+#+filetags: :knowledge:domain:structure_note:marketdata:requirements:resolution:
 #+created: 2026-07-23
 #+updated: 2026-07-30
 

--- a/doc/knowledge/domain/multi_curve_construction.org
+++ b/doc/knowledge/domain/multi_curve_construction.org
@@ -155,6 +155,7 @@ documentation).
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — the hub.
 - [[id:5170B17B-188B-45CA-A1B6-1F27A97E1CF8][Interest Rate Benchmark Types: IBOR vs. RFR]] — the risk difference between the two curve roles.
 - [[id:6EA42D11-94F4-4D3A-9A51-024EC56EFC44][Funding and Projection Curves]] — the family structure this build order applies to.

--- a/doc/knowledge/domain/onshore_offshore_curve_namespacing.org
+++ b/doc/knowledge/domain/onshore_offshore_curve_namespacing.org
@@ -66,6 +66,7 @@ with this jurisdictional boundary.
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:29F0F3B1-91A6-42BD-A53F-97F1E72A4FB9][Interest Rate Curve Families]] — the hub.
 - [[id:CD3E82C6-AE56-4D06-B949-0B3A5CE7A5FC][Deliverability and non-deliverable instruments]] — the pseudo currency code mechanism this note applies to curves.
 - [[id:5DD9A309-91E0-4CAB-BD9D-6ECB3B5EB58E][Currency pairs]] — the companion FX hub.

--- a/doc/knowledge/domain/paper_gjr_garch_nn_option_pricing.org
+++ b/doc/knowledge/domain/paper_gjr_garch_nn_option_pricing.org
@@ -400,7 +400,8 @@ For supported asset classes the workflow is:
 
 * See also
 
-- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
+
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note for this cluster; this page sits alongside its sequence rather than in it.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — catalogue of ORE option vol quote types this method can populate.
 - [[id:84E7CEA8-9654-431C-A8D1-C8B97E35B6D5][Paper summary: Gaussian GenAI — Synthetic Market Data Generation]] — P-measure GMM generation; MDN provides the Q-measure density.
 - [[id:EC220F01-1844-4EED-A61D-BCF9F01EE00C][Paper summary: mixture-preserving, arbitrage-free vol-surface interpolation]] — arbitrage-free surface interpolation; complements MDN output.

--- a/doc/knowledge/domain/paper_gjr_garch_nn_option_pricing.org
+++ b/doc/knowledge/domain/paper_gjr_garch_nn_option_pricing.org
@@ -400,6 +400,7 @@ For supported asset classes the workflow is:
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — catalogue of ORE option vol quote types this method can populate.
 - [[id:84E7CEA8-9654-431C-A8D1-C8B97E35B6D5][Paper summary: Gaussian GenAI — Synthetic Market Data Generation]] — P-measure GMM generation; MDN provides the Q-measure density.
 - [[id:EC220F01-1844-4EED-A61D-BCF9F01EE00C][Paper summary: mixture-preserving, arbitrage-free vol-surface interpolation]] — arbitrage-free surface interpolation; complements MDN output.

--- a/doc/knowledge/domain/paper_vol_surface_interpolation_arbitrage_free.org
+++ b/doc/knowledge/domain/paper_vol_surface_interpolation_arbitrage_free.org
@@ -267,6 +267,7 @@ this method and is not covered by the paper.
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — catalogue of ORE vol surface quote types this method applies to.
 - [[id:84E7CEA8-9654-431C-A8D1-C8B97E35B6D5][Paper summary: Gaussian GenAI — Synthetic Market Data Generation]] — GMM-based P-measure generation; this paper is the Q-measure arbitrage-free layer on top.
 - [[id:3F849D36-022B-49CC-AD71-791481F36581][Paper summary: GJR-GARCH neural-network option pricing]] — alternative route to risk-neutral densities via a neural surrogate.

--- a/doc/knowledge/domain/paper_vol_surface_interpolation_arbitrage_free.org
+++ b/doc/knowledge/domain/paper_vol_surface_interpolation_arbitrage_free.org
@@ -267,7 +267,8 @@ this method and is not covered by the paper.
 
 * See also
 
-- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
+
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note for this cluster; this page sits alongside its sequence rather than in it.
 - [[id:F9AE7F54-D995-476A-BA24-93698BF5029D][ORE market data catalogue]] — catalogue of ORE vol surface quote types this method applies to.
 - [[id:84E7CEA8-9654-431C-A8D1-C8B97E35B6D5][Paper summary: Gaussian GenAI — Synthetic Market Data Generation]] — GMM-based P-measure generation; this paper is the Q-measure arbitrage-free layer on top.
 - [[id:3F849D36-022B-49CC-AD71-791481F36581][Paper summary: GJR-GARCH neural-network option pricing]] — alternative route to risk-neutral densities via a neural surrogate.

--- a/doc/knowledge/domain/pillar.org
+++ b/doc/knowledge/domain/pillar.org
@@ -90,6 +90,7 @@ Bootstrapping Architecture]].
 
 * See also
 
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Term Structures and Tenors]] — the hub.
 - [[id:0AC88EB3-DB7F-4135-9DA6-0ED4583FEC29][Tenor]] — the general label; pillar is the subset of tenors actually quoted for a given curve.
 - [[id:3A6CF3BC-3378-4F84-B0B6-F5D6F488AC33][Term Structure]] — the series a curve's pillars are bootstrapped into.

--- a/doc/knowledge/domain/skew_stickiness_ratio.org
+++ b/doc/knowledge/domain/skew_stickiness_ratio.org
@@ -444,6 +444,7 @@ sources:
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:0CD30407-D67D-499C-B9AB-F268D05F40E4][Volatility]] — the generic concept this page builds on: implied vs
   realised vol, the Black-Scholes sigma parameter, the smile.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — how the surface is quoted (ATM/RR/STR

--- a/doc/knowledge/domain/var_and_vol_derivatives.org
+++ b/doc/knowledge/domain/var_and_vol_derivatives.org
@@ -370,6 +370,7 @@ the example variance option trade in the section =Variance Option=.
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes,
   with the alphabetical product run.
 

--- a/doc/knowledge/domain/vol_surface_no_arbitrage_conditions.org
+++ b/doc/knowledge/domain/vol_surface_no_arbitrage_conditions.org
@@ -404,6 +404,7 @@ for (Date d : surface->optionDateFromTime(expiry)) {
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]]
 - [[id:EC220F01-1844-4EED-A61D-BCF9F01EE00C][Paper summary: mixture-preserving, arbitrage-free vol-surface interpolation]]
 - [[id:3F849D36-022B-49CC-AD71-791481F36581][Paper summary: GJR-GARCH neural-network option pricing]]

--- a/doc/knowledge/domain/volatility.org
+++ b/doc/knowledge/domain/volatility.org
@@ -191,6 +191,7 @@ moved. It does not tell you how stable the law that moved it is.
 
 * See also
 
+- [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — pillar quoting, delta conventions, smile
   models, and cross-time interpolation for the FX-specific implied
   vol surface.

--- a/doc/knowledge/domain/volatility_hub.org
+++ b/doc/knowledge/domain/volatility_hub.org
@@ -36,8 +36,16 @@ realised-versus-implied distinction the rest of the cluster depends on.
 [[id:351CB816-28F5-428A-A289-414B6F4B9F36][GARCH Volatility Models]] — read
 second, while still on realised volatility. Volatility clusters rather than
 arriving independently each day, and GARCH is the standard way to model
-that. It belongs before the surface because it explains why volatility is
-not a constant, which is the reason a surface has shape at all.
+that. Read it here rather than later for one specific connection: the
+leverage asymmetry a GJR-GARCH captures produces qualitatively the same
+negative skew the surface shows, which makes the surface's shape legible
+when you meet it.
+
+Do not carry that further than it goes. Realised volatility is a
+time-series property under the real-world measure; the surface's shape
+across strike is a risk-neutral pricing phenomenon driven by the pricing
+density, jumps and tail risk. The two rhyme at the leverage effect and are
+not the same claim.
 
 ** 2. The surface
 
@@ -76,6 +84,7 @@ the surface as an input: they are priced off it rather than contributing
 to it.
 
 ** The papers, when the question is method
+# aside
 
 Two research notes sit alongside rather than in the sequence. Reach for
 them when the question is how to do something rather than what it is.

--- a/doc/knowledge/domain/volatility_hub.org
+++ b/doc/knowledge/domain/volatility_hub.org
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: 576D0E28-E783-44D4-9C0F-C7ADD307539E
+:END:
+#+title: Volatility
+#+description: Structure note for the volatility cluster: the statistical concept, the implied surface built from it, the no-arbitrage conditions it must satisfy, how it moves, and what is traded on it.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:structure_note:volatility:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+* Summary
+
+Volatility is one word for two different things, and most confusion in
+this cluster comes from sliding between them. *Realised* volatility is a
+statistic: the dispersion of returns actually observed. *Implied*
+volatility is a price: the number that makes a pricing model reproduce a
+quoted option premium. The first is measured from history, the second is
+backed out of the market, and they agree only by coincidence.
+
+The cluster follows that split and then its consequences. Once implied
+volatility is understood as a price, it has a term structure and a strike
+structure — a *surface* — which must obey constraints or it admits
+arbitrage, which moves in a particular way when spot moves, and which can
+itself be traded. Read in that order: the concept, the surface, the
+constraints on the surface, its dynamics, and finally the instruments.
+
+* Reading order
+
+** 1. The concept
+
+[[id:0CD30407-D67D-499C-B9AB-F268D05F40E4][Volatility]] — start here.
+Dispersion of returns, standard deviation, annualisation, and the
+realised-versus-implied distinction the rest of the cluster depends on.
+
+[[id:351CB816-28F5-428A-A289-414B6F4B9F36][GARCH Volatility Models]] — read
+second, while still on realised volatility. Volatility clusters rather than
+arriving independently each day, and GARCH is the standard way to model
+that. It belongs before the surface because it explains why volatility is
+not a constant, which is the reason a surface has shape at all.
+
+** 2. The surface
+
+[[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]] — the
+structure, construction and conventions: pillars in expiry and in delta,
+and the quoting conventions that make FX different from equities. This is
+the cluster's centre of gravity; everything after it is either a constraint
+on the surface or a consequence of it.
+
+** 3. What the surface must satisfy
+
+[[id:3F7A2C91-84BE-4E12-B5D0-1D6E5F08A432][Vol Surface No-Arbitrage
+Conditions]] — what arbitrage means for a surface and the conditions one
+must satisfy to be free of it. Read directly after the surface: these are
+the constraints any interpolation or fitting has to respect, and a surface
+that violates them prices a free lunch.
+
+** 4. How the surface moves
+
+[[id:96108D1A-6808-4D68-B226-FD03192C8009][Skew Stickiness Ratio]] — sticky
+strike against sticky delta, and what happens to the smile when spot moves.
+This is a dynamics question and only arises once the static shape is
+settled.
+
+[[id:0C37CE80-6795-4DEB-A318-975C53A21A0C][FX Vol Surface Driving]] — the
+driver and derived pattern applied to surfaces, for the case where one
+surface is generated deterministically from another rather than quoted in
+its own right.
+
+** 5. What is traded on it
+
+[[id:D3DF8CDD-2BD9-44BC-B805-D06C8A6C2074][Variance and Volatility
+Derivatives]] — variance and volatility swaps and options, with barriers,
+corridors and baskets. Last in the sequence because these instruments take
+the surface as an input: they are priced off it rather than contributing
+to it.
+
+** The papers, when the question is method
+
+Two research notes sit alongside rather than in the sequence. Reach for
+them when the question is how to do something rather than what it is.
+
+- [[id:EC220F01-1844-4EED-A61D-BCF9F01EE00C][Arbitrage-free surface interpolation]] — interpolating a surface without violating the conditions above.
+- [[id:3F849D36-022B-49CC-AD71-791481F36581][GJR-GARCH and neural option pricing]] — combining the realised-volatility model with a learned pricer.
+
+* What this cluster does not cover
+
+Interest rate curves are the other term structure and have their own
+structure note. They share the pillar-and-interpolation machinery, so the
+vocabulary carries over, but nothing else does: a curve discounts and a
+surface prices optionality.
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the index this structure note hangs from.
+- [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] — the sibling term-structure cluster.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — what a structure note is and why the order is authored rather than computed.

--- a/doc/knowledge/external/postgresql_row-level_security.org
+++ b/doc/knowledge/external/postgresql_row-level_security.org
@@ -66,6 +66,7 @@ through application bugs or direct database access.
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — how this project applies RLS for tenant isolation
   and service-role separation.
 - [[id:81AB065B-E6EB-4CC2-BB18-F3FD2652EC47][PostgreSQL Architecture]] — broader database conventions: schema

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -20,6 +20,26 @@ are looking for. The [[id:CF2C4F3A-9C5C-4E7A-9E16-2A3A8C1D4C11][external/]] subf
 about systems and concepts ORE Studio does not own. For user-facing
 documentation see [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]].
 
+* Where to start
+
+This index says which pages exist. A
+[[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][structure note]] says which to
+read, in what order, and why that order — the judgement search cannot
+supply. If your subject has one, start there rather than here.
+
+#+ATTR_HTML: :class hug-leading
+| Cluster | Read it to be competent at |
+|---------+----------------------------|
+| [[id:FD427B5B-BDC5-4803-AFCD-97A59E31FE25][Market Data Requirements and Resolution]] | How a logical need for market data becomes concrete items |
+| [[id:FA45D3D1-C3D9-4FDB-B03B-8AB724D71092][Interest Rate Curves]] | Discounting, bootstrapping, and the multi-curve family |
+| [[id:576D0E28-E783-44D4-9C0F-C7ADD307539E][Volatility]] | Realised against implied, the surface, and what trades on it |
+| [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] | Who an actor is, and where each layer enforces it |
+| [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] | The methodology the code generator implements |
+| [[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity Lifecycle]] | The order an entity's layers must be built in |
+
+Every structure note carries the =structure_note= tag, so listing that tag
+returns the complete set.
+
 * Domain
 
 Finance concepts the codebase relies on, grouped by topic.

--- a/doc/knowledge/masd/facet.org
+++ b/doc/knowledge/masd/facet.org
@@ -72,6 +72,7 @@ suppresses all of its archetypes' output.
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — methodology overview and the conceptual model.
 - [[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physical Space]] — the TS→Part→Facet→Archetype hierarchy and the PMM.
 - [[id:E7B74138-9ADA-4B4B-A983-23B3FDB55F44][Technical Space]] — the language ecosystem whose artefacts a facet groups.

--- a/doc/knowledge/masd/logical_space.org
+++ b/doc/knowledge/masd/logical_space.org
@@ -124,6 +124,7 @@ receiving side is described in [[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physic
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — methodology overview and the conceptual model.
 - [[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physical Space]] — how logical entities become physical artefacts.
 - [[id:E7B74138-9ADA-4B4B-A983-23B3FDB55F44][Technical Space]] — the language/platform ecosystem that hosts projections.

--- a/doc/knowledge/masd/masd.org
+++ b/doc/knowledge/masd/masd.org
@@ -272,6 +272,7 @@ MASD frames automation as a spectrum rather than a binary:
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 ** MASD concept docs (this folder)
 
 - [[id:4F24EEB9-58F1-42FD-BF4F-121D890F2D85][Logical Space]] — the LMM: entity types, packages, abstraction levels, and

--- a/doc/knowledge/masd/masd_hub.org
+++ b/doc/knowledge/masd/masd_hub.org
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: 338DCC6D-4913-4FDC-9078-1F0B0486A9E5
+:END:
+#+title: MASD
+#+description: Structure note for the MASD cluster: the methodology, its four spaces, the variability that shapes generated output, and how ORE Studio instantiates it.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:masd:structure_note:codegen:modeling:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+* Summary
+
+MASD is the methodology the code generator implements, and the cluster is
+best read as one idea unfolded. The idea: describe a domain once, in a
+space that knows nothing about any programming language, then project that
+description into as many languages and file layouts as you need. Everything
+else is the machinery that makes the projection well defined.
+
+So the order is the projection itself. Start with the methodology and its
+metamodels. Then the *logical* space, which is what you author. Then the
+*technical* and *physical* spaces, which are what you project into. Then
+*facets*, which group the projected artefacts. Then *variability*, which
+is how one logical model yields different output without being forked.
+Finish with how this project actually instantiates all of it, which is
+where the abstractions acquire file paths.
+
+Reading the spaces out of order is the common mistake. Physical space
+looks approachable because it is just files, but its concepts are defined
+against the logical model they came from, and it reads as arbitrary
+without it.
+
+* Reading order
+
+** 1. The methodology
+
+[[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — start here. The
+logical-physical split and the four metamodels. Read it as a map: it names
+every part the following pages treat in detail, and the names do not
+change afterwards.
+
+** 2. What you author
+
+[[id:4F24EEB9-58F1-42FD-BF4F-121D890F2D85][Logical Space]] — the Logical
+Metamodel, its packages, and its levels of abstraction. This is the space
+a modeller works in and the only one where a domain concept exists as
+itself rather than as a projection of itself.
+
+** 3. What you project into
+
+[[id:E7B74138-9ADA-4B4B-A983-23B3FDB55F44][Technical Space]] — a language
+or platform with its conventions. Read before physical space, because it
+is what makes a physical artefact meaningful: the same logical class is a
+different file in C++ than it is in SQL.
+
+[[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physical Space]] — files,
+folders, file morphology, and the component structure. Now the file layout
+reads as a consequence rather than a convention.
+
+** 4. How the projected artefacts group
+
+[[id:B079DA67-8408-4BD0-A93C-D108AC780872][Facet]] — a container for
+related artefacts of one technical space. Facets are what the generator's
+templates are organised by, so this is the page that connects the
+methodology to the template library.
+
+** 5. How one model yields different output
+
+[[id:CE95C751-2125-4BA9-A78D-C30F9540FC5E][Variability]] — the Variability
+Metamodel: features, profiles, and non-structural variation. Read after
+facets, because variability is expressed as choices within a projection
+and there is nothing to vary until the projection exists.
+
+** 6. How this project does it
+
+[[id:43FF3591-AD18-4CE3-8239-A220862C9B5A][Applied MASD]] — the mapping
+from each MASD concept onto ORE Studio's own directories, models and
+templates. This is where the vocabulary acquires paths, and it is the page
+to return to when a concept is clear in theory and unclear in the tree.
+
+[[id:608675E1-4284-4902-99AC-4DA565390AFB][Entity Lifecycle]] — the
+cross-facet ordering: which layer of an entity is generated before which,
+and why. Read last, and read it before doing any entity work: it is the
+operational consequence of everything above, and the order it prescribes
+is not negotiable.
+
+* What this cluster does not cover
+
+The skills framework borrows MASD's shape — a target with a type, and
+operations registered against the type — but it is a separate cluster with
+its own entry point.
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the index this structure note hangs from.
+- [[id:AEBC2BC9-A854-4CEC-BA88-1602490AC762][Skill architecture]] — the same dispatch shape, applied to skills rather than code.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — what a structure note is and why the order is authored rather than computed.

--- a/doc/knowledge/masd/physical_space.org
+++ b/doc/knowledge/masd/physical_space.org
@@ -157,6 +157,7 @@ regeneration. See [[id:4F24EEB9-58F1-42FD-BF4F-121D890F2D85][Logical Space]] for
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — methodology overview and the conceptual model.
 - [[id:4F24EEB9-58F1-42FD-BF4F-121D890F2D85][Logical Space]] — the meta-model that physical artefacts are projected from.
 - [[id:E7B74138-9ADA-4B4B-A983-23B3FDB55F44][Technical Space]] — the outermost grouping in physical space.

--- a/doc/knowledge/masd/technical_space.org
+++ b/doc/knowledge/masd/technical_space.org
@@ -68,6 +68,7 @@ without affecting the others.
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — methodology overview and the conceptual model.
 - [[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physical Space]] — the TS→Part→Facet→Archetype hierarchy and the PMM.
 - [[id:4F24EEB9-58F1-42FD-BF4F-121D890F2D85][Logical Space]] — the meta-model that logical entities live in.

--- a/doc/knowledge/masd/variability.org
+++ b/doc/knowledge/masd/variability.org
@@ -142,6 +142,7 @@ override them surgically at component or element level.
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — methodology overview and the conceptual model.
 - [[id:B079DA67-8408-4BD0-A93C-D108AC780872][Facet]] — what variability most often controls (facet activation).
 - [[id:787A7429-71D5-4295-829B-A9B56275B1F8][Physical Space]] — the space whose regions variability enables or disables.

--- a/doc/knowledge/security/identity_and_access_hub.org
+++ b/doc/knowledge/security/identity_and_access_hub.org
@@ -1,0 +1,80 @@
+:PROPERTIES:
+:ID: AF46793A-FF6C-4066-A059-279CE9936420
+:END:
+#+title: Identity and Access
+#+description: Structure note for the identity and access cluster: who an actor is, what roles grant them, how a service acts for a user, and where the database enforces the boundary.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:security:structure_note:identity:access:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+* Summary
+
+Access control in this system is decided in two places, and knowing which
+is which is the point of reading the cluster in order. The *application*
+decides what an authenticated actor is allowed to ask for, through roles
+and permissions. The *database* decides what rows that actor may see at
+all, through row-level security. The second is the backstop: a bug in the
+first is contained by it, which is why both exist.
+
+Between those two sits the awkward case that generates most of the
+subtlety here — a service acting on behalf of a user rather than as
+itself. Read the cluster as: what an identity is, what a role grants it,
+how a service borrows one, and what the database enforces regardless.
+
+* Reading order
+
+** 1. What an identity is
+
+[[id:8AEB87D6-0CE2-1434-E71B-60BEAE20ADF0][Identity and Access
+Management]] — start here. The identity lifecycle, authentication against
+authorisation, and the vocabulary the rest of the cluster uses. The
+authentication and authorisation distinction is worth slowing down on:
+almost every access bug is one being mistaken for the other.
+
+** 2. What a role grants
+
+[[id:3CAA394F-E84C-3434-331B-6E664F7E84D2][Role-Based Access Control]] —
+roles compose permissions, users are assigned roles. Read second, because
+it is the concrete model the abstract vocabulary above resolves to, and it
+is what the application layer actually consults.
+
+[[id:C84899BD-5EC8-4AA7-88D7-CE7ED19BC573][Book Access and Permissions]] —
+the same model applied to the entity where it matters most. Useful as the
+worked example: the allowed-currency set that constrains what may be
+booked shows permissions doing real domain work rather than guarding a
+screen.
+
+** 3. How a service acts for a user
+
+[[id:3E20C1A0-7BA1-4F31-8C34-1E5F13558890][Service-to-Service Auth
+Patterns]] — what happens when one service must call another, and the
+choice between a service acting as itself and acting for the caller.
+
+[[id:AAC60D20-8696-4455-9292-E8FAE1389CBC][Internal Actor Impersonation]] —
+the pattern we use: a service self-mints a short-lived token impersonating
+a specific end user. Read it straight after the patterns note, because it
+is the one we chose from among them, and read both before touching any
+service-to-service call.
+
+** 4. What the database enforces regardless
+
+[[id:B28747DF-A735-1C84-4E43-11ADFA8B05E3][PostgreSQL Row-Level Security]] —
+the database mechanism, described before any project-specific use of it.
+Deliberately last: it is the backstop, and it is easier to see why the
+backstop is shaped as it is once the application-level model above is
+clear. An agent changing a query that crosses a tenant boundary should
+have read this page first.
+
+* Reading it in reverse
+
+There is one case for inverting the order. If you are debugging a query
+that returns fewer rows than expected, start at row-level security and
+work upwards: the database is the layer most likely to be silently
+filtering, and it does so by design rather than by error.
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the index this structure note hangs from.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — what a structure note is and why the order is authored rather than computed.

--- a/doc/knowledge/security/identity_and_access_management.org
+++ b/doc/knowledge/security/identity_and_access_management.org
@@ -50,6 +50,7 @@ right resource.
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.core]] — domain types and business logic.
 - [[id:3CAA394F-E84C-3434-331B-6E664F7E84D2][Role-Based Access Control]] — the role/permission model that
   backs authorisation.

--- a/doc/knowledge/security/role_based_access_control.org
+++ b/doc/knowledge/security/role_based_access_control.org
@@ -47,6 +47,7 @@ their assignments live in [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.co
 
 * See also
 
+- [[id:AF46793A-FF6C-4066-A059-279CE9936420][Identity and Access]] — the structure note that orders this cluster, and where to read this page in it.
 - [[id:8AEB87D6-0CE2-1434-E71B-60BEAE20ADF0][Identity and Access Management]] — the security subsystem that
   applies this model.
 - [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.core]] — where the role/permission entities live.

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -105,7 +105,12 @@ It then enters =compass-helm=, which matches the work to a *method* and
 copies that method's phases in. The method opens by
 grounding itself in the domain, resolving each concept it touches to a
 knowledge document and treating an unresolved one as the first task
-([[id:F5CB5A45-6557-410B-9E4F-542957561A16][Regulatory Functions]]). It states
+([[id:F5CB5A45-6557-410B-9E4F-542957561A16][Regulatory Functions]]). Where
+the concept belongs to a cluster with a
+[[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][structure note]], grounding reads
+that note first and follows its order: it names which pages are
+load-bearing and which can wait, which a search ranking cannot. Listing the
+=structure_note= tag returns the clusters that have one. It states
 a finish condition, backed by a *specification* where behaviour is involved.
 
 The method's phases cite *principles* for judgement calls and call

--- a/projects/modeling/applied_masd.org
+++ b/projects/modeling/applied_masd.org
@@ -546,6 +546,7 @@ as the fitness function.
 
 * See also
 
+- [[id:338DCC6D-4913-4FDC-9078-1F0B0486A9E5][MASD]] — the structure note that orders this cluster, and where to read this page in it.
 ** MASD methodology (knowledge)
 
 - [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — the methodology and conceptual model this document applies.

--- a/projects/modeling/entity_lifecycle.org
+++ b/projects/modeling/entity_lifecycle.org
@@ -5,7 +5,7 @@
 #+description: The cross-facet lifecycle of an ORE Studio entity: layer ordering, type mappings, and service conventions spanning all MASD facets.
 #+type: knowledge
 #+level: cross
-#+filetags: :knowledge:masd:facet:modeling:architecture:entity:lifecycle:
+#+filetags: :knowledge:masd:facet:modeling:architecture:entity:lifecycle:structure_note:
 #+created: 2026-05-21
 #+updated: 2026-05-21
 
@@ -47,18 +47,26 @@ D --> Q  : service → Qt model
 @enduml
 #+end_src
 
-Build all layers in order. An exposure layer must not be created
-before its domain type and SQL schema are merged.
+Build all layers in order, which is the argued reading order for this
+cluster as well as the build order. An exposure layer must not be created
+before its domain type and SQL schema are merged: every exposure layer
+projects the domain type, so building one first means guessing at a shape
+that is still moving, and the SQL schema is what fixes that shape. The five
+exposure layers are independent of each other and may be built in any
+order among themselves, or in parallel.
+
+Each row's pattern document is the page to read before writing that layer;
+each row's recipe carries the commands.
 
 | Layer | Skill | Pattern doc | Recipe |
 |---|---|---|---|
-| Domain type | [[id:B1450696-8C51-4CC5-8910-84912A411AB6][domain-type-creator]] | (this doc §Type mappings) | — |
-| SQL schema | [[id:A08FC2A2-4E42-41EC-AC92-D1AF50DC61CB][sql-schema-creator]] | [[id:5CB31A0E-4E38-4521-B0EE-E4396C3E2936][SQL entity schema patterns]] | [[id:479F858E-AA31-4DB4-ABE9-A0ED7CEBF098][How do I create a new entity SQL schema?]] |
+| Domain type | [[id:B1450696-8C51-4CC5-8910-84912A411AB6][compass-code-add-domain-type]] | (this doc §Type mappings) | — |
+| SQL schema | [[id:A08FC2A2-4E42-41EC-AC92-D1AF50DC61CB][compass-codegen-add-sql-schema]] | [[id:5CB31A0E-4E38-4521-B0EE-E4396C3E2936][SQL entity schema patterns]] | [[id:479F858E-AA31-4DB4-ABE9-A0ED7CEBF098][How do I create a new entity SQL schema?]] |
 | HTTP endpoints | [[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][compass-codegen-add-surface-entity]] | [[id:579910D3-89FF-4820-9A9B-57508FF39096][HTTP entity patterns]] | [[id:C9EEAAD1-1E78-4775-A05F-19573E669BD9][How do I create HTTP endpoints for a new entity?]] |
-| CLI commands | [[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][cli-entity-creator]] | [[id:05891220-2503-48A0-ADF5-13EC95B605D7][CLI entity patterns]] | [[id:662881DC-1371-4DAD-A868-72D8BAE0E919][How do I create CLI commands for a new entity?]] |
+| CLI commands | [[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][compass-codegen-add-surface-entity]] | [[id:05891220-2503-48A0-ADF5-13EC95B605D7][CLI entity patterns]] | [[id:662881DC-1371-4DAD-A868-72D8BAE0E919][How do I create CLI commands for a new entity?]] |
 | Shell commands | [[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][compass-codegen-add-surface-entity]] | [[id:E38360B6-99FF-4AF0-937F-58F31BD573F5][Shell entity patterns]] | [[id:083C1060-F952-4505-B066-FED5684CDD5D][How do I create shell commands for a new entity?]] |
 | Wt UI | [[id:809AAE41-950C-4E0C-85B7-0D50BC4A775F][compass-codegen-add-surface-entity]] | [[id:ACF334D8-703B-4020-A48E-F8A8E5090E72][Wt entity patterns]] | [[id:6FDB2F56-789F-4AD4-879E-BA5A1621F807][How do I create Wt widgets for a new entity?]] |
-| Qt UI | [[id:C6ADAC80-F4E6-44E8-9525-3760CB98C41D][qt-entity-creator]] | [[id:2FDDC2F6-C510-4A86-8C50-D79C83EDDFFF][Qt entity patterns]] | [[id:25167ED8-6CCC-43AC-9978-026E6AD581FC][How do I create Qt UI for a new entity?]] |
+| Qt UI | [[id:C6ADAC80-F4E6-44E8-9525-3760CB98C41D][compass-codegen-add-qt-entity]] | [[id:2FDDC2F6-C510-4A86-8C50-D79C83EDDFFF][Qt entity patterns]] | [[id:25167ED8-6CCC-43AC-9978-026E6AD581FC][How do I create Qt UI for a new entity?]] |
 
 * Type mappings
 
@@ -192,7 +200,7 @@ must be replaced with generated output once the profile exists.
 * See also
 
 - [[id:0CBA2F23-7F5F-433D-921A-D9C056BD9CA8][entity-creator]] — orchestrator skill; use this when adding a new entity.
-- [[id:B1450696-8C51-4CC5-8910-84912A411AB6][domain-type-creator]] — first layer skill.
+- [[id:B1450696-8C51-4CC5-8910-84912A411AB6][compass-code-add-domain-type]] — first layer skill.
 - [[id:08FBD248-257A-A474-DD43-DB08949978F1][ORE Studio Codegen]] — codegen component model, profile catalogue, model schema.
 - [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ORE Studio SQL Schema]] — schema mental model and PostgreSQL setup.
 - [[id:50246CF5-EB61-4261-890F-4E75D3241863][ores.cpp.repository]], [[id:A5B138BE-4244-42C5-9EE7-FF9B4C8AB6B3][ores.cpp.service-app]] — the literate templates for the repository and service facets.


### PR DESCRIPTION
## Summary

The knowledge index says which pages exist. It cannot say which of forty are load-bearing, nor in what order to read them, and that judgement is authored rather than computed. Six domain clusters now have a structure note that supplies it.

## Changes

- Two clusters already had their entry point: market data resolution was a full structure note under the name hub note, and entity lifecycle already carried the layer ordering per row. Both are now named and tagged as such, and the entity lifecycle states why its order holds rather than only asserting it.
- Interest Rate Curves — pillars before interpolation, because interpolation is only a question once the curve is known to be defined at finitely many points.
- Volatility — realised before implied, because the surface is a price rather than a measurement.
- Identity and Access — the application layer before the database backstop, with the reverse order given for the one case that inverts it, debugging a query that returns too few rows.
- MASD — logical space before physical, because a file layout reads as arbitrary without the model it projects.
- link_structure_notes.py adds a back-link from every page a hub orders, so a reader who lands by search learns the order exists. The hubs declare their own membership and the outward-pointing sections are headings so the scan can stop there. --check runs in Doc Lint as the seventh check.
- Zettelkasten described the theory and said we had none; it now carries the convention and the three rules that keep a note honest. The grounding phase reads a cluster's structure note first where one exists.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Add structure notes to the knowledge Zettelkasten](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_knowledge_structure_notes.html) | 6766A23C-0357-4873-B5BF-B5A71BF0B1D5 |
| Environment | bright_faraday | |

## Testing

Plan. Write the notes, wire them both ways, prove the set is listable as a whole, and run the docs checks over a change touching forty documents.

Evidence. docs. compass list --tag structure_note returns all six. 33 back-links added across the pages the hubs order, and link_structure_notes.py --check passes. compass lint: clean, durable-link advisory unchanged at its pre-existing 158. Site build: Build succeeded, which is the check that matters for a change spanning this many documents. misspell-fixer on the four new notes and the script: nothing to replace.

Limitations. No code was touched, so no build, ctest or drift run. The reading orders are judgements and the reviewer should challenge them rather than check them: I argued each from the dependencies between the pages, not from measured reader behaviour. Interpolation is ordered by two hubs and carries a back-link to each, which is expected in a Zettelkasten rather than a fault. Clusters beyond the six named in the task still have only the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)