### PR TITLE
[doc] Add knowledge pages on trade structures and confirmations

### DIFF
--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_25:v0:
 #+created: 2026-08-04
 #+updated: 2026-08-11
-#+environment: bright_faraday
+#+environment: eager_maxwell
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -48,7 +48,7 @@ come up rather than scoping the whole story up front.
 | [[id:CBE53221-9F38-4C94-8AE5-AA86867965C8][Add compass-code-review-comments skill]] | DONE | 2026-08-11 | 2026-08-11 | New Claude Code skill that reviews and cleans code comments, wired into CLAUDE.md so it applies to all code we create or edit. |
 | [[id:374CFD96-B8B0-4812-9870-FF91168EE828][Document Skew Stickiness Ratio knowledge page]] | DONE | | 2026-08-25 | Add a knowledge page on how implied volatility surfaces move when spot moves: sticky strike vs sticky delta, the Skew Stickiness Ratio (SSR) that measures ATM-vol response against the ATM skew, and its effect on delta and gamma. |
 | [[id:A572C320-A132-477B-9170-6CB5A0466D2D][Expand the Random Walk knowledge page]] | DONE | | 2026-09-10 | Fold the stationarity, unit-root and first-passage material into the Random Walk knowledge page, with the source attributed. |
-| [[id:520A54D4-6B70-4217-9B90-4D1F3361DCE9][Write knowledge pages on structures and deal composition]] | BACKLOG | | | Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts. |
+| [[id:520A54D4-6B70-4217-9B90-4D1F3361DCE9][Write knowledge pages on structures and deal composition]] | STARTED | 2026-09-11 | | Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
@@ -48,6 +48,7 @@ come up rather than scoping the whole story up front.
 | [[id:CBE53221-9F38-4C94-8AE5-AA86867965C8][Add compass-code-review-comments skill]] | DONE | 2026-08-11 | 2026-08-11 | New Claude Code skill that reviews and cleans code comments, wired into CLAUDE.md so it applies to all code we create or edit. |
 | [[id:374CFD96-B8B0-4812-9870-FF91168EE828][Document Skew Stickiness Ratio knowledge page]] | DONE | | 2026-08-25 | Add a knowledge page on how implied volatility surfaces move when spot moves: sticky strike vs sticky delta, the Skew Stickiness Ratio (SSR) that measures ATM-vol response against the ATM skew, and its effect on delta and gamma. |
 | [[id:A572C320-A132-477B-9170-6CB5A0466D2D][Expand the Random Walk knowledge page]] | DONE | | 2026-09-10 | Fold the stationarity, unit-root and first-passage material into the Random Walk knowledge page, with the source attributed. |
+| [[id:520A54D4-6B70-4217-9B90-4D1F3361DCE9][Write knowledge pages on structures and deal composition]] | BACKLOG | | | Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/story.org
@@ -48,7 +48,7 @@ come up rather than scoping the whole story up front.
 | [[id:CBE53221-9F38-4C94-8AE5-AA86867965C8][Add compass-code-review-comments skill]] | DONE | 2026-08-11 | 2026-08-11 | New Claude Code skill that reviews and cleans code comments, wired into CLAUDE.md so it applies to all code we create or edit. |
 | [[id:374CFD96-B8B0-4812-9870-FF91168EE828][Document Skew Stickiness Ratio knowledge page]] | DONE | | 2026-08-25 | Add a knowledge page on how implied volatility surfaces move when spot moves: sticky strike vs sticky delta, the Skew Stickiness Ratio (SSR) that measures ATM-vol response against the ATM skew, and its effect on delta and gamma. |
 | [[id:A572C320-A132-477B-9170-6CB5A0466D2D][Expand the Random Walk knowledge page]] | DONE | | 2026-09-10 | Fold the stationarity, unit-root and first-passage material into the Random Walk knowledge page, with the source attributed. |
-| [[id:520A54D4-6B70-4217-9B90-4D1F3361DCE9][Write knowledge pages on structures and deal composition]] | STARTED | 2026-09-11 | | Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts. |
+| [[id:520A54D4-6B70-4217-9B90-4D1F3361DCE9][Write knowledge pages on structures and deal composition]] | DONE | 2026-09-11 | 2026-09-11 | Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
@@ -33,11 +33,11 @@ settled with the requester when the work starts.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-09-11                               |
 
 * Acceptance
@@ -49,11 +49,32 @@ settled with the requester when the work starts.
 
 * Plan
 
-(Implementation strategy. Written when work starts; key decisions
-are distilled into the parent story's =* Decisions= at close, but the
-plan itself stays — it is the historical record of what we did.)
+Two knowledge pages, not one. The material splits on a natural seam:
+how a deal is composed, and what happens when the composed deal
+changes. Each page stands alone and links to the other.
+
+1. =doc/knowledge/domain/trade_structures.org= — the composition
+   ladder, the rule that a leg is a trade with its own identifier, the
+   deal topology, structure operations, and the linkages between
+   trades.
+2. =doc/knowledge/domain/confirmations_and_versioning.org= — the
+   confirmation model, the internal and external version rule, the
+   amendment classification, and the confirmable events.
+
+Grounding rules for both pages:
+
+- Use the market term, not a local one. Check each term against FpML,
+  the ISDA Common Domain Model, the CFTC and EMIR rules, and the
+  published vendor material for Murex, Calypso and OpenGamma Strata.
+- Cite the source for every external claim, with a link.
+- Tie each page to our implementation in an "In ORE Studio" section,
+  and link the existing knowledge notes rather than restating them.
+- No pseudo-XML examples. Use tables and prose.
 
 * Notes
+
+Both pages are domain-level. They ground development rather than
+describe a screen or a component.
 
 * Test Scenarios
 
