### PR TITLE
[ores.ore] Map only what the v17 trade schema holds for a bond future

### DIFF
--- a/doc/agile/versions/v0/sprint_25/update-ore-to-v17/story.org
+++ b/doc/agile/versions/v0/sprint_25/update-ore-to-v17/story.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_25:v0:
 #+created: 2026-09-11
 #+updated: 2026-09-11
-#+environment: eager_maxwell
+#+environment: bright_faraday
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:0E7321A7-A66D-4CE6-B3E7-89F2E35CA48B][Sprint 25]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -60,6 +60,7 @@ version it wants and we can compare the two on live jobs.
 | [[id:E6AD2AD9-2EF9-4F3E-8D10-526E0B60232A][Build and vendor the ORE v1.8.17.0 engine package]] | DONE | 2026-09-11 | 2026-09-12 | Build the v1.8.17.0 engine into one self-contained package with external/ore/tools/package_ore.sh, self-test it against TA002, and commit it beside the v1.8.16.0 package. |
 | [[id:ADA8C792-C844-485E-81EE-8BA4073FF3F8][Publish both ORE engine versions during provisioning]] | STARTED | 2026-09-11 | | Register both engine versions in the compute seed and publish both packages during ACME provisioning, so a grid job can run on v1.8.16.0 or v1.8.17.0. |
 | [[id:64CB13D8-4848-4C66-8B6B-5946A4F4D8FF][Cover the seven new ORE v1.8.17.0 trade types]] | BACKLOG | | | Add mapper and round-trip coverage for the trade types that appear for the first time in v1.8.17.0, none of which maps into an ORES trading type today. |
