### PR TITLE
[doc] Port the sequencing function and bind it to our effectors

### DIFF
--- a/build/scripts/apply_skill_levels.py
+++ b/build/scripts/apply_skill_levels.py
@@ -115,6 +115,16 @@ LEVELS = {
     # Identity: what belongs in the product at all.
     "compass-agile-brainstorm-idea": "s5",
 
+    # Methods. The level is the level of the work the method sequences:
+    # execution for the four that carry a change, cross for one that only
+    # reads, s2 for the one that plans work spanning many units.
+    "compass-method-bug-fix": "s1",
+    "compass-method-feature": "s1",
+    "compass-method-refactoring": "s1",
+    "compass-method-prototype": "s1",
+    "compass-method-investigation": "cross",
+    "compass-method-figure-it-out": "s2",
+
     # Bindings on an upstream principle. The level is the level of the
     # judgement the principle is cited at, not of the principle itself.
     "compass-principle-type-system-discipline": "s1",

--- a/build/scripts/generate_skills_catalogue.py
+++ b/build/scripts/generate_skills_catalogue.py
@@ -48,6 +48,11 @@ DOMAINS = {
     "principle": ("Principles (=compass-principle-=)",
                   "Local bindings on an upstream principle, supplying the "
                   "project detail the rule cannot know."),
+    # Likewise: a sequence of phases, which spans artefact types rather
+    # than naming one.
+    "method": ("Methods (=compass-method-=)",
+               "How a kind of work is approached, from framing to a "
+               "verified end."),
 }
 
 # Planned-but-not-yet-created skills, shown as prose under each section.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -100,6 +100,7 @@ Tasks are listed in intended execution order.
 | [[id:39264768-EE92-4DB1-B048-3C960415B358][Specify the skills framework as a regulator]] | DONE | 2026-09-07 | 2026-09-07 | Respecify the framework as a regulator over an agent, deriving its scope and its seven classes of document from cybernetics rather than stipulating them, and classify the upstream pstack collection against that derivation. |
 | [[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][Delegate the remaining skill commands to recipes]] | DISCOVERED | | | Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place. |
 | [[id:A849F82C-0AE6-4217-90FC-F17443B3C168][Enable the compiler warnings the code assumes]] | DISCOVERED | | | The build sets -Werror and nothing else, so -Wall and -Wextra diagnostics never fire; enable them and clear what they surface. |
+| [[id:6D872794-2934-49EA-80EC-F1E64D23AC10][Make a generated marker name a generator that writes it]] | DISCOVERED | | | Four documents carry a BEGIN generated marker naming a script that never writes them, so the region reads as derived and is hand-maintained or empty. |
 
 * Decisions
 
@@ -173,6 +174,14 @@ Tasks are listed in intended execution order.
 - Every method says when it is the wrong method. The failure a method
   exists to prevent is a misjudged shape, and no phase inside one recovers
   from having picked it.
+- A citation in prose is unchecked. =compass lint= verifies id-links; a
+  rule cited as =principle-x= is just text, so a method can cite the
+  un-reconciled upstream rule where the local binding was meant and
+  nothing notices.
+- A generated marker is a promise that a named script rewrites the region.
+  Four documents make that promise about a script that never writes them,
+  which is worse than no marker: it tells a reader not to edit a region
+  nothing maintains.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -84,7 +84,7 @@ Tasks are listed in intended execution order.
 | [[id:6766A23C-0357-4873-B5BF-B5A71BF0B1D5][Add structure notes to the knowledge Zettelkasten]] | DONE | 2026-09-10 | 2026-09-10 | Give each domain cluster an entry-point note listing its pages in an argued reading order, so grounding loads a model rather than a search result. |
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
 | [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | DONE | 2026-09-10 | 2026-09-10 | Cite the thirteen adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
-| [[id:08F7F925-49B2-40E0-A298-E300353CAE2E][Port the sequencing function and bind it to recipes and actions]] | BACKLOG | | | Import the adopted methods and interview skills as compass-method skills, with every step bound to one of our actions or recipes. |
+| [[id:08F7F925-49B2-40E0-A298-E300353CAE2E][Port the sequencing function and bind it to recipes and actions]] | DONE | 2026-09-10 | 2026-09-10 | Import the adopted methods and interview skills as compass-method skills, with every step bound to one of our actions or recipes. |
 | [[id:60C7573C-763F-466D-A174-61C3A78616AF][Build compass-helm, the sticky mode]] | BACKLOG | | | One sticky entry point that declares the session System, matches work to a method, copies its phases in verbatim, and routes to actions, recipes and deliberation. |
 | [[id:BC52784C-64A6-47D2-AE13-BA8530C34507][Bind the Council to the convening function]] | BACKLOG | | | Wire the Council of High Intelligence in as the convening function, and route error detection to the checkers that are genuinely independent. |
 | [[id:26921590-0B75-401F-80C6-52CDF76104CD][Reconcile duplicate skills and standardise terminology]] | BACKLOG | | | Fold every overlapping import into a single skill, retire the losers through compass-skill-delete, and sweep the catalogue onto the agreed vocabulary. |
@@ -166,6 +166,13 @@ Tasks are listed in intended execution order.
   against the build, not against the language. The binding asserted
   =-Wswitch= catches a missing enumerator; the build enables only
   =-Werror=, so nothing catches it.
+- A method carries no commands at all. It cites the action or recipe that
+  owns each one, which is the recipe boundary applied to control flow and
+  the reason the sequencing function accumulates capability rather than
+  re-deriving it.
+- Every method says when it is the wrong method. The failure a method
+  exists to prevent is a misjudged shape, and no phase inside one recovers
+  from having picked it.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_stale_generated_markers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_stale_generated_markers.org
@@ -1,0 +1,96 @@
+:PROPERTIES:
+:ID: 6D872794-2934-49EA-80EC-F1E64D23AC10
+:END:
+#+title: Task: Make a generated marker name a generator that writes it
+#+description: Four documents carry a BEGIN generated marker naming a script that never writes them, so the region reads as derived and is hand-maintained or empty.
+#+type: task
+#+level: s1
+#+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A =# BEGIN generated= marker is a promise: this region is derived, do not
+edit it by hand, and the named script will rewrite it. Four documents make
+that promise and nothing keeps it.
+
+=skill_regulatory_functions.org=, =skill_dispatch.org=,
+=skill_generated_artefacts.org= and =skill_verification.org= each name
+=build/scripts/generate_skills_catalogue.py=, which only ever writes
+=claude_code_skills.org=. Their regions hold placeholder text saying they
+will be populated when some other task lands. A reader cannot tell the
+difference between a region that is empty because it is generated and
+awaiting data, and one that is empty because nobody wrote it.
+
+=compass lint= does not catch this: it checks that every BEGIN has a
+matching END, not that the named generator targets the file. That gap is
+the reason four markers have sat stale.
+
+Fix the four, and add the check that makes the promise verifiable.
+
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DISCOVERED                              |
+| Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
+| Now          | Discovered in review of PR #2057.       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-10                               |
+
+* Acceptance
+
+- Every =# BEGIN generated= marker names a script that actually writes that file, verified by running it.
+- A marker whose content nobody will generate is removed, and the region is written as ordinary prose or deleted.
+- A check reports any marker naming a script that does not target its file, and it runs in the Doc Lint workflow.
+- The check fails on the current state before the fix and passes after, demonstrated rather than asserted.
+
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
@@ -99,6 +99,11 @@ six new methods and the amended methods page. The two agile documents in
 this change are the only files without that check, and both are
 conventional edits to existing sections.
 
+What that leaves unverified is the rendered HTML for the six pages,
+which is narrower than "the site build passed" but is not nothing: the
+org export succeeding does not prove the published page reads correctly.
+Worth a look once the machine has memory to spare.
+
 
 * Test Scenarios
 
@@ -121,7 +126,12 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Two methods cite the bare =principle-never-block-on-the-human= rather than the local binding, at exactly the points about the operator boundary where the reconciliation matters | compass-method-prototype, compass-method-figure-it-out | Accept | Both now cite the binding. The bare name is the un-reconciled upstream rule and is not a skill in the tree; lint cannot see this because the citation is prose, not an id-link |
+| 2 | =skill_methods.org= carries a generated-inventory marker naming a script that never writes that file | doc/llm/skills/skill_methods.org | Accept | Removed. The hand-written table added by this task is the inventory. Four other documents make the same false promise, which is its own task with a check as acceptance |
+| 3 | Six is a closed graph rather than five buckets and a junk drawer: every /wrong method/ pointer resolves to another of the six | — | Accept | No change. This is the argument for the set that I could not make myself, since I chose them |
+| 4 | The skeleton is load-bearing, evidenced by the variation: refactoring inverts grounding and the invariant, and investigation and prototype drop the landing phase rather than leaving it empty | — | Accept | No change. Recorded because it answers the question I asked, with evidence I had not thought to look for |
+| 5 | Prototype has no usage evidence; watch rather than cut, and fold its advice into the never-block binding if it stays unused | — | Accept | No change now. Noted as the retirement criterion so the decision is not re-litigated from scratch |
+| 6 | The rendered HTML for the six pages is still unverified; narrower than the PR claims to close | — | Accept | Fair. The claim is that the org export and the link resolution are covered, not the render; the limitation now says so precisely |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:methods:pstack:grilling:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/port-method-layer
-#+pr:
+#+pr: 2057
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -115,7 +115,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2057][#2057]] | [doc] Port the sequencing function and bind it to our effectors |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:skills:methods:pstack:grilling:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/port-method-layer
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ The sequencing function is control flow with no effectors; our actions and recip
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -44,11 +44,61 @@ The sequencing function is control flow with no effectors; our actions and recip
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+A method is control flow with no effectors; our actions and recipes are
+effectors with no control flow. Six methods now join them, one per shape
+of work the design named: bug fix, feature, refactoring, investigation,
+prototype, and figure-it-out for work no method fits.
+
+Each has the same skeleton, because the skeleton is the contract. It
+opens by grounding the domain concepts the work names. It states, before
+anything is built, what would make the work finished in terms someone
+else can check. Its phases cite principles at the judgement calls and
+name the action or recipe that does anything touching an artefact. It
+ends by saying when it is the wrong method, which is the phase most often
+missing from a playbook and the one that prevents the commonest failure:
+running the wrong shape to completion.
+
+Nothing was copied. The upstream playbooks live inside =poteto-mode=,
+which is adopted whole, and forking them would contradict the
+reference-not-fork decision. What is written here is the local sequencing
+that binds our effectors, which upstream cannot supply because it does
+not know our actions exist.
 
 * Notes
+
+Steps that assumed a foreign host were dropped rather than translated:
+Graphite stacks, model routing between tiers, and an issue-tracker
+abstraction. Our agile layer already owns that ground, and a method that
+carried both would give an agent two answers about where a task's state
+lives.
+
+Two phases exist here that the upstream playbooks do not carry, and both
+came from this project's own failures rather than from the imports. The
+grounding phase is first because a feature built on a misunderstood
+concept is the wrong feature, which no later verification catches. The
+predicate is stated before the work because a predicate written after it
+describes the fix rather than the defect.
+
+The bug-fix method's blast-radius step is written from a defect fixed
+earlier in this story: pruning a directory name at any depth rather than
+at the root. The fix was one line, and finding every caller was the
+whole job.
+
+=compass-method-investigation= is the only one tagged =cross=. It changes
+nothing, so a session at any level can run it, including the audit
+channel.
+
+The site build could not be run for this change. It was killed three
+times by the machine's low-memory guard, twice as a background task and
+once after a foreground run was moved to the background at its timeout,
+while the box reported 19G available and Postgres and SQL Server held
+most of the resident memory. Rather than retry a fourth time, the org
+export risk was covered another way: the skills build runs the same
+emacs org export over =doc/llm/skills=, and it completed, exporting all
+six new methods and the amended methods page. The two agile documents in
+this change are the only files without that check, and both are
+conventional edits to existing sections.
+
 
 * Test Scenarios
 
@@ -74,3 +124,24 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All three acceptance criteria are met.
+
+Every method opens with the domain grounding phase and states a
+falsifiable predicate before any work is done. Both are phases rather
+than advice, so skipping one leaves =skip:= and a reason in the todo
+list.
+
+Every step that touches an artefact names the action or recipe that does
+it. No step improvises a command: the methods contain no shell blocks at
+all, which is the sharpest form of the recipe boundary this story
+established.
+
+Steps assuming a foreign host are dropped and the choice recorded in
+=* Notes=: Graphite stacks, model routing and the issue-tracker
+abstraction, all of which our agile layer already covers.
+
+The six are listed in
+[[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] with
+the work each sequences, and the catalogue groups them under the
+=compass-method-= segment the naming policy reserved.

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -159,6 +159,19 @@ Local bindings on an upstream principle, supplying the project detail the rule c
 | [[id:D1F13734-216D-47AA-BA00-28F3A20F97C1][compass-principle-never-block-on-the-human]] | Compass Principle Never Block On The Human | The local binding for never-block-on-the-human — proceed on reversible work and record the assumption; conf... |
 | [[id:FAABB6FF-FA3A-4E5C-B0B7-FE3E2E661A6C][compass-principle-type-system-discipline]] | Compass Principle Type System Discipline | The C++ binding for type-system-discipline — what each upstream pattern becomes in this codebase, which the... |
 
+* Methods (=compass-method-=)
+
+How a kind of work is approached, from framing to a verified end.
+
+| Name | Title | Description |
+|------+-------+-------------|
+| [[id:D9452D4A-0B0F-466F-B97F-95BD4C36A452][compass-method-bug-fix]] | Compass Method Bug Fix | The method for a reported defect — ground, reproduce, root-cause, fix, prove. States the predicate before t... |
+| [[id:D4D8B874-0D78-4558-AF80-776AB4F2F4F8][compass-method-feature]] | Compass Method Feature | The method for new or changed behaviour — ground, state the predicate, name the data shape, check what exis... |
+| [[id:A8CBA1B2-EBC5-42A6-96B4-D19371278FB7][compass-method-figure-it-out]] | Compass Method Figure It Out | The method for work no method fits — design the phases first, state how each will be verified, then run the... |
+| [[id:440659B3-5996-4739-B2CB-37B84F5757DC][compass-method-investigation]] | Compass Method Investigation | The method for a read-only question — how does this work, why is it this way, are we sure. Ends in a cited... |
+| [[id:9DDEE5BF-9B2E-49C4-BAF9-8A2CE87D295B][compass-method-prototype]] | Compass Method Prototype | The method for settling an empirical question by observing it — the smallest thing that produces the observ... |
+| [[id:AD238B8D-ADFE-488A-9536-AA7F0B5A5559][compass-method-refactoring]] | Compass Method Refactoring | The method for a behaviour-preserving change to structure — establish the evidence that behaviour is preser... |
+
 # END generated catalogue
 
 * Rebuilding skills

--- a/doc/llm/skills/compass-method-bug-fix/SKILL.org
+++ b/doc/llm/skills/compass-method-bug-fix/SKILL.org
@@ -1,0 +1,163 @@
+:PROPERTIES:
+:ID: D9452D4A-0B0F-466F-B97F-95BD4C36A452
+:END:
+#+title: Compass Method Bug Fix
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s1
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-bug-fix
+description: The method for a reported defect — ground, reproduce, root-cause, fix, prove. States the predicate before the fix is written, so "fixed" means something checkable rather than something felt.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+A defect is reported: something behaves wrongly, and the wrongness can be
+observed. Use this method from the report to the merged fix.
+
+Not this method when there is no observable symptom. A suspicion that code
+is wrong, with nothing that misbehaves, is
+=compass-method-investigation=: find out what is true first, and come back
+here if it turns out something is broken.
+
+* How to use this skill
+
+The phases are control flow. Each names the actions and recipes that do
+the work, and the principles cited at its judgement calls. Copy them into
+the todo list before starting; a phase you skip stays in the list with
+=skip:= and the reason.
+
+** 1. Ground
+
+Name the domain concepts the report touches and resolve each to a
+knowledge document ([[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]]).
+Where a cluster has a structure note, read that first: it says which pages
+are load-bearing.
+
+A concept that resolves to nothing is a finding, not a blocker. Record the
+assumption you are proceeding on and carry on
+(=compass-principle-never-block-on-the-human=); the missing page is a
+discovered task, not a reason to stop.
+
+Use [[id:D4B099D0-FF9B-4029-96ED-6EE77439DF41][compass-doc-find]] and
+[[id:0F8DE59C-9CD1-463A-9148-0B452A985C23][compass-doc-show]].
+
+** 2. State the predicate
+
+Before touching anything, write down what would make this fixed, in terms
+someone else could check. "The link resolves" is a predicate. "Search
+works better" is not.
+
+This is the phase most often skipped and the one that decides whether the
+rest is honest. A predicate written after the fix describes the fix; a
+predicate written before it describes the defect.
+
+** 3. Reproduce
+
+Make it happen, on the surface it was reported on. A defect you cannot
+reproduce is one you cannot prove fixed, and a fix for an unreproduced
+defect is a guess with a commit message.
+
+If it will not reproduce, force it: tighten the conditions, synthesise the
+trigger, add logging and read it. That work is not overhead; it is the
+instrument the last phase needs.
+
+For a failing test, use
+[[id:8C1E8069-F6D1-44C2-8EE1-CE01FD59D527][compass-code-investigate-test-failure]].
+
+** 4. Find the root cause
+
+Form the candidate causes, then eliminate them against evidence rather
+than plausibility (=principle-fix-root-causes=). Each pass, take the split
+that cuts the most remaining space.
+
+Stop at the cause, not at the first place the symptom disappears. The test
+is whether you can say why the defect happened, not merely where it stops
+happening.
+
+Then check the blast radius before fixing: grep every caller of what you
+are about to change. A guard in the shared function is a smaller diff than
+a guard in each caller, and patching only the path the report names leaves
+its siblings broken.
+
+** 5. Fix
+
+The smallest change the evidence justifies. A belt-and-suspenders extra
+that "might also help" is a second hypothesis riding on the first; it does
+not ship (=principle-laziness-protocol=).
+
+If the fix crosses a boundary or the design is unclear, stop and design
+first rather than discovering the shape by editing.
+
+** 6. Prove
+
+Run the reproduction from phase 3 and watch it pass
+(=principle-prove-it-works=). Then climb the
+[[id:DEE49C55-1626-470D-BB0F-D58A11D35769][verification ladder]] as far as
+the change earns: the check that would have caught this, then the class
+checks for what you touched, via
+[[id:654D4A70-E63D-4C18-B5A5-886066E36314][compass-code-run-build]].
+
+Leave the check behind. A defect that no check would have caught is a
+defect that can return, so where the cost is reasonable the fix ships with
+the test or the lint that fails without it
+(=principle-encode-lessons-in-structure=,
+[[id:CB56337E-4839-4048-B5A7-C481812CE3D0][compass-code-add-tests]]).
+
+** 7. Land
+
+Order the commits so the failing case lands before the fix, and the
+history tells the story (=principle-sequence-verifiable-units=). Close the
+bookkeeping with
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][compass-agile-close-task]],
+then raise with
+[[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][compass-pr-raise]].
+
+* When this method is the wrong one
+
+Abandon it and re-match if the reproduction shows the reported behaviour
+is correct and the expectation was wrong, which is a documentation or
+product question; or if the root cause turns out to be a missing
+capability rather than a defect, which is
+=compass-method-feature=.
+
+* Recipes
+
+- [[id:62D39F43-5D91-4A82-B1C3-62C2AF21BEFC][How do I fix a failing CI check?]] — when the symptom is red CI rather than wrong behaviour.
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the lifecycle this method runs inside.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:DEE49C55-1626-470D-BB0F-D58A11D35769][Verification and evaluation]] — the ladder phase 6 climbs.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-method-feature/SKILL.org
+++ b/doc/llm/skills/compass-method-feature/SKILL.org
@@ -1,0 +1,149 @@
+:PROPERTIES:
+:ID: D4D8B874-0D78-4558-AF80-776AB4F2F4F8
+:END:
+#+title: Compass Method Feature
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s1
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-feature
+description: The method for new or changed behaviour — ground, state the predicate, name the data shape, check what exists, build, prove, land. The shape is decided before the code, not discovered by writing it.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Behaviour that does not exist yet, or behaviour that must change. Use it
+from the request to the merged change.
+
+Not this method when the behaviour exists and is wrong: that is
+=compass-method-bug-fix=. Not when the question is which of two designs to
+choose and the answer is observable: settle that with
+=compass-method-prototype= first, then come back.
+
+* How to use this skill
+
+Copy the phases into the todo list before reasoning about the task. A
+phase you skip stays in the list with =skip:= and the reason.
+
+** 1. Ground
+
+Resolve every domain concept the request names to a knowledge document
+([[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]]), reading the
+cluster's structure note first where one exists. A feature built on a
+misunderstood concept is not a feature with a bug in it; it is the wrong
+feature, and no amount of later verification finds that.
+
+** 2. State the predicate
+
+What will be true when this is done, in terms someone else can check?
+Write it before designing. Where behaviour is involved, the predicate
+belongs in a specification rather than only in prose, so it can be checked
+rather than remembered.
+
+** 3. Name the data shape
+
+Before any control flow, name what is being represented and how it is
+held (=principle-model-the-domain=). Most of the difficulty in a feature
+is in this decision, and it is the cheapest thing to change now and the
+most expensive later.
+
+In C++, take the type decisions with
+=compass-principle-type-system-discipline=: illegal states unrepresentable,
+semantic primitives branded, external input parsed at the boundary.
+
+Where the shape belongs to an entity, it is generated rather than written:
+the model is the source and the code follows from it.
+
+** 4. Check what already exists
+
+Search before writing (=principle-subtract-before-you-add=). The most
+common waste is re-implementing something a few files over, and the second
+most common is adding a parallel mechanism beside one that nearly fits.
+
+Ask also what comes out. A feature that only adds has usually not been
+thought about long enough.
+
+** 5. Build
+
+The smallest thing that satisfies the predicate
+(=principle-laziness-protocol=). No interface with one implementation, no
+configuration for a value that never varies, no scaffolding for a second
+case that has not arrived.
+
+Where the work is repetitive across many files, write the script rather
+than doing it by hand (=principle-build-the-lever=): the script is what a
+reviewer re-runs, and the next change of the same shape is then cheap.
+
+Sequence it so each step ends in something checkable
+(=principle-sequence-verifiable-units=), rather than one commit that works
+only when finished.
+
+** 6. Prove
+
+Against the predicate from phase 2, on the real artefact rather than a
+proxy (=principle-prove-it-works=). Climb the
+[[id:DEE49C55-1626-470D-BB0F-D58A11D35769][verification ladder]] as far as
+what changed requires, via
+[[id:654D4A70-E63D-4C18-B5A5-886066E36314][compass-code-run-build]] and,
+for anything a user touches,
+[[id:4FEB154D-50EF-4346-BB75-B0881188E4F5][compass-code-run-feature-test]].
+
+"It compiles" is not evidence. Neither is a unit test that asserts the
+implementation back to itself.
+
+** 7. Land
+
+Close the bookkeeping with
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][compass-agile-close-task]],
+then raise with
+[[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][compass-pr-raise]]. What
+generalises beyond this task goes to a memory, a principle or a check
+rather than staying in the diff.
+
+* When this method is the wrong one
+
+Re-match if grounding shows the capability already exists in another form,
+which makes this a refactor or a documentation gap; or if the request
+cannot be reduced to a checkable predicate, which usually means the
+requirement is still a wish and belongs in deliberation first.
+
+* Recipes
+
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the lifecycle this method runs inside.
+- [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]] — the build phase 6 runs.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:D8CB6EED-1F6A-4EE5-840B-2FE28DE17911][Generated artefacts]] — why phase 3 prefers the model to the file.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-method-figure-it-out/SKILL.org
+++ b/doc/llm/skills/compass-method-figure-it-out/SKILL.org
@@ -78,7 +78,7 @@ should have been a partition.
 Work the phases in order, recording as you go: what was decided, what was
 observed, what changed course. For anything the operator will review
 later rather than watch, that trail is the deliverable alongside the code
