### PR TITLE
[codegen] Bind custom C++ types to the headers that define them

### DIFF
--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -112,7 +112,7 @@ Tasks are listed in intended execution order.
 | [[id:C8C1316A-07A5-47E2-9077-FF0664C511AF][Run the component architecture audit in CI]] | BACKLOG | | | validate_docs.py is the audit's automated half and no workflow runs it; its exception file kept a real finding quiet until someone looked by hand. |
 | [[id:4B43941A-957B-4FC9-82BD-AB131F541825][Register composite parts in their component CMakeLists]] | DONE | 2026-09-11 | 2026-09-11 | Eighteen composites still register each part in projects/CMakeLists.txt; the target shape adds the component there and its parts in the component's own CMakeLists. |
 | [[id:9747E4C5-734E-4F75-AD8B-CEB4C9089B76][Give every composite a group model]] | BACKLOG | | | Eight composites have no group-level component_overview.org, so codegen cannot generate their root CMakeLists and their parts are undeclared. |
-| [[id:3B57DD4B-E6CB-48CC-803A-74834270AB9E][Bind custom C++ types to the headers that define them]] | STARTED | 2026-09-12 | | A column can declare any cpp_type but its header is listed separately by hand, so the two can drift apart or the include can be forgotten entirely. |
+| [[id:3B57DD4B-E6CB-48CC-803A-74834270AB9E][Bind custom C++ types to the headers that define them]] | DONE | 2026-09-12 | 2026-09-12 | A column can declare any cpp_type but its header is listed separately by hand, so the two can drift apart or the include can be forgotten entirely. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.org
@@ -112,6 +112,7 @@ Tasks are listed in intended execution order.
 | [[id:C8C1316A-07A5-47E2-9077-FF0664C511AF][Run the component architecture audit in CI]] | BACKLOG | | | validate_docs.py is the audit's automated half and no workflow runs it; its exception file kept a real finding quiet until someone looked by hand. |
 | [[id:4B43941A-957B-4FC9-82BD-AB131F541825][Register composite parts in their component CMakeLists]] | DONE | 2026-09-11 | 2026-09-11 | Eighteen composites still register each part in projects/CMakeLists.txt; the target shape adds the component there and its parts in the component's own CMakeLists. |
 | [[id:9747E4C5-734E-4F75-AD8B-CEB4C9089B76][Give every composite a group model]] | BACKLOG | | | Eight composites have no group-level component_overview.org, so codegen cannot generate their root CMakeLists and their parts are undeclared. |
+| [[id:3B57DD4B-E6CB-48CC-803A-74834270AB9E][Bind custom C++ types to the headers that define them]] | STARTED | 2026-09-12 | | A column can declare any cpp_type but its header is listed separately by hand, so the two can drift apart or the include can be forgotten entirely. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
@@ -83,7 +83,12 @@ via its "Verifies task" field.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | The matching rule tests only the leftmost occurrence, so a column containing a registered name inside a longer identifier hides a later column that genuinely declares it | org_loader.py | Accept | A real bug. Each column is now searched separately and every occurrence within it, which removes the failure by construction rather than patching the index arithmetic. Regression test added with the reviewer's exact case |
+| 2 | My own test could not have caught it: it only ever put one type in the list, so the hidden-later-occurrence path was untested | test_custom_type_headers.py | Accept | The more useful half of the finding. The test proved the rule on cases I had already thought of |
+| 3 | =::= is not a boundary, so a bare =domain::product_type= matches inside any longer namespace ending the same way, and such a collision is invisible to the one-type-one-header check | org_loader.py | Accept | Fixed rather than documented. A preceding =::= now rules the occurrence out, so a name qualified by another namespace is a different type. That also makes the =ores::trading::domain::product_type= row load-bearing instead of redundant |
+| 4 | The delete-the-include experiment is a valid proof that the registry supplies a missing header, and does not happen to exercise the matching bug | — | Accept | No change. Worth recording that the two findings sit on different axes: the experiment proves the mechanism acts, and says nothing about which names it matches |
+| 5 | Ambiguity as a hard error is a reasonable trade against per-component scoping | — | Accept | No change |
+| 6 | The audit-ordering change reads consistently across both documents | — | Accept | No change |
 
 * Result
 