+| [[id:67DA4CE7-A259-491F-9015-7220BC5FBAA6][Generate the ORE reference data types and fix the bond future mapper]] | DONE | 2026-09-12 | 2026-09-12 | main does not build: ORE v17 moved the bond future's contract terms from the trade into reference data, which codegen never emitted because xsdcpp only generates types reachable from the Trade root. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_25/update-ore-to-v17/task_generate_ore_reference_data_types.org
+++ b/doc/agile/versions/v0/sprint_25/update-ore-to-v17/task_generate_ore_reference_data_types.org
@@ -1,0 +1,167 @@
+:PROPERTIES:
+:ID: 67DA4CE7-A259-491F-9015-7220BC5FBAA6
+:END:
+#+title: Task: Fix the bond future mapper against v17
+#+description: main does not build: the bond future mapper reads trade-level members ORE v17 moved into reference data.
+#+type: task
+#+level: s1
+#+filetags: :update-ore-to-v17:sprint_25:v0:
+#+owner: marco
+#+branch: feature/generate-ore-reference-data-types
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-09-12
+#+updated: 2026-09-12
+#+environment: bright_faraday
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A34F4835-5CA5-4F30-91D6-90975354534C][Update ORE to v17]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=projects/ores.ore= builds again.
+
+ORE v17 cut =bondFutureData= to what belongs to a trade — the contract
+it is on, the size, the direction — and moved the contract's own terms
+into a =BondFutureReferenceData= datum. The mapper still reads the
+moved members, so it does not compile, and the round-trip test asserts
+them.
+
+This restores the build and nothing more. Generating the reference
+data types and reshaping the bond model to match ORE's trade/reference
+split is the larger piece of work, and it is separate.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                              |
+| Parent story | [[id:A34F4835-5CA5-4F30-91D6-90975354534C][Update ORE to v17]] |
+| Now          | Nothing. |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing. |
+| Last touched | 2026-09-12                               |
+
+* Acceptance
+
+- =projects/ores.ore= compiles, including the four test files that
+  were never in the compile database.
+- The mapper reads and writes only what the v17 trade schema holds.
+- Every relocated field is named in place, with where it went, so the
+  loss is stated rather than silent.
+- The round-trip test asserts the relocated fields stay unset rather
+  than being invented from the trade.
+
+* Plan
+
+(Implementation strategy. Written when work starts; key decisions
+are distilled into the parent story's =* Decisions= at close, but the
+plan itself stays — it is the historical record of what we did.)
+
+* Notes
+
+** How it reached main
+
+Two PRs developed in parallel. The v17 sync cut =bondFutureData= down
+while the bond rework added the code reading its old members, and
+neither branch saw the other until both landed. The sync's own record
+concluded that upstream had restructured =bondFutureData= but "no ORES
+code reads them, so nothing else broke" — true of everything except
+the mapper being written at the same time.
+
+** Why the sweep missed it
+
+Four test files added by the bond PR are not in the compile database,
+because it has not been reconfigured since. Nothing had syntax-checked
+them, so the first count of the damage said one file when it was two.
+
+** What the fields did
+
+They were relocated, not deleted. =bondFutureReferenceDatum= in
+=referencedata.xsd= holds Currency, DeliveryBasket, DeliverableGrade,
+LastTradingDate, LastDeliveryDate, Settlement, DirtyQuotation (renamed
+from SettlementDirty), ContractMonth, RootDate, ExpiryBasis,
+SettlementBasis, ExpiryLag, SettlementLag, plus ScheduleData and
+BondData. =FairPrice= is the exception: it is in no v17 schema at all.
+
+Our codegen never emitted those types. =xsdcpp= generates what is
+reachable from a root element, =input.xsd= declares only =Trade= and
+=SubTrade=, and =ReferenceData= is a root of its own that nothing in
+the trade graph points at. 522 of the schema's 560 named complexTypes
+are generated; the 38 missing are the reference data family and the
+other sibling documents.
+
+
+* Test Scenarios
+
+Manual QA scenarios (scaffolded via =compass add test_scenario=, run
+through the QA Validation Runner panel) that verify this task. Link
+new ones here as they're created; the scenario doc itself links back
+via its "Verifies task" field.
+
+| Scenario | State | Notes |
+|----------+-------+-------|
+|          |       |       |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+=projects/ores.ore= builds: 90 of 90 translation units compile, from
+88 before.
+
+The mapper reads and writes only what the v17 trade schema holds —
+=ContractName=, =ContractNotional=, =LongShort= — and every relocated
+field is named where it used to be read, with where it went, so a
+reader meets the loss rather than inferring it from an absence.
+=FairPrice= is called out separately because it was deleted from the
+schema rather than moved.
+
+The round-trip test's fixture was hand-authored against v16 and is
+invalid under v17. It now states the three fields the schema keeps and
+asserts the relocated ones stay unset, which is the behaviour that
+matters: they are not invented from the trade.
+
+Removing the =SettlementDirty= read orphaned =flag_of=, which the
+=-Wunused-function= gate caught on the next compile.
+
+Two findings beyond the fix, both recorded rather than folded in. The
+four test files the bond PR added are not in the compile database, so
+nothing had ever syntax-checked them — which is why the first count of
+the damage said one file when it was two. And =misspell-fixer= fails
+on =task_sync-ore-examples-and-xsd.org=, untouched here: it quotes the
+upstream identifier =LOAD_PROFILE_1_EXPLICT= verbatim and that record
+declines correcting it, because the portfolio references the name.
+Running the fixer rewrites the record into a falsehood. It wants an
+ignore entry.
+
+* Audit
+
+Run before closing, on =ores.ore=.
+
+Passing: composite shape with =api=, =core= and =service= and a root
+=CMakeLists.txt= that adds them; no leftover artefacts; no
+platform-specific code; every test file named =_tests.cpp=; the
+automated half clean at 43 components.
+
+One finding, already filed: =ores.ore= has no group-level
+=modeling/component_overview.org=, so it is one of the eight
+composites whose root cannot be generated. Tracked by
+[[id:9747E4C5-734E-4F75-AD8B-CEB4C9089B76][Give every composite a group model]].
+
+The manual checklist's deeper items — type naming, misplaced files,
+complexity — were not walked. This change touches two files in a
+component of ninety, and walking the full checklist on it would be
+theatre rather than evidence; the shape and hygiene checks above are
+what a two-file fix warrants.

--- a/doc/agile/versions/v0/sprint_25/update-ore-to-v17/task_generate_ore_reference_data_types.org
+++ b/doc/agile/versions/v0/sprint_25/update-ore-to-v17/task_generate_ore_reference_data_types.org
@@ -8,7 +8,7 @@
 #+filetags: :update-ore-to-v17:sprint_25:v0:
 #+owner: marco
 #+branch: feature/generate-ore-reference-data-types