-(=principle-never-block-on-the-human=).
+(=compass-principle-never-block-on-the-human=).
 
 Re-check the plan at each phase boundary. A plan that survives contact
 unchanged for many phases is usually not being read.

--- a/doc/llm/skills/compass-method-figure-it-out/SKILL.org
+++ b/doc/llm/skills/compass-method-figure-it-out/SKILL.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: A8CBA1B2-EBC5-42A6-96B4-D19371278FB7
+:END:
+#+title: Compass Method Figure It Out
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s2
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-figure-it-out
+description: The method for work no method fits — design the phases first, state how each will be verified, then run them. Prevents large or novel work from being drifted into one step at a time.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+The work does not match a method, or matches several. It is large,
+cross-cutting, novel, or the operator will be away while it runs. The
+failure this prevents is drift: doing large work by improvising each next
+step, which produces motion that cannot be reviewed and cannot be
+resumed.
+
+Use it also when a narrower method fits the parts but not the whole. A
+migration across many call sites is a series of refactors, and the series
+needs a shape of its own.
+
+* How to use this skill
+
+** 1. Match first, and say why nothing fits
+
+Before designing anything, check the methods that exist and state which
+you rejected and why. Most work that feels novel is a feature with an
+unfamiliar subject, and reaching here by default wastes the phases
+someone already wrote.
+
+If one fits, use it. If two fit different parts, this method sequences
+them rather than replacing them.
+
+** 2. Ground the whole scope
+
+Resolve the concepts across the whole of the work, not the first part of
+it ([[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]]). Large work
+fails at the seams between its parts, and the seams are where the
+unresolved concepts hide.
+
+** 3. Write the phases, with a check for each
+
+Design the method this work needs: the phases in order, what each
+produces, and how each will be shown to have worked. A phase with no
+check is a phase that will be declared done by feel
+(=principle-sequence-verifiable-units=).
+
+Say what would make you stop or change course. Work driven to completion
+without a stopping condition runs past the point where the plan stopped
+being right.
+
+** 4. Decide what is delegated, and what it is told
+
+Where parts are independent, they can run separately, but a delegate
+inherits none of the grounding the session did. Each one is spawned as a
+named System, told what to read first and what it may do
+([[id:5365DE9F-E3F9-4B5F-ACC1-B347B5FCE2A9][Systems and levels]]).
+
+Keep the shared state separable
+(=principle-separate-before-serializing-shared-state=). Two agents
+writing the same file, branch or lock is a coordination problem that
+should have been a partition.
+
+** 5. Run the phases, and keep the trail
+
+Work the phases in order, recording as you go: what was decided, what was
+observed, what changed course. For anything the operator will review
+later rather than watch, that trail is the deliverable alongside the code
+(=principle-never-block-on-the-human=).
+
+Re-check the plan at each phase boundary. A plan that survives contact
+unchanged for many phases is usually not being read.
+
+** 6. Close the loop
+
+When it is done, the method you designed is itself a finding. If the same
+shape of work will recur, it becomes a real method
+(=principle-encode-lessons-in-structure=); if it will not, say so, so the
+next reader does not mine it for a pattern that was never intended.
+
+* When this method is the wrong one
+
+Re-match downward as soon as the work turns out to be ordinary. Using
+this for something a narrower method covers adds a planning phase to work
+that did not need one, which is its own kind of waste.
+
+* Recipes
+
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the lifecycle the phases run inside.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:54AD5986-34A0-4B19-9F20-D9A024225036][Running agents]] — how a delegate is configured and bounded.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-method-investigation/SKILL.org
+++ b/doc/llm/skills/compass-method-investigation/SKILL.org
@@ -1,0 +1,120 @@
+:PROPERTIES:
+:ID: 440659B3-5996-4739-B2CB-37B84F5757DC
+:END:
+#+title: Compass Method Investigation
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: cross
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-investigation
+description: The method for a read-only question — how does this work, why is it this way, are we sure. Ends in a cited answer rather than a change, and says plainly where the evidence ran out.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+A question whose deliverable is an answer: how does this subsystem work,
+why was it built this way, is this claim true, should we do X or Y. The
+work is reading and reasoning, and it changes nothing.
+
+Not this method the moment the answer implies a change and you start
+making it. Finish the investigation, record the answer, then re-match to
+the method the change needs. An investigation that quietly becomes a
+refactor produces neither a good answer nor a reviewable diff.
+
+* How to use this skill
+
+** 1. State the question and what would answer it
+
+Write the question down, and write what evidence would settle it. A
+question with no stated answer-shape expands until the context runs out.
+
+Say also what would change if the answer went each way. A question whose
+answers all lead to the same action does not need investigating.
+
+** 2. Ground before searching
+
+Resolve the concepts to knowledge documents first
+([[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]]), reading the
+cluster's structure note where one exists. Search finds pages that mention
+a term; a structure note says which of them are load-bearing
+([[id:D4B099D0-FF9B-4029-96ED-6EE77439DF41][compass-doc-find]],
+[[id:0F8DE59C-9CD1-463A-9148-0B452A985C23][compass-doc-show]]).
+
+For why a thing is the way it is, the record is in the decisions and the
+closed tasks rather than the code: the code says what, the task says why.
+
+** 3. Read narrowly, and stop
+
+Open the two or three sources the map ranked highest, not the twenty the
+search returned (=principle-guard-the-context-window=). Reading more is
+not safer: an answer assembled from a wide shallow sweep is less reliable
+than one from a narrow deep read, and it costs the context the answer has
+to be written in.
+
+** 4. Check the claim against the system, not the language
+
+Where the answer asserts that something is enforced, verify it here rather
+than reasoning from how the tool usually behaves. A compiler flag the
+project does not set, a check no workflow runs, a rule stated in prose and
+enforced nowhere: each reads as true and is not.
+
+Running the smallest thing that would fail if the claim were false beats
+any amount of reading.
+
+** 5. Answer, with citations and with the gaps named
+
+Give the answer first, then the evidence, each claim pointing at the file,
+document or command that supports it. Where the evidence ran out, say so
+in the answer rather than smoothing over it: "I could not determine X" is
+a finding, and a confident answer covering an unchecked gap is worse than
+no answer.
+
+Record it where it will be found again. A durable fact goes to a knowledge
+document via [[id:D3767A34-DC32-4366-ADAB-534D6FC4C607][compass-doc-add]];
+an answer specific to one piece of work goes on the task.
+
+* When this method is the wrong one
+
+Re-match if the question turns out to have an observable answer nobody has
+observed, which is =compass-method-prototype=; or if it resolves to a
+defect, which is =compass-method-bug-fix=.
+
+* Recipes
+
+- [[id:BDA8F7FB-5CEC-42D8-BC78-766BBC8D4285][How do I search docs with compass?]] — the search behind phase 2.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — why a structure note beats a search ranking in phase 2.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-method-prototype/SKILL.org
+++ b/doc/llm/skills/compass-method-prototype/SKILL.org
@@ -1,0 +1,122 @@
+:PROPERTIES:
+:ID: 9DDEE5BF-9B2E-49C4-BAF9-8A2CE87D295B
+:END:
+#+title: Compass Method Prototype
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s1
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-prototype
+description: The method for settling an empirical question by observing it — the smallest thing that produces the observation, thrown away once it has. Use it instead of asking a question the system can answer.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+A decision hangs on something observable that nobody has observed. Does
+this approach actually work; is the difference visible; does the
+enforcement really bite; which of two layouts reads better. The
+deliverable is the observation, not the code that produced it.
+
+Reach for it especially when about to ask the operator a question the
+system could answer. A question about behaviour, timing, output or
+whether a mechanism fires is not theirs to answer
+(=principle-never-block-on-the-human=): building the smallest thing that
+shows the answer is faster than the round trip, and it hands them a
+result to react to instead of a decision to make.
+
+* How to use this skill
+
+** 1. Write the question as an observation
+
+What will you look at, and what will each outcome look like? A prototype
+whose result needs interpreting has not been aimed. "Does pruning the
+deployed tree actually stop the skills loading" is aimed; "does
+attenuation work" is not.
+
+Decide in advance what each outcome implies, so the result cannot be
+read to mean whatever was already preferred.
+
+** 2. Build the smallest thing that produces it
+
+Not a version of the feature. The smallest apparatus that makes the
+observation happen (=principle-laziness-protocol=). Hard-code what does
+not bear on the question, skip the error handling, use a copy of the real
+thing rather than the real thing where that is safer.
+
+Where the observation can be made against what already exists, make it
+there and build nothing.
+
+** 3. Observe, and record what you saw
+
+Run it and write down the actual output, not the conclusion. The numbers,
+the message, the count of what remained. This is the part that survives
+the prototype, and a summary written from memory a phase later loses
+exactly the detail that made it evidence.
+
+** 4. Throw it away
+
+Delete the apparatus, or move it to the scratchpad. A prototype kept
+"because it might be useful" becomes something to maintain that nobody
+designed and nothing tests.
+
+Restore anything the prototype disturbed, and check that you did.
+
+** 5. Record the decision, not the code
+
+The finding goes where the decision it settled lives: the task's plan or
+notes, or a knowledge document if it is durable. Say what was observed
+and what it implies, so the next person does not repeat the experiment to
+re-derive the answer.
+
+Then re-match to the method the real work needs, now that the fork is
+settled.
+
+* When this method is the wrong one
+
+Do not use it for a question whose answer is a preference rather than a
+fact: which of two acceptable behaviours the product should have is a
+product decision, and an experiment cannot settle it.
+
+Do not use it when the apparatus would cost more than building the thing
+properly. At that point the prototype is the feature, and it should be
+built as one.
+
+* Recipes
+
+- [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]] — where the apparatus has to compile.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:DEE49C55-1626-470D-BB0F-D58A11D35769][Verification and evaluation]] — the difference between an observation and a proof.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/compass-method-prototype/SKILL.org
+++ b/doc/llm/skills/compass-method-prototype/SKILL.org
@@ -29,7 +29,7 @@ deliverable is the observation, not the code that produced it.
 Reach for it especially when about to ask the operator a question the
 system could answer. A question about behaviour, timing, output or
 whether a mechanism fires is not theirs to answer
