### PR TITLE
[doc] Cite the principles under the citation function

### DIFF
--- a/build/scripts/apply_skill_levels.py
+++ b/build/scripts/apply_skill_levels.py
@@ -115,6 +115,11 @@ LEVELS = {
     # Identity: what belongs in the product at all.
     "compass-agile-brainstorm-idea": "s5",
 
+    # Bindings on an upstream principle. The level is the level of the
+    # judgement the principle is cited at, not of the principle itself.
+    "compass-principle-type-system-discipline": "s1",
+    "compass-principle-never-block-on-the-human": "cross",
+
     # Every level acts on these: the documents and skills themselves, and
     # the orientation any System starts from.
     "compass-doc-add": "cross",

--- a/build/scripts/generate_skills_catalogue.py
+++ b/build/scripts/generate_skills_catalogue.py
@@ -43,6 +43,11 @@ DOMAINS = {
     "devops": ("DevOps (=compass-devops-=)",
                "Environment, database, services, shell, client, site."),
     "skill": ("Skills (=compass-skill-=)", "The skills themselves."),
+    # Not a domain: the reserved second segment for a rule that is cited
+    # rather than run. See the naming conventions.
+    "principle": ("Principles (=compass-principle-=)",
+                  "Local bindings on an upstream principle, supplying the "
+                  "project detail the rule cannot know."),
 }
 
 # Planned-but-not-yet-created skills, shown as prose under each section.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -83,7 +83,7 @@ Tasks are listed in intended execution order.
 | [[id:F4EF0C2D-B32E-4705-AE0F-AAC3E027FF59][Separate skill judgement from recipe commands]] | DONE | 2026-09-10 | 2026-09-10 | Make every action delegate its commands to a recipe and keep only the judgement, so each has one source of truth. |
 | [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | DONE | 2026-09-10 | 2026-09-10 | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
-| [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | BACKLOG | | | Cite the eleven adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
+| [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | DONE | 2026-09-10 | 2026-09-10 | Cite the thirteen adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
 | [[id:08F7F925-49B2-40E0-A298-E300353CAE2E][Port the sequencing function and bind it to recipes and actions]] | BACKLOG | | | Import the adopted methods and interview skills as compass-method skills, with every step bound to one of our actions or recipes. |
 | [[id:60C7573C-763F-466D-A174-61C3A78616AF][Build compass-helm, the sticky mode]] | BACKLOG | | | One sticky entry point that declares the session System, matches work to a method, copies its phases in verbatim, and routes to actions, recipes and deliberation. |
 | [[id:BC52784C-64A6-47D2-AE13-BA8530C34507][Bind the Council to the convening function]] | BACKLOG | | | Wire the Council of High Intelligence in as the convening function, and route error detection to the checkers that are genuinely independent. |
@@ -155,6 +155,12 @@ Tasks are listed in intended execution order.
 - A hub declares its own cluster membership, and the sections that point
   outside it are headings so a script can tell the difference. The first
   back-link sweep wrongly claimed four pages a hub merely cross-referenced.
+- A principle is cited, not copied. Forking an upstream rule severs the
+  feedback path that lets it improve; the local artefact is the grouping and
+  the bindings where our detail differs, and nothing else.
+- Every candidate principle is tested against the encode-as-a-check rule
+  before it earns a place in the citation function. The shared stash stack
+  went that way: it is a hook now, not a paragraph.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -99,6 +99,7 @@ Tasks are listed in intended execution order.
 | [[id:9F694794-A0A0-4625-A6C9-38B8743EC2FF][Add the missing document type templates to codegen]] | BACKLOG | | | The design type has a contract and no mustache template, so compass add design does not exist; audit every type contract against the template library. |
 | [[id:39264768-EE92-4DB1-B048-3C960415B358][Specify the skills framework as a regulator]] | DONE | 2026-09-07 | 2026-09-07 | Respecify the framework as a regulator over an agent, deriving its scope and its seven classes of document from cybernetics rather than stipulating them, and classify the upstream pstack collection against that derivation. |
 | [[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][Delegate the remaining skill commands to recipes]] | DISCOVERED | | | Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place. |
+| [[id:A849F82C-0AE6-4217-90FC-F17443B3C168][Enable the compiler warnings the code assumes]] | DISCOVERED | | | The build sets -Werror and nothing else, so -Wall and -Wextra diagnostics never fire; enable them and clear what they surface. |
 
 * Decisions
 
@@ -161,6 +162,10 @@ Tasks are listed in intended execution order.
 - Every candidate principle is tested against the encode-as-a-check rule
   before it earns a place in the citation function. The shared stash stack
   went that way: it is a hook now, not a paragraph.
+- A document that claims a compiler enforces something must be checked
+  against the build, not against the language. The binding asserted
+  =-Wswitch= catches a missing enumerator; the build enables only
+  =-Werror=, so nothing catches it.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_enable_compiler_warnings.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_enable_compiler_warnings.org
@@ -1,0 +1,99 @@
+:PROPERTIES:
+:ID: A849F82C-0AE6-4217-90FC-F17443B3C168
+:END:
+#+title: Task: Enable the compiler warnings the code assumes
+#+description: The build sets -Werror and nothing else, so -Wall and -Wextra diagnostics never fire; enable them and clear what they surface.
+#+type: task
+#+level: s1
+#+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The build escalates warnings to errors and enables almost none of them.
+=projects/CMakeLists.txt= sets =-Werror= for GCC and Clang and nothing
+else; =-Wall= and =-Wextra= are absent from every =CMakeLists.txt= and
+=.cmake= in the tree. =-Werror= only escalates what is already on, so the
+diagnostics that catch real defects never fire.
+
+The concrete case that surfaced this: a =switch= over an =enum class= that
+misses an enumerator compiles clean here. =-Wswitch= would catch it and
+arrives with =-Wall=, so today nothing does. Verified by compiling a
+non-exhaustive switch with =-Werror= alone, which succeeded.
+
+That makes a type-discipline rule this project relies on unenforceable,
+and it is why =compass-principle-type-system-discipline= currently has to
+describe exhaustive matching as advice rather than as a mechanism.
+
+The sweep is the work rather than the flag. 174 files carry a =default:=
+label in a switch, and each one has to be judged: a =default:= on a closed
+enum hides exactly the case the warning exists to find, while a
+=default:= over an open set is legitimate.
+
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DISCOVERED                              |
+| Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
+| Now          | Discovered in review of PR #2056.       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-10                               |
+
+* Acceptance
+
+- =-Wall= and =-Wextra= are enabled for GCC and Clang, with the MSVC equivalent alongside the existing =/WX=.
+- Everything the new warnings surface is fixed rather than suppressed; any suppression names the reason in place.
+- A =switch= over a closed enum that misses an enumerator fails the build, demonstrated by a case that fails before the fix and passes after.
+- =default:= labels over closed enums are removed where the enum is genuinely closed, and kept where the set is open.
+- The exhaustive-matching section of =compass-principle-type-system-discipline= is rewritten to describe a mechanism rather than an aspiration.
+
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:principles:pstack:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/port-principles-layer
-#+pr:
+#+pr: 2056
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -107,7 +107,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2056][#2056]] | [doc] Cite the principles under the citation function |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
@@ -35,7 +35,7 @@ The citation function holds rules an agent cites rather than runs. Port the psta
 
 * Acceptance
 
-- Every adopted principle is a loadable skill named after its rule.
+- Every adopted principle is loadable and cited by name from our catalogue. Amended from /ported as its own skill/ once the reference-not-fork decision landed; see =* Result=.
 - Principles written for another language or host are adapted, and the adaptation is recorded as a divergence.
 - never-block-on-the-human is reconciled against our conventions on irreversible actions and unrequested pull requests, and the resolution is recorded.
 - An index lists the principles by group so a method can read the set at task start.
@@ -113,7 +113,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | The C++ binding says a missing enumerator is caught by =-Wswitch=, but the build sets only =-Werror=, which does not enable it | doc/llm/skills/compass-principle-type-system-discipline/SKILL.org | Accept | Verified before acting: a non-exhaustive switch compiles clean with =-Werror= alone. The section now says the warning is off and why the advice still holds, and enabling it is its own task |
+| 2 | The acceptance bullet still reads /ported as its own skill/, so a reader skimming the table sees a criterion the work does not meet | task_port_principles_layer.org | Accept | Amended to /loadable and cited by name/, with the amendment and its date-ordered reason stated in place rather than only in the Result |
+| 3 | =sequence-verifiable-units= sits at the gate beside =prove-it-works=, but sequencing is a planning decision | doc/llm/skills/principles.org | Accept | Moved to /before writing anything/, with the reason: a split settled as the pull request opens has already cost what it was going to cost |
+| 4 | The citation-not-porting call is right, and grounded in a decision that predates this PR | — | Accept | No change. The reviewer checked the decision log rather than taking the task's framing on trust, which is what makes the verdict worth having |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.org
@@ -2,18 +2,18 @@
 :ID: A7BCF024-9222-40C3-9151-AFE9C9B4BDBE
 :END:
 #+title: Task: Cite the principles under the citation function
-#+description: REFRAMED by the reference approach. The eleven adopted pstack principles are referenced upstream rather than ported; this task now covers citing them from our catalogue and writing the thin local bindings, not copying them.
+#+description: REFRAMED by the reference approach. The thirteen adopted pstack principles are referenced upstream rather than ported; this task now covers citing them from our catalogue and writing the thin local bindings, not copying them.
 #+type: task
 #+level: s1
 #+filetags: :llm:skills:principles:pstack:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/port-principles-layer
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ The citation function holds rules an agent cites rather than runs. Port the psta
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -45,11 +45,52 @@ The citation function holds rules an agent cites rather than runs. Port the psta
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The acceptance was written before the reference approach settled, so it
+asks for principles to be ported as skills. Porting them would fork
+thirteen upstream documents, which the collection page argues against at
+length and which the abandoned attribution task already decided against.
+The work therefore cites rather than copies, and writes a local skill only
+where the upstream rule is wrong in local detail.
+
+[[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] is the index: the
+thirteen grouped by when they are cited — before writing, while designing,
+while working, at the gate, after the fact — so a phase can reach for the
+two that bear on its decision rather than reading the set. It carries the
+upstream attribution once for the collection, which is where the
+attribution belongs when nothing is forked.
+
+Two needed a binding. =type-system-discipline= is written for TypeScript
+and its intent survives the move to C++ while several mechanisms do not,
+so the binding is a translation table plus the two patterns the language
+makes harder: exhaustive matching, which the compiler will not enforce
+once a =default:= label appears, and branding, which costs a struct and
+its operators rather than a type alias. =never-block-on-the-human= reads
+as opposed to our confirmation conventions and is not, so the binding
+states the single criterion that resolves it: proceed where a written
+record makes the choice reversible, confirm where the cost is paid before
+anyone reads the trail.
 
 * Notes
+
+The audit said eleven of twenty-one principles were adopted; its own table
+says thirteen. Two rows had been changed to Adopt with a note reading "see
+below" and the count was never updated. Fixed here, in the collection page
+and in the two agile documents repeating the figure, because the set this
+task cites is the set that table defines.
+
+The encode-as-a-check test found one rule worth moving out of prose.
+=separate-before-serializing-shared-state= is literally true of the stash
+stack: every worktree shares one, so a bare push contends for its top and
+a bare pop can take another session's work. That rule existed only as
+prose in the session prompt, so it is now a =PreToolUse= hook that denies
+the two bare forms and names the safe ones in the denial.
+
+Writing the hook demonstrated the point twice over. Its first pattern
+denied =echo git stash is shared=, which meant the deployed hook blocked
+the very commands I was using to fix it — the rule was live and enforcing
+before it was right. The parser now reads the subcommand rather than
+matching the tail, and the false positive has its own test.
+
 
 * Test Scenarios
 
@@ -75,3 +116,31 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All seven acceptance criteria are met, with one reinterpreted against a
+later decision and the reinterpretation recorded.
+
+Reinterpreted: /every adopted principle is a loadable skill named after
+its rule/. The thirteen are loadable as the upstream skills they already
+are, and they are cited from
+[[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] rather than
+copied. Forking them would contradict the reference-not-fork argument the
+collection page makes and the attribution task that was abandoned on those
+grounds.
+
+The two principles wrong in local detail have bindings:
+=compass-principle-type-system-discipline= recasts the rule for C++, and
+=compass-principle-never-block-on-the-human= reconciles it against our
+conventions on irreversible and outward-facing actions. Both divergences
+are stated in the binding itself rather than in a changelog.
+
+The index groups the thirteen by the moment they are cited, which is what
+lets a method read the set at task start without reading all of it. The
+upstream repository, plugin, version and maintainers are recorded once for
+the collection, which is the right granularity when nothing is forked.
+
+Every candidate was tested against the encode-as-a-check rule. One moved:
+the shared stash stack is now enforced by a hook rather than advised in
+prose. The seven rules a check already carries are listed in the index
+with what checks them, so an agent can see why they are absent from the
+citation list.

--- a/doc/llm/claude_code_settings.org
+++ b/doc/llm/claude_code_settings.org
@@ -905,6 +905,184 @@ def test_recording_failure_never_blocks_the_tool(monkeypatch, tmp_path):
     assert hook.main() == 0
 #+end_src
 
+** Deny bare use of the shared stash stack
+
+Every worktree in the fleet shares one stash stack, because the stack
+lives in the common git directory rather than in the checkout. A bare
+=git stash= pushes onto a stack other sessions are also pushing onto, and
+a bare =git stash pop= takes whatever is on top — which may be another
+session's work, in another worktree, mid-task.
+
+This is [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][principle-separate-before-serializing-shared-state]]
+in its most literal form, and the principle's own advice is the fix:
+eliminate the sharing rather than coordinate over it. A temporary commit
+on the branch shares nothing. Where the stash is genuinely wanted, a
+tagged entry addressed by its own hash shares the stack without
+contending for its top.
+
+The rule was prose before it was a hook, and prose is what a session
+under pressure skips. The hook denies the two bare forms and names the
+safe ones in the denial, so the correction arrives with the refusal
+rather than in a document the agent would have to already be reading.
+
+*What is denied.* =git stash= and =git stash save= with no message, and
+=git stash pop= in any form. What stays allowed: =push= with a message,
+=apply= against an explicit entry, =list=, =show=, and =drop=.
+
+#+begin_src python :tangle ../../projects/ores.compass/src/deny_bare_stash_hook.py :mkdirp yes :shebang "#!/usr/bin/env python3"
+"""PreToolUse hook: deny bare use of the shared git stash stack.
+
+Every worktree shares one stack, so a bare push contends for its top and
+a bare pop can take another session's work. See
+doc/llm/claude_code_settings.org's Hooks section.
+"""
+import json
+import re
+import sys
+
+# Each invocation in the command line, taken up to the next shell
+# separator so a compound command is checked per part.
+INVOCATION_RE = re.compile(r"(?:^|[\s&;(])git\s+stash\b([^&;|)]*)")
+MESSAGE_RE = re.compile(r"(?:^|\s)(?:-m|--message)(?:[=\s]|$)")
+
+# The forms that add an entry to the stack. Everything else either names
+# the entry it acts on (apply, drop, show) or is not a stash command at
+# all, which matters because the words appear in prose about this rule.
+PUSHES = {"", "push", "save"}
+
+DENIAL_MESSAGE = (
+    "The stash stack is shared by every worktree in the fleet, so a bare "
+    "`git stash` contends for its top and a bare `git stash pop` can take "
+    "another session's work.\n"
+    "Prefer a temporary WIP commit, which shares nothing. If you do need "
+    "the stash: `git stash push -u -m \"<unique-tag>\"`, capture the SHA "
+    "with `git stash list --format='%H %gs'`, and restore with "
+    "`git stash apply <sha>` rather than pop. Drop the entry afterwards, "
+    "re-finding it by tag.\n"
+)
+
+
+def denied(command: str) -> bool:
+    """True when the command pushes onto or pops off the shared stack
+    without naming what it acts on."""
+    for m in INVOCATION_RE.finditer(command):
+        rest = m.group(1)
+        words = [w for w in rest.split() if not w.startswith("-")]
+        sub = words[0] if words else ""
+        if sub == "pop":
+            return True
+        if sub not in PUSHES:
+            continue
+        # A message is what makes the entry findable again by its own tag
+        # rather than by its position on a stack others are pushing to.
+        if not MESSAGE_RE.search(rest):
+            return True
+    return False
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+        return 0
+    if denied(data.get("tool_input", {}).get("command", "")):
+        sys.stderr.write(DENIAL_MESSAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+#+end_src
+
+#+begin_src python :tangle ../../projects/ores.compass/tests/test_deny_bare_stash_hook.py :mkdirp yes
+"""
+Tests for the bare-stash PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_bare_stash_hook.py -v
+No live database required.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_bare_stash_hook as hook
+
+
+def run(command, monkeypatch, tool_name="Bash"):
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return hook.main()
+
+
+def test_bare_stash_is_denied(monkeypatch):
+    assert run("git stash", monkeypatch) == 2
+
+
+def test_bare_pop_is_denied(monkeypatch):
+    assert run("git stash pop", monkeypatch) == 2
+
+
+def test_pop_with_a_ref_is_still_denied(monkeypatch):
+    """A ref does not help: the entry it names may be another session's."""
+    assert run("git stash pop stash@{0}", monkeypatch) == 2
+
+
+def test_save_without_a_message_is_denied(monkeypatch):
+    assert run("git stash save", monkeypatch) == 2
+
+
+def test_tagged_push_is_allowed(monkeypatch):
+    assert run('git stash push -u -m "wip-bright-faraday"', monkeypatch) == 0
+
+
+def test_apply_against_an_explicit_entry_is_allowed(monkeypatch):
+    assert run("git stash apply 8f2a1c3", monkeypatch) == 0
+
+
+def test_reads_are_allowed(monkeypatch):
+    assert run("git stash list", monkeypatch) == 0
+    assert run("git stash show -p", monkeypatch) == 0
+
+
+def test_drop_is_allowed(monkeypatch):
+    assert run("git stash drop stash@{2}", monkeypatch) == 0
+
+
+def test_denial_survives_a_compound_command(monkeypatch):
+    assert run("cd /tmp && git stash", monkeypatch) == 2
+
+
+def test_unrelated_commands_pass(monkeypatch):
+    assert run("git status", monkeypatch) == 0
+
+
+def test_the_words_inside_a_message_are_not_a_command(monkeypatch):
+    """The first pattern denied this, which blocked writing about the
+    rule while explaining it."""
+    assert run("echo git stash is shared", monkeypatch) == 0
+
+
+def test_push_with_flags_but_no_message_is_denied(monkeypatch):
+    assert run("git stash push -u", monkeypatch) == 2
+
+
+def test_other_tools_are_ignored(monkeypatch):
+    assert run("git stash", monkeypatch, tool_name="Read") == 0
+
+
+def test_malformed_payload_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
+#+end_src
+
 #+begin_src json :tangle no :noweb-ref hooks-pretooluse
     "PreToolUse": [
       {
@@ -922,6 +1100,15 @@ def test_recording_failure_never_blocks_the_tool(monkeypatch, tmp_path):
           {
             "type": "command",
             "command": "sh -c 'f=projects/ores.compass/src/record_skill_selection_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=projects/ores.compass/src/deny_bare_stash_hook.py; if [ -f \"$f\" ]; then python3 \"$f\"; else exit 0; fi'"
           }
         ]
       }

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -150,6 +150,15 @@ The skills themselves.
 | [[id:44D7A328-F69C-4EE9-83A5-74BD3634AD69][compass-skill-review]] | Skill Review Skill | Review existing skills against the skill contract. Use when auditing skill quality, before adding a new ski... |
 | [[id:52DA0E52-ABB6-4AC3-A586-BA6336F08FDA][compass-skill-show-catalogue]] | Skill Show Catalogue | Show the skills catalogue nicely grouped by domain prefix, with each skill's name, title, and description —... |
 
+* Principles (=compass-principle-=)
+
+Local bindings on an upstream principle, supplying the project detail the rule cannot know.
+
+| Name | Title | Description |
+|------+-------+-------------|
+| [[id:D1F13734-216D-47AA-BA00-28F3A20F97C1][compass-principle-never-block-on-the-human]] | Compass Principle Never Block On The Human | The local binding for never-block-on-the-human — proceed on reversible work and record the assumption; conf... |
+| [[id:FAABB6FF-FA3A-4E5C-B0B7-FE3E2E661A6C][compass-principle-type-system-discipline]] | Compass Principle Type System Discipline | The C++ binding for type-system-discipline — what each upstream pattern becomes in this codebase, which the... |
+
 # END generated catalogue
 
 * Rebuilding skills

--- a/doc/llm/skills/compass-principle-never-block-on-the-human/SKILL.org
+++ b/doc/llm/skills/compass-principle-never-block-on-the-human/SKILL.org
@@ -1,0 +1,105 @@
+:PROPERTIES:
+:ID: D1F13734-216D-47AA-BA00-28F3A20F97C1
+:END:
+#+title: Compass Principle Never Block On The Human
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: cross
+#+filetags: :llm:skill:skills:claude_code:principle:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-principle-never-block-on-the-human
+description: The local binding for never-block-on-the-human — proceed on reversible work and record the assumption; confirm what a record cannot repair, which here means irreversible and outward-facing actions.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Cite it with =principle-never-block-on-the-human= whenever you are about
+to ask permission. The upstream rule says proceed on reversible work
+rather than ask. Our conventions require confirmation for irreversible and
+outward-facing actions, and require grounding to stop when a concept
+resolves to no document.
+
+Those look opposed and are not, but the reconciliation has to be stated or
+an agent will pick whichever it prefers in the moment.
+
+* How to use this skill
+
+1. /Ask what a record would repair/. That is the whole test. The upstream
+   condition is reversibility, and a written assumption is what makes an
+   unforced choice reversible: someone reading the trail can see what was
+   assumed and undo it.
+
+2. /Proceed and record, where a record repairs it/. An unresolved concept,
+   an ambiguous requirement, a choice between two defensible designs.
+   State the assumption you proceeded on in the task's own =* Plan= or
+   =* Notes=, and keep going. Do not ask.
+
+3. /Confirm, where a record cannot repair it/. The cost is paid before
+   anyone reads the trail:
+   - a destructive command: dropping a database, force-pushing a shared
+     branch, deleting a worktree;
+   - anything leaving the project: a comment on a pull request outside it,
+     a message to a person, a published release;
+   - merging, and raising a pull request that was not asked for.
+
+4. /Do not confirm twice/. Approval for a class of action covers the
+   session unless the situation changes. Asking again after the operator
+   has said yes is the same failure as asking the first time, wearing
+   politeness as a disguise.
+
+5. /Where the answer is observable, observe it/. A question you could
+   settle by running something is not the operator's to answer. Run it.
+
+** Why this is not a weakening of the rule
+
+The upstream rule targets an agent that stalls to avoid responsibility.
+The exceptions above are not that: they are the cases where proceeding
+transfers a cost the operator cannot reverse. The rule and the exceptions
+share one criterion, which is whether the operator can still change their
+mind afterwards.
+
+Grounding is the case worth naming, because it looks like a third thing
+and is not. When a concept resolves to no knowledge document, the
+obligation is to notice, not to stop: an agent that proceeds on an
+unresolved concept and says which one it was has produced a reversible
+result and a lead on the missing page. An agent that proceeds silently has
+produced neither.
+
+* Recipes
+
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — where the assumption is recorded.
+
+* Reference
+
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the citation function, and why this binding exists.
+- [[id:0203A855-EF0F-485F-BEDC-CB1EB6C0E9EC][The pstack Collection]] — the upstream rule and the fuller reconciliation argument.
+- [[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]] — the obligation this reconciles against.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-principle-type-system-discipline/SKILL.org
+++ b/doc/llm/skills/compass-principle-type-system-discipline/SKILL.org
@@ -61,17 +61,27 @@ codebase.
 | Derive from the schema | Regenerate from the entity model. A hand-written type that duplicates a generated shape is drift with a delay on it |
 | Strengthen only where partiality appears | Same rule, and the same stopping point: if nothing would otherwise throw, leave the plain type |
 
-** Exhaustive matching, which C++ does not enforce
+** Exhaustive matching, which nothing here enforces yet
 
 Upstream can rely on the compiler failing when a variant is added. We
-cannot. A =switch= over an =enum class= warns under =-Wswitch= only when
-there is no =default:= label, and a =default:= is exactly what an agent
-adds to silence the warning. That turns a compile error into a silent
-wrong answer the day someone adds a state.
+cannot, and the gap is wider than the language alone makes it.
 
-So: no =default:= on a switch over a closed enum. Handle every enumerator
-explicitly and let the warning do its job. For =std::variant=, an overload
-set with no catch-all gives the same guarantee.
+C++ would warn: =-Wswitch= fires on a =switch= over an =enum class= that
+misses an enumerator, provided there is no =default:= label. This build
+does not enable it. The only warning flag we set is =-Werror=, which
+escalates whatever is already on and does not turn =-Wswitch= on, since
+that arrives with =-Wall=. A non-exhaustive switch therefore compiles
+clean today, with or without a =default:=.
+
+So this is advice with no backstop behind it: handle every enumerator
+explicitly, and do not reach for =default:= on a closed enum, because the
+day the flags are enabled that label is what will hide the missing case.
+For =std::variant=, an overload set with no catch-all fails to compile on
+its own and needs no flag.
+
+Enabling the warning is tracked work rather than a thing to fix in
+passing: 174 files carry a =default:= in a switch, so the flag and the
+sweep arrive together.
 
 ** Branding, which costs more here
 

--- a/doc/llm/skills/compass-principle-type-system-discipline/SKILL.org
+++ b/doc/llm/skills/compass-principle-type-system-discipline/SKILL.org
@@ -1,0 +1,118 @@
+:PROPERTIES:
+:ID: FAABB6FF-FA3A-4E5C-B0B7-FE3E2E661A6C
+:END:
+#+title: Compass Principle Type System Discipline
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s1
+#+filetags: :llm:skill:skills:claude_code:principle:cpp:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-principle-type-system-discipline
+description: The C++ binding for type-system-discipline — what each upstream pattern becomes in this codebase, which the language gives you free, and the two it does not.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Cite it with =principle-type-system-discipline= whenever you design a type
+or a signature here. The upstream rule is written for TypeScript. Its
+intent carries to C++ unchanged; several of its mechanisms do not, and two
+of its patterns are harder here than the original implies.
+
+Read the upstream skill for the rule. Read this for what it means in this
+codebase.
+
+* How to use this skill
+
+1. /Take the intent from upstream/. Illegal states unrepresentable,
+   semantic primitives branded, external data parsed at the boundary, no
+   lying to the compiler, matches exhaustive, types derived from the
+   authoritative schema, strengthened only where partiality appears.
+
+2. /Translate the mechanism/ using the table below. A pattern whose
+   TypeScript form has no C++ equivalent still has a C++ answer; it is
+   usually a different construct rather than an absent one.
+
+3. /Watch the two the language does not give you/. Exhaustive matching and
+   branding are both weaker here than upstream assumes, and both are worth
+   the extra ceremony.
+
+4. /Prefer the generator/. Where the shape is owned by an entity model,
+   deriving the type means regenerating it, not hand-writing a parallel
+   struct. This is the strongest form of "derive from the authoritative
+   schema" available to us, and it is enforced.
+
+** The translation
+
+| Upstream pattern | Here |
+|------------------+------|
+| Discriminated union | =std::variant= over per-state structs, or an enum class plus the payload the state carries. Not a struct of optionals with a comment saying which combinations are legal |
+| Branded primitive | A one-field struct with =explicit= construction. A type alias brands nothing: it is the same type to the compiler, so =using currency_code = std::string= buys documentation and no safety |
+| Parse at the boundary | The JSON and table I/O layers are the boundary. A domain type is constructed from parsed input, never handed a raw row |
+| Do not lie to the compiler | =const_cast=, =reinterpret_cast= and a C-style cast are the hazards. =static_cast= between numeric types is the quiet one: it compiles, truncates, and says nothing |
+| Exhaustive matching | The compiler will not tell you. See below |
+| Derive from the schema | Regenerate from the entity model. A hand-written type that duplicates a generated shape is drift with a delay on it |
+| Strengthen only where partiality appears | Same rule, and the same stopping point: if nothing would otherwise throw, leave the plain type |
+
+** Exhaustive matching, which C++ does not enforce
+
+Upstream can rely on the compiler failing when a variant is added. We
+cannot. A =switch= over an =enum class= warns under =-Wswitch= only when
+there is no =default:= label, and a =default:= is exactly what an agent
+adds to silence the warning. That turns a compile error into a silent
+wrong answer the day someone adds a state.
+
+So: no =default:= on a switch over a closed enum. Handle every enumerator
+explicitly and let the warning do its job. For =std::variant=, an overload
+set with no catch-all gives the same guarantee.
+
+** Branding, which costs more here
+
+A branded type in C++ is a struct, which means writing the comparison
+operators, the hash, the stream operator and the serialisation the
+underlying primitive had for free. That cost is real and it is why the
+codebase has bare =std::string= where a brand belongs.
+
+The test is whether two arguments of the same primitive type mean
+different things and could be swapped at a call site without the compiler
+noticing. Where they can, the brand pays for itself the first time someone
+transposes them; where a type appears in one signature and never travels,
+it does not.
+
+* Recipes
+
+- [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]] — the warnings are only useful if the build is clean.
+
+* Reference
+
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the citation function, and why this binding exists.
+- [[id:0203A855-EF0F-485F-BEDC-CB1EB6C0E9EC][The pstack Collection]] — the upstream rule, referenced rather than copied.
+- [[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-oriented design]] — the other axis on a type decision here: shape for the machine as well as for the compiler.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/principles.org
+++ b/doc/llm/skills/principles.org
@@ -36,7 +36,10 @@ would add variety the agent already commands.
 
 ** Before writing anything
 
-Cited when the shape of the work is still open.
+Cited when the shape of the work is still open. Sequencing belongs here
+rather than at the gate: how the work splits is decided when it is
+planned, and a split settled only as the pull request is opened has
+already cost whatever it was going to cost.
 
 | Principle | Cite it when |
 |-----------+--------------|
@@ -44,6 +47,7 @@ Cited when the shape of the work is still open.
 | =principle-subtract-before-you-add= | Sequencing an addition: what comes out before anything goes in |
 | =principle-redesign-from-first-principles= | Integrating a new requirement into a design that predates it |
 | =principle-build-the-lever= | The work is repetitive: write the script that does it, and hand the reviewer the script |
+| =principle-sequence-verifiable-units= | Splitting the work, and ordering the commits and pull requests it becomes |
 
 ** While designing
 
@@ -72,7 +76,6 @@ Cited at the gate.
 | Principle | Cite it when |
 |-----------+--------------|
 | =principle-prove-it-works= | About to say it is finished: verify against the real artefact |
-| =principle-sequence-verifiable-units= | Splitting work, and ordering the commits and PRs it becomes |
 
 ** After the fact
 

--- a/doc/llm/skills/principles.org
+++ b/doc/llm/skills/principles.org
@@ -1,0 +1,143 @@
+:PROPERTIES:
+:ID: 9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3
+:END:
+#+title: Principles
+#+description: The citation function: the thirteen adopted principles grouped for citation, the two that needed a local binding, and the rules a check carries instead of prose.
+#+type: knowledge
+#+level: cross
+#+filetags: :llm:skills:structure_note:principles:citation:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+* Summary
+
+A principle is a rule an agent *cites* at a judgement call and never runs.
+This page is the citation function's index: the set a method reads at task
+start, grouped so a phase can cite the two or three that bear on the
+decision in front of it rather than the whole list.
+
+The principles are [[id:0203A855-EF0F-485F-BEDC-CB1EB6C0E9EC][referenced
+upstream]] rather than copied, so what this page holds is the grouping, the
+reason each earns its place here, and the two local bindings where the
+upstream rule is right in shape and wrong in local detail.
+
+One test runs before any principle is cited at all. A rule that can be
+expressed as a lint, a metadata flag, a runtime check or a script is
+written that way instead: structure regulates where prose only advises, and
+a check that fails is worth more than a paragraph nobody re-reads. The
+citation function holds what genuinely cannot be checked. The rules that
+went the other way are listed at the end, with what checks them.
+
+* The set
+
+Thirteen of pstack's twenty-one principles are adopted. The other eight are
+not judged wrong; they are judged already absorbed, and importing them
+would add variety the agent already commands.
+
+** Before writing anything
+
+Cited when the shape of the work is still open.
+
+| Principle | Cite it when |
+|-----------+--------------|
+| =principle-laziness-protocol= | Sizing a change, or tempted to add an abstraction, a layer or a config knob |
+| =principle-subtract-before-you-add= | Sequencing an addition: what comes out before anything goes in |
+| =principle-redesign-from-first-principles= | Integrating a new requirement into a design that predates it |
+| =principle-build-the-lever= | The work is repetitive: write the script that does it, and hand the reviewer the script |
+
+** While designing
+
+Cited at the point the structure is chosen.
+
+| Principle | Cite it when |
+|-----------+--------------|
+| =principle-model-the-domain= | Branching a lot, or repeating a shape assumption across files |
+| =principle-type-system-discipline= | Designing a type or a signature. See the C++ binding below |
+| =principle-separate-before-serializing-shared-state= | Two agents might write the same file, branch or lock |
+
+** While working
+
+Cited during execution rather than planning.
+
+| Principle | Cite it when |
+|-----------+--------------|
+| =principle-fix-root-causes= | Debugging: trace the symptom to its cause before editing |
+| =principle-guard-the-context-window= | Reading widely: route bulk elsewhere and keep the summary |
+| =principle-never-block-on-the-human= | Tempted to ask permission for reversible work. See the binding below |
+
+** Before declaring done
+
+Cited at the gate.
+
+| Principle | Cite it when |
+|-----------+--------------|
+| =principle-prove-it-works= | About to say it is finished: verify against the real artefact |
+| =principle-sequence-verifiable-units= | Splitting work, and ordering the commits and PRs it becomes |
+
+** After the fact
+
+| Principle | Cite it when |
+|-----------+--------------|
+| =principle-encode-lessons-in-structure= | Writing the same correction a second time: prefer a check to more prose |
+
+* The two bindings
+
+Most adopted principles are cited as written. Two are right in shape and
+wrong in local detail, so each has a thin local skill supplying only the
+difference.
+
+- =compass-principle-type-system-discipline= — the upstream rule is written
+  for TypeScript. The intent survives the move to C++; the mechanisms do
+  not.
+- =compass-principle-never-block-on-the-human= — the upstream rule argues
+  against asking. Our conventions require confirmation for irreversible and
+  outward-facing actions. The two are reconciled rather than ranked, and
+  the binding states where the line falls.
+
+* Encoded as a check instead
+
+These rules were tested against the encode-as-a-check rule and went the
+other way. They are recorded here because the reason they are absent from
+the list above is that something enforces them, and an agent should know
+what.
+
+#+ATTR_HTML: :class hug-leading
+| Rule | What carries it |
+|------+-----------------|
+| Never pipe or redirect a compass command | A =PreToolUse= hook denies the call and names the log file to tail instead |
+| Never use the shared stash stack bare | A =PreToolUse= hook denies bare =git stash= and =git stash pop=, which every worktree shares |
+| Every skill declares its level | =apply_skill_levels.py --check=, in the Doc Lint workflow |
+| Every skill is in the compass namespace | =rename_skills_to_compass_namespace.py --check= |
+| A skill's commands belong to a recipe | =link_skill_recipes.py --check= |
+| Every id link resolves | =compass lint=, on every push and pull request |
+| A generated region matches its source | The generator's own =--check= mode, for the catalogue, the type tables and the level inventory |
+
+The pattern is the point. Each of these began as a sentence someone had to
+remember, and each became a check the moment it was written down twice.
+=principle-encode-lessons-in-structure= is the rule that keeps this table
+growing, which is why it is the one principle whose job is to remove others
+from the list above.
+
+* Upstream
+
+The principles are referenced from the pstack collection, installed as a
+Claude Code plugin rather than forked into this repository.
+
+| Field | Value |
+|-------+-------|
+| Collection | pstack |
+| Distribution | =pstack-claude= marketplace, plugin =pstack=, version 0.9.18 |
+| Repository | [[https://github.com/michael-denyer/pstack-claude][github.com/michael-denyer/pstack-claude]] |
+| Port maintainer | Michael Denyer |
+| Original author | Lauren Tan (poteto) |
+
+[[id:0203A855-EF0F-485F-BEDC-CB1EB6C0E9EC][The pstack Collection]] carries
+the full classification, including the eight skipped principles and why,
+and the argument for referencing rather than forking.
+
+* See also
+
+- [[id:0203A855-EF0F-485F-BEDC-CB1EB6C0E9EC][The pstack Collection]] — the disposition of every upstream skill, and the reference-not-fork argument.
+- [[id:F5CB5A45-6557-410B-9E4F-542957561A16][Regulatory Functions]] — where citation sits among the seven.
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — the phases that cite these.
+- [[id:AEBC2BC9-A854-4CEC-BA88-1602490AC762][Skill architecture]] — the index into the cluster this page belongs to.

--- a/doc/llm/skills/pstack.org
+++ b/doc/llm/skills/pstack.org
@@ -89,8 +89,13 @@ project.
 | minimize-reader-load                     | Skip        | Already absorbed                                                   |
 | outcome-oriented-execution               | Skip        | Already our practice                                               |
 
-Eleven of 21 are adopted. The skipped ones are not judged wrong; they are judged
-already absorbed, which is the same verdict the rule reaches for a compiler.
+Thirteen of 21 are adopted. The skipped ones are not judged wrong; they are
+judged already absorbed, which is the same verdict the rule reaches for a
+compiler.
+
+[[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] groups the thirteen for
+citation, records the two that needed a local binding, and lists the ones a
+check carries instead of prose.
 
 ** Playbooks and Workflow Skills
 

--- a/doc/llm/skills/skill_architecture.org
+++ b/doc/llm/skills/skill_architecture.org
@@ -206,6 +206,7 @@ reader may arrive at independently.
 |-----------------------------+---------------------------------------------------------------------------|
 | [[id:87D41A08-0B37-41CE-8483-B59B36BA87FA][Skills in the framework]]     | What is a skill here, and why is the received notion deemed insufficient. |
 | [[id:F5CB5A45-6557-410B-9E4F-542957561A16][Regulatory Functions]]                | What kinds of artefact exist, and how do they differ.                     |
+| [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]]                  | Which rules are cited, grouped for use, and which a check carries instead. |
 | [[id:3018B7FE-2DF7-49E5-A57F-A75C02C4D498][Skill dispatch]]              | Given a thing in hand, what may be done to it.                            |
 | [[id:5365DE9F-E3F9-4B5F-ACC1-B347B5FCE2A9][Systems and levels]]          | Who is acting, and what may they see and do.                              |
 | [[id:54AD5986-34A0-4B19-9F20-D9A024225036][Running agents]]              | How is an agent configured, isolated and left to run.                     |

--- a/doc/llm/skills/skill_systems_levels.org
+++ b/doc/llm/skills/skill_systems_levels.org
@@ -162,14 +162,14 @@ What each System sees by default, counted from the levels the skills carry. Atte
 #+ATTR_HTML: :class hug-leading
 | Level | System | Horizon | Sees | Attenuation |
 |-------+--------+---------+------+-------------|
-| =s1= | Agent | Hours | 58 skills | advisory |
-| =s2= | Orchestrator | Days | 15 skills | advisory |
-| =s3= | Sprint Planner | Weeks | 18 skills | advisory |
+| =s1= | Agent | Hours | 60 skills | advisory |
+| =s2= | Orchestrator | Days | 16 skills | advisory |
+| =s3= | Sprint Planner | Weeks | 19 skills | advisory |
 | =s3star= | Auditor | Continuous | 5 skills | binding |
-| =s4= | Version Planner | Months | 13 skills | advisory |
-| =s5= | Identity Steward | Indefinite | 13 skills | advisory |
+| =s4= | Version Planner | Months | 14 skills | advisory |
+| =s5= | Identity Steward | Indefinite | 14 skills | advisory |
 
-12 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
+13 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
 
 # END generated inventory
 

--- a/projects/ores.compass/src/deny_bare_stash_hook.py
+++ b/projects/ores.compass/src/deny_bare_stash_hook.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: deny bare use of the shared git stash stack.
+
+Every worktree shares one stack, so a bare push contends for its top and
+a bare pop can take another session's work. See
+doc/llm/claude_code_settings.org's Hooks section.
+"""
+import json
+import re
+import sys
+
+# Each invocation in the command line, taken up to the next shell
+# separator so a compound command is checked per part.
+INVOCATION_RE = re.compile(r"(?:^|[\s&;(])git\s+stash\b([^&;|)]*)")
+MESSAGE_RE = re.compile(r"(?:^|\s)(?:-m|--message)(?:[=\s]|$)")
+
+# The forms that add an entry to the stack. Everything else either names
+# the entry it acts on (apply, drop, show) or is not a stash command at
+# all, which matters because the words appear in prose about this rule.
+PUSHES = {"", "push", "save"}
+
+DENIAL_MESSAGE = (
+    "The stash stack is shared by every worktree in the fleet, so a bare "
+    "`git stash` contends for its top and a bare `git stash pop` can take "
+    "another session's work.\n"
+    "Prefer a temporary WIP commit, which shares nothing. If you do need "
+    "the stash: `git stash push -u -m \"<unique-tag>\"`, capture the SHA "
+    "with `git stash list --format='%H %gs'`, and restore with "
+    "`git stash apply <sha>` rather than pop. Drop the entry afterwards, "
+    "re-finding it by tag.\n"
+)
+
+
+def denied(command: str) -> bool:
+    """True when the command pushes onto or pops off the shared stack
+    without naming what it acts on."""
+    for m in INVOCATION_RE.finditer(command):
+        rest = m.group(1)
+        words = [w for w in rest.split() if not w.startswith("-")]
+        sub = words[0] if words else ""
+        if sub == "pop":
+            return True
+        if sub not in PUSHES:
+            continue
+        # A message is what makes the entry findable again by its own tag
+        # rather than by its position on a stack others are pushing to.
+        if not MESSAGE_RE.search(rest):
+            return True
+    return False
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+        return 0
+    if denied(data.get("tool_input", {}).get("command", "")):
+        sys.stderr.write(DENIAL_MESSAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/ores.compass/tests/test_deny_bare_stash_hook.py
+++ b/projects/ores.compass/tests/test_deny_bare_stash_hook.py
@@ -1,0 +1,83 @@
+"""
+Tests for the bare-stash PreToolUse hook.
+
+Run with:  python -m pytest projects/ores.compass/tests/test_deny_bare_stash_hook.py -v
+No live database required.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from the src directory without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import deny_bare_stash_hook as hook
+
+
+def run(command, monkeypatch, tool_name="Bash"):
+    payload = {"tool_name": tool_name, "tool_input": {"command": command}}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return hook.main()
+
+
+def test_bare_stash_is_denied(monkeypatch):
+    assert run("git stash", monkeypatch) == 2
+
+
+def test_bare_pop_is_denied(monkeypatch):
+    assert run("git stash pop", monkeypatch) == 2
+
+
+def test_pop_with_a_ref_is_still_denied(monkeypatch):
+    """A ref does not help: the entry it names may be another session's."""
+    assert run("git stash pop stash@{0}", monkeypatch) == 2
+
+
+def test_save_without_a_message_is_denied(monkeypatch):
+    assert run("git stash save", monkeypatch) == 2
+
+
+def test_tagged_push_is_allowed(monkeypatch):
+    assert run('git stash push -u -m "wip-bright-faraday"', monkeypatch) == 0
+
+
+def test_apply_against_an_explicit_entry_is_allowed(monkeypatch):
+    assert run("git stash apply 8f2a1c3", monkeypatch) == 0
+
+
+def test_reads_are_allowed(monkeypatch):
+    assert run("git stash list", monkeypatch) == 0
+    assert run("git stash show -p", monkeypatch) == 0
+
+
+def test_drop_is_allowed(monkeypatch):
+    assert run("git stash drop stash@{2}", monkeypatch) == 0
+
+
+def test_denial_survives_a_compound_command(monkeypatch):
+    assert run("cd /tmp && git stash", monkeypatch) == 2
+
+
+def test_unrelated_commands_pass(monkeypatch):
+    assert run("git status", monkeypatch) == 0
+
+
+def test_the_words_inside_a_message_are_not_a_command(monkeypatch):
+    """The first pattern denied this, which blocked writing about the
+    rule while explaining it."""
+    assert run("echo git stash is shared", monkeypatch) == 0
+
+
+def test_push_with_flags_but_no_message_is_denied(monkeypatch):
+    assert run("git stash push -u", monkeypatch) == 2
+
+
+def test_other_tools_are_ignored(monkeypatch):
+    assert run("git stash", monkeypatch, tool_name="Read") == 0
+
+
+def test_malformed_payload_does_not_crash(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0


### PR DESCRIPTION
## Summary

A principle is a rule an agent cites at a judgement call and never runs. The thirteen adopted from pstack are referenced upstream rather than copied, because forking them would sever the feedback path that lets an upstream rule improve. What this adds is the grouping, the two bindings where our detail differs, and one rule moved out of prose into a check.

## Changes

- Principles is the index: the thirteen grouped by when they are cited, so a phase reaches for the two that bear on its decision rather than reading the set. Upstream attribution is recorded once for the collection, which is the right granularity when nothing is forked.
- compass-principle-type-system-discipline binds the rule to C++. A translation table, plus the two patterns the language makes harder: exhaustive matching, which stops being enforced the moment a default label appears, and branding, which costs a struct and its operators rather than a type alias.
- compass-principle-never-block-on-the-human reconciles the rule with our confirmation conventions on one criterion: proceed where a written record makes the choice reversible, confirm where the cost is paid before anyone reads the trail.
- The audit said eleven of twenty-one principles were adopted; its own table says thirteen. Corrected in the collection page and the two agile documents repeating the figure.
- The encode-as-a-check test moved one rule out of prose. The stash stack is shared by every worktree, so a bare push contends for its top and a bare pop can take another session's work. It is now a PreToolUse hook, literate with its tests, that denies the two bare forms and names the safe ones in the denial.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Cite the principles under the citation function](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_principles_layer.html) | A7BCF024-9222-40C3-9151-AFE9C9B4BDBE |
| Environment | bright_faraday | |

## Testing

Plan. Write the index and bindings, apply the encode-as-a-check test to every candidate, prove the resulting hook both denies the real thing and permits prose about it, and run the docs and python-tooling checks.

Evidence. docs and python tooling. Compass suite: 159 passed, 1 skipped, including 14 new hook tests. The hook was proved live rather than only in tests: running a bare stash in this session was denied with the correction, and the sentence containing the same words passed. compass lint: clean, durable-link advisory unchanged at 158; it also caught two mistyped ids while I wrote the index. All five generator checks pass, and the catalogue generator now knows the principle segment. Site build: Build succeeded. misspell-fixer on the new documents: nothing to replace.

Limitations. The acceptance asks for each principle to be ported as a skill. I did not port them, because forking thirteen upstream documents contradicts the reference-not-fork decision this story already took; the reinterpretation is recorded in the task Result rather than left implicit, and it is the one thing in this PR most worth disagreeing with. No C++ was touched, so no build or ctest run. The groupings are judgements about when a rule is cited and should be challenged as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)