-#+pr:
+#+pr: 2076
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-09-12
@@ -108,7 +108,7 @@ via its "Verifies task" field.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/2076][#2076]] | [ores.ore] Map only what the v17 trade schema holds for a bond future |
 
 * Review
 

--- a/projects/ores.ore/core/src/domain/bond_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/bond_instrument_mapper.cpp
@@ -159,13 +159,6 @@ int count_of(const std::string& text, int fallback) {
     }
 }
 
-// The schema states a boolean as a string in several spellings. This is
-// the same set the generated bool_ enumeration carries.
-bool flag_of(const std::string& text) {
-    return text == "Y" || text == "YES" || text == "TRUE" || text == "True" || text == "true" ||
-           text == "1";
-}
-
 // A generated wrapper derives from the string type it carries, and a
 // std::string does not convert to a derived type, so the reverse
 // direction writes through the base reference.
@@ -1452,35 +1445,15 @@ bond_instrument_data bond_instrument_mapper::forward_bond_future(
     future.contract_name = d.ContractName;
     future.contract_notional = number_of(d.ContractNotional, 0.0);
     future.long_short = d.LongShort;
-    if (d.Currency)
-        future.currency = to_string(*d.Currency);
-    if (d.ContractMonth)
-        future.contract_month = *d.ContractMonth;
-    if (d.DeliverableGrade)
-        future.deliverable_grade = *d.DeliverableGrade;
-    if (d.FairPrice)
-        future.fair_price = number_of(*d.FairPrice, 0.0);
-    if (d.Settlement)
-        future.settlement = *d.Settlement;
-    if (d.SettlementDirty)
-        future.settlement_dirty = flag_of(*d.SettlementDirty);
-    if (d.RootDate)
-        future.root_date = *d.RootDate;
-    if (d.ExpiryBasis)
-        future.expiry_basis = *d.ExpiryBasis;
-    if (d.SettlementBasis)
-        future.settlement_basis = *d.SettlementBasis;
-    if (d.ExpiryLag)
-        future.expiry_lag = count_of(*d.ExpiryLag, 0);
-    if (d.SettlementLag)
-        future.settlement_lag = count_of(*d.SettlementLag, 0);
-    if (d.LastTradingDate)
-        future.last_trading_date = *d.LastTradingDate;
-    if (d.LastDeliveryDate)
-        future.last_delivery_date = *d.LastDeliveryDate;
-    if (d.DeliveryBasket)
-        for (const auto& id : d.DeliveryBasket->Id)
-            result.future_delivery_basket.push_back(id);
+    // v17 moved the contract's own terms out of the trade and into the
+    // BondFutureReferenceData datum keyed by ContractName: currency,
+    // contract month, deliverable grade, settlement and its basis,
+    // expiry basis, the two lags, root date, last trading and delivery
+    // dates, and the delivery basket. They are properties of the
+    // contract rather than of a trade on it, which is why they moved.
+    // Nothing reads them here because the reference data document is
+    // not yet parsed; the fields stay unset rather than being invented
+    // from the trade. FairPrice is not in v17 at all.
     stamp_audit(future);
     result.future = future;
     return result;
@@ -1692,33 +1665,13 @@ trade bond_instrument_mapper::reverse_bond_future(const bond_instrument_data& da
         set_text(d.ContractName, f.contract_name);
         set_text(d.ContractNotional, format_number(f.contract_notional));
         set_text(d.LongShort, f.long_short);
-        if (!f.currency.empty())
-            d.Currency = parse_code(f.currency, currency_code_count, currencyCode::USD);
-        set_optional_text(d.ContractMonth, f.contract_month);
-        set_optional_text(d.DeliverableGrade, f.deliverable_grade);
-        if (f.fair_price != 0.0)
-            set_optional_text(d.FairPrice, format_number(f.fair_price));
-        set_optional_text(d.Settlement, f.settlement);
-        if (f.settlement_dirty)
-            set_optional_text(d.SettlementDirty, "true");
-        set_optional_text(d.RootDate, f.root_date);
-        set_optional_text(d.ExpiryBasis, f.expiry_basis);
-        set_optional_text(d.SettlementBasis, f.settlement_basis);
-        if (f.expiry_lag != 0)
-            set_optional_text(d.ExpiryLag, std::to_string(f.expiry_lag));
-        if (f.settlement_lag != 0)
-            set_optional_text(d.SettlementLag, std::to_string(f.settlement_lag));
-        set_optional_text(d.LastTradingDate, f.last_trading_date);
-        set_optional_text(d.LastDeliveryDate, f.last_delivery_date);
-    }
-    if (!data.future_delivery_basket.empty()) {
-        deliveryBasket basket;
-        for (const auto& id : data.future_delivery_basket) {
-            deliveryBasket_Id_t entry;
-            static_cast<std::string&>(entry) = id;
-            basket.Id.push_back(std::move(entry));
-        }
-        d.DeliveryBasket = std::move(basket);
+        // The contract's own terms belong to the BondFutureReferenceData
+        // datum in v17, not to the trade, so there is nowhere here to
+        // write currency, contract month, deliverable grade, settlement
+        // and its basis, expiry basis, the lags, root date, or the last
+        // trading and delivery dates. Writing them would produce a
+        // document the schema rejects. They are exported once the
+        // reference data document is emitted alongside the portfolio.
     }
     t.BondFutureData = std::move(d);
     return t;

--- a/projects/ores.ore/core/tests/xml_bond_fact_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_bond_fact_mapper_roundtrip_tests.cpp
@@ -920,11 +920,18 @@ TEST_CASE("bond_trs_price_type_and_payer_come_from_the_document", tags) {
 // The future row
 // =============================================================================
 
-TEST_CASE("bond_future_maps_every_fact_column_and_the_basket", tags) {
+TEST_CASE("bond_future_maps_the_trade_level_facts", tags) {
     auto lg(make_logger(test_suite));
 
     // No example document states a BondFuture, so the trade is authored
-    // after the schema's bondFutureData.
+    // after the schema's bondFutureData. In v17 that type holds only
+    // what belongs to the trade: the contract it is on, the size, and
+    // the direction. The contract's own terms — currency, month,
+    // deliverable grade, settlement and its basis, expiry basis, the
+    // lags, root date, last trading and delivery dates, and the
+    // delivery basket — moved to the BondFutureReferenceData datum
+    // keyed by ContractName, and are covered once that document is
+    // parsed. FairPrice was dropped from the schema outright.
     const std::string xml = R"(
 <Portfolio>
   <Trade id="Future">
@@ -933,23 +940,6 @@ TEST_CASE("bond_future_maps_every_fact_column_and_the_basket", tags) {
       <ContractName>Euro-Bund-Future</ContractName>
       <ContractNotional>100000</ContractNotional>
       <LongShort>Long</LongShort>
-      <Currency>EUR</Currency>
-      <ContractMonth>2026-03</ContractMonth>
-      <DeliverableGrade>Bund</DeliverableGrade>
-      <FairPrice>132.45</FairPrice>
-      <Settlement>Physical</Settlement>
-      <SettlementDirty>true</SettlementDirty>
-      <RootDate>2026-03-10</RootDate>
-      <ExpiryBasis>Annual</ExpiryBasis>
-      <SettlementBasis>Annual</SettlementBasis>
-      <ExpiryLag>2</ExpiryLag>
-      <SettlementLag>3</SettlementLag>
-      <LastTradingDate>2026-03-06</LastTradingDate>
-      <LastDeliveryDate>2026-03-10</LastDeliveryDate>
-      <DeliveryBasket>
-        <Id>DE0001102325</Id>
-        <Id>DE0001102333</Id>
-      </DeliveryBasket>
     </BondFutureData>
   </Trade>
 </Portfolio>
@@ -962,43 +952,28 @@ TEST_CASE("bond_future_maps_every_fact_column_and_the_basket", tags) {
     CHECK(f.contract_name == "Euro-Bund-Future");
     CHECK(f.contract_notional == Approx(100000.0));
     CHECK(f.long_short == "Long");
-    CHECK(f.currency == "EUR");
-    CHECK(f.contract_month == "2026-03");
-    CHECK(f.deliverable_grade == "Bund");
-    CHECK(f.fair_price == Approx(132.45));
-    CHECK(f.settlement == "Physical");
-    CHECK(f.settlement_dirty);
-    CHECK(f.root_date == "2026-03-10");
-    CHECK(f.expiry_basis == "Annual");
-    CHECK(f.settlement_basis == "Annual");
-    CHECK(f.expiry_lag == 2);
-    CHECK(f.settlement_lag == 3);
-    CHECK(f.last_trading_date == "2026-03-06");
-    CHECK(f.last_delivery_date == "2026-03-10");
     CHECK(f.modified_by == "ores");
     CHECK(f.change_reason_code == "system.external_data_import");
+
+    // The relocated terms have no source in the trade, so they stay at
+    // their defaults rather than being invented from it.
+    CHECK(f.currency.empty());
+    CHECK(f.contract_month.empty());
+    CHECK(f.deliverable_grade.empty());
+    CHECK(r.future_delivery_basket.empty());
 
     // A future carries no bond terms, so the issue row its NOT NULL
     // issue_id points at is minted empty.
     CHECK(r.issue.security_id.empty());
     CHECK(r.instrument.issue_id == r.issue.issue_id);
-    CHECK(r.future_delivery_basket == std::vector<std::string>{"DE0001102325", "DE0001102333"});
 
     const auto rt = bond_instrument_mapper::reverse_bond_future(r);
     REQUIRE(rt.BondFutureData);
     CHECK(std::string(rt.BondFutureData->ContractName) == "Euro-Bund-Future");
     CHECK(std::string(rt.BondFutureData->LongShort) == "Long");
     CHECK(std::stod(std::string(rt.BondFutureData->ContractNotional)) == Approx(100000.0));
-    REQUIRE(rt.BondFutureData->Currency);
-    CHECK(ores::ore::domain::to_string(*rt.BondFutureData->Currency) == "EUR");
-    REQUIRE(rt.BondFutureData->SettlementDirty);
-    CHECK(std::string(*rt.BondFutureData->SettlementDirty) == "true");
-    REQUIRE(rt.BondFutureData->DeliveryBasket);
-    REQUIRE(rt.BondFutureData->DeliveryBasket->Id.size() == 2);
-    CHECK(std::string(rt.BondFutureData->DeliveryBasket->Id[0]) == "DE0001102325");
-    CHECK(std::string(rt.BondFutureData->DeliveryBasket->Id[1]) == "DE0001102333");
 
-    BOOST_LOG_SEV(lg, info) << "BondFuture fact row and delivery basket mapped.";
+    BOOST_LOG_SEV(lg, info) << "BondFuture trade-level facts mapped.";
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

main did not build. ORE v17 cut bondFutureData down to what belongs to a trade and moved the contract's own terms into a BondFutureReferenceData datum; the mapper still read the moved members and the test asserted them. This restores the build and nothing more — generating the reference data types and reshaping the bond model to match ORE's trade/reference split is separate and larger.

## Changes

- Map only ContractName, ContractNotional and LongShort, naming every relocated field where it used to be read and where it went
- Rewrite the round-trip fixture to the v17 shape and assert the relocated fields stay unset rather than being invented from the trade
- Remove flag_of, orphaned when the SettlementDirty read went, and caught by the unused-function gate
- Record how this reached main, and that four test files are absent from the compile database so nothing had checked them

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Update ORE to v17](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/update-ore-to-v17/story.html) | A34F4835-5CA5-4F30-91D6-90975354534C |
| Task | [Fix the bond future mapper against v17](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_25/update-ore-to-v17/task_generate_ore_reference_data_types.html) | 67DA4CE7-A259-491F-9015-7220BC5FBAA6 |
| Environment | bright_faraday | |

## Testing

Plan. Code class. The break is a compile failure, so the check is that every translation unit in the component compiles, including the four test files the compile database does not carry.

Evidence. code; 90 of 90 ores.ore translation units compile, from 88 before — verified by a syntax-only sweep over the compile database plus the four test files checked against a sibling's command; compass lint clean; validate_docs 43 components; the component audit's shape and hygiene checks walked and recorded on the task.

Limitations. No ctest: the bond round-trip tests need a build this machine has not completed, so the rewritten test is verified to compile rather than to pass. No full build beyond ores.ore. misspell-fixer fails on an untouched file in the same directory, which quotes an upstream identifier its own record declines to correct; left alone rather than falsified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)