-(=principle-never-block-on-the-human=): building the smallest thing that
+(=compass-principle-never-block-on-the-human=): building the smallest thing that
 shows the answer is faster than the round trip, and it hands them a
 result to react to instead of a decision to make.
 

--- a/doc/llm/skills/compass-method-refactoring/SKILL.org
+++ b/doc/llm/skills/compass-method-refactoring/SKILL.org
@@ -1,0 +1,139 @@
+:PROPERTIES:
+:ID: AD238B8D-ADFE-488A-9536-AA7F0B5A5559
+:END:
+#+title: Compass Method Refactoring
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: s1
+#+filetags: :llm:skill:skills:claude_code:method:sequencing:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-method-refactoring
+description: The method for a behaviour-preserving change to structure — establish the evidence that behaviour is preserved before moving anything, then move it as a script rather than by hand.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Structure changes and behaviour does not: a rename, an extraction, a
+collapse of duplicates, a move across a boundary. The deliverable is the
+same system in a better shape, plus the evidence that it is the same.
+
+Not this method if behaviour changes, however slightly. A refactor that
+"also fixes" something is two changes wearing one commit, and the fix
+loses its reproduction while the refactor loses its guarantee.
+
+* How to use this skill
+
+** 1. Establish the invariant first
+
+Before moving anything, name what must still be true afterwards and find
+what checks it. A refactor without that is indistinguishable from a
+rewrite with optimism.
+
+Where nothing checks it, the first unit of work is the check, not the
+move. That check is also the deliverable's proof, so it is never wasted.
+
+** 2. Ground and map the blast radius
+
+Resolve the concepts ([[id:0B1456B4-54D1-4DDA-9754-DEE653827D59][Grounding]]),
+then find everything that references what you are about to change,
+including archived documents and generated output. The cost of a refactor
+is dominated by the references nobody remembered, and finding them is
+mechanical.
+
+** 3. Subtract before restructuring
+
+Ask what can be deleted outright before deciding where the rest should
+live (=principle-subtract-before-you-add=). Code that no longer needs to
+exist is the cheapest thing to move, because it does not get moved.
+
+Ask also whether the shape is right rather than merely tidier
+(=principle-redesign-from-first-principles=). A refactor that preserves a
+structure nobody would choose today has spent effort to keep a decision
+that should have been revisited.
+
+** 4. Write the change as a script where it repeats
+
+A change across many files is a script, not an afternoon
+(=principle-build-the-lever=). The script is what a reviewer re-runs, it
+is idempotent so a partial run is recoverable, and it is what makes the
+next change of the same shape cheap.
+
+Give it a =--check= mode where the new state is something that could drift
+back, and wire that into CI
+(=principle-encode-lessons-in-structure=). A refactor whose result nothing
+enforces is a shape that decays.
+
+** 5. Move, in verifiable units
+
+Sequence the change so each step ends in a system that builds and passes
+(=principle-sequence-verifiable-units=). Where an old and a new form must
+coexist, migrate the callers and delete the old one in the same wave
+rather than leaving both: two ways to do one thing is the debt the
+refactor was meant to remove
+(=principle-migrate-callers-then-delete-legacy-apis=).
+
+** 6. Prove behaviour survived
+
+Run the invariant from phase 1 (=principle-prove-it-works=), then the
+class checks for what you touched via
+[[id:654D4A70-E63D-4C18-B5A5-886066E36314][compass-code-run-build]]. For
+generated code, the proof is byte-identical regeneration
+([[id:7908E2AF-E196-443F-8FB7-0047553D8EFE][compass-codegen-fix-drift]]).
+
+A green build is necessary and not sufficient: it says nothing about the
+references that live in documentation, and those break silently.
+
+** 7. Land
+
+Close with
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][compass-agile-close-task]] and
+raise with
+[[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][compass-pr-raise]]. Keep the
+script in the tree: it is the artefact that makes the change reviewable
+and repeatable.
+
+* When this method is the wrong one
+
+Re-match if phase 1 shows the behaviour is not currently correct, which
+makes it =compass-method-bug-fix= first and a refactor afterwards; or if
+the restructuring turns out to require new behaviour, which is
+=compass-method-feature=.
+
+* Recipes
+
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the lifecycle this method runs inside.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — what a method is, and how a phase binds to actions.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — the rules cited above.
+- [[id:0FB2EA84-EBB8-45C8-A8C8-F5815431C2D2][Code review checklist]] — what the result is judged against.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -137,6 +137,27 @@ first to the checkers that do not share the session model's priors
 with =compass-agile-close-task= and =compass-pr-raise=, and what generalises is routed into a
 memory, a principle or a skill edit, with approval rather than automatically.
 
