### PR TITLE
[doc] Build compass-helm, the sticky mode

### DIFF
--- a/build/scripts/apply_skill_levels.py
+++ b/build/scripts/apply_skill_levels.py
@@ -115,6 +115,10 @@ LEVELS = {
     # Identity: what belongs in the product at all.
     "compass-agile-brainstorm-idea": "s5",
 
+    # The mode. It declares the System rather than belonging to one, so
+    # every level can enter it.
+    "compass-helm": "cross",
+
     # Methods. The level is the level of the work the method sequences:
     # execution for the four that carry a change, cross for one that only
     # reads, s2 for the one that plans work spanning many units.

--- a/build/scripts/generate_skills_catalogue.py
+++ b/build/scripts/generate_skills_catalogue.py
@@ -53,6 +53,11 @@ DOMAINS = {
     "method": ("Methods (=compass-method-=)",
                "How a kind of work is approached, from framing to a "
                "verified end."),
+    # A bare noun rather than a domain: the mode is a posture, not an
+    # operation on a target.
+    "helm": ("The mode (=compass-helm=)",
+             "The sticky posture a session enters, which matches work to "
+             "a method and routes to everything else."),
 }
 
 # Planned-but-not-yet-created skills, shown as prose under each section.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -101,6 +101,7 @@ Tasks are listed in intended execution order.
 | [[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][Delegate the remaining skill commands to recipes]] | DISCOVERED | | | Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place. |
 | [[id:A849F82C-0AE6-4217-90FC-F17443B3C168][Enable the compiler warnings the code assumes]] | DISCOVERED | | | The build sets -Werror and nothing else, so -Wall and -Wextra diagnostics never fire; enable them and clear what they surface. |
 | [[id:6D872794-2934-49EA-80EC-F1E64D23AC10][Make a generated marker name a generator that writes it]] | DONE | | | Four documents carry a BEGIN generated marker naming a script that never writes them, so the region reads as derived and is hand-maintained or empty. |
+| [[id:4302B38D-B857-464E-97C1-A7E54A2DE70C][Validate the matching rule and the decline path in use]] | DISCOVERED | | | The matching rule and the mode's refusal are specified and each has at most one run behind it; gather evidence from real uses and amend what the cases break. |
 
 * Decisions
 
@@ -189,6 +190,10 @@ Tasks are listed in intended execution order.
   that carries the discipline. The failure it prevents is reading a
   method and then writing a bespoke plan that drops the inconvenient
   phases.
+- A rule about what counts as wrong must name the contract it is wrong
+  against. Without that anchor, any change of mind about what is correct
+  can be phrased as a symptom and borrow the defect machinery for work
+  that has nothing to root-cause.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -85,7 +85,7 @@ Tasks are listed in intended execution order.
 | [[id:894E9BD8-6808-403A-9878-ABFA51710A74][Add a knowledge gap check for domain work]] | BACKLOG | | | A compass check that extracts the domain concepts a work item names and reports which have no resolving knowledge document. |
 | [[id:A7BCF024-9222-40C3-9151-AFE9C9B4BDBE][Cite the principles under the citation function]] | DONE | 2026-09-10 | 2026-09-10 | Cite the thirteen adopted pstack principles from our catalogue and write the thin local bindings; they are referenced upstream, not copied. |
 | [[id:08F7F925-49B2-40E0-A298-E300353CAE2E][Port the sequencing function and bind it to recipes and actions]] | DONE | 2026-09-10 | 2026-09-10 | Import the adopted methods and interview skills as compass-method skills, with every step bound to one of our actions or recipes. |
-| [[id:60C7573C-763F-466D-A174-61C3A78616AF][Build compass-helm, the sticky mode]] | BACKLOG | | | One sticky entry point that declares the session System, matches work to a method, copies its phases in verbatim, and routes to actions, recipes and deliberation. |
+| [[id:60C7573C-763F-466D-A174-61C3A78616AF][Build compass-helm, the sticky mode]] | DONE | 2026-09-10 | 2026-09-10 | One sticky entry point that declares the session System, matches work to a method, copies its phases in verbatim, and routes to actions, recipes and deliberation. |
 | [[id:BC52784C-64A6-47D2-AE13-BA8530C34507][Bind the Council to the convening function]] | BACKLOG | | | Wire the Council of High Intelligence in as the convening function, and route error detection to the checkers that are genuinely independent. |
 | [[id:26921590-0B75-401F-80C6-52CDF76104CD][Reconcile duplicate skills and standardise terminology]] | BACKLOG | | | Fold every overlapping import into a single skill, retire the losers through compass-skill-delete, and sweep the catalogue onto the agreed vocabulary. |
 | [[id:C4ADAD7A-949E-48D3-941D-706E7B71D30D][Verify the rebuilt skill catalogue end to end]] | BACKLOG | | | Regenerate, rebuild, deploy and prove the whole catalogue loads and dispatches, with no stale directories left behind. |
@@ -100,7 +100,7 @@ Tasks are listed in intended execution order.
 | [[id:39264768-EE92-4DB1-B048-3C960415B358][Specify the skills framework as a regulator]] | DONE | 2026-09-07 | 2026-09-07 | Respecify the framework as a regulator over an agent, deriving its scope and its seven classes of document from cybernetics rather than stipulating them, and classify the upstream pstack collection against that derivation. |
 | [[id:86F4C1E0-6F35-4AA7-9C95-3991D4F5F831][Delegate the remaining skill commands to recipes]] | DISCOVERED | | | Multi-step skills still carry commands their recipes own; sweep the 105 remaining shell blocks so the command lives in exactly one place. |
 | [[id:A849F82C-0AE6-4217-90FC-F17443B3C168][Enable the compiler warnings the code assumes]] | DISCOVERED | | | The build sets -Werror and nothing else, so -Wall and -Wextra diagnostics never fire; enable them and clear what they surface. |
-| [[id:6D872794-2934-49EA-80EC-F1E64D23AC10][Make a generated marker name a generator that writes it]] | DISCOVERED | | | Four documents carry a BEGIN generated marker naming a script that never writes them, so the region reads as derived and is hand-maintained or empty. |
+| [[id:6D872794-2934-49EA-80EC-F1E64D23AC10][Make a generated marker name a generator that writes it]] | DONE | | | Four documents carry a BEGIN generated marker naming a script that never writes them, so the region reads as derived and is hand-maintained or empty. |
 
 * Decisions
 
@@ -182,6 +182,13 @@ Tasks are listed in intended execution order.
   Four documents make that promise about a script that never writes them,
   which is worse than no marker: it tells a reader not to edit a region
   nothing maintains.
+- The mode is entered, not remembered. A method an agent must think to
+  reach for is the one it forgets on the task that needed it, so the
+  sticky posture is where the value is rather than in any single method.
+- Copying a method's phases in verbatim, before reasoning, is the step
+  that carries the discipline. The failure it prevents is reading a
+  method and then writing a bespoke plan that drops the inconvenient
+  phases.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :llm:skills:mode:pstack:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/add-helm-mode-skill
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
 #+updated: 2026-08-26
-#+environment:
+#+environment: bright_faraday
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -26,12 +26,12 @@ pstack's most valuable structural idea is that one skill is sticky: entered once
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-08-26                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-10                               |
 
 * Acceptance
 
@@ -50,11 +50,44 @@ pstack's most valuable structural idea is that one skill is sticky: entered once
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+The blocking criterion came first, because the mode cannot ship without
+it. The matching rule is five ordered questions, taking the first that
+answers yes, ordered by how sharply they discriminate rather than by how
+common they are. Two matching the same work is resolved by that ordering;
+two matching different parts is not a tie at all, and
+=compass-method-figure-it-out= sequences them. Nothing matching sends the
+reader to the limits first, because most unmatched requests are unmatched
+for being too small.
+
+Question 2 outranks question 5 deliberately, and the ordering is the
+substance of the rule rather than an implementation detail: work that
+adds a capability because the current one misbehaves is a defect first,
+and fixing it without reproducing it is how a symptom gets papered over
+with a feature.
+
+Then the mode. Eight steps: decline if the work does not earn it, declare
+the System, read the principles index, match, copy the phases in
+verbatim, run them routing outward, delegate as this same mode, close.
 
 * Notes
+
+The verbatim copy is step 5 rather than something the phases mention in
+passing, because the acceptance is right that it is the part most easily
+lost. The failure is not refusing a phase; it is reading a method,
+forming a private understanding of it, and writing a plan that quietly
+drops what was inconvenient. Copying first makes the drop visible,
+because the phase is sitting in the list with nothing next to it.
+
+Declining is step 1 for the same reason it is worth having at all. A mode
+that fires on everything trains people to route around it, and a mode
+that cannot say /this is not worth my cost/ is one that will be
+disabled rather than used.
+
+=compass-helm= is a bare noun, which the naming registers did not admit.
+The register gains the noun rather than bending the verb rule around it,
+recorded in the decision log with =compass-mode= noted as the rejected
+alternative: accurate, and forgettable.
+
 
 * Test Scenarios
 
@@ -80,3 +113,36 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All twelve acceptance criteria are met, including the blocking one.
+
+Blocking, first: the matching predicate is specified in
+[[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] —
+the ordered rule, the arbitration for two matches of each shape, and the
+null case — before the mode shipped.
+
+The mode is sticky and can be stood down at any turn. Entering it
+declares the System, which attenuates the catalogue. It reads the
+principles index at task start. It copies a matched method's phases in
+verbatim before task-specific reasoning, and a skipped phase stays in the
+list with its reason, silent skipping refused. It can decline, and says
+when the heavy path is not worth its cost. The request shape is
+documented. A delegate is spawned as this same mode rather than a generic
+agent, and an existing one is resumed rather than a sibling spawned
+beside it.
+
+The name is in the decision log as a bare-noun extension with
+=compass-mode= as the rejected alternative.
+
+Exercised end to end on real work, which is why the stale-marker task
+lands in this pull request rather than its own. The mode declined
+nothing, declared s1, read the principles, matched the work to
+=compass-method-bug-fix= on question 2, copied the seven phases in, and
+ran them: reproduced four markers naming a script that never writes them,
+found the cause in =compass lint= checking only BEGIN/END pairing, fixed
+the cause with =_lint_marker_generators=, and proved it by the check
+failing on the four before and passing after.
+
+That run is the evidence for the mode, and it also closes
+[[id:6D872794-2934-49EA-80EC-F1E64D23AC10][the marker task]] it was run
+on.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
@@ -110,7 +110,10 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Question 2 does not anchor /wrongly/ to an existing contract, so a requirement changing retroactively reads as a defect with nothing to root-cause: an endpoint returning 200 since it shipped, and a new client needing 207 | doc/llm/skills/skill_methods.org | Accept | A case I did not construct and could not have, having written the rule. Q2 now requires the behaviour to have been wrong against a contract already in force, with the counter-example stated so the clause is not later read as pedantry |
+| 2 | Declining is more real than decorative — two independent routes reach it — but no run has exercised it | — | Accept | Folded into the validation task with the matching rule, since both are specified and unproven for the same reason |
+| 3 | Every step binds; the attenuation is live rather than aspirational, evidenced by the regenerated level counts moving | — | Accept | No change. The one thing the reviewer could not check, that the harness loads the skill, this session can: it appeared in the catalogue after the bundle rebuild |
+| 4 | Two tasks in one PR is the right call, because the exercise is the acceptance rather than a stand-in; the cost is that the lint fix cannot now be reverted alone | — | Accept | No change. The cost is real and worth naming, which is why it is recorded here rather than only agreed |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.org
@@ -8,7 +8,7 @@
 #+filetags: :llm:skills:mode:pstack:unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/add-helm-mode-skill
-#+pr:
+#+pr: 2059
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-08-26
@@ -104,7 +104,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2059][#2059]] | [doc] Build compass-helm, the sticky mode |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_stale_generated_markers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_fix_stale_generated_markers.org
@@ -45,9 +45,9 @@ Fix the four, and add the check that makes the promise verifiable.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | DISCOVERED                              |
+| State        | DONE                              |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Discovered in review of PR #2057.       |
+| Now          | Done; PR pending.                       |
 | Waiting on   | Nothing.                               |
 | Next         | Begin implementation.                  |
 | Last touched | 2026-09-10                               |
@@ -64,9 +64,23 @@ Fix the four, and add the check that makes the promise verifiable.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Run as the first exercise of =compass-helm=, which is why it lands in
+that task's pull request rather than its own. The mode matched it to
+=compass-method-bug-fix= on question 2 of the matching rule — something
+is observably wrong — and the phases were worked in order.
+
+Reproduce: four documents name =generate_skills_catalogue.py=, which
+only ever writes =claude_code_skills.org=.
+
+Root cause: =compass lint= checked that every BEGIN has a matching END
+and nothing else. Whether the named script targets the file was never
+tested, which is why four markers sat stale without anything noticing.
+
+Fix at the cause: =_lint_marker_generators= reads each marker's named
+script and checks that it mentions the file it claims to write, keyed on
+the directory name for a =SKILL.org=. Then the four regions become
+prose, because a marker is an instruction about a script and there is no
+script to instruct about.
 
 * Notes
 
@@ -94,3 +108,21 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All four acceptance criteria are met.
+
+Every marker now names a script that writes its file, and the three
+legitimate ones — the catalogue, the level inventory, the two type
+tables — pass unchanged.
+
+The four regions whose content nobody generates are prose now, each
+saying what would be generated and what has to exist first, so a reader
+can tell an empty generated region from a promise nobody kept.
+
+The check runs in =compass lint=, and therefore in the Doc Lint
+workflow.
+
+It failed before the fix, naming the four files and lines, and passes
+after. That was the point of the acceptance: the check that would have
+caught the defect is demonstrated against the defect rather than
+asserted against a clean tree.

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_validate_helm_matching.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_validate_helm_matching.org
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: 4302B38D-B857-464E-97C1-A7E54A2DE70C
+:END:
+#+title: Task: Validate the matching rule and the decline path in use
+#+description: The matching rule and the mode's refusal are specified and each has at most one run behind it; gather evidence from real uses and amend what the cases break.
+#+type: task
+#+level: s1
+#+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two parts of =compass-helm= are specified and barely used.
+
+The matching rule has one run behind it, on work that matched question 2
+cleanly. A rule validated by a single use has not met the case that
+breaks it, and one such case already surfaced in review before the mode
+shipped: a requirement changing retroactively reads as observably wrong
+while having nothing to root-cause. That produced the /contract already
+in force/ clause, which is itself unvalidated.
+
+The decline path has no runs at all. Step 1 says the mode can refuse
+work that does not earn its cost, and two independent routes reach that
+exit, but nothing has yet gone through it. A refusal nobody has
+exercised is a refusal nobody knows fires.
+
+Gather the evidence from real uses rather than from constructed
+examples, and amend the rule where a case breaks it.
+
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DISCOVERED                              |
+| Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
+| Now          | Discovered in review of PR #2059.       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-10                               |
+
+* Acceptance
+
+- At least six real uses of the mode are recorded, with the question that matched and the method chosen.
+- At least one recorded use declines, and the reason it declined is stated.
+- At least one recorded use hits the two-methods case, and which arbitration applied.
+- Every case where the rule gave the wrong answer is recorded, with what the rule was amended to.
+- The /contract already in force/ clause is either confirmed by a case or removed as unnecessary.
+- Where a question never fires across the sample, it is challenged: an unused question is either missing its cases or is not discriminating.
+
+
+-
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -172,6 +172,14 @@ How a kind of work is approached, from framing to a verified end.
 | [[id:9DDEE5BF-9B2E-49C4-BAF9-8A2CE87D295B][compass-method-prototype]] | Compass Method Prototype | The method for settling an empirical question by observing it — the smallest thing that produces the observ... |
 | [[id:AD238B8D-ADFE-488A-9536-AA7F0B5A5559][compass-method-refactoring]] | Compass Method Refactoring | The method for a behaviour-preserving change to structure — establish the evidence that behaviour is preser... |
 
+* The mode (=compass-helm=)
+
+The sticky posture a session enters, which matches work to a method and routes to everything else.
+
+| Name | Title | Description |
+|------+-------+-------------|
+| [[id:0CEA32ED-0F13-4F95-BE30-52506FCED156][compass-helm]] | Compass Helm | The sticky mode. Declares the session System, matches the work to a method, copies that method's phases int... |
+
 # END generated catalogue
 
 * Rebuilding skills

--- a/doc/llm/skills/compass-helm/SKILL.org
+++ b/doc/llm/skills/compass-helm/SKILL.org
@@ -1,0 +1,167 @@
+:PROPERTIES:
+:ID: 0CEA32ED-0F13-4F95-BE30-52506FCED156
+:END:
+#+title: Compass Helm
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+level: cross
+#+filetags: :llm:skill:skills:claude_code:mode:
+#+created: 2026-09-10
+#+updated: 2026-09-10
+
+#+begin_export markdown
+---
+name: compass-helm
+description: The sticky mode. Declares the session System, matches the work to a method, copies that method's phases into the todo list verbatim before any task-specific reasoning, and routes to actions, recipes and deliberation as the phases fire. Stays on across turns until stood down.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Enter it at the start of substantial work and leave it on. It is sticky:
+once entered it governs every turn until stood down, so a method is not
+something to remember reaching for.
+
+The request shape:
+
+#+begin_example
+compass-helm <what you observed, or what you want>
+Done means <something the agent can run or inspect>.
+Keep <the behaviour that must not change>.
+#+end_example
+
+State the goal and the constraints, not the skills to run. An agent
+handed both a goal and a step-list follows the step-list and drops the
+method's gates.
+
+*Stand it down* by saying so. The mode ends immediately and the session
+continues as an ordinary one.
+
+* How to use this skill
+
+** 1. Decline, if the work does not earn it
+
+Say so plainly and fall through to the plain action skills. Moving a
+date, fixing a sentence, changing one configuration value, answering a
+question: none of these want a declared System, a grounding phase and a
+decision trail, and a mode that fires on everything trains people to
+route around it.
+
+The mode earns its cost when a plausible diff is not enough: work that
+must be reproduced before it is fixed, a design decision expensive to
+reverse, a run long enough that a human reviews it afterwards, or a
+domain the agent has not grounded itself in.
+
+Declining is a normal outcome, not a failure to engage.
+
+** 2. Declare the System
+
+Name the level the session is acting at, which attenuates the catalogue
+to the slice in scope
+([[id:5365DE9F-E3F9-4B5F-ACC1-B347B5FCE2A9][Systems and levels]]). The
+narrowing is advisory everywhere except the audit channel: reach outside
+it by saying so.
+
+Declare it once, at the start, and say which. A session that never
+declares is acting at every level at once, which is the variety problem
+the levels exist to solve.
+
+** 3. Read the principles index
+
+Read [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] at task
+start, grouped by the moment each is cited. This is what makes a
+citation possible later: a rule the session has not loaded is a rule it
+will not think to cite at the judgement call.
+
+** 4. Match the work to a method
+
+Apply the matching rule in
+[[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]]: the
+ordered questions, the arbitration when two match, and the null case.
+Say which method matched and why, in one line. A match nobody can see is
+a match nobody can dispute.
+
+** 5. Copy the phases in verbatim
+
+Write the matched method's phases into the todo list *before* reasoning
+about the task, in the method's own words and order.
+
+This is the step that carries the value and the step most easily lost.
+The known failure is reading a method, forming a private understanding
+of it, and writing a bespoke plan that quietly drops the phases that
+were inconvenient. Copying first makes the drop visible, because the
+phase is sitting in the list.
+
+A phase deliberately skipped stays in the list with =skip:= and the
+reason. Silent skipping is refused: if the reason cannot be written down
+it is not a decision, it is an omission.
+
+** 6. Run the phases, routing outward
+
+Work the phases in order. As each fires:
+
+- anything touching an artefact calls an *action*;
+- any command comes from a *recipe*, and a missing effector becomes a
+  recipe rather than an inline command;
+- a judgement call cites a *principle* by name;
+- a fork the evidence cannot settle convenes *deliberation*, and the
+  verdict is recorded on the work.
+
+Re-check the match at each phase boundary. Discovering the shape was
+misjudged is a reason to re-match, not to push on through phases that no
+longer fit.
+
+** 7. Delegate as this same mode
+
+A delegate is spawned as a named System under this mode, never as a
+generic agent. It inherits none of the session's grounding, so the brief
+states what it must read first and what it may do
+([[id:54AD5986-34A0-4B19-9F20-D9A024225036][Running agents]]).
+
+Resume an existing delegate rather than spawning a sibling beside it.
+Two delegates on one piece of work contend for the same files and
+produce two partial answers.
+
+** 8. Close the loop
+
+Finish through the actions:
+[[id:67FDB9A1-3EBE-45A5-97BD-5E5123661553][compass-agile-close-task]]
+then [[id:4DF9BFE8-DC28-4220-AFF0-68E0A7CD5D2B][compass-pr-raise]]. What
+generalises beyond this piece of work goes to a memory, a principle or a
+check, with approval rather than automatically.
+
+* Recipes
+
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — the lifecycle the mode drives.
+- [[id:FE388774-0714-4D93-AEB0-D6221314D4F9][How do I orient a new session?]] — what to run before declaring the System.
+
+* Reference
+
+- [[id:E8311826-9900-4932-AFFB-A8AF663414DF][Methods and the mode]] — the matching rule, the request shape, and the limits.
+- [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] — read at task start, cited at the judgement calls.
+- [[id:5365DE9F-E3F9-4B5F-ACC1-B347B5FCE2A9][Systems and levels]] — what declaring a System attenuates.
+- [[id:AEBC2BC9-A854-4CEC-BA88-1602490AC762][Skill architecture]] — the three entry points, of which this is the third.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENSE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/skill_architecture.org
+++ b/doc/llm/skills/skill_architecture.org
@@ -156,9 +156,10 @@ The composition model is independent of any particular way of using it. Three
 entry points are supported. The first is to *invoke an action*, where both the
 operation and its target are already known. The second is to *dispatch on a
 target* with =compass-act=, where the target is known and the operation is not.
-The third is to *enter the mode* with =compass-helm=, which declares a System,
-matches the work to a method, and routes to the other two as the method's phases
-fire.
+The third is to *enter the mode* with
+[[id:0CEA32ED-0F13-4F95-BE30-52506FCED156][compass-helm]], which declares a
+System, matches the work to a method, and routes to the other two as the
+method's phases fire.
 
 The mode is a convenience over methods rather than a precondition for them: a
 method may be invoked directly, as may an action. Separating the three in this

--- a/doc/llm/skills/skill_dispatch.org
+++ b/doc/llm/skills/skill_dispatch.org
@@ -82,10 +82,10 @@ noun*.
 
 ** Inventory
 
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Target type against verb, with the source each type resolves from. Populated
-when the dispatcher lands.
-# END generated inventory
+Target type against verb, with the source each type resolves from.
+Not yet written: it is generated from the verb table, which arrives
+with the dispatcher. Until then the types and their operations are
+in [[id:F5CB5A45-6557-410B-9E4F-542957561A16][Regulatory Functions]].
 
 * See also
 

--- a/doc/llm/skills/skill_generated_artefacts.org
+++ b/doc/llm/skills/skill_generated_artefacts.org
@@ -104,10 +104,9 @@ read the diff and decide whether it is plausible; it regenerates and compares.
 
 ** Inventory
 
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Model type, the profile it binds to, and the drift check guarding it. Populated
-when the drift checks are wired.
-# END generated inventory
+Model type, the profile it binds to, and the drift check guarding it.
+Not yet written: it is generated from the drift registry, which
+arrives when the codegen drift checks are wired into CI.
 
 * See also
 

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -74,6 +74,63 @@ Do not list the skills you want run. State the goal and the constraints;
 the method owns the sequence. An agent handed both a goal and a
 step-list follows the step-list and drops the method's gates.
 
+** Matching a Request to a Method
+
+Matching is the first decision and the one no later phase recovers from,
+so it is a stated rule rather than a judgement made fresh each time.
+
+*** The rule
+
+Ask these in order and take the first that answers yes. They are ordered
+by how sharply they discriminate, not by how common they are.
+
+1. *Does the work change nothing?* The deliverable is an answer, a
+   diagnosis, a recommendation. → =compass-method-investigation=.
+2. *Is something already behaving wrongly, observably?* There is a
+   symptom someone could be shown. → =compass-method-bug-fix=.
+3. *Does behaviour stay the same while structure changes?* A rename, an
+   extraction, a collapse, a move. → =compass-method-refactoring=.
+4. *Does the next decision hinge on something observable that nobody has
+   observed?* → =compass-method-prototype=, then match again once the
+   fork is settled.
+5. *Otherwise, behaviour is new or changed.* →
+   =compass-method-feature=.
+
+Question 2 outranks question 5 deliberately. Work that adds a capability
+because the current one misbehaves is a defect first: fixing it without
+reproducing it is how a symptom gets papered over with a feature.
+
+*** When two match
+
+Two methods matching is nearly always one of two shapes, and they are
+handled differently.
+
+- *Two match the same work.* The earlier question wins, because the
+  ordering is by discrimination: a refactor that also fixes a defect is
+  a defect, and the refactor follows separately once the fix has landed
+  with its reproduction.
+- *Two match different parts of the work.* Neither wins.
+  =compass-method-figure-it-out= sequences them, and each part runs
+  under its own method inside that sequence. A migration across many
+  call sites is this shape: a series of refactors that needs a plan of
+  its own.
+
+The test that separates them is whether one predicate can describe the
+finished state. If it can, it is one piece of work with two candidate
+methods; if it takes two, it is two pieces of work.
+
+*** When none matches
+
+First check the limits below. Most unmatched requests are unmatched
+because they are too small for a method at all, and the answer is a
+plain action skill rather than a bespoke sequence.
+
+Where the work is substantial and genuinely fits no method, that is
+=compass-method-figure-it-out=, whose first phase is to say which
+methods were rejected and why. An unmatched request is a finding: if the
+same shape arrives twice, the second time it should be matching
+something.
+
 ** Limits of the Mode
 
 The machinery has a cost, and a mode that fires on everything trains

--- a/doc/llm/skills/skill_methods.org
+++ b/doc/llm/skills/skill_methods.org
@@ -86,8 +86,10 @@ by how sharply they discriminate, not by how common they are.
 
 1. *Does the work change nothing?* The deliverable is an answer, a
    diagnosis, a recommendation. → =compass-method-investigation=.
-2. *Is something already behaving wrongly, observably?* There is a
-   symptom someone could be shown. → =compass-method-bug-fix=.
+2. *Is something already behaving wrongly, observably, against a
+   contract already in force?* There is a symptom someone could be
+   shown, and the behaviour was wrong when it happened rather than made
+   wrong afterwards. → =compass-method-bug-fix=.
 3. *Does behaviour stay the same while structure changes?* A rename, an
    extraction, a collapse, a move. → =compass-method-refactoring=.
 4. *Does the next decision hinge on something observable that nobody has
@@ -98,7 +100,19 @@ by how sharply they discriminate, not by how common they are.
 
 Question 2 outranks question 5 deliberately. Work that adds a capability
 because the current one misbehaves is a defect first: fixing it without
-reproducing it is how a symptom gets papered over with a feature.
+reproducing it is how a symptom gets papered over with a feature. A crash
+under load and an unhandled input both reproduce, root-cause and get
+fixed by adding what was missing, so bug fix is right even though the fix
+adds something.
+
+The clause about a contract already in force is what stops question 2
+swallowing everything. A requirement can change and recast behaviour
+nobody complained about as wrong: an endpoint that has returned 200 for a
+partial success since it shipped, and a new client that needs 207. That
+reads as observably wrong and is not a defect — nothing misbehaved, the
+requirement is what is new, and there is nothing to root-cause. It is
+question 5. Without the clause, any change of mind about what is correct
+could be phrased as a symptom and borrow the bug-fix machinery.
 
 *** When two match
 

--- a/doc/llm/skills/skill_naming_conventions.org
+++ b/doc/llm/skills/skill_naming_conventions.org
@@ -228,6 +228,7 @@ where an author naming something will meet it. Take the first match.
 | =helm= as a bare name | The mode is a posture, not an operation on a target, so it takes no domain and no object. =compass-mode= was rejected as accurate and forgettable |
 | Level values spelled =s3star=, not =s3*= | The value is a filetag and a directory-safe token; =*= is neither |
 | Further verbs land with the ported methods | The port has not run, so the verbs its steps need are not yet knowable. Each arrives with its own entry here rather than being guessed now |
+| =compass-helm= admitted as a bare noun | A mode is a posture rather than an operation on a target, so it parses as neither =<domain>-<verb>= nor a reserved segment. =compass-mode= was rejected as accurate and forgettable; the register gains the noun rather than bending the verb rule around it |
 | /System/ preferred over /function/ for the role a session adopts | The design's terminology table said /function/, which now collides with /regulatory function/. The architecture resolves it to /System/, and the glossary follows the architecture |
 
 * Upstream skills

--- a/doc/llm/skills/skill_regulatory_functions.org
+++ b/doc/llm/skills/skill_regulatory_functions.org
@@ -675,10 +675,11 @@ The placement procedure. Take the first match.
 
 ** Inventory
 
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Every skill, grouped by the regulatory function it offers. Populated when the
-classification task lands.
-# END generated inventory
+Every skill grouped by the regulatory function it offers.
+Not yet written: the classification exists per skill but nothing
+derives the grouping. The catalogue in
+[[id:2003934B-ED05-D114-404B-08C0E0D844BB][Skills]] groups by domain
+in the meantime.
 
 * See also
 

--- a/doc/llm/skills/skill_systems_levels.org
+++ b/doc/llm/skills/skill_systems_levels.org
@@ -162,14 +162,14 @@ What each System sees by default, counted from the levels the skills carry. Atte
 #+ATTR_HTML: :class hug-leading
 | Level | System | Horizon | Sees | Attenuation |
 |-------+--------+---------+------+-------------|
-| =s1= | Agent | Hours | 65 skills | advisory |
-| =s2= | Orchestrator | Days | 18 skills | advisory |
-| =s3= | Sprint Planner | Weeks | 20 skills | advisory |
+| =s1= | Agent | Hours | 66 skills | advisory |
+| =s2= | Orchestrator | Days | 19 skills | advisory |
+| =s3= | Sprint Planner | Weeks | 21 skills | advisory |
 | =s3star= | Auditor | Continuous | 5 skills | binding |
-| =s4= | Version Planner | Months | 15 skills | advisory |
-| =s5= | Identity Steward | Indefinite | 15 skills | advisory |
+| =s4= | Version Planner | Months | 16 skills | advisory |
+| =s5= | Identity Steward | Indefinite | 16 skills | advisory |
 
-14 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
+15 skills are tagged =cross= and appear in every advisory slice: the documents and the skills themselves, and the orientation any System starts from.
 
 # END generated inventory
 

--- a/doc/llm/skills/skill_verification.org
+++ b/doc/llm/skills/skill_verification.org
@@ -245,10 +245,11 @@ it was used and the work landed.
 
 ** Inventory
 
-# BEGIN generated inventory (build/scripts/generate_skills_catalogue.py)
-Every independent checker, what it proves, and where it is enforced. Populated
-when the ladder lands.
-# END generated inventory
+Every independent checker, what it proves, and where it is enforced.
+Not yet written: it is generated from the workflow definitions, which
+needs the ladder settled first. The checks that exist today are listed
+in [[id:9F3A6B21-0D74-4C58-A5E2-8C1B47E0D9F3][Principles]] under the
+rules a check carries.
 
 * See also
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2446,6 +2446,43 @@ def _lint_generator_markers(files):
     return out
 
 
+_MARKER_SOURCE_RE = re.compile(
+    r"^#\s*BEGIN generated\s+\S+\s+\(([^)]+)\)\s*$", re.M)
+
+
+def _lint_marker_generators(files):
+    """Report a generated marker naming a script that never writes it.
+
+    A marker is an instruction: this region is derived, do not edit it,
+    the named script will rewrite it. A marker naming a script that does
+    not target the file is worse than no marker, because it tells a
+    reader to leave alone a region nothing maintains.
+
+    A generator names the file it writes, so the test is whether the
+    script's source mentions it. For a SKILL.org the name that identifies
+    it is its directory.
+    """
+    out = []
+    for rel, text in files:
+        for m in _MARKER_SOURCE_RE.finditer(text):
+            script = Path(PROJECT_ROOT) / m.group(1).strip()
+            lineno = text[:m.start()].count("\n") + 1
+            if not script.is_file():
+                out.append((str(rel), lineno,
+                            f"marker names {m.group(1)}, which does not exist"))
+                continue
+            try:
+                source = script.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            needle = rel.parent.name if rel.name == "SKILL.org" else rel.name
+            if needle not in source:
+                out.append((str(rel), lineno,
+                            f"marker names {m.group(1)}, which never writes "
+                            f"this file"))
+    return out
+
+
 def _lint_durable_links(files, id_types):
     """Report durable documents linking into agile content."""
     out = []
@@ -2496,7 +2533,8 @@ def cmd_lint(argv):
         description=(
             "Validate the org corpus. Checks filetags (every tag lowercase, "
             "matching [a-z][a-z0-9_-]*), generator markers (every BEGIN has a "
-            "matching END on its own line), dangling id links (every "
+            "matching END on its own line, naming a script that writes "
+            "this file), dangling id links (every "
             "[[id:...]] resolves), and links from durable documents "
             "into agile content. All but the last are enforced; the durable "
             "link check is advisory unless --strict-links is given."
@@ -2547,6 +2585,7 @@ def cmd_lint(argv):
             break
 
     markers = _lint_generator_markers(files)
+    marker_sources = _lint_marker_generators(files)
     id_types = _collect_org_types(files)
     links = _lint_durable_links(files, id_types)
     dangling = _lint_dangling_links(files, id_types)
@@ -2565,6 +2604,13 @@ def cmd_lint(argv):
         print(f"❌  generator markers: {len(markers)} violation(s):\n",
               file=sys.stderr)
         for path, lineno, msg in markers:
+            print(f"  {path}:{lineno}: {msg}", file=sys.stderr)
+
+    if marker_sources:
+        failed = True
+        print(f"\u274c  generated markers: {len(marker_sources)} name a "
+              f"script that does not write them:\n", file=sys.stderr)
+        for path, lineno, msg in marker_sources:
             print(f"  {path}:{lineno}: {msg}", file=sys.stderr)
 
     if dangling:


### PR DESCRIPTION
## Summary

A method an agent must remember to reach for is the one it forgets on the task that needed it. The mode is entered once and governs every turn until stood down: it declares the System, matches the work to a method, copies that method's phases in verbatim, and routes to actions, recipes and deliberation as they fire.

## Changes

- The blocking criterion first: the matching predicate is specified before the mode ships. Five ordered questions, first yes wins, ordered by how sharply they discriminate rather than how common they are. Question 2 outranks question 5 deliberately, because work that adds a capability due to a misbehaving one is a defect first.
- Two methods matching the same work is settled by that ordering. Two matching different parts is not a tie at all, and figure-it-out sequences them. Nothing matching sends the reader to the limits first, because most unmatched requests are too small for a method.
- The mode is eight steps: decline if the work does not earn it, declare the System, read the principles index, match, copy the phases in verbatim, run them routing outward, delegate as this same mode, close.
- The verbatim copy is its own step because it is the one most easily lost. The failure is not refusing a phase; it is reading a method and writing a bespoke plan that drops the inconvenient ones. Copying first makes the drop visible.
- Declining is step 1. A mode that fires on everything trains people to route around it, and one that cannot say this is not worth my cost gets disabled rather than used.
- compass-helm is a bare noun, admitted to the register with a decision-log entry; compass-mode was rejected as accurate and forgettable.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Build compass-helm, the sticky mode](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_add_helm_mode_skill.html) | 60C7573C-763F-466D-A174-61C3A78616AF |
| Environment | bright_faraday | |

## Testing

Plan. Specify the blocking predicate, build the mode, wire it into the levels, the catalogue and the architecture's third entry point, then exercise it end to end on real work rather than asserting that it works.

Evidence. docs and python tooling. Exercised end to end: the mode declared s1, matched compass-method-bug-fix on question 2 of its own rule, copied the seven phases in, and ran them on the stale-marker defect — reproduced four markers naming a script that never writes them, traced the cause to compass lint checking only BEGIN/END pairing, fixed the cause with _lint_marker_generators, and proved it with the check failing on exactly those four and passing after. That run also closes the marker task, which is why it lands here. Compass suite: 159 passed, 1 skipped. compass lint clean, all five generator checks pass, bundle rebuilt and the harness loaded compass-helm.

Limitations. The site build still cannot run here; four low-memory kills are captured separately, so the rendered pages are unverified while the org export and link resolution are covered. Two tasks land in one PR, deliberately: the acceptance requires the mode be exercised on real work before the task closes, and inventing a throwaway exercise would have proved less than doing filed work with it. The matching rule is specified but has one run behind it; whether the ordering holds is a question for the next several uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)