@@ -106,9 +111,19 @@ model and regenerating =marketdata= left the generated header
 unchanged and still including it — the registry supplied what the
 model stopped declaring, which the byte-identical run cannot show.
 
-Nine tests cover it. One earned its place on the first run: checking
+Twelve tests cover it. One earned its place on the first run: checking
 that every registered header exists on disk caught that a simple
 component nests one level shallower than a part of a composite.
+
+Review found a real bug in the matching rule and a second, subtler
+one. The rule tested only the leftmost occurrence of a registered
+name across an entity's types joined into one string, so a column
+holding a longer identifier could hide a later column that genuinely
+declared the type. Each column is now searched separately, and every
+occurrence within it. A preceding =::= also counts as a boundary now,
+so a name qualified by another namespace is a different type rather
+than an incidental substring match that would resolve to the wrong
+component's header.
 
 The registry rejects binding one type to two headers. A bare
 =domain::= name is component-relative rather than globally unique, so

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
@@ -8,7 +8,7 @@
 #+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
 #+owner: marco
 #+branch: feature/bind-custom-types-to-headers
-#+pr:
+#+pr: 2071
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-12
@@ -77,7 +77,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2071][#2071]] | [codegen] Bind custom C++ types to the headers that define them |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: 3B57DD4B-E6CB-48CC-803A-74834270AB9E
+:END:
+#+title: Task: Bind custom C++ types to the headers that define them
+#+description: A column can declare any cpp_type but its header is listed separately by hand, so the two can drift apart or the include can be forgotten entirely.
+#+type: task
+#+level: s1
+#+filetags: :unify_llm_skills_catalogue:sprint_25:v0:
+#+owner: marco
+#+branch: feature/bind-custom-types-to-headers
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-12
+#+updated: 2026-09-12
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Declaring a registered custom type in a column is enough; codegen supplies the header that defines it.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                                |
+| Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
+| Now          | Building the registry.                 |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-09-12                               |
+
+* Acceptance
+
+- A registry declares each custom domain type and the header that defines it.
+- A column whose cpp_type is a registered type pulls that header into the entity's includes without the model repeating it.
+- Wrapped forms of a registered type, such as an optional or a vector of it, resolve to the same header.
+- Regenerating every component in the drift registry stays byte-identical.
+- cron_expression is registered, proving the mechanism on the type that motivated it.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
+++ b/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.org
@@ -26,11 +26,11 @@ Declaring a registered custom type in a column is enough; codegen supplies the h
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                                |
+| State        | DONE                                |
 | Parent story | [[id:2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC][Unify the LLM skills catalogue]] |
-| Now          | Building the registry.                 |
+| Now          | Nothing. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing. |
 | Last touched | 2026-09-12                               |
 
 * Acceptance
@@ -42,6 +42,19 @@ Declaring a registered custom type in a column is enough; codegen supplies the h
 - cron_expression is registered, proving the mechanism on the type that motivated it.
 
 * Plan
+
+Find out whether the mechanism is needed before designing one. The
+survey settled it: eight custom types are already in use across the
+corpus — four domain enums, the =tenant_id= value type,
+=year_month_day=, and both spellings of =product_type= — and each one
+has its header written out by hand in the entity that uses it. The
+loader's own comment already named the case it could not derive.
+
+Design for byte-identity. Anything that reorders existing include
+lists rewrites 171 models, so the mechanism adds only what is missing.
+That also makes the first verification meaningful: if regeneration is
+unchanged, the registry agrees with every include a human wrote.
+
 
 (Implementation strategy. Written when work starts; key decisions
 are distilled into the parent story's =* Decisions= at close, but the
@@ -73,3 +86,46 @@ via its "Verifies task" field.
 |   |                 |      |          |       |
 
 * Result
+
+All five acceptance criteria are met.
+
+=projects/modeling/cpp_custom_types.org= registers nine types against
+the headers that define them. A column declaring a registered type
+pulls its header in, and wrapped forms resolve to the same header
+because the wrapper is not what needs including.
+
+Eight of the nine were already in use and had their headers written
+out by hand. =cron_expression= is the ninth, registered for the
+scheduler resync that motivated the task.
+
+Verified two ways, because either alone proves half of it.
+Regenerating all eight registry components is byte-identical, so the
+registry agrees with every include a human wrote and nothing existing
+moved. Then deleting the =asset_class= include from =feed_binding='s
+model and regenerating =marketdata= left the generated header
+unchanged and still including it — the registry supplied what the
+model stopped declaring, which the byte-identical run cannot show.
+
+Nine tests cover it. One earned its place on the first run: checking
+that every registered header exists on disk caught that a simple
+component nests one level shallower than a part of a composite.
+
+The registry rejects binding one type to two headers. A bare
+=domain::= name is component-relative rather than globally unique, so
+an ambiguity introduced later has to fail rather than resolve to
+whichever row comes first.
+
+* Audit
+
+Run before closing, per the trigger this task tightened.
+
+The components touched are =ores.codegen= and =projects/modeling=.
+=ores.codegen= is a tool component, and the audit is explicit that
+tool components keep their own documented trees rather than the
+api/core/service shape its checklist governs, so the C++ component
+checklist does not apply to it. The automated half passes: 43
+components, no findings. =projects/modeling= is a modeling directory
+rather than a component and the audit does not cover it.
+
+No C++ domain component was touched, so no component audit was due
+beyond this.

--- a/doc/knowledge/architecture/component_architecture_audit.org
+++ b/doc/knowledge/architecture/component_architecture_audit.org
@@ -38,8 +38,11 @@ Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
 
 A component audit runs every so often, and always on these triggers:
 
-- A component reaches zero codegen drift. Audit it right after its
-  drift-baseline story closes, while the component is fresh.
+- A component reaches zero codegen drift. Audit it /before/ the task
+  that cleared it closes, not after. Clearing drift says the generated
+  tree matches the generator and nothing more, so closing on that
+  alone declares a component sound on evidence nobody gathered. The
+  close-task skill carries this as its first step.
 - The component's folder layout or codegen templates change.
 - A new sub-component is added to a composite.
 - Any doubt appears about a component's shape or structure.

--- a/doc/llm/skills/compass-agile-close-task/SKILL.org
+++ b/doc/llm/skills/compass-agile-close-task/SKILL.org
@@ -37,20 +37,33 @@ routine review feedback as reopening the task by default.
 
 * How to use this skill
 
-1. /Flip the state/ — task DONE, story table row synced, journal stamped:
+1. /Run the component audit first, when the task touched a component/.
+   Clearing codegen drift, moving a part, adding a facet — none of it
+   says the component has a legal shape, and =validate_docs= is only
+   the audit's automated half. Walk
+   [[id:45CAC01F-BC56-4600-B206-EEE7545AE3AB][the component architecture audit]] over each component the task
+   touched, and record what it found on the task. A component whose
+   task closed without it has been declared done on evidence nobody
+   gathered.
+
+   #+begin_src sh :results verbatim
+   projects/ores.codegen/validate_docs.sh
+   #+end_src
+
+2. /Flip the state/ — task DONE, story table row synced, journal stamped:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh task done <task-slug>
    #+end_src
 
 
-2. /Write the =* Result=/ by hand: what shipped, what acceptance was met.
+3. /Write the =* Result=/ by hand: what shipped, what acceptance was met.
 
-3. /Distill the =* Plan=/ into the parent story's =* Decisions= if it holds durable choices.
+4. /Distill the =* Plan=/ into the parent story's =* Decisions= if it holds durable choices.
 
-4. /Cascade if last task/: when no open tasks remain, set the story DONE in =story.org= /and/ its row in =sprint.org= — both files in the same commit.
+5. /Cascade if last task/: when no open tasks remain, set the story DONE in =story.org= /and/ its row in =sprint.org= — both files in the same commit.
 
-5. /Commit/ per [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]]: =[agile] Close <task>=. This commit is
+6. /Commit/ per [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]]: =[agile] Close <task>=. This commit is
    part of what =compass-pr-raise= pushes when it opens the PR — not a
    follow-up. Once the PR is open, CI and review run against a branch
    that already reflects the task as done; when CI goes green