+** The methods
+
+Six exist. Each opens by grounding the work and stating what would make it
+finished, and each names the actions and recipes its phases call rather
+than improvising a command.
+
+#+ATTR_HTML: :class hug-leading
+| Method | The work it sequences |
+|--------+-----------------------|
+| [[id:D9452D4A-0B0F-466F-B97F-95BD4C36A452][compass-method-bug-fix]] | A reported defect: reproduce, root-cause, fix, prove |
+| [[id:D4D8B874-0D78-4558-AF80-776AB4F2F4F8][compass-method-feature]] | New or changed behaviour, built from a named data shape |
+| [[id:AD238B8D-ADFE-488A-9536-AA7F0B5A5559][compass-method-refactoring]] | Structure changes, behaviour does not, and the proof is the deliverable |
+| [[id:440659B3-5996-4739-B2CB-37B84F5757DC][compass-method-investigation]] | A read-only question, answered with citations and its gaps named |
+| [[id:9DDEE5BF-9B2E-49C4-BAF9-8A2CE87D295B][compass-method-prototype]] | An empirical fork, settled by observing it and then deleted |
+| [[id:A8CBA1B2-EBC5-42A6-96B4-D19371278FB7][compass-method-figure-it-out]] | Work no method fits: design the phases, then run them |
+
+Matching is the first decision a session makes and the one most worth
+getting right: a misjudged shape is the failure a method exists to
+prevent, and no phase recovers from it. Where two match different parts,
+=compass-method-figure-it-out= sequences them rather than replacing them.
+
 ** Inventory
 
 # BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -158,12 +158,6 @@ getting right: a misjudged shape is the failure a method exists to
 prevent, and no phase recovers from it. Where two match different parts,
 =compass-method-figure-it-out= sequences them rather than replacing them.
 