@@ -79,3 +100,26 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+Two domain-level knowledge pages shipped under =doc/knowledge/domain/=,
+both wired into the knowledge hub and the tag inventory:
+
+- =trade_structures.org= — how a deal is built from its parts: the
+  composition ladder, the rule that a leg is a trade with its own
+  identifier, the deal topology, structure operations, and the linkages
+  between trades.
+- =confirmations_and_versioning.org= — what a confirmation is, the
+  internal and external version model, the four amendment axes, and the
+  events that must be re-confirmed.
+
+Every external claim cites a source: FpML, the ISDA Common Domain
+Model, CFTC Part 23 and Part 45, EMIR and its risk mitigation RTS,
+CPMI-IOSCO guidance on the unique transaction identifier, the ISDA
+Novation Protocol, EMTA NDF template terms, and OpenGamma Strata. The
+terminology is checked against the published vendor material for Murex
+and Calypso.
+
+Acceptance is met: the pages exist, link to and from the hub, and the
+site build succeeds with both pages published. =compass lint --path
+doc= exits non-zero on dangling id links, and it does so identically on
+=origin/main= (620 violations on both), so this change adds none.

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: 520A54D4-6B70-4217-9B90-4D1F3361DCE9
+:END:
+#+title: Task: Write knowledge pages on structures and deal composition
+#+description: Add knowledge pages under doc/knowledge/ covering trade structures and how ORE composes a deal from its parts.
+#+type: task
+#+level: s1
+#+filetags: :documentation-improvements:sprint_25:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-11
+#+updated: 2026-09-11
+#+environment:
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add knowledge pages under =doc/knowledge/= on trade structures and deal
+composition in ORE: how a deal is assembled from its parts, such as legs,
+components, and nested trades, and how ORE models the composed forms.
+
+The pages complement the product catalogue in =doc/knowledge/domain/=.
+That catalogue describes products one by one. The new pages explain the
+structural patterns the products share. The exact set of pages is
+settled with the requester when the work starts.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-11                               |
+
+* Acceptance
+
+- The knowledge pages on structures and deal composition exist under
+  =doc/knowledge/=, link to and from the knowledge hub, and publish on
+  the site.
+- =compass lint --path doc= passes and the site build succeeds.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
@@ -7,13 +7,13 @@
 #+level: s1
 #+filetags: :documentation-improvements:sprint_25:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/document-structures-and-deal-composition
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-11
 #+updated: 2026-09-11
-#+environment:
+#+environment: eager_maxwell
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -33,7 +33,7 @@ settled with the requester when the work starts.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:B660460A-682B-4728-9A8F-21B9A9AF52E4][Documentation improvements]] |
 | Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
@@ -97,7 +97,7 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 5637545488 | Stray trailing =**= on two headings, which renders as literal asterisks | doc/knowledge/domain/confirmations_and_versioning.org | Accepted | Fixed in 9892d0922b. Removed the trailing =**= from "The trade population" and "What travels with the trade". |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
+++ b/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.org
@@ -8,7 +8,7 @@
 #+filetags: :documentation-improvements:sprint_25:v0:
 #+owner: marco
 #+branch: feature/document-structures-and-deal-composition