--- a/projects/modeling/cpp_custom_types.org
+++ b/projects/modeling/cpp_custom_types.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: B868C4DA-D1BC-411B-A2DE-A68386CC9E1C
+:END:
+#+title: C++ Custom Types
+#+description: Registry binding each custom C++ column type to the header that defines it, so a model declares the type and codegen supplies the include.
+#+type: knowledge
+#+level: cross
+#+filetags: :codegen:cpp:types:
+#+created: 2026-09-12
+#+updated: 2026-09-12
+
+* Summary
+
+A column declares its C++ type with =:cpp_type:=, and the type may be
+anything the generated header can name: a standard type, a domain enum,
+or a value type such as =cron_expression=. Whatever the type, the
+header that defines it has to be included, and until this registry the
+two were stated separately — the type in the column, the header in the
+entity's =** Domain includes= block. Nothing connected them, so an
+include could be forgotten, or left behind when the type changed.
+
+This registry is the connection. A column whose =:cpp_type:= names a
+type below pulls that type's header into the entity's includes without
+the model repeating it.
+
+* Detail
+
+** What is registered
+
+Only types whose header codegen cannot otherwise derive. A plain
+=std::string= or =int= needs no row: the domain-header template emits
+the standard includes it always needs. A row earns its place when
+forgetting the header would fail the build.
+
+The match covers wrapped forms. A column typed
+=std::optional<cron_expression>= or =std::vector<domain::scope>=
+resolves to the same header as the bare type, because the wrapper is
+not what needs including.
+
+An entity that already lists the header in its =** Domain includes=
+block keeps working unchanged: the registry adds only what is missing,
+so registering a type that models already declare by hand changes
+nothing.
+
+** Order
+
+The order includes appear in is not meaningful. Codegen runs
+clang-format over its C++ output, and =.clang-format= sets
+=SortIncludes= with =IncludeBlocks: Merge=, so the emitted header
+carries clang-format's order whatever order the model lists them in.
+
+* The registry
+
+| Type | Header |
+|------+--------|
+| =cron_expression= | ="ores.scheduler.api/domain/cron_expression.hpp"= |
+| =domain::asset_class= | ="ores.marketdata.api/domain/asset_class.hpp"= |
+| =domain::binding_mode= | ="ores.synthetic.api/domain/binding_mode.hpp"= |
+| =domain::product_type= | ="ores.trading.api/domain/product_type.hpp"= |
+| =domain::scope= | ="ores.synthetic.api/domain/scope.hpp"= |
+| =domain::series_subclass= | ="ores.marketdata.api/domain/series_subclass.hpp"= |
+| =ores::trading::domain::product_type= | ="ores.trading.api/domain/product_type.hpp"= |
+| =std::chrono::year_month_day= | =<chrono>= |
+| =utility::uuid::tenant_id= | ="ores.utility/uuid/tenant_id.hpp"= |
+
+A =domain::= name is component-relative rather than globally unique.
+Each one above resolves to exactly one header across the corpus today,
+and the loader rejects a registry that binds the same type to two
+headers, so an ambiguity introduced later fails rather than picking a
+side.
+
+* See also
+
+- [[id:A57C28EA-EB88-4C0A-BDDF-F414CCCF96F7][Variability Profiles]] — the other registry the org loader reads from this directory.

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -134,6 +134,84 @@ def _load_profile_assignments(slug: str) -> tuple[tuple[str, Any], ...]:
     return tuple(out)
 
 
+@lru_cache(maxsize=None)
+def _load_custom_type_headers() -> tuple[tuple[str, str], ...]:
+    """Parse projects/modeling/cpp_custom_types.org into (type, header) pairs.
+
+    A column's ``:cpp_type:`` may name a type the domain-header template
+    cannot derive an include for -- a domain enum, a value type such as
+    ``cron_expression``. The registry binds each to the header that
+    defines it so the model states the type once instead of stating the
+    type and remembering the header separately.
+
+    Rejects a registry that binds one type to two headers: a bare
+    ``domain::`` name is component-relative rather than globally unique,
+    so an ambiguity introduced later must fail rather than resolve to
+    whichever row happens to come first.
+    """
+    path = _PROFILES_DIR / "cpp_custom_types.org"
+    if not path.is_file():
+        return ()
+    doc = parse_org(path.read_text(encoding="utf-8"))
+    section = _section(doc.root, "The registry")
+    if not section:
+        return ()
+    out: dict[str, str] = {}
+    for row in _parse_org_table_rows(section):
+        name = row.get("Type", "").strip().strip("=")
+        header = row.get("Header", "").strip().strip("=")
+        if not name or not header:
+            continue
+        if name in out and out[name] != header:
+            raise ValueError(
+                f"cpp_custom_types.org binds '{name}' to both "
+                f"{out[name]} and {header}; a type must name one header")
+        out[name] = header
+    return tuple(sorted(out.items()))
+
+
+def _headers_for_types(cpp_types: list[str]) -> list[str]:
+    """Registered headers the given column types need, in registry order.
+
+    Matches wrapped forms too: ``std::optional<cron_expression>`` needs
+    the same header as ``cron_expression``, because the wrapper is not
+    what needs including. Matching on the token rather than on equality
+    is what makes that work, and the delimiters guard against a
+    substring hit inside a longer identifier.
+    """
+    joined = " ".join(cpp_types)
+    out: list[str] = []
+    for name, header in _load_custom_type_headers():
+        if name not in joined:
+            continue
+        before = joined[joined.index(name) - 1] if joined.index(name) else " "
+        after_at = joined.index(name) + len(name)
+        after = joined[after_at] if after_at < len(joined) else " "
+        if before.isalnum() or before == "_" or after.isalnum() or after == "_":
+            continue
+        if header not in out:
+            out.append(header)
+    return out
+
+
+def _with_registered_headers(includes: dict, columns: list) -> None:
+    """Add the headers the columns' registered custom types need.
+
+    Appends rather than reorders, and only what is missing, so a model
+    that already lists the header by hand is untouched -- which is what
+    keeps regeneration byte-identical for every entity that predates the
+    registry. Order does not matter in the output: codegen runs
+    clang-format, and .clang-format sorts and merges include blocks.
+    """
+    types = [str(c.get("cpp_type", "")) for c in columns if c.get("cpp_type")]
+    if not types:
+        return
+    domain = includes.setdefault("domain", [])
+    for header in _headers_for_types(types):
+        if header not in domain:
+            domain.append(header)
+
+
 def _parse_physical_space_table(root: OrgNode) -> dict[str, bool]:
     """Parse a ``* Physical space`` heading's ``| Address | Enabled |`` table
     (if present) into ``{address: enabled}`` -- the same shape
@@ -1314,6 +1392,7 @@ def org_document_to_model(doc: OrgDocument) -> dict[str, Any]:
                     if t not in _ENTITY_HEADER_STANDARD_INCLUDES
                 ] if ent else [],
             }
+            _with_registered_headers(cpp_out["includes"], de.get("columns", []))
         conv = _section(cpp_section, "Conventions")
         if conv:
             for k, v in conv.properties.items():
@@ -1720,6 +1799,7 @@ def load_org_junction_model(path: Path | str) -> dict[str, Any]:
                     if t not in _ENTITY_HEADER_STANDARD_INCLUDES
                 ] if ent else [],
             }
+            _with_registered_headers(cpp_out["includes"], columns)
         conv = _section(cpp_section, "Conventions")
         if conv:
             for k, v in conv.properties.items():

--- a/projects/ores.codegen/src/codegen/org_loader.py
+++ b/projects/ores.codegen/src/codegen/org_loader.py
@@ -173,23 +173,35 @@ def _load_custom_type_headers() -> tuple[tuple[str, str], ...]:
 def _headers_for_types(cpp_types: list[str]) -> list[str]:
     """Registered headers the given column types need, in registry order.
 