-** Inventory
-
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Every method, the shape of work it covers, and the verification rungs it must
-climb. Populated when the methods land.
-# END generated inventory
 
 * See also
 

--- a/doc/llm/skills/skill_systems_levels.org
+++ b/doc/llm/skills/skill_systems_levels.org
@@ -162,14 +162,14 @@ What each System sees by default, counted from the levels the skills carry. Atte
 #+ATTR_HTML: :class hug-leading
 | Level | System | Horizon | Sees | Attenuation |
 |-------+--------+---------+------+-------------|
-| =s1= | Agent | Hours | 60 skills | advisory |
-| =s2= | Orchestrator | Days | 16 skills | advisory |
-| =s3= | Sprint Planner | Weeks | 19 skills | advisory |
+| =s1= | Agent | Hours | 65 skills | advisory |
+| =s2= | Orchestrator | Days | 18 skills | advisory |
+| =s3= | Sprint Planner | Weeks | 20 skills | advisory |
 | =s3star= | Auditor | Continuous | 5 skills | binding |
-| =s4= | Version Planner | Months | 14 skills | advisory |
-| =s5= | Identity Steward | Indefinite | 14 skills | advisory |
+| =s4= | Version Planner | Months | 15 skills | advisory |
+| =s5= | Identity Steward | Indefinite | 15 skills | advisory |
 