-#+pr:
+#+pr: 2063
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-11
@@ -91,7 +91,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2063][#2063]] | [doc] Add knowledge pages on trade structures and confirmations |
 
 * Review
 

--- a/doc/knowledge/domain/confirmations_and_versioning.org
+++ b/doc/knowledge/domain/confirmations_and_versioning.org
@@ -1,0 +1,359 @@
+:PROPERTIES:
+:ID: 74721BF2-2290-4AA7-8871-E215DA04351F
+:END:
+#+title: Confirmations and Deal Versioning
+#+description: What a trade confirmation is, the internal and external version model, amendment classification, and the events that must be re-confirmed.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:trading:confirmations:versioning:
+#+created: 2026-09-11
+#+updated: 2026-09-11
+
+* Summary
+
+A confirmation is the written record of a deal that both parties accept
+as binding. The trade exists without it, but nothing else in the
+process does: settlement, collateral, netting, reporting and dispute
+resolution all read the confirmed terms.
+
+Every change to a deal raises two questions that look like one. Has the
+deal changed? And has the agreement with the customer changed? The
+answers differ often enough that systems keep two version numbers, one
+internal and one external. The external version moves only when the
+customer's terms move, and it is the handle the customer's records
+match.
+
+This page states the confirmation model, the two-version rule, the
+classification of amendments, and the events that must be re-confirmed.
+
+* Detail
+
+** What a confirmation is
+
+A confirmation is a legal document, not a report. The CFTC defines
+confirming as the consummation of legally binding documentation that
+memorializes the agreement of the parties to all terms of a swap, and
+requires that a confirmation be in writing and that it legally
+supersede any previous agreement. Under the ISDA Master Agreement the
+parties exchange documents and other confirming evidence, each a
+Confirmation, and each Transaction is evidenced by one.
+
+Three properties follow, and each has a system consequence.
+
+1. The confirmation supersedes what came before. A new confirmation
+   replaces the previous one; it does not accumulate.
+2. It is bilateral. Both parties hold the same document, and both can
+   enforce it.
+3. It is the record of the terms, not of the trade. A trade can exist
+   unconfirmed; it cannot settle unconfirmed.
+
+** Verification, affirmation, confirmation
+
+Three steps sit between an execution and a confirmed deal, and the
+words are not interchangeable.
+
+| Step | Who acts | What it establishes | System consequence |
+|------+----------+---------------------+--------------------|
+| Verification | The firm, internally | Our record matches the execution | A verified trade may enter the population |
+| Affirmation | The two counterparties, on the economic terms | Both sides agree the terms | The trade is affirmable; a query is raised instead if the terms differ |
+| Confirmation | The two counterparties, in writing | The binding record, superseding earlier agreement | The trade is confirmed as of a version |
+
+Affirmation is not confirmation, and a platform makes the difference
+easy to miss. DTCC Deriv/SERV ran an affirmation service, AffirmXpress,
+in which a counterparty reviewed a broker's trade details and affirmed
+or queried them, and an affirmed trade could flow automatically to the
+matching and confirmation service "resulting in legal confirmation
+within seconds of affirmation". The affirmation was the trigger; the
+confirmation was the legal act.
+
+The three steps also age differently. An unverified trade is an
+internal control exception. An unconfirmed trade is a counterparty
+risk, because the terms are not yet enforceable in the form the parties
+agreed.
+
+** Why confirmation timing is regulated
+
+Confirmation backlogs were an operational risk long before they were
+regulated. The 2005 ISDA Novation Protocol existed to clear a backlog
+that was largely novation-driven, and both major regimes now set
+deadlines of their own.
+
+- In the United States, CFTC rule 17 CFR 23.501 requires a swap dealer
+  or major swap participant to have written procedures to execute a
+  confirmation for each swap, with time limits that depend on the
+  counterparty type and the asset class. Subpart I of Part 23 also
+  covers portfolio reconciliation (23.502), portfolio compression
+  (23.503) and swap trading relationship documentation (23.504).
+- Also in the United States, 17 CFR Part 45 separates primary economic
+  terms data from confirmation data. Primary economic terms are the
+  terms the counterparties match or affirm when they verify a swap;
+  confirmation data are the terms they match and agree when they
+  confirm it. Both must reach a swap data repository, on a schedule
+  tied to the confirmation.
+- In the European Union, EMIR Article 11(1) requires procedures for
+  timely confirmation of non-cleared OTC derivative contracts, and
+  Article 12 of the risk mitigation RTS, Commission Delegated
+  Regulation (EU) No 149/2013, sets the deadlines: T+1 for credit and
+  interest rate derivatives between financial counterparties, T+2 for
+  equity, FX and commodity derivatives, and longer windows where one
+  party is a non-financial counterparty below the clearing threshold.
+  Article 12(4) adds a monthly reporting duty for unconfirmed trades
+  outstanding more than five business days.
+
+The European Commission has stated that the deadlines require
+procedures that enable confirmation within the period, and are not hard
+deadlines in themselves. The practical reading is the same either way:
+a trade that ages past its deadline is an exception that must be
+counted, explained and cleared.
+
+** The two-version rule
+
+A deal carries two version numbers.
+
+- The /internal version/ moves on every recorded change to the deal. It
+  is the audit spine. It answers "what did we hold, and when".
+- The /external version/ moves only when the terms the customer has
+  agreed to change. It is the commercial spine. It answers "what has
+  the customer agreed to".
+
+The rule in one sentence: a trade changes version only if the agreement
+with the customer has changed.
+
+The external version is the handle the customer's records match. When a
+client queries a trade, they quote the version they hold. A system that
+bumps the external version for internal reasons forces a confirmation
+the customer never agreed to and never asked for.
+
+Two consequences are worth stating plainly:
+
+1. Authorisation does not bump either version. Authorisation is our
+   workflow state, not a term of the deal. Treating it as a term would
+   make the firm issue confirmations for its own internal approvals.
+   Authorisation is metadata on the trade.
+2. An economic change is normally confirmable, and a non-economic
+   change normally is not. The two properties are close, but they are
+   not the same property, and the next section separates them.
+
+** Classification of an amendment
+
+Amendments are classified on four orthogonal axes. They are not values
+of one enumeration, and an amendment sits on all four at once.
+
+| Axis | Values | What it decides |
+|------+--------+-----------------|
+| Economic | Economic / non-economic | Whether the deal must be revalued |
+| Confirmable | Confirmable / non-confirmable | Whether a new confirmation is issued |
+| Real | Real / null | Whether anything at all feeds downstream |
+| Customer-visible | External version moves / does not move | Whether the customer sees a change |
+
+Two combinations deserve a note.
+
+A /null amend/ is real on none of the axes. The value entered equals
+the value held, so nothing changed. The record of the attempt is worth
+keeping for the audit trail, but a null amend must not move the
+external version and must not raise a confirmation.
+
+A /misbooking correction/ is real and economic, and it is confirmable,
+even though it is not a change of mind. It corrects an error in the
+original booking terms, so the confirmed terms change, and the customer
+must agree them again.
+
+** One activity per version
+
+Each version carries one activity record that states why it exists.
+Where several causes land at once, the system records them in a fixed
+priority order and the highest-priority cause names the version. The
+priority order exists because one-activity-per-version is an aim, not a
+guarantee: a batch may deliver a rate reset and a correction together.
+
+** Confirmable events
+
+The events that raise a confirmation:
+
+| Event | Notes |
+|-------+-------|
+| New | The original trade input |
+| Amend | Only when the amend is confirmable |
+| Close out, full | The parties end the deal early |
+| Close out, partial | The unclosed remainder is re-confirmed under the same trade |
+| Cancellation | A trade booked in error and removed in its entirety |
+| Trigger | A barrier is crossed, whether the barrier activates or knocks out the deal |
+| Exercise | The holder exercises an option under the deal |
+| Partial exercise | The holder exercises part of a structure; the untouched legs stay live |
+| Rate reset | A rate is reset under the terms of the deal |
+| Strike fixing | A strike is fixed from an observed level |
+| Restructure | The deal is replaced by a new version |
+
+The list is not a list of trade events. It is the subset of trade
+events that change the terms the customer has agreed to, or that the
+deal itself requires the customer to acknowledge in writing.
+
+Events that are not on the list are not confirmed: authorisation states,
+internal book moves, netting and settlement mechanics, market fixings
+the contract already provides for, and annotations such as hedge links
+and user-defined links. [[id:FC31FC9C-7A6E-4EFD-8A62-6DE4137F7160][Trade Structures and Deal Composition]] carries
+the full table of linkages and marks which ones have an economic
+effect.
+
+** Undoing an event
+
+Most confirmable events have a mirror. A cancellation is undone by a
+reinstatement, a restructure by a reversion, a confirmation by an
+un-confirm. Two rules govern the family:
+
+1. Never delete a version. Post the mirror event and let the record
+   show both.
+2. A matched pair is P&L neutral. The mirror event restores the prior
+   state exactly, so the pair moves no value.
+
+The second rule is the test of a correct implementation. If undoing an
+event changes the P&L, the undo is not a mirror; it is a second event.
+
+** Confirming a deal and confirming a structure
+
+A structure is confirmed as a whole when the parts have no independent
+existence to the customer. The test is not the size of the deal, it is
+the typeness:
+
+- A structure whose legs exist only as parts of the deal confirms as
+  one document. A partial close-out of such a deal produces one
+  confirmation for the remainder, not one per leg.
+- A package of trades that the customer holds under its own terms per
+  trade confirms trade by trade, even though the trades were executed
+  together.
+
+Netting complicates the picture, and the rules depend on the cause. An
+execution algorithm produces many fills that collapse to one ticket, so
+one confirmation covers the lot. A scheduled netting under a hedging
+programme produces one confirmation per netting date. In both cases the
+confirmation follows the trade population, not the message flow.
+
+** The trade population**
+
+A trade must be in the population before it can receive events. The
+population is a state machine, and the states track the confirmation
+steps above: captured, verified, affirmed, confirmed. The states are
+not decoration. Each one gates a different capability, and the useful
+implementation reads the gate rather than re-deriving the state at each
+call site.
+
+** What travels with the trade**
+
+Confirmation intent is a property of the trade, not of a separate
+workflow. A message that carries a trade therefore carries, alongside
+the terms:
+
+- The intent to confirm, and whether that intent is active.
+- The authorisation state and the actor who set it.
+- The event timestamps, at the precision the matching service needs.
+- The identifiers, long and short, so the receiving system can match
+  the trade to its own record.
+- The eligibility of the trade for transaction reporting.
+- The version the message confirms.
+
+The last item is the one most often dropped, and it is the one that
+makes reconciliation possible. A confirmation that does not name the
+version it confirms cannot be matched against the customer's record.
+
+** The document itself
+
+The confirmed document and the booked trade are related but not
+identical. Confirmations are often enriched by hand while they are
+drafted, because the legal text carries terms the booking system does
+not hold: governing law, additional representations, and the settlement
+and account details the two parties have agreed.
+
+Two consequences:
+
+- The confirmation is a document with a life of its own. It is stored,
+  versioned and retrieved as a document, not regenerated on demand.
+- Reconstructing the booked trade from the confirmation is not
+  guaranteed, and reconstructing the confirmation from the booked
+  trade is not either. The link between them is the trade identifier
+  and the version.
+
+Settlement instructions are the common case of a term that lives on the
+confirmation more than on the trade. See
+[[id:0929B047-1A31-3514-9EDB-EF7B4F012C5D][Standing Settlement Instructions]].
+
+** Special cases
+
+| Case | What changes |
+|------+--------------|
+| Non-deliverable forward | The fixing source and the non-deliverable settlement terms are the load-bearing ones. EMTA publishes template terms per currency pair, and a template applies only to trades from its effective date onward, so the version of the template matters. The Master Confirmation Agreement for NDF transactions provides the framework. |
+| Barrier option | Some dealers issue the confirmation "with docs" and some "without docs"; a trade that was documented one way cannot be re-documented the other without a new confirmation. |
+| Broker-executed trade | The trade passes through a sandbox or pre-live environment before it reaches the live system, and the confirmation carries the version from the originating system. |
+| Cleared trade | The original trade is extinguished at acceptance for clearing and replaced by two clearing swaps. The clearing house assigns its own internal identifiers, and those form part of the confirmation data. |
+
+** In ORE Studio
+
+We have the versioning primitives and we do not yet have the
+confirmation model.
+
+What exists:
+
+- Reference data versions a composite by touching the parent when a
+  child changes, so "as of version N" is a temporal window join. See
+  [[id:BA159E88-74EB-4401-91CC-1DE7DF5AE50A][Temporal Composite Entity Versioning: Target State]].
+- Trading does not adopt that design. Each entity versions on its own
+  spine and the composite read is a temporal join over keys. See
+  [[id:dfe15809-ab5a-4eb7-8afb-251bf5d0b911][A data-oriented data model for ores.trading]].
+- The blotter exposes the deal actions that produce versions: Amend,
+  Cancel, Clone and Roll Forward. See
+  [[id:3976695F-F526-4C2A-80ED-89B54854CF6D][Trade Blotter]].
+
+What is missing, and what development should add:
+
+1. An external version, distinct from the internal version, and bumped
+   only by a change to the customer's terms.
+2. Authorisation recorded as trade metadata, never as a version cause.
+3. One activity record per version, carrying the cause, with a stated
+   priority order when several causes coincide.
+4. A confirmable flag derived from the amend classification, not
+   inferred from the presence of a value change.
+5. Undo events that post a mirror version and never delete one.
+6. The confirmed version stamped on every outgoing confirmation
+   message.
+
+** Sources
+
+- CFTC, 17 CFR Part 23 Subpart I, Swap Documentation (confirmation,
+  portfolio reconciliation, compression, relationship documentation):
+  https://www.law.cornell.edu/cfr/text/17/part-23/subpart-I
+- CFTC, 17 CFR 45.1 definitions: primary economic terms data,
+  confirmation data, life cycle event:
+  https://www.govinfo.gov/content/pkg/CFR-2013-title17-vol1/pdf/CFR-2013-title17-vol1-sec45-1.pdf
+- EMIR, Article 11, risk mitigation techniques for non-cleared OTC
+  derivative contracts: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32012R0648
+- Commission Delegated Regulation (EU) No 149/2013, Article 12, timely
+  confirmation: https://www.legislation.gov.uk/eur/2013/149/chapter/VIII/adopted
+- ESMA, Questions and Answers on EMIR implementation:
+  https://www.esma.europa.eu/sites/default/files/library/esma70-1861941480-52_qa_on_emir_implementation.pdf
+- DTCC Deriv/SERV AffirmXpress (archived product page):
+  https://web.archive.org/web/20071105023716/http://www.dtcc.com/products/derivserv/suite/affirmxpress.php
+- FpML 5.10, Messaging Framework (confirmation and trade change
+  messages): https://www.fpml.org/docs/FpML5-messaging-framework-2.pdf
+- FpML 5, post-trade events (amendment, increase, termination,
+  novation):
+  https://cdn.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/schemaDocumentation/schemas/fpml-business-events-5-11_xsd/groups/PostTradeEventsBase.model.html
+- ISDA Common Domain Model, Event Model (a lifecycle event as atomic
+  primitive instructions over trade states):
+  https://cdm.finos.org/docs/6.0.0/event-model/
+- EMTA, NDF template terms and FX market practice:
+  https://www.emta.org/
+- Foreign Exchange Committee, Master Confirmation Agreement for
+  Non-Deliverable Forward FX Transactions, Practice Notes:
+  https://resources.newyorkfed.org/medialibrary/microsites/fmlg/files/documentation/practicenotes.pdf
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes.
+- [[id:FC31FC9C-7A6E-4EFD-8A62-6DE4137F7160][Trade Structures and Deal Composition]] — the composition model
+  whose changes this page classifies.
+- [[id:3976695F-F526-4C2A-80ED-89B54854CF6D][Trade Blotter]] — the deal actions that produce versions.
+- [[id:BA159E88-74EB-4401-91CC-1DE7DF5AE50A][Temporal Composite Entity Versioning: Target State]] — the versioning
+  spine our entities already carry.
+- [[id:dfe15809-ab5a-4eb7-8afb-251bf5d0b911][A data-oriented data model for ores.trading]] — the per-entity
+  versioning the trading component targets.
+- [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]] — trade activity categories, and why a version
+  boundary matters to an attribution run.