-    Matches wrapped forms too: ``std::optional<cron_expression>`` needs
-    the same header as ``cron_expression``, because the wrapper is not
-    what needs including. Matching on the token rather than on equality
-    is what makes that work, and the delimiters guard against a
-    substring hit inside a longer identifier.
+    Matches a registered name as a whole type name inside each column's
+    declared type, so ``std::optional<cron_expression>`` needs the same
+    header as ``cron_expression`` -- the wrapper is not what needs
+    including.
+
+    Two boundary rules make that safe. A neighbouring identifier
+    character rules the occurrence out, so ``asset_class_id`` is not a
+    use of ``asset_class``. A preceding ``::`` rules it out too, so the
+    bare ``domain::product_type`` does not match inside
+    ``ores::trading::domain::product_type``: a name qualified by a
+    different namespace is a different type, and matching it here would
+    resolve it to another component's header without the registry's
+    one-type-one-header check ever seeing the collision. Each spelling
+    in use therefore earns its own row.
+
+    Every column is searched, and every occurrence within it. An
+    earlier column that merely contains a registered name must not hide
+    a later column that actually declares it.
     """
-    joined = " ".join(cpp_types)
+    pattern_cache = [
+        (header, re.compile(
+            r"(?<![A-Za-z0-9_:])" + re.escape(name) + r"(?![A-Za-z0-9_])"))
+        for name, header in _load_custom_type_headers()
+    ]
     out: list[str] = []
-    for name, header in _load_custom_type_headers():
-        if name not in joined:
+    for header, pattern in pattern_cache:
+        if header in out:
             continue
-        before = joined[joined.index(name) - 1] if joined.index(name) else " "
-        after_at = joined.index(name) + len(name)
-        after = joined[after_at] if after_at < len(joined) else " "
-        if before.isalnum() or before == "_" or after.isalnum() or after == "_":
-            continue
-        if header not in out:
+        if any(pattern.search(t) for t in cpp_types):
             out.append(header)
     return out
 

--- a/projects/ores.codegen/tests/test_custom_type_headers.py
+++ b/projects/ores.codegen/tests/test_custom_type_headers.py
@@ -50,6 +50,32 @@ def test_a_longer_identifier_is_not_a_match():
     assert _headers_for_types(["cron_expression_list"]) == []
 
 
+def test_a_colliding_earlier_column_does_not_hide_a_later_real_one():
+    """The first occurrence of a name is not the only one that counts.
+
+    Scanning one joined string and boundary-checking only its leftmost
+    hit dropped the header here: asset_class_id comes first, fails the
+    check, and the genuine asset_class column after it was never seen.
+    """
+    headers = _headers_for_types(["domain::asset_class_id",
+                                  "domain::asset_class"])
+    assert headers == ['"ores.marketdata.api/domain/asset_class.hpp"']
+
+
+def test_a_different_namespace_is_a_different_type():
+    """A preceding :: is a boundary, or one component's type resolves to
+    another's header without the one-type-one-header check ever seeing
+    the collision."""
+    assert _headers_for_types(["other::ns::product_type"]) == []
+
+
+def test_each_spelling_in_use_has_its_own_row():
+    trading = '"ores.trading.api/domain/product_type.hpp"'
+    assert _headers_for_types(["domain::product_type"]) == [trading]
+    assert _headers_for_types(
+        ["ores::trading::domain::product_type"]) == [trading]
+
+
 def test_injection_adds_only_what_is_missing():
     includes = {"domain": ["<string>"]}
     _with_registered_headers(includes, [{"cpp_type": "cron_expression"}])

--- a/projects/ores.codegen/tests/test_custom_type_headers.py
+++ b/projects/ores.codegen/tests/test_custom_type_headers.py
@@ -1,0 +1,86 @@
+"""Tests for the custom-type to header registry.
+
+Run::
+
+    python3 -m pytest projects/ores.codegen/tests/test_custom_type_headers.py
+
+A column declares its C++ type; the header defining that type used to be
+stated separately in the entity's Domain includes block, with nothing
+connecting the two. The registry in projects/modeling/cpp_custom_types.org
+binds them, so declaring the type is enough.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "projects/ores.codegen/src"))
+
+from codegen.org_loader import (  # noqa: E402
+    _headers_for_types,
+    _load_custom_type_headers,
+    _with_registered_headers,
+)
+
+CRON = '"ores.scheduler.api/domain/cron_expression.hpp"'
+
+
+def test_registry_loads():
+    assert dict(_load_custom_type_headers())["cron_expression"] == CRON
+
+
+def test_bare_type_resolves():
+    assert _headers_for_types(["cron_expression"]) == [CRON]
+
+
+def test_wrapped_type_resolves_to_the_same_header():
+    """The wrapper is not what needs including."""
+    assert _headers_for_types(["std::optional<cron_expression>"]) == [CRON]
+    assert _headers_for_types(["std::vector<cron_expression>"]) == [CRON]
+
+
+def test_unregistered_type_needs_nothing():
+    assert _headers_for_types(["std::string", "int"]) == []
+
+
+def test_a_longer_identifier_is_not_a_match():
+    """Substring matching would bind any name containing a registered one."""
+    assert _headers_for_types(["prefixed_cron_expression"]) == []
+    assert _headers_for_types(["cron_expression_list"]) == []
+
+
+def test_injection_adds_only_what_is_missing():
+    includes = {"domain": ["<string>"]}
+    _with_registered_headers(includes, [{"cpp_type": "cron_expression"}])
+    assert includes["domain"] == ["<string>", CRON]
+
+
+def test_injection_leaves_a_declared_header_alone():
+    """What keeps regeneration byte-identical for models predating this."""
+    includes = {"domain": [CRON, "<string>"]}
+    _with_registered_headers(includes, [{"cpp_type": "cron_expression"}])
+    assert includes["domain"] == [CRON, "<string>"]
+
+
+def test_columns_without_types_are_ignored():
+    includes = {"domain": ["<string>"]}
+    _with_registered_headers(includes, [{"column": "id"}])
+    assert includes["domain"] == ["<string>"]
+
+
+def test_every_registered_header_exists_on_disk():
+    """A registry entry pointing at a header nobody has is a broken promise."""
+    missing = []
+    for name, header in _load_custom_type_headers():
+        if not header.startswith('"'):
+            continue  # a standard library header, not a repo path
+        rel = header.strip('"')
+        # A part of a composite nests one level deeper than a simple
+        # component: ores.scheduler/api/include/... against
+        # ores.utility/include/...
+        hits = (list((REPO_ROOT / "projects").glob(f"*/*/include/{rel}"))
+                + list((REPO_ROOT / "projects").glob(f"*/include/{rel}")))
+        if not hits:
+            missing.append((name, header))
+    assert missing == []