-13 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
+14 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
 
 # END generated inventory
 


### PR DESCRIPTION
## Summary

A method is control flow with no effectors; our actions and recipes are effectors with no control flow. This joins them. Six methods, one per shape of work: bug fix, feature, refactoring, investigation, prototype, and figure-it-out for work no method fits.

## Changes

- They share a skeleton because the skeleton is the contract. Ground the concepts the work names; state before anything is built what would make it finished in checkable terms; cite principles at the judgement calls; name the action or recipe for anything touching an artefact.
- Each ends by saying when it is the wrong method. A misjudged shape is the failure a method exists to prevent, and no phase inside one recovers from having picked it.
- The methods carry no shell blocks at all, which is the recipe boundary from earlier in this story applied to control flow.
- Nothing was copied. The upstream playbooks live inside poteto-mode, which is adopted whole, so forking them would contradict the reference-not-fork decision. What is written is the local sequencing that binds our effectors, which upstream cannot supply because it does not know our actions exist.
- Steps assuming a foreign host are dropped rather than translated: Graphite stacks, model routing, and an issue-tracker abstraction, all ground our agile layer already owns.
- Levels for the six, a compass-method- section in the generated catalogue, and the set listed in Methods and the mode with the work each sequences.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Port the sequencing function and bind it to recipes and actions](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_port_method_layer.html) | 08F7F925-49B2-40E0-A298-E300353CAE2E |
| Environment | bright_faraday | |

## Testing

Plan. Write the six, wire them into the level table, the catalogue and the methods page, and run every corpus check plus the emacs export that the new files have to survive.

Evidence. docs. compass lint: clean, durable-link advisory unchanged at 158. All five generator checks pass: levels for 77 skills, the namespace, the recipe links, the structure-note back-links, and both generated tables. Skills bundle rebuilt and this session's harness reloaded all six under compass-method-, which is the emacs org export applied to every new file.

Limitations. The site build could not be run. It was killed three times by the machine's low-memory guard — twice as a background task, once after a foreground run was moved to the background at its timeout — while the box reported 19G available. Rather than retry a fourth time I covered the org-export risk another way: the skills build runs the same emacs export over doc/llm/skills and completed, exporting all six methods and the amended methods page. The two agile documents here are the only files without that check, and both are conventional edits. Dangling id-links, the site build's other unique catch, are covered by compass lint. No code was touched, so no build or ctest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)