--- a/doc/knowledge/domain/confirmations_and_versioning.org
+++ b/doc/knowledge/domain/confirmations_and_versioning.org
@@ -228,7 +228,7 @@ one confirmation covers the lot. A scheduled netting under a hedging
 programme produces one confirmation per netting date. In both cases the
 confirmation follows the trade population, not the message flow.
 
-** The trade population**
+** The trade population
 
 A trade must be in the population before it can receive events. The
 population is a state machine, and the states track the confirmation
@@ -237,7 +237,7 @@ not decoration. Each one gates a different capability, and the useful
 implementation reads the gate rather than re-deriving the state at each
 call site.
 
-** What travels with the trade**
+** What travels with the trade
 
 Confirmation intent is a property of the trade, not of a separate
 workflow. A message that carries a trade therefore carries, alongside

--- a/doc/knowledge/domain/trade_structures.org
+++ b/doc/knowledge/domain/trade_structures.org
@@ -1,0 +1,398 @@
+:PROPERTIES:
+:ID: FC31FC9C-7A6E-4EFD-8A62-6DE4137F7160
+:END:
+#+title: Trade Structures and Deal Composition
+#+description: How a deal is built from its parts: the composition ladder, deal topology, structure operations, and the linkages between trades.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:domain:finance:trading:structures:deal_composition:
+#+created: 2026-09-11
+#+updated: 2026-09-11
+
+* Summary
+
+A trade structure is one deal assembled from several parts. The parts
+are legs, and each leg is itself a trade with its own identifier. A
+structure is the set of those trades plus the rules that bind them: the
+role each leg plays, the pricing that reads them together, and the one
+commercial act the customer sees.
+
+This page fixes the vocabulary. It gives the composition ladder from a
+same-family strategy to an untyped package, the rule that binds a
+structure to its legs, the operations that create and reshape a
+structure, and the portfolio-level operations that replace trades
+outright. It closes with how ORE Studio models composition today and
+what the target model changes.
+
+* Detail
+
+** Why composition needs its own vocabulary
+
+A single trade is a product with a payoff. A structure is not a bigger
+product. It is a small graph of trades with rules about who plays which
+part.
+
+The distinction matters because every layer of the system needs it. The
+pricer needs to read the legs as one deal. The blotter needs to show the
+deal as one row and the legs as children of it. The confirmer needs to
+know which changes to the legs the customer must agree to again. The
+ledger and the netting engine need the leaves, not the container.
+
+Loose usage of the words causes defects. "Structure", "group" and "set"
+are not synonyms:
+
+- A /structure/ binds its parts economically. The parts have roles, and
+  the whole prices differently from the sum of the parts. A straddle is
+  a structure.
+- A /group/ is a bundle a user assembles for convenience. The trades in
+  it keep their own economics. A hedge group is a group.
+- A /set/ is a collection with no relationship at all. A portfolio of
+  unrelated trades is a set.
+
+Reserve "structure" for the first case. The other two are display and
+organisation concepts, and they belong to the blotter, not to the trade
+model.
+
+** The composition ladder
+
+Structures form a ladder. Each rung binds the legs more weakly than the
+rung above it, and holds more of them.
+
+| Rung | Binds the legs by | Example | Industry name |
+|------+-------------------+---------+---------------|
+| Strategy | One product family, one pricing model, fixed leg roles | Straddle, risk reversal, butterfly, calendar spread | FpML =strategy=; "combination" in front-office systems |
+| Typed structure | Legs from different families, roles fixed in the type | Callable swap, convertible bond, total return swap with a funding leg | A qualified product in the CDM |
+| Dynamically typed structure | Roles read from data at run time | Generic scripted product; an exotic whose payoff comes from a script | FpML generic products; scripted trades |
+| Untyped structure (package) | Nothing economic; a container | Composite trade, portfolio basket, a package executed as one order | FpML =tradePackage=; block then allocate |
+
+Two rules hold across the ladder. A structure may contain another
+structure, so the ladder nests. And a structure is priced as a whole at
+the top rungs and as the sum of its parts at the bottom rung.
+
+FpML carries the top rung as the =strategy= element, which substitutes
+for the abstract =product= element of a trade. It holds a repeating
+=product= child, one per leg, plus =strategyComponentIdentifier= for the
+legs and an optional =premiumProductReference= that names the leg which
+carries the premium. FpML never recommends the older =multiLeg= boolean,
+because the strategy structure says the same thing with more detail.
+
+** A leg is a trade, not a property
+
+The load-bearing rule of the whole page: an atomic deal has a unique
+identifier, and a leg of a structure is an atomic deal.
+
+Consequences:
+
+1. The premium leg is a trade in its own right, not a field on the
+   option. It has its own currency, payment date and identifier.
+2. Brokerage is a separate leg. The dealer's margin stays visible and
+   reportable instead of being netted into a price.
+3. Composition is by key, not by ownership. A structure refers to its
+   legs; it does not own them. A leg can be unlinked from one structure
+   and linked to another without being rewritten.
+
+The third consequence is a data-model constraint, not a preference.
+Where a model stores a leg as an owned child of a parent object, every
+read of the parent drags in the whole subtree, and no read can cross
+structures. Where a leg is a row with a key, the structure is a join.
+[[id:dfe15809-ab5a-4eb7-8afb-251bf5d0b911][A data-oriented data model for ores.trading]] states the same rule for
+the trading component: =trade=, =instrument= and =leg= are sets of rows
+joined by keys, and no aggregate versions as a whole.
+
+** The deal topology of a structure
+
+A structure is a tree. The root is the deal the customer sees. The
+leaves are the trades that carry cash flows. Inner nodes may be further
+structures.
+
+A worked shape, from a strategy structure that wraps an inner option
+structure:
+
+- Structure: the customer-facing deal.
+  - Vanilla group: an inner structure holding one option and its
+    side trades.
+    - Vanilla option: the leg that carries the payoff.
+    - FX trade: the leg that fixes the currency of the premium.
+    - Premium: the leg that pays for the option.
+    - Brokerage: the leg that carries the dealer's margin.
+  - Hedge legs: the trades the desk books to flatten the risk of the
+    option.
+
+Four rules govern this tree:
+
+1. Every node that carries a cash flow or a valuation is a trade with an
+   identifier. Container nodes are the only exception, and they hold no
+   economics of their own.
+2. The arrangement is built by a pipeline that spans pricing, booking
+   and post-processing. One stage prices the package, the next books the
+   legs, the last attaches the hedge and the settlement instructions.
+3. Downstream systems read the leaves. Valuation, netting, ledger
+   posting and regulatory reporting all work on trades, not on the
+   container.
+4. The tree may be rebuilt. A restructure of the deal produces a new
+   version of the tree with new links, and it leaves the old version
+   readable.
+
+** Pricing a structure
+
+A pricing run has two modes, and they answer different questions.
+
+- /Structure mode/ treats the deal as one unit. It uses one model for
+  the parts that interact, and it produces one price for the deal. A
+  callable swap is priced this way, because the call right and the swap
+  are one instrument economically.
+- /Leg mode/ prices each trade on its own and reports the results side
+  by side. It answers the question "what is each piece worth", which is
+  what the trader needs in order to hedge.
+
+Most front-office screens offer both, plus a condensed and an expanded
+presentation of the same tree. The condensed view shows the structure as
+one line; the expanded view shows the legs. The two views read the same
+data.
+
+The same split appears in other systems. OpenGamma Strata composes a
+=Swap= from one or more =SwapLeg= objects, notes that a swap has two
+legs in most cases but may have one, three or more, and resolves the
+whole into a =ResolvedSwapLeg= per leg before pricing. The resolution
+step is the boundary between "the deal as modelled" and "the deal as
+priced", and it is a useful pattern to copy: keep the trade shape and
+the pricing shape separate.
+
+Pricing a structure can also mean stripping it. Structure stripping
+prices the deal as one unit and shows the equivalent set of independent
+legs, so that a desk can see what it would take to hedge the deal trade
+by trade. In our UI this is the master deal plus its calendar: the
+master deal is the priced unit, and the calendar holds the legs.
+
+** Structure versioning
+
+Versioning follows the composition rule: a change anywhere in the tree
+is a change to the structure. The rules in brief:
+
+- A change to any component increments the structure version. The
+  version belongs to the deal, not to the leg.
+- Authorisation does not increment it. Authorisation is metadata about
+  the deal, not a term of it.
+- An economic change is confirmable. A life-cycle event that the
+  contract already provides for is not.
+
+The full model, with the amend classification and the confirmable-event
+list, is on [[id:74721BF2-2290-4AA7-8871-E215DA04351F][Confirmations and Deal Versioning]].
+
+** Structure operations
+
+| Operation | What it does | Economic effect |
+|-----------+--------------+-----------------|
+| Create from existing trades | Assemble a structure from trades already booked | None until the structure is confirmed |
+| Unstructure | Drop the structure and keep the legs as independent trades | None; presentation only |
+| Split (allocate) | Give part of a trade or a structure to another book or account | None; ownership only |
+| Merge (aggregate, net) | Combine trades into one trade, or into a netted position | Yes; the old trades close and a new one opens |
+| Link / unlink | Attach or detach a trade from a structure or from another trade | None; the link carries no cash flow |
+| Lock / unlock | Freeze a structure against edits | None |
+| Roll / restructure | Replace the current version with a new one | Yes; a confirmable amendment |
+
+The table separates two kinds of operation that look alike in a UI.
+Split, link, unstructure and lock change only what the system records
+about the deal. Merge, roll and any change to a term change the deal
+itself, and they travel to the customer as a confirmation.
+
+** Linkages between trades
+
+Structures are the strongest form of linkage between trades, but not
+the only one. Trading systems record a family of links. Each link has a
+cause and an economic effect, and the two are not the same thing.
+
+| Linkage | Cause | Economic effect |
+|---------+-------+-----------------|
+| Close-out, full or partial | The parties agree to end a trade early | Yes; the trade terminates or downsizes |
+| Novation or assignment | One party transfers its position to a third party | Yes; the counterparty changes |
+| Roll or restructure | The parties replace the deal with a new one | Yes; a new version supersedes the old |
+| Partial exercise | The holder exercises part of a deal | Yes; the exercised part settles and the rest continues |
+| Expiry and exercise | The contract reaches a date in its terms | Yes |
+| Netting | The parties agree to settle amounts net | No; settlement mechanics only |
+| Tom/Next funding | The desk funds a currency position overnight | No; funding mechanics only |
+| Spot sweep | The desk sweeps residual currency balances | No; cash management only |
+| End-of-month and start-of-year cleardown | The desk resets positions at a period boundary | No |
+| NDF fixing | The rate for a non-deliverable forward is fixed | No; the trade already provides for it |
+| Wash or back-to-back | The desk offsets a position with a matching trade | No; risk routing only |
+| Hedge link | The desk marks a trade as the hedge of another trade | No |
+| User-defined link | A user records an arbitrary association | No |
+
+The right-hand column is the one that decides behaviour. A link with an
+economic effect is a trade event: it changes the deal, it carries a
+version, and it may need a confirmation. A link with no economic effect
+is an annotation: it is recorded, displayed and reported, and it changes
+no term.
+
+Novation deserves one further note, because it changes the parties
+rather than the terms. Under the ISDA Master Agreement a party may not
+transfer its interest without the prior written consent of the other
+party, and the 2005 ISDA Novation Protocol sets a same-day consent
+process between the transferor, the transferee and the remaining party.
+The substance is that a novation is a new legal relationship, not an
+edit to an existing one, and a system that models it as an edit loses
+the audit trail.
+
+[[id:3976695F-F526-4C2A-80ED-89B54854CF6D][Trade Blotter]] describes these operations as the front office sees
+them: Link / Unlink, Allocate (Split), Aggregate / Net, and Roll
+Forward.
+
+** Portfolio-level composition: compression and tear-ups
+
+The largest composition operation runs across portfolios rather than
+inside one deal.
+
+Portfolio compression, also called a tear-up, terminates trades that
+offset each other and replaces them with a smaller set that carries the
+same net risk. TriOptima introduced the practice to the interest rate
+swap market in 2003 through its triReduce service, and it runs cycles
+for trades cleared at LCH SwapClear. ISDA reported $164 trillion of
+notional eliminated industry-wide through compression by the end of
+2011, and LCH announced that SwapClear had compressed over $1
+quadrillion of notional by 2016.
+
+Compression is the clearest case for treating a composition change as
+one atomic event. The ISDA Common Domain Model states the same rule:
+compression downsizes or terminates several trades while it creates
+new ones, and those primitive changes happen together or not at all. A
+system that applies them one at a time exposes a book that never
+existed.
+
+Compression also breaks the identifier chain, by design. Under the
+CPMI-IOSCO guidance on the unique transaction identifier, a new UTI is
+required when a transaction is replaced by one or more other
+transactions, including through compression, allocation or a change of
+counterparty, while a pure amendment keeps the existing UTI. The
+original UTI stays with the original trade. Clearing houses keep the
+link explicit: Eurex records the superseded identifier in a
+=priorUTI= field on the new trade.
+
+Both obligations pull in the same direction for us. Keep the successor
+link on the replacement trade, and never reuse an identifier.
+
+** What the customer sees
+
+The customer sees the structure, not the legs. The confirmation, the
+statement and the reporting describe one deal with one set of terms.
+Two consequences follow for the trade model:
+
+- A structure is confirmed as a whole. A partial confirmation of the
+  parts would leave the customer's record and ours describing different
+  deals.
+- Presentation terms belong to the structure. Zero-premium quotes,
+  budget rates and protection and participation axes are ways of
+  describing the deal to the customer. They are not legs.
+
+The confirmation side of this is on
+[[id:74721BF2-2290-4AA7-8871-E215DA04351F][Confirmations and Deal Versioning]].
+
+** Naming across systems
+
+The concepts on this page are industry-wide, and the names differ.
+
+| Concept | Name in the source we follow |
+|---------+------------------------------|
+| Same-family structure | FpML =strategy=; a "combination" in several front-office systems |
+| Multi-leg container | FpML =tradePackage=; a package in post-trade messaging |
+| Leg | FpML =product= child of a strategy; =SwapLeg= and =ResolvedSwapLeg= in OpenGamma Strata |
+| Untyped container | ORE =CompositeTrade=; portfolio basket in ORE and FpML |
+| Composition change | A business event made of primitive instructions in the ISDA CDM |
+| Replacing trades without changing net risk | Compression; a tear-up in interest rate and credit markets |
+
+Vendor front-office systems agree on the verbs even where they differ
+on the nouns. The published Calypso and Nasdaq training catalogue names
+the same life-cycle events we do, including ALLOCATION, MATURE, RATE
+RESET, ROLLOVER and TERMINATION, and it names single-leg trade capture
+as its own topic. Murex markets MX.3 with a structuring tool and life
+cycle management at both bulk and trade level. Neither point needs more
+than this: the vocabulary on this page is the vocabulary of the market,
+not a local dialect.
+
+** In ORE Studio
+
+The trading component has no object graph today. Its entities are
+separate tables, and
+[[id:dfe15809-ab5a-4eb7-8afb-251bf5d0b911][A data-oriented data model for ores.trading]] records the consequence:
+ownership and aggregate versioning do not exist as model concepts, and
+the composite as-of read is a temporal join over keys rather than a
+version on the parent.
+
+The pieces that exist:
+
+- =CompositeTrade= is our untyped structure today. It bundles component
+  trades into one position, reports one NPV in one currency, and
+  aggregates the notional of its components by a chosen method. See
+  [[id:2D1B9342-FC33-49DF-8F23-5B2248968156][Composite Trade]].
+- The trade blotter shows a structure view: structures collapse to one
+  header row with a disclosure triangle, and the structure view tabs the
+  legs by type. See [[id:3976695F-F526-4C2A-80ED-89B54854CF6D][Trade Blotter]].
+- Reference data uses aggregate versioning: a write to a child bumps
+  the parent's version in the same transaction, which makes "the
+  composite as of version N" a temporal window join. See
+  [[id:BA159E88-74EB-4401-91CC-1DE7DF5AE50A][Temporal Composite Entity Versioning: Target State]].
+
+The target for trading follows the relational reading instead. A
+composite instrument is =composite_instruments= rows and
+=composite_legs= rows joined by keys, a leg is keyed by its instrument
+and its leg sequence, and each entity versions on its own spine. The
+aggregate version of the reference-data model is deliberately not
+adopted for trading, because it is object-graph thinking. See
+[[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-Oriented Design in ORE Studio]] for the review criteria that
+follow from this.
+
+Development on structures should ground on four rules:
+
+1. Every atomic trade gets a unique identifier, including premium,
+   brokerage and hedge legs.
+2. A structure references its legs by key. No parent owns a child.
+3. The structure version is read from the legs, not stored beside them.
+4. A link that carries an economic effect is a trade event; a link that
+   carries none is an annotation.
+
+** Sources
+
+- FpML, =strategy= element:
+  https://www.fpml.org/spec/fpml-5-8-6-tr-1/html/recordkeeping/schemaDocumentation/schemas/fpml-doc-5-8_xsd/elements/strategy.html
+- FpML 5, post-trade events (amendment, increase, termination, novation):
+  https://cdn.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/schemaDocumentation/schemas/fpml-business-events-5-11_xsd/groups/PostTradeEventsBase.model.html
+- FpML 5.10, Messaging Framework:
+  https://www.fpml.org/docs/FpML5-messaging-framework-2.pdf
+- ISDA Common Domain Model, Event Model:
+  https://cdm.finos.org/docs/6.0.0/event-model/
+- OpenGamma Strata, =SwapLeg=:
+  https://strata.opengamma.io/apidocs/com/opengamma/strata/product/swap/SwapLeg.html
+- ISDA, Interest Rate Swaps Compression: A Progress Report (February
+  2012): https://www.isda.org/a/R0DDE/irs-compression-progress-report-feb-2012.pdf
+- LCH.Clearnet, TriOptima and SwapClear terminate USD interest rate
+  swaps (4 August 2011):
+  https://ftp.lchclearnet.com/media_centre/press_releases/2011-08-04.asp
+- CPMI-IOSCO, Harmonisation of the Unique Transaction Identifier:
+  Technical Guidance (28 February 2017):
+  https://www.bis.org/cpmi/publ/d158.htm
+- Eurex Clearing, change of unique transaction identifier (clearing
+  circular): https://www.eurex.com/ec-en/find/circulars/clearing-circular-3237254
+- ISDA, Novation Protocol: https://www.isda.org/traditional-protocol/isda-novation-protocol/
+- Murex, treasury management (MX.3 structuring and life cycle
+  management): https://www.murex.com/en/solutions/business-solutions/treasury-management
+- Nasdaq Calypso, learning catalogue (trade capture and structured
+  product life-cycle events): https://learncalypso.nasdaq.com/courses/how-to-videos
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the hub of all knowledge notes.
+- [[id:74721BF2-2290-4AA7-8871-E215DA04351F][Confirmations and Deal Versioning]] — the confirmation model
+  that a structure version drives.
+- [[id:3976695F-F526-4C2A-80ED-89B54854CF6D][Trade Blotter]] — the structure view, and the deal actions that
+  operate on a structure.
+- [[id:2D1B9342-FC33-49DF-8F23-5B2248968156][Composite Trade]] — ORE's untyped structure, and the notional
+  aggregation methods it offers.
+- [[id:dfe15809-ab5a-4eb7-8afb-251bf5d0b911][A data-oriented data model for ores.trading]] — why composition is
+  keys and joins, not an object graph.
+- [[id:BBD43BF2-9FEE-42B0-A667-9468AF759DC2][Data-Oriented Design in ORE Studio]] — the review criteria that
+  follow from that model.
+- [[id:BA159E88-74EB-4401-91CC-1DE7DF5AE50A][Temporal Composite Entity Versioning: Target State]] — the
+  aggregate-versioning design used by reference data.
+- [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]] — why the version of a structure matters to the
+  attribution of a P&L move.
+- [[id:5FC58A79-DBC9-46AF-9AAA-2C80B3A47850][Books and portfolios]] — where structures sit in the book
+  hierarchy.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -410,6 +410,13 @@ organised by asset class on the [[id:C5C95B29-2EF9-4DFC-9E04-428C41C1925D][ORE P
   regulatory classification: intent-based assignment, presumptive
   lists, trading desk structure, capital treatment, switching
   restrictions.
+- [[id:FC31FC9C-7A6E-4EFD-8A62-6DE4137F7160][Trade Structures and Deal Composition]] — how a deal is
+  built from its parts: the composition ladder, the rule that a
+  leg is a trade with its own identifier, structure operations,
+  and the linkages between trades.
+- [[id:74721BF2-2290-4AA7-8871-E215DA04351F][Confirmations and Deal Versioning]] — what a confirmation is,
+  the internal and external version model, amendment
+  classification, and the events that must be re-confirmed.
 
 ** Data quality
 

--- a/doc/meta/tag_inventory.org
+++ b/doc/meta/tag_inventory.org
@@ -208,12 +208,14 @@ Tags that describe the business or technical domain of the content.
 | =commodityswaption= | Commodity swaptions and commodity derivatives markets. |
 | =commodityvarianceswap= | Commodity variance swaps and commodity volatility markets. |
 | =compositetrade= | Composite trades and multi-component trade structures. |
+| =confirmations= | Trade confirmation, affirmation, and confirmation controls. |
 | =convertiblebond= | Convertible bonds and hybrid equity-debt instruments. |
 | =currencies= | Currency reference data. |
 | =counterparty= | Counterparty entity and management. |
 | =cpiswap= | CPI inflation swaps and inflation-linked markets. |
 | =creditdefaultswap= | Single-name credit default swaps and credit markets. |
 | =creditlinkedswap= | Credit linked swaps and structured credit. |
+| =deal_composition= | Deal composition: structures, legs, and the linkages between trades. |
 | =deployment= | Deployment and environment provisioning. |
 | =documentation= | Documentation tooling and conventions. |
 | =domain= | Business domain modelling. |
@@ -280,6 +282,7 @@ Tags that describe the business or technical domain of the content.
 | =security= | Security features and hardening (also component tag). |
 | =sprint= | Sprint-level document (also type tag). |
 | =strikeresettableoption= | Strike resettable options and trigger-reset option structures. |
+| =structures= | Trade structures and multi-leg deal composition. |
 | =swap= | Swap products and interest-rate derivatives. |
 | =swaption= | Swaptions and the interest rate option market. |
 | =syntheticcdo= | Synthetic collateralised debt obligations and tranches. |
@@ -290,6 +293,7 @@ Tags that describe the business or technical domain of the content.
 | =ui= | User interface design and implementation. |
 | =ux= | User experience. |
 | =var_and_vol_derivatives= | Exotic variance and volatility swaps and options with barriers and corridors. |
+| =versioning= | Versioning of deals and entities: internal and external versions. |
 | =window_barrieroption= | Window barrier options and time-windowed barrier structures. |
 | =worstofbasketswap= | Worst of basket swaps and basket trigger structures. |
 | =yyswap= | Year-on-year inflation swaps and inflation-linked markets. |


### PR DESCRIPTION
## Summary

Two domain-level knowledge pages ground how ORE models a composed deal and how it versions one. The existing product catalogue describes products one at a time; these pages describe the structural patterns the products share.

## Changes

- Add doc/knowledge/domain/trade_structures.org: the composition ladder from a same-family strategy to an untyped package, the rule that a leg is a trade with its own identifier, the deal topology, structure operations, the linkages between trades, and portfolio compression.
- Add doc/knowledge/domain/confirmations_and_versioning.org: what a confirmation is, the verification/affirmation/confirmation split, the internal and external version rule, the four amendment axes, the confirmable events, and the undo family.
- Cite every external claim: FpML, the ISDA Common Domain Model, CFTC Part 23 Subpart I and Part 45.1, EMIR Article 11 and RTS 149/2013 Article 12, CPMI-IOSCO UTI guidance, the ISDA Novation Protocol, EMTA NDF template terms, and OpenGamma Strata. Terminology is checked against published Murex and Calypso material.
- Wire both pages into the knowledge hub and add the structures, deal_composition, confirmations and versioning tags to the tag inventory.
- Verification: docs class; local site build clean (exit 0), both pages published under build/output/site/OreStudio/doc/knowledge/domain/ and linked from the hub. compass lint --path doc exits non-zero on dangling id links, identically on origin/main (620 violations on both), so this change adds none.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Documentation improvements](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/documentation-improvements/story.html) | B660460A-682B-4728-9A8F-21B9A9AF52E4 |
| Task | [Write knowledge pages on structures and deal composition](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/documentation-improvements/task_document-structures-and-deal-composition.html) | 520A54D4-6B70-4217-9B90-4D1F3361DCE9 |
| Environment | eager_maxwell | |

## Testing

Plan. Read the two new pages on the built site and follow each cross-link to its target page.

Evidence. Site build exit 0; build/output/site/OreStudio/doc/knowledge/domain/trade_structures.html and confirmations_and_versioning.html written; the hub page carries both links.

Limitations. No automated check covers knowledge-page prose. The lint baseline of 620 dangling id links is pre-existing and unaddressed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)