### PR DESCRIPTION
## Summary

A column could already declare any cpp_type, but the header defining it was listed separately by hand with nothing connecting the two, so the include could be forgotten or left behind when the type changed. A registry now binds them. Eight of the nine registered types are already in use; cron_expression is the ninth, registered for the scheduler resync that motivated this.

## Changes

- Add projects/modeling/cpp_custom_types.org, binding each custom type to its header
- Resolve wrapped forms such as an optional or vector of a registered type to the same header
- Add only missing headers and never reorder, which is what keeps every model predating the registry byte-identical
- Reject a registry binding one type to two headers, since a bare domain:: name is component-relative
- Audit a component before closing its task rather than after — the ordering that let analytics close on codegen drift alone

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify the LLM skills catalogue](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/story.html) | 2FCD10F0-E7B5-4CBA-A7C7-E28845DB8AAC |
| Task | [Bind custom C++ types to the headers that define them](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/unify_llm_skills_catalogue/task_bind_custom_types_to_headers.html) | 3B57DD4B-E6CB-48CC-803A-74834270AB9E |
| Environment | bright_faraday | |

## Testing

Plan. Docs plus python tooling. The registry must both change nothing that exists and actually supply a header a model stops declaring, so it needs two opposite verifications rather than one.

Evidence. docs + python tooling; site build succeeded (exit 0, 5313 nodes, no errors — the five error matches in the log are filenames); check_component_drift.py --all byte-identical, so the registry agrees with every include a human wrote; deleting the asset_class include from feed_binding's model left the generated header unchanged and still including it, proving the registry supplies it; codegen pytest 192 passed; compass pytest 159 passed 1 skipped; check_model_drift.py clean; validate_docs 43 components; compass lint clean; misspell-fixer exit 0.

Limitations. No C++ build: no generated C++ changed, which the byte-identical regeneration establishes. The component audit's manual checklist was not walked, because the only component touched is ores.codegen, a tool component the checklist does